### PR TITLE
feat(messages): tactical chat invite over APRS DM

### DIFF
--- a/graywolf/pkg/configstore/messages.go
+++ b/graywolf/pkg/configstore/messages.go
@@ -116,3 +116,20 @@ func (s *Store) ListEnabledTacticalCallsigns(ctx context.Context) ([]TacticalCal
 	var out []TacticalCallsign
 	return out, s.db.WithContext(ctx).Where("enabled = ?", true).Order("callsign").Find(&out).Error
 }
+
+// GetTacticalCallsignByCallsign returns the entry whose Callsign
+// equals the uppercase-normalized argument. Returns (nil, nil) on
+// not-found to match the other singleton getters. Used by the invite
+// accept handler so it can upsert without racing the autoincrement
+// ID.
+func (s *Store) GetTacticalCallsignByCallsign(ctx context.Context, callsign string) (*TacticalCallsign, error) {
+	var t TacticalCallsign
+	err := s.db.WithContext(ctx).Where("callsign = ?", callsign).First(&t).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}

--- a/graywolf/pkg/configstore/migrate.go
+++ b/graywolf/pkg/configstore/migrate.go
@@ -57,12 +57,19 @@ type migration struct {
 //	    from the struct tags, but the migration-list entry lets us
 //	    evolve the index shape independently and keeps the intent
 //	    centralized with the partial index above.
+//	6 — messages_kind_backfill: backfill legacy messages.kind rows to
+//	    'text'. AutoMigrate adds the column with a DEFAULT clause, but
+//	    SQLite ALTER TABLE ADD COLUMN DEFAULT only applies to rows
+//	    inserted AFTER the ALTER — legacy rows end up with NULL. This
+//	    migration rewrites them to 'text' explicitly so every downstream
+//	    reader can trust the column.
 var schemaMigrations = []migration{
 	{version: 1, name: "beacon_compress_default", phase: postAutoMigrate, run: migrateBeaconCompressDefault},
 	{version: 2, name: "channel_device_fields", phase: preAutoMigrate, run: migrateChannelDeviceFields},
 	{version: 3, name: "drop_channel_tx_timing", phase: preAutoMigrate, run: migrateDropChannelTxTiming},
 	{version: 4, name: "messages_partial_retry_index", phase: postAutoMigrate, run: migrateMessagesPartialRetryIndex},
 	{version: 5, name: "messages_thread_rollup_index", phase: postAutoMigrate, run: migrateMessagesThreadRollupIndex},
+	{version: 6, name: "messages_kind_backfill", phase: postAutoMigrate, run: migrateMessagesKindBackfill},
 }
 
 // runMigrations applies every pending migration in the given phase,
@@ -200,5 +207,21 @@ func migrateMessagesPartialRetryIndex(tx *gorm.DB) error {
 func migrateMessagesThreadRollupIndex(tx *gorm.DB) error {
 	return tx.Exec(
 		`CREATE INDEX IF NOT EXISTS idx_msg_thread ON messages(thread_kind, thread_key, created_at)`,
+	).Error
+}
+
+// migrateMessagesKindBackfill rewrites every legacy messages.kind to
+// 'text'. AutoMigrate adds the column with DEFAULT 'text' NOT NULL,
+// but SQLite's ALTER TABLE ADD COLUMN ... DEFAULT only applies the
+// default to newly-inserted rows; existing rows get NULL (or an empty
+// string when SQLite reinterprets the NOT NULL constraint silently),
+// and relying on the GORM tag to paper over that at read time is
+// exactly the "defensive render-time fallback" the plan forbids.
+//
+// UPDATE … WHERE kind IS NULL OR kind = '' is idempotent: once the
+// column is fully populated, the statement is a no-op.
+func migrateMessagesKindBackfill(tx *gorm.DB) error {
+	return tx.Exec(
+		`UPDATE messages SET kind = 'text' WHERE kind IS NULL OR kind = ''`,
 	).Error
 }

--- a/graywolf/pkg/configstore/migrate_test.go
+++ b/graywolf/pkg/configstore/migrate_test.go
@@ -146,6 +146,123 @@ func TestForeignKeyCascade_PttConfig(t *testing.T) {
 	}
 }
 
+// TestLegacyMessagesKindBackfill builds a database file with a
+// pre-Phase-1-invite messages schema (no kind / invite_tactical /
+// invite_accepted_at columns), seeds it with legacy rows, stamps
+// PRAGMA user_version at 5 (the version before the kind-backfill
+// migration), then re-opens with the current binary.
+//
+// After Open, every row must carry kind='text'. Two paths can reach
+// that invariant:
+//   - AutoMigrate's ADD COLUMN ... NOT NULL DEFAULT 'text' (SQLite
+//     applies constant defaults to pre-existing rows at ADD time).
+//   - Migration 6's explicit UPDATE … WHERE kind IS NULL OR kind = ''.
+//
+// The test asserts the *observable* contract (every legacy row ends
+// with kind='text') without caring which layer did the work. If a
+// future SQLite quirk leaves rows with NULL or empty kind, migration
+// 6 is the safety net; this test fails if both paths are broken.
+func TestLegacyMessagesKindBackfill(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy_messages.db")
+
+	// Build a pre-Phase-1-invite schema directly — no kind columns.
+	// The column list matches the Message model as of migration 5.
+	// Keep in sync with models.go if new pre-invite columns arrive.
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	_, err = raw.Exec(`
+CREATE TABLE messages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  direction TEXT NOT NULL,
+  our_call TEXT NOT NULL,
+  peer_call TEXT NOT NULL,
+  from_call TEXT NOT NULL,
+  to_call TEXT NOT NULL,
+  text TEXT NOT NULL,
+  msg_id TEXT,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  received_at DATETIME,
+  sent_at DATETIME,
+  acked_at DATETIME,
+  ack_state TEXT NOT NULL DEFAULT 'none',
+  source TEXT NOT NULL DEFAULT '',
+  channel INTEGER NOT NULL DEFAULT 0,
+  path TEXT,
+  via TEXT,
+  raw_tnc2 TEXT,
+  unread NUMERIC NOT NULL DEFAULT 0,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  next_retry_at DATETIME,
+  failure_reason TEXT,
+  reply_ack_id TEXT,
+  is_ack NUMERIC NOT NULL DEFAULT 0,
+  is_rej NUMERIC NOT NULL DEFAULT 0,
+  is_bulletin NUMERIC NOT NULL DEFAULT 0,
+  is_nws NUMERIC NOT NULL DEFAULT 0,
+  prefer_is NUMERIC NOT NULL DEFAULT 0,
+  deleted_at DATETIME,
+  thread_kind TEXT NOT NULL DEFAULT 'dm',
+  thread_key TEXT NOT NULL DEFAULT '',
+  received_by_call TEXT
+);
+INSERT INTO messages (direction, our_call, peer_call, from_call, to_call, text, created_at, updated_at, thread_kind, thread_key)
+  VALUES ('in',  'N0CALL', 'W1ABC', 'W1ABC', 'N0CALL', 'hello 1', '2026-01-01 00:00:00', '2026-01-01 00:00:00', 'dm',       'W1ABC');
+INSERT INTO messages (direction, our_call, peer_call, from_call, to_call, text, created_at, updated_at, thread_kind, thread_key)
+  VALUES ('out', 'N0CALL', 'W1ABC', 'N0CALL', 'W1ABC', 'hello 2', '2026-01-02 00:00:00', '2026-01-02 00:00:00', 'dm',       'W1ABC');
+INSERT INTO messages (direction, our_call, peer_call, from_call, to_call, text, created_at, updated_at, thread_kind, thread_key)
+  VALUES ('in',  'N0CALL', 'TAC',   'W9XYZ', 'TAC',    'hello 3', '2026-01-03 00:00:00', '2026-01-03 00:00:00', 'tactical', 'TAC');
+-- Stamp the pre-Phase-1-invite user_version so the new migration runs.
+PRAGMA user_version = 5;
+`)
+	raw.Close()
+	if err != nil {
+		t.Fatalf("seed pre-invite messages schema: %v", err)
+	}
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open legacy messages db: %v", err)
+	}
+	defer s.Close()
+
+	// Every legacy row must be kind='text' after migration.
+	var rows []struct {
+		ID   uint64
+		Kind string
+	}
+	if err := s.DB().Raw(`SELECT id, kind FROM messages ORDER BY id`).Scan(&rows).Error; err != nil {
+		t.Fatalf("scan messages.kind: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 legacy rows, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.Kind != "text" {
+			t.Errorf("row id=%d kind=%q, want %q", r.ID, r.Kind, "text")
+		}
+	}
+
+	// No row should have NULL kind either (the CHECK constraint would
+	// have rejected it, but belt-and-braces: count the SQL-level NULLs).
+	var nullCount int
+	if err := s.DB().Raw(`SELECT COUNT(*) FROM messages WHERE kind IS NULL OR kind = ''`).Scan(&nullCount).Error; err != nil {
+		t.Fatalf("scan null kinds: %v", err)
+	}
+	if nullCount != 0 {
+		t.Errorf("found %d rows with NULL or empty kind after migration; want 0", nullCount)
+	}
+
+	// user_version must have advanced to at least 6.
+	var version int
+	s.DB().Raw("PRAGMA user_version").Scan(&version)
+	if version < 6 {
+		t.Errorf("user_version = %d, want >= 6 after invite-kind migration", version)
+	}
+}
+
 // TestLegacySchemaUpgrade builds a database file with the pre-split
 // channels columns (audio_device_id/audio_channel) and confirms that
 // Open applies migration 2, preserves the row, and retrofits the new

--- a/graywolf/pkg/configstore/models.go
+++ b/graywolf/pkg/configstore/models.go
@@ -408,6 +408,23 @@ type Message struct {
 	ThreadKind     string         `gorm:"size:10;not null;default:'dm';index:idx_msg_thread,priority:1" json:"thread_kind"` // dm | tactical
 	ThreadKey      string         `gorm:"size:9;not null;default:'';index:idx_msg_thread,priority:2" json:"thread_key"`     // peer callsign for dm, tactical label for tactical
 	ReceivedByCall string         `gorm:"size:9" json:"received_by_call"`                                                   // tactical outbound: first acker's call
+	// Kind classifies the message body so the UI can render specialized
+	// affordances (e.g. an Accept button for tactical invites) without
+	// having to re-parse the wire text. Defaults to "text"; "invite"
+	// marks a `!GW1 INVITE <TAC>` DM. The CHECK constraint pins the
+	// enum at the SQL layer as a backstop against accidental writes of
+	// other values from SQL shells or future migrations. No index — the
+	// column is never a query predicate, only a display tag.
+	Kind string `gorm:"size:10;not null;default:'text';check:kind IN ('text','invite')" json:"kind"`
+	// InviteTactical is the tactical callsign referenced by an invite
+	// message. Empty when Kind != "invite". Size 9 mirrors ThreadKey /
+	// TacticalCallsign.Callsign.
+	InviteTactical string `gorm:"size:9;not null;default:''" json:"invite_tactical"`
+	// InviteAcceptedAt records when the local operator accepted this
+	// invite. Audit-only: UI rendering of "Joined" keys off the live
+	// TacticalSet cache, not this column, so first-paint is race-free
+	// on refresh. Nil until accept. No index.
+	InviteAcceptedAt *time.Time `json:"invite_accepted_at,omitempty"`
 }
 
 // TableName pins the messages table name to the plural lower-case form

--- a/graywolf/pkg/messages/event_hub.go
+++ b/graywolf/pkg/messages/event_hub.go
@@ -27,6 +27,12 @@ const (
 	// EventMessageDeleted is emitted when an operator soft-deletes
 	// an outbound or inbound row via REST.
 	EventMessageDeleted = "message.deleted"
+	// EventMessageUpdated is emitted when a row's rendered state
+	// changes without a more specific event (e.g. an invite gets
+	// InviteAcceptedAt stamped). The webapi SSE layer already maps
+	// unknown event types to the "updated" wire kind, but handlers
+	// should prefer this constant for readability.
+	EventMessageUpdated = "message.updated"
 )
 
 // Event is the payload delivered to subscribers. MessageID is 0 for

--- a/graywolf/pkg/messages/invite.go
+++ b/graywolf/pkg/messages/invite.go
@@ -1,0 +1,43 @@
+package messages
+
+import "regexp"
+
+// inviteWireRe is the strict wire format for a tactical-invite APRS
+// message body: `!GW1 INVITE <TAC>`. The `!GW1` sigil reserves a
+// versioned namespace for future verbs (LEAVE, notes, multi-tactical)
+// and makes the framing unambiguous versus a casual DM that happens to
+// contain the word "INVITE".
+//
+// Strictness is intentional:
+//   - Anchored at both ends (`^...$`): no trailing text, no leading
+//     whitespace. Whitespace-tolerance invites footguns where a wire
+//     corruption paints a normal DM as an invite.
+//   - Uppercase only. APRS addressee casing is normalized by the router
+//     already, but we apply the same rule to the tactical token here so
+//     `!gw1 invite tac-net` is rejected at persist time rather than
+//     silently upcased.
+//   - Tactical character class matches TacticalCallsign.Callsign: 1-9
+//     of [A-Z0-9-].
+//
+// Keep this regex identical to the plan's §"Wire protocol" anchor; the
+// inbound detector and any future outbound wire-builder must agree on
+// exactly one shape.
+var inviteWireRe = regexp.MustCompile(`^!GW1 INVITE ([A-Z0-9-]{1,9})$`)
+
+// ParseInvite returns the referenced tactical callsign and ok=true iff
+// text is a valid invite wire body per the strict grammar above. It is
+// deliberately side-effect-free: the caller (Router.persistInbound)
+// decides what to do with the result (stamp Kind=invite + InviteTactical
+// on the Message row, or fall through to plain text).
+//
+// ParseInvite does NOT lowercase, trim, or normalize text — the APRS
+// body is persisted verbatim and we classify on exactly what was
+// received. A legacy `INVITE TAC` body (no sigil) returns ok=false and
+// persists as plain text.
+func ParseInvite(text string) (tactical string, ok bool) {
+	m := inviteWireRe.FindStringSubmatch(text)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}

--- a/graywolf/pkg/messages/invite_test.go
+++ b/graywolf/pkg/messages/invite_test.go
@@ -1,0 +1,73 @@
+package messages
+
+import "testing"
+
+// TestParseInvite covers the strict `!GW1 INVITE <TAC>` wire grammar.
+// The goal of the table is to pin every rejection reason we care about
+// (missing sigil, trailing noise, bad casing, out-of-range tactical) so
+// a future regex edit that loosens one axis lights up here immediately.
+func TestParseInvite(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantTac  string
+		wantOk   bool
+	}{
+		// ---- positive cases ------------------------------------------
+		{name: "simple", in: "!GW1 INVITE TAC", wantTac: "TAC", wantOk: true},
+		{name: "with_hyphen", in: "!GW1 INVITE TAC-NET", wantTac: "TAC-NET", wantOk: true},
+		{name: "numeric_tac", in: "!GW1 INVITE NET1", wantTac: "NET1", wantOk: true},
+		{name: "single_char_tac", in: "!GW1 INVITE A", wantTac: "A", wantOk: true},
+		{name: "nine_char_tac_max", in: "!GW1 INVITE ABCDEFGHI", wantTac: "ABCDEFGHI", wantOk: true},
+		{name: "hyphens_allowed_everywhere", in: "!GW1 INVITE A-B-C-D-E", wantTac: "A-B-C-D-E", wantOk: true},
+
+		// ---- rejected: missing or wrong sigil ------------------------
+		{name: "legacy_no_sigil", in: "INVITE TAC-NET", wantOk: false},
+		{name: "wrong_sigil_version", in: "!GW2 INVITE TAC", wantOk: false},
+		{name: "missing_bang", in: "GW1 INVITE TAC", wantOk: false},
+		{name: "empty", in: "", wantOk: false},
+
+		// ---- rejected: casing ----------------------------------------
+		{name: "lowercase_sigil", in: "!gw1 INVITE TAC", wantOk: false},
+		{name: "lowercase_verb", in: "!GW1 invite TAC", wantOk: false},
+		{name: "lowercase_tactical", in: "!GW1 INVITE tac", wantOk: false},
+		{name: "mixed_case_tactical", in: "!GW1 INVITE Tac", wantOk: false},
+
+		// ---- rejected: length bounds ---------------------------------
+		{name: "empty_tactical", in: "!GW1 INVITE ", wantOk: false},
+		{name: "ten_char_tactical", in: "!GW1 INVITE ABCDEFGHIJ", wantOk: false},
+
+		// ---- rejected: invalid chars in tactical ---------------------
+		{name: "underscore_in_tactical", in: "!GW1 INVITE TAC_NET", wantOk: false},
+		{name: "space_in_tactical", in: "!GW1 INVITE TAC NET", wantOk: false},
+		{name: "slash_in_tactical", in: "!GW1 INVITE TAC/1", wantOk: false},
+		{name: "dot_in_tactical", in: "!GW1 INVITE TAC.NET", wantOk: false},
+
+		// ---- rejected: trailing / leading / interior whitespace ------
+		{name: "trailing_space", in: "!GW1 INVITE TAC ", wantOk: false},
+		{name: "trailing_newline", in: "!GW1 INVITE TAC\n", wantOk: false},
+		{name: "leading_space", in: " !GW1 INVITE TAC", wantOk: false},
+		{name: "double_space_between_verb_and_tac", in: "!GW1 INVITE  TAC", wantOk: false},
+		{name: "missing_space_between_verb_and_tac", in: "!GW1 INVITETAC", wantOk: false},
+
+		// ---- rejected: trailing text / notes -------------------------
+		{name: "trailing_note", in: "!GW1 INVITE TAC hello", wantOk: false},
+		{name: "extra_verb", in: "!GW1 INVITE TAC INVITE TAC", wantOk: false},
+
+		// ---- rejected: other verbs -----------------------------------
+		{name: "leave_verb", in: "!GW1 LEAVE TAC", wantOk: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			gotTac, gotOk := ParseInvite(tt.in)
+			if gotOk != tt.wantOk {
+				t.Fatalf("ParseInvite(%q) ok = %v, want %v", tt.in, gotOk, tt.wantOk)
+			}
+			if gotTac != tt.wantTac {
+				t.Fatalf("ParseInvite(%q) tactical = %q, want %q", tt.in, gotTac, tt.wantTac)
+			}
+		})
+	}
+}

--- a/graywolf/pkg/messages/router.go
+++ b/graywolf/pkg/messages/router.go
@@ -435,6 +435,17 @@ func (r *Router) persistInbound(
 		ReplyAckID: m.ReplyAck,
 		ThreadKind: threadKind,
 		ThreadKey:  threadKey,
+		Kind:       MessageKindText,
+	}
+	// Detect tactical-invite wire bodies on DM rows only. ParseInvite
+	// is strict: valid iff `^!GW1 INVITE <TAC>$`. On match we stamp
+	// Kind=invite + InviteTactical so the UI can render the accept
+	// affordance; otherwise the row remains a plain text DM.
+	if threadKind == ThreadKindDM {
+		if tac, ok := ParseInvite(m.Text); ok {
+			row.Kind = MessageKindInvite
+			row.InviteTactical = tac
+		}
 	}
 	if pkt.Direction == aprs.DirectionRF {
 		row.Channel = uint32(pkt.Channel)

--- a/graywolf/pkg/messages/router_test.go
+++ b/graywolf/pkg/messages/router_test.go
@@ -991,3 +991,158 @@ func TestRouterCloseReturnsNil(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 }
+
+// TestRouterInboundInviteClassified exercises the ParseInvite call in
+// persistInbound: a DM body matching `!GW1 INVITE <TAC>` must stamp
+// Kind=invite + InviteTactical on the persisted row.
+func TestRouterInboundInviteClassified(t *testing.T) {
+	r, store, _, _, _, _, cleanup := buildRouter(t, "N0CALL", nil)
+	defer cleanup()
+
+	pkt := makeMessagePacket(t, "W1ABC", "N0CALL", "!GW1 INVITE TAC-NET", "101", aprs.DirectionRF)
+	if err := r.SendPacket(context.Background(), pkt); err != nil {
+		t.Fatalf("SendPacket: %v", err)
+	}
+	waitFor(t, time.Second, func() bool {
+		ms, _, _ := store.List(context.Background(), Filter{})
+		return len(ms) == 1
+	}, "invite row persisted")
+
+	ms, _, _ := store.List(context.Background(), Filter{})
+	row := ms[0]
+	if row.Kind != MessageKindInvite {
+		t.Fatalf("Kind = %q, want %q", row.Kind, MessageKindInvite)
+	}
+	if row.InviteTactical != "TAC-NET" {
+		t.Fatalf("InviteTactical = %q, want TAC-NET", row.InviteTactical)
+	}
+	if row.ThreadKind != ThreadKindDM {
+		t.Fatalf("ThreadKind = %q, want dm", row.ThreadKind)
+	}
+	if row.InviteAcceptedAt != nil {
+		t.Errorf("InviteAcceptedAt must be nil on fresh invite, got %v", row.InviteAcceptedAt)
+	}
+}
+
+// TestRouterInboundInviteMalformedBodyIsText verifies that a DM that
+// almost looks like an invite (lowercase sigil, trailing note,
+// missing token) persists as a plain text row, not an invite.
+func TestRouterInboundInviteMalformedBodyIsText(t *testing.T) {
+	r, store, _, _, _, _, cleanup := buildRouter(t, "N0CALL", nil)
+	defer cleanup()
+
+	// Trailing note — strict regex rejects this.
+	pkt := makeMessagePacket(t, "W1ABC", "N0CALL", "!GW1 INVITE TAC-NET pls join", "102", aprs.DirectionRF)
+	if err := r.SendPacket(context.Background(), pkt); err != nil {
+		t.Fatalf("SendPacket: %v", err)
+	}
+	waitFor(t, time.Second, func() bool {
+		ms, _, _ := store.List(context.Background(), Filter{})
+		return len(ms) == 1
+	}, "row persisted")
+
+	ms, _, _ := store.List(context.Background(), Filter{})
+	row := ms[0]
+	if row.Kind != MessageKindText {
+		t.Fatalf("Kind = %q, want %q for malformed invite", row.Kind, MessageKindText)
+	}
+	if row.InviteTactical != "" {
+		t.Errorf("InviteTactical = %q, want empty on text row", row.InviteTactical)
+	}
+}
+
+// TestRouterInboundInviteTacticalRouteNotClassifiedAsInvite asserts
+// that a tactical-addressed packet whose body matches the invite
+// grammar is still persisted as Kind=text: invites are a DM-only
+// construct by design (the plan reserves `!GW1 INVITE ...` on a DM
+// body; misuse on a tactical thread shouldn't render an accept
+// button).
+func TestRouterInboundInviteTacticalRouteNotClassifiedAsInvite(t *testing.T) {
+	r, store, _, _, _, _, cleanup := buildRouter(t, "N0CALL", []string{"NET"})
+	defer cleanup()
+
+	pkt := makeMessagePacket(t, "W1ABC", "NET", "!GW1 INVITE TAC-NET", "103", aprs.DirectionRF)
+	if err := r.SendPacket(context.Background(), pkt); err != nil {
+		t.Fatalf("SendPacket: %v", err)
+	}
+	waitFor(t, time.Second, func() bool {
+		ms, _, _ := store.List(context.Background(), Filter{})
+		return len(ms) == 1
+	}, "row persisted")
+
+	ms, _, _ := store.List(context.Background(), Filter{})
+	row := ms[0]
+	if row.Kind != MessageKindText {
+		t.Fatalf("tactical-addressed invite-looking body must persist as text; got Kind=%q", row.Kind)
+	}
+	if row.ThreadKind != ThreadKindTactical {
+		t.Fatalf("ThreadKind = %q, want tactical", row.ThreadKind)
+	}
+}
+
+// TestRouterInboundInviteDedupWindowKeepsKind verifies that when two
+// identical invite packets arrive inside the dedup window, the
+// single persisted row retains Kind=invite — the dedup path is
+// independent of Kind classification.
+func TestRouterInboundInviteDedupWindowKeepsKind(t *testing.T) {
+	r, store, _, _, _, _, cleanup := buildRouter(t, "N0CALL", nil)
+	defer cleanup()
+
+	pkt := makeMessagePacket(t, "W1ABC", "N0CALL", "!GW1 INVITE TAC-NET", "110", aprs.DirectionRF)
+	if err := r.SendPacket(context.Background(), pkt); err != nil {
+		t.Fatalf("SendPacket 1: %v", err)
+	}
+	waitFor(t, time.Second, func() bool {
+		ms, _, _ := store.List(context.Background(), Filter{})
+		return len(ms) == 1
+	}, "first invite row")
+
+	// Byte-for-byte duplicate.
+	pkt2 := makeMessagePacket(t, "W1ABC", "N0CALL", "!GW1 INVITE TAC-NET", "110", aprs.DirectionRF)
+	if err := r.SendPacket(context.Background(), pkt2); err != nil {
+		t.Fatalf("SendPacket 2: %v", err)
+	}
+	// Let the pipeline settle — dedup suppresses the Insert but still
+	// emits the auto-ACK, so we can't rely on a row-count transition.
+	time.Sleep(100 * time.Millisecond)
+
+	ms, _, _ := store.List(context.Background(), Filter{})
+	if len(ms) != 1 {
+		t.Fatalf("dedup must suppress second Insert; got %d rows", len(ms))
+	}
+	if ms[0].Kind != MessageKindInvite {
+		t.Fatalf("Kind = %q after dedup, want %q", ms[0].Kind, MessageKindInvite)
+	}
+}
+
+// TestRouterInboundRFInviteNoSpecialHandling verifies that an
+// invite body arriving over RF from a remote station persists as
+// Kind=invite with no special RF-vs-IS branching. The plan notes
+// that "trust" is not enforced server-side: any inbound invite
+// classifies normally and relies on operator judgment for the
+// accept flow.
+func TestRouterInboundRFInviteNoSpecialHandling(t *testing.T) {
+	r, store, _, _, _, _, cleanup := buildRouter(t, "N0CALL", nil)
+	defer cleanup()
+
+	pkt := makeMessagePacket(t, "W1ABC-7", "N0CALL", "!GW1 INVITE TAC-NET", "120", aprs.DirectionRF)
+	if err := r.SendPacket(context.Background(), pkt); err != nil {
+		t.Fatalf("SendPacket: %v", err)
+	}
+	waitFor(t, time.Second, func() bool {
+		ms, _, _ := store.List(context.Background(), Filter{})
+		return len(ms) == 1
+	}, "RF invite persisted")
+
+	ms, _, _ := store.List(context.Background(), Filter{})
+	row := ms[0]
+	if row.Kind != MessageKindInvite {
+		t.Fatalf("Kind = %q, want %q", row.Kind, MessageKindInvite)
+	}
+	if row.FromCall != "W1ABC-7" {
+		t.Errorf("FromCall = %q, want W1ABC-7 (preserved verbatim)", row.FromCall)
+	}
+	if row.Source != string(aprs.DirectionRF) {
+		t.Errorf("Source = %q, want rf", row.Source)
+	}
+}

--- a/graywolf/pkg/messages/service.go
+++ b/graywolf/pkg/messages/service.go
@@ -3,13 +3,26 @@ package messages
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"regexp"
 	"sync"
 
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/stationcache"
 	"github.com/chrissnell/graywolf/pkg/txgovernor"
 )
+
+// tacticalCallsignRe is the canonical APRS tactical-callsign regex:
+// 1-9 uppercase alnum or hyphen. Kept local to the service so the
+// invite validator and any future tactical-keyed send path agree on
+// one shape. Matches the wire regex in pkg/messages/invite.go.
+var tacticalCallsignRe = regexp.MustCompile(`^[A-Z0-9-]{1,9}$`)
+
+// ErrInvalidInvite indicates SendMessage was invoked with Kind=invite
+// but InviteTactical was absent or malformed. Returned to handlers so
+// they can surface a 400 to REST callers.
+var ErrInvalidInvite = errors.New("messages: invite requires a valid invite_tactical")
 
 // ServiceConfigReader is the narrow read/write surface the Service
 // needs from *configstore.Store. Kept as an interface so tests can
@@ -295,7 +308,10 @@ func (s *Service) ReloadTacticalCallsigns(ctx context.Context) error {
 type SendMessageRequest struct {
 	// To is the destination callsign (DM) or tactical label. Required.
 	To string
-	// Text is the message body (<=67 APRS chars). Required.
+	// Text is the message body (<=67 APRS chars). Required unless
+	// Kind == MessageKindInvite, in which case the service builds the
+	// wire body server-side from InviteTactical and the caller's Text
+	// is ignored.
 	Text string
 	// OurCall is the source callsign — usually the operator's
 	// primary callsign (possibly with SSID). Required.
@@ -303,6 +319,13 @@ type SendMessageRequest struct {
 	// ThreadKind is optional; when empty, Service derives it from
 	// the tactical set (exact match → tactical, else DM).
 	ThreadKind string
+	// Kind classifies the outbound row. Empty or "text" is a normal
+	// DM/tactical message; "invite" triggers invite semantics below.
+	Kind string
+	// InviteTactical is the tactical callsign referenced by an
+	// invite. Required and validated when Kind == "invite"; ignored
+	// otherwise. Uppercase, 1-9 of [A-Z0-9-].
+	InviteTactical string
 }
 
 // SendMessage persists the outbound row via store.Insert (allocating
@@ -317,11 +340,29 @@ func (s *Service) SendMessage(ctx context.Context, req SendMessageRequest) (*con
 	if req.To == "" {
 		return nil, errors.New("messages: SendMessage requires To")
 	}
-	if req.Text == "" {
-		return nil, errors.New("messages: SendMessage requires Text")
-	}
 	if req.OurCall == "" {
 		return nil, errors.New("messages: SendMessage requires OurCall")
+	}
+
+	// Invite branch: the server is the single source of truth for the
+	// wire body — we validate the tactical and construct
+	// `!GW1 INVITE <TAC>` ourselves, discarding any client-supplied
+	// Text. This mirrors the inbound ParseInvite contract: the wire
+	// format lives in exactly two places (this builder and the
+	// parser), both agreeing on the strict grammar.
+	bodyKind := MessageKindText
+	inviteTactical := ""
+	text := req.Text
+	if req.Kind == MessageKindInvite {
+		tac := req.InviteTactical
+		if tac == "" || !tacticalCallsignRe.MatchString(tac) {
+			return nil, fmt.Errorf("%w: %q", ErrInvalidInvite, tac)
+		}
+		bodyKind = MessageKindInvite
+		inviteTactical = tac
+		text = "!GW1 INVITE " + tac
+	} else if text == "" {
+		return nil, errors.New("messages: SendMessage requires Text")
 	}
 
 	kind := req.ThreadKind
@@ -334,14 +375,16 @@ func (s *Service) SendMessage(ctx context.Context, req SendMessageRequest) (*con
 	}
 
 	row := &configstore.Message{
-		Direction:  "out",
-		OurCall:    req.OurCall,
-		FromCall:   req.OurCall,
-		ToCall:     req.To,
-		Text:       req.Text,
-		ThreadKind: kind,
-		AckState:   AckStateNone,
-		Unread:     false,
+		Direction:      "out",
+		OurCall:        req.OurCall,
+		FromCall:       req.OurCall,
+		ToCall:         req.To,
+		Text:           text,
+		ThreadKind:     kind,
+		AckState:       AckStateNone,
+		Unread:         false,
+		Kind:           bodyKind,
+		InviteTactical: inviteTactical,
 	}
 	// DM requires a msgid; tactical may omit.
 	if kind == ThreadKindDM {

--- a/graywolf/pkg/messages/service_test.go
+++ b/graywolf/pkg/messages/service_test.go
@@ -2,6 +2,7 @@ package messages
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -287,6 +288,119 @@ func TestService_SendMessage_TacticalDerivedFromSet(t *testing.T) {
 	}
 	if row.MsgID != "" {
 		t.Errorf("tactical row has msg_id %q, want empty", row.MsgID)
+	}
+}
+
+// TestService_SendMessage_InviteBuildsWireBody asserts that when
+// Kind=invite + InviteTactical are supplied, the service constructs
+// the wire body server-side as "!GW1 INVITE <TAC>" and stamps Kind
+// and InviteTactical on the persisted row. Any client-supplied Text
+// is overwritten — the server is the single source of truth for the
+// wire format.
+func TestService_SendMessage_InviteBuildsWireBody(t *testing.T) {
+	svc, _, _, cleanup := buildService(t)
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	row, err := svc.SendMessage(ctx, SendMessageRequest{
+		OurCall:        "N0CALL",
+		To:             "W1ABC",
+		Text:           "ignored by server",
+		Kind:           MessageKindInvite,
+		InviteTactical: "TAC-NET",
+	})
+	if err != nil {
+		t.Fatalf("SendMessage invite: %v", err)
+	}
+	if row.Kind != MessageKindInvite {
+		t.Errorf("Kind = %q, want %q", row.Kind, MessageKindInvite)
+	}
+	if row.InviteTactical != "TAC-NET" {
+		t.Errorf("InviteTactical = %q, want TAC-NET", row.InviteTactical)
+	}
+	if want := "!GW1 INVITE TAC-NET"; row.Text != want {
+		t.Errorf("Text = %q, want %q (server must construct the wire body)", row.Text, want)
+	}
+	if row.ThreadKind != ThreadKindDM {
+		t.Errorf("ThreadKind = %q, want dm (invite is DM by construction)", row.ThreadKind)
+	}
+	if row.MsgID == "" {
+		t.Error("DM invite must have a msg_id allocated")
+	}
+}
+
+// TestService_SendMessage_InviteEmptyTextAllowed verifies that an
+// invite send with an empty Text does not trip the "Text required"
+// guard — the server builds the wire body from InviteTactical and
+// doesn't need a caller-supplied body.
+func TestService_SendMessage_InviteEmptyTextAllowed(t *testing.T) {
+	svc, _, _, cleanup := buildService(t)
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	row, err := svc.SendMessage(ctx, SendMessageRequest{
+		OurCall:        "N0CALL",
+		To:             "W1ABC",
+		Kind:           MessageKindInvite,
+		InviteTactical: "TAC",
+	})
+	if err != nil {
+		t.Fatalf("SendMessage invite with empty Text: %v", err)
+	}
+	if want := "!GW1 INVITE TAC"; row.Text != want {
+		t.Errorf("Text = %q, want %q", row.Text, want)
+	}
+}
+
+// TestService_SendMessage_InviteRejectsMalformedTactical asserts that
+// a send with Kind=invite but a malformed InviteTactical returns
+// ErrInvalidInvite (so the webapi layer can surface a 400) rather
+// than silently corrupting a row.
+func TestService_SendMessage_InviteRejectsMalformedTactical(t *testing.T) {
+	svc, _, _, cleanup := buildService(t)
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	cases := []struct {
+		name string
+		tac  string
+	}{
+		{"empty", ""},
+		{"lowercase", "tac-net"},
+		{"too long", "TOOLONGTACTICAL"},
+		{"invalid chars", "TAC_NET"},
+		{"space", "TAC NET"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.SendMessage(ctx, SendMessageRequest{
+				OurCall:        "N0CALL",
+				To:             "W1ABC",
+				Kind:           MessageKindInvite,
+				InviteTactical: tc.tac,
+			})
+			if err == nil {
+				t.Fatal("expected error for malformed InviteTactical, got nil")
+			}
+			if !errors.Is(err, ErrInvalidInvite) {
+				t.Errorf("error = %v, want wraps ErrInvalidInvite", err)
+			}
+		})
 	}
 }
 

--- a/graywolf/pkg/messages/store.go
+++ b/graywolf/pkg/messages/store.go
@@ -40,6 +40,16 @@ const (
 	AckStateBroadcast = "broadcast"
 )
 
+// MessageKind wire values. Classifies the body of a persisted message
+// so the UI can render specialized affordances (invite → Accept button)
+// without re-parsing the APRS text. "text" is the legacy default for
+// every row written before the invite feature landed; migration 6
+// backfills legacy NULL/"" rows to "text" explicitly.
+const (
+	MessageKindText   = "text"
+	MessageKindInvite = "invite"
+)
+
 // Folder discriminator for List.
 const (
 	FolderAll    = "all"

--- a/graywolf/pkg/webapi/docs/gen/swagger.json
+++ b/graywolf/pkg/webapi/docs/gen/swagger.json
@@ -3921,6 +3921,63 @@
                 }
             }
         },
+        "/tacticals": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "messages"
+                ],
+                "summary": "Accept a tactical invite (subscribe)",
+                "operationId": "acceptTacticalInvite",
+                "parameters": [
+                    {
+                        "description": "Tactical + optional source message id",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.AcceptInviteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.AcceptInviteResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/tx-timing": {
             "get": {
                 "security": [
@@ -4677,6 +4734,39 @@
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
                     "type": "number"
+                }
+            }
+        },
+        "dto.AcceptInviteRequest": {
+            "type": "object",
+            "required": [
+                "callsign"
+            ],
+            "properties": {
+                "callsign": {
+                    "description": "Callsign is the tactical label to subscribe to. Required. Must\nmatch the APRS tactical syntax (1-9 of [A-Z0-9-]) after uppercase\nnormalization.",
+                    "type": "string"
+                },
+                "source_message_id": {
+                    "description": "SourceMessageID, when non-zero, identifies the inbound invite\nmessage that triggered the accept. Used only for audit — the\nhandler sets InviteAcceptedAt on that row if it resolves to a\nvalid invite for the same tactical. Zero = accept without audit.",
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.AcceptInviteResponse": {
+            "type": "object",
+            "properties": {
+                "already_member": {
+                    "description": "AlreadyMember is true when the operator was already subscribed\nand enabled before this request. Lets the UI suppress the\n\"Joined TAC\" toast and emit \"Already a member\" instead.",
+                    "type": "boolean"
+                },
+                "tactical": {
+                    "description": "Tactical is the post-accept state of the subscription. Always\npopulated with Enabled=true (accept is the \"turn it on\" verb).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/dto.TacticalCallsignResponse"
+                        }
+                    ]
                 }
             }
         },
@@ -5645,11 +5735,23 @@
                 "id": {
                     "type": "integer"
                 },
+                "invite_accepted_at": {
+                    "description": "InviteAcceptedAt is audit-only: set when the local operator\naccepted this invite. The UI must NOT use this to decide \"joined\"\nstate — that comes from the live TacticalSet cache. Kept so\noperators can see when/if an invite was acted on.",
+                    "type": "string"
+                },
+                "invite_tactical": {
+                    "description": "InviteTactical is the tactical callsign referenced by an invite.\nEmpty (and omitted) on non-invite rows.",
+                    "type": "string"
+                },
                 "is_ack": {
                     "type": "boolean"
                 },
                 "is_bulletin": {
                     "type": "boolean"
+                },
+                "kind": {
+                    "description": "Kind is the body classification. Always populated — \"text\" for\nnormal messages, \"invite\" for tactical invitations. Never omitted\nso clients can use a simple equality check without worrying about\na legacy empty string.",
+                    "type": "string"
                 },
                 "msg_id": {
                     "type": "string"
@@ -5832,6 +5934,14 @@
                     "description": "ClientID is an opaque client-side correlation token. Echoed back\nunchanged in the response so the optimistic UI can reconcile its\nlocal row with the persisted ID.",
                     "type": "string"
                 },
+                "invite_tactical": {
+                    "description": "InviteTactical is the tactical callsign referenced by an invite.\nMust be set when Kind == \"invite\"; ignored otherwise.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind classifies the outbound row. Empty or \"text\" is a normal\nDM/tactical message; \"invite\" makes the sender build a\n`!GW1 INVITE \u003cInviteTactical\u003e` body and stamp the row with\nKind=invite + InviteTactical. The sender (Phase 2) is\nresponsible for honoring this; the DTO just carries it.",
+                    "type": "string"
+                },
                 "path": {
                     "description": "Path overrides the default RF path from preferences. Empty =\nuse MessagePreferences.DefaultPath.",
                     "type": "string"
@@ -5841,7 +5951,7 @@
                     "type": "boolean"
                 },
                 "text": {
-                    "description": "Text is the message body (\u003c= 67 APRS chars after validation).",
+                    "description": "Text is the message body (\u003c= 67 APRS chars after validation).\nIgnored when Kind == \"invite\" — the server builds the wire body\nfrom InviteTactical.",
                     "type": "string"
                 },
                 "to": {

--- a/graywolf/pkg/webapi/docs/gen/swagger.yaml
+++ b/graywolf/pkg/webapi/docs/gen/swagger.yaml
@@ -390,6 +390,39 @@ definitions:
         description: mph (1-minute sustained)
         type: number
     type: object
+  dto.AcceptInviteRequest:
+    properties:
+      callsign:
+        description: |-
+          Callsign is the tactical label to subscribe to. Required. Must
+          match the APRS tactical syntax (1-9 of [A-Z0-9-]) after uppercase
+          normalization.
+        type: string
+      source_message_id:
+        description: |-
+          SourceMessageID, when non-zero, identifies the inbound invite
+          message that triggered the accept. Used only for audit — the
+          handler sets InviteAcceptedAt on that row if it resolves to a
+          valid invite for the same tactical. Zero = accept without audit.
+        type: integer
+    required:
+      - callsign
+    type: object
+  dto.AcceptInviteResponse:
+    properties:
+      already_member:
+        description: |-
+          AlreadyMember is true when the operator was already subscribed
+          and enabled before this request. Lets the UI suppress the
+          "Joined TAC" toast and emit "Already a member" instead.
+        type: boolean
+      tactical:
+        allOf:
+          - $ref: '#/definitions/dto.TacticalCallsignResponse'
+        description: |-
+          Tactical is the post-accept state of the subscription. Always
+          populated with Enabled=true (accept is the "turn it on" verb).
+    type: object
   dto.AgwRequest:
     properties:
       callsigns:
@@ -1025,10 +1058,29 @@ definitions:
         type: string
       id:
         type: integer
+      invite_accepted_at:
+        description: |-
+          InviteAcceptedAt is audit-only: set when the local operator
+          accepted this invite. The UI must NOT use this to decide "joined"
+          state — that comes from the live TacticalSet cache. Kept so
+          operators can see when/if an invite was acted on.
+        type: string
+      invite_tactical:
+        description: |-
+          InviteTactical is the tactical callsign referenced by an invite.
+          Empty (and omitted) on non-invite rows.
+        type: string
       is_ack:
         type: boolean
       is_bulletin:
         type: boolean
+      kind:
+        description: |-
+          Kind is the body classification. Always populated — "text" for
+          normal messages, "invite" for tactical invitations. Never omitted
+          so clients can use a simple equality check without worrying about
+          a legacy empty string.
+        type: string
       msg_id:
         type: string
       next_retry_at:
@@ -1163,6 +1215,19 @@ definitions:
           unchanged in the response so the optimistic UI can reconcile its
           local row with the persisted ID.
         type: string
+      invite_tactical:
+        description: |-
+          InviteTactical is the tactical callsign referenced by an invite.
+          Must be set when Kind == "invite"; ignored otherwise.
+        type: string
+      kind:
+        description: |-
+          Kind classifies the outbound row. Empty or "text" is a normal
+          DM/tactical message; "invite" makes the sender build a
+          `!GW1 INVITE <InviteTactical>` body and stamp the row with
+          Kind=invite + InviteTactical. The sender (Phase 2) is
+          responsible for honoring this; the DTO just carries it.
+        type: string
       path:
         description: |-
           Path overrides the default RF path from preferences. Empty =
@@ -1174,7 +1239,10 @@ definitions:
           of the current fallback policy.
         type: boolean
       text:
-        description: Text is the message body (<= 67 APRS chars after validation).
+        description: |-
+          Text is the message body (<= 67 APRS chars after validation).
+          Ignored when Kind == "invite" — the server builds the wire body
+          from InviteTactical.
         type: string
       to:
         description: |-
@@ -4373,6 +4441,42 @@ paths:
       summary: System status dashboard
       tags:
         - status
+  /tacticals:
+    post:
+      consumes:
+        - application/json
+      operationId: acceptTacticalInvite
+      parameters:
+        - description: Tactical + optional source message id
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/dto.AcceptInviteRequest'
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.AcceptInviteResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Accept a tactical invite (subscribe)
+      tags:
+        - messages
   /tx-timing:
     get:
       operationId: listTxTiming

--- a/graywolf/pkg/webapi/docs/op_ids.go
+++ b/graywolf/pkg/webapi/docs/op_ids.go
@@ -222,6 +222,7 @@ const (
 	OpUpdateTacticalCallsign  = "updateTacticalCallsign"
 	OpDeleteTacticalCallsign  = "deleteTacticalCallsign"
 	OpGetTacticalParticipants = "getTacticalParticipants"
+	OpAcceptTacticalInvite    = "acceptTacticalInvite"
 	OpAutocompleteStations    = "autocompleteStations"
 )
 

--- a/graywolf/pkg/webapi/dto/messages.go
+++ b/graywolf/pkg/webapi/dto/messages.go
@@ -142,6 +142,8 @@ type SendMessageRequest struct {
 	// label for a group broadcast. Uppercase-normalized server-side.
 	To string `json:"to"`
 	// Text is the message body (<= 67 APRS chars after validation).
+	// Ignored when Kind == "invite" — the server builds the wire body
+	// from InviteTactical.
 	Text string `json:"text"`
 	// PreferIS, when true, routes the outbound via APRS-IS regardless
 	// of the current fallback policy.
@@ -155,6 +157,15 @@ type SendMessageRequest struct {
 	// unchanged in the response so the optimistic UI can reconcile its
 	// local row with the persisted ID.
 	ClientID string `json:"client_id,omitempty"`
+	// Kind classifies the outbound row. Empty or "text" is a normal
+	// DM/tactical message; "invite" makes the sender build a
+	// `!GW1 INVITE <InviteTactical>` body and stamp the row with
+	// Kind=invite + InviteTactical. The sender (Phase 2) is
+	// responsible for honoring this; the DTO just carries it.
+	Kind string `json:"kind,omitempty"`
+	// InviteTactical is the tactical callsign referenced by an invite.
+	// Must be set when Kind == "invite"; ignored otherwise.
+	InviteTactical string `json:"invite_tactical,omitempty"`
 }
 
 // Validate enforces the minimal invariants every compose request must
@@ -200,6 +211,19 @@ type MessageResponse struct {
 	ThreadKind     string     `json:"thread_kind"`
 	ThreadKey      string     `json:"thread_key"`
 	ReceivedByCall string     `json:"received_by_call,omitempty"`
+	// Kind is the body classification. Always populated — "text" for
+	// normal messages, "invite" for tactical invitations. Never omitted
+	// so clients can use a simple equality check without worrying about
+	// a legacy empty string.
+	Kind string `json:"kind"`
+	// InviteTactical is the tactical callsign referenced by an invite.
+	// Empty (and omitted) on non-invite rows.
+	InviteTactical string `json:"invite_tactical,omitempty"`
+	// InviteAcceptedAt is audit-only: set when the local operator
+	// accepted this invite. The UI must NOT use this to decide "joined"
+	// state — that comes from the live TacticalSet cache. Kept so
+	// operators can see when/if an invite was acted on.
+	InviteAcceptedAt *time.Time `json:"invite_accepted_at,omitempty"`
 }
 
 // MessageFromModel renders one row into its DTO. Channel is surfaced
@@ -229,9 +253,12 @@ func MessageFromModel(m configstore.Message) MessageResponse {
 		FailureReason:  m.FailureReason,
 		IsAck:          m.IsAck,
 		IsBulletin:     m.IsBulletin,
-		ThreadKind:     m.ThreadKind,
-		ThreadKey:      m.ThreadKey,
-		ReceivedByCall: m.ReceivedByCall,
+		ThreadKind:       m.ThreadKind,
+		ThreadKey:        m.ThreadKey,
+		ReceivedByCall:   m.ReceivedByCall,
+		Kind:             m.Kind,
+		InviteTactical:   m.InviteTactical,
+		InviteAcceptedAt: nilUTC(m.InviteAcceptedAt),
 	}
 	if m.Channel != 0 {
 		c := m.Channel
@@ -451,6 +478,37 @@ func TacticalCallsignFromModel(m configstore.TacticalCallsign) TacticalCallsignR
 		CreatedAt: m.CreatedAt.UTC(),
 		UpdatedAt: m.UpdatedAt.UTC(),
 	}
+}
+
+// AcceptInviteRequest is the body accepted by the accept-invite endpoint
+// (Phase 2 wires POST /api/tacticals/subscribe or similar). Acceptance
+// is tactical-keyed, not message-keyed: the message ID is optional and
+// exists only to let the handler stamp InviteAcceptedAt on the originating
+// row for audit.
+type AcceptInviteRequest struct {
+	// Callsign is the tactical label to subscribe to. Required. Must
+	// match the APRS tactical syntax (1-9 of [A-Z0-9-]) after uppercase
+	// normalization.
+	Callsign string `json:"callsign" binding:"required"`
+	// SourceMessageID, when non-zero, identifies the inbound invite
+	// message that triggered the accept. Used only for audit — the
+	// handler sets InviteAcceptedAt on that row if it resolves to a
+	// valid invite for the same tactical. Zero = accept without audit.
+	SourceMessageID uint `json:"source_message_id"`
+}
+
+// AcceptInviteResponse is the body returned by a successful accept.
+// Never returns 409 — "already a member" is a normal success with
+// AlreadyMember=true so the client can render a distinct toast without
+// error-handling ceremony.
+type AcceptInviteResponse struct {
+	// Tactical is the post-accept state of the subscription. Always
+	// populated with Enabled=true (accept is the "turn it on" verb).
+	Tactical TacticalCallsignResponse `json:"tactical"`
+	// AlreadyMember is true when the operator was already subscribed
+	// and enabled before this request. Lets the UI suppress the
+	// "Joined TAC" toast and emit "Already a member" instead.
+	AlreadyMember bool `json:"already_member"`
 }
 
 // --- Participants --------------------------------------------------------

--- a/graywolf/pkg/webapi/messages.go
+++ b/graywolf/pkg/webapi/messages.go
@@ -222,9 +222,24 @@ func (s *Server) sendMessage(w http.ResponseWriter, r *http.Request) {
 		badRequest(w, err.Error())
 		return
 	}
-	if err := req.Validate(); err != nil {
-		badRequest(w, err.Error())
-		return
+	// Invite requests skip the default Text validation: the server
+	// builds the wire body from InviteTactical, so an empty Text is
+	// valid and a client-supplied Text is ignored downstream.
+	isInvite := strings.EqualFold(req.Kind, messages.MessageKindInvite)
+	if isInvite {
+		if err := dto.ValidateAddressee(req.To); err != nil {
+			badRequest(w, err.Error())
+			return
+		}
+		if strings.TrimSpace(req.InviteTactical) == "" {
+			badRequest(w, "invite_tactical is required when kind=invite")
+			return
+		}
+	} else {
+		if err := req.Validate(); err != nil {
+			badRequest(w, err.Error())
+			return
+		}
 	}
 	// Loopback guard — client must not target its own base callsign.
 	ourCall, err := s.resolveOurCall(r.Context())
@@ -237,17 +252,26 @@ func (s *Server) sendMessage(w http.ResponseWriter, r *http.Request) {
 		badRequest(w, "cannot send a message to our own callsign")
 		return
 	}
-	row, err := svc.SendMessage(r.Context(), messages.SendMessageRequest{
+	svcReq := messages.SendMessageRequest{
 		To:      to,
 		Text:    req.Text,
 		OurCall: ourCall,
-	})
+	}
+	if isInvite {
+		svcReq.Kind = messages.MessageKindInvite
+		svcReq.InviteTactical = strings.ToUpper(strings.TrimSpace(req.InviteTactical))
+	}
+	row, err := svc.SendMessage(r.Context(), svcReq)
 	if err != nil {
 		if errors.Is(err, messages.ErrMsgIDExhausted) {
 			serviceUnavailable(w, "all 999 msgid slots for this peer are outstanding; retry later")
 			return
 		}
 		if errors.Is(err, messages.ErrInvalidThreadKind) {
+			badRequest(w, err.Error())
+			return
+		}
+		if errors.Is(err, messages.ErrInvalidInvite) {
 			badRequest(w, err.Error())
 			return
 		}

--- a/graywolf/pkg/webapi/messages_test.go
+++ b/graywolf/pkg/webapi/messages_test.go
@@ -17,8 +17,10 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/chrissnell/graywolf/pkg/ax25"
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/messages"
+	"github.com/chrissnell/graywolf/pkg/txgovernor"
 	"github.com/chrissnell/graywolf/pkg/webapi/dto"
 )
 
@@ -344,6 +346,181 @@ func TestSendMessage_Unavailable(t *testing.T) {
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rec.Code)
 	}
+}
+
+// TestSendMessage_InviteRoundTrip asserts that a POST with
+// kind=invite + invite_tactical passes the fields through to the
+// service layer unchanged. The fake service records the call so we
+// can assert on the forwarded struct.
+func TestSendMessage_InviteRoundTrip(t *testing.T) {
+	sentCh := make(chan messages.SendMessageRequest, 1)
+	svc := &fakeMessagesSvc{
+		sendFn: func(ctx context.Context, req messages.SendMessageRequest) (*configstore.Message, error) {
+			sentCh <- req
+			return &configstore.Message{
+				ID:             99,
+				Direction:      "out",
+				OurCall:        req.OurCall,
+				FromCall:       req.OurCall,
+				ToCall:         req.To,
+				Text:           "!GW1 INVITE TAC-NET",
+				ThreadKind:     messages.ThreadKindDM,
+				ThreadKey:      req.To,
+				MsgID:          "002",
+				CreatedAt:      time.Now(),
+				AckState:       messages.AckStateNone,
+				Kind:           messages.MessageKindInvite,
+				InviteTactical: "TAC-NET",
+			}, nil
+		},
+	}
+	_, mux, _ := newMessagesTestServer(t, svc)
+
+	body := `{"to":"W1ABC","text":"","kind":"invite","invite_tactical":"TAC-NET"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got := <-sentCh
+	if got.Kind != messages.MessageKindInvite {
+		t.Errorf("Kind forwarded = %q, want %q", got.Kind, messages.MessageKindInvite)
+	}
+	if got.InviteTactical != "TAC-NET" {
+		t.Errorf("InviteTactical forwarded = %q, want TAC-NET", got.InviteTactical)
+	}
+	// Response echoes the server-built wire body.
+	var resp dto.MessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Text != "!GW1 INVITE TAC-NET" {
+		t.Errorf("response Text = %q, want the server-built wire body", resp.Text)
+	}
+	if resp.Kind != messages.MessageKindInvite {
+		t.Errorf("response Kind = %q, want %q", resp.Kind, messages.MessageKindInvite)
+	}
+}
+
+// TestSendMessage_InviteMissingTactical asserts that a kind=invite
+// request without invite_tactical is rejected at the webapi
+// boundary with 400, not forwarded to the service.
+func TestSendMessage_InviteMissingTactical(t *testing.T) {
+	called := false
+	svc := &fakeMessagesSvc{
+		sendFn: func(ctx context.Context, req messages.SendMessageRequest) (*configstore.Message, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	_, mux, _ := newMessagesTestServer(t, svc)
+
+	body := `{"to":"W1ABC","text":"","kind":"invite"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/messages", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if called {
+		t.Error("service SendMessage must NOT be called when invite_tactical is missing")
+	}
+}
+
+// TestSendMessage_InviteEndToEndPersistsRow wires the real messages
+// Service + Store and verifies that a kind=invite POST results in a
+// persisted row with Kind=invite, InviteTactical=TAC-NET, and the
+// server-built wire body — i.e., the full round trip through the
+// send path.
+func TestSendMessage_InviteEndToEndPersistsRow(t *testing.T) {
+	ctx := context.Background()
+	store, err := configstore.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.UpsertIGateConfig(ctx, &configstore.IGateConfig{
+		Callsign: "N0CALL", Server: "rotate.aprs2.net", Port: 14580,
+		Passcode: "-1", TxChannel: 1, RfChannel: 1, MaxMsgHops: 2, GateRfToIs: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	msgStore := messages.NewStore(store.DB())
+	svc, err := messages.NewService(messages.ServiceConfig{
+		Store:       msgStore,
+		ConfigStore: store,
+		TxSink:      &inviteFakeSink{},
+		TxHookReg:   &inviteNopHookReg{},
+		OurCall:     func() string { return "N0CALL" },
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer svc.Stop()
+
+	srv, err := NewServer(Config{
+		Store:  store,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.SetMessagesService(svc)
+	srv.SetMessagesStore(msgStore)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	// Client deliberately sends a bogus Text to prove the server
+	// overwrites it.
+	body := `{"to":"W1ABC","text":"IGNORED","kind":"invite","invite_tactical":"TAC-NET"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Pull the row back and assert persisted state.
+	rows, _, err := msgStore.List(ctx, messages.Filter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 persisted row, got %d", len(rows))
+	}
+	row := rows[0]
+	if row.Kind != messages.MessageKindInvite {
+		t.Errorf("Kind = %q, want %q", row.Kind, messages.MessageKindInvite)
+	}
+	if row.InviteTactical != "TAC-NET" {
+		t.Errorf("InviteTactical = %q, want TAC-NET", row.InviteTactical)
+	}
+	if want := "!GW1 INVITE TAC-NET"; row.Text != want {
+		t.Errorf("persisted Text = %q, want %q (server must overwrite the client body)", row.Text, want)
+	}
+}
+
+// inviteFakeSink + inviteNopHookReg are minimal stubs so the Service
+// can be constructed without dragging in the full txgovernor wiring.
+// They intentionally discard submissions — the invite tests care
+// about persistence, not radio I/O.
+type inviteFakeSink struct{}
+
+func (inviteFakeSink) Submit(ctx context.Context, ch uint32, frame *ax25.Frame, src txgovernor.SubmitSource) error {
+	return nil
+}
+
+type inviteNopHookReg struct{}
+
+func (inviteNopHookReg) AddTxHook(h txgovernor.TxHook) (uint64, func()) {
+	return 0, func() {}
 }
 
 // --- DELETE /api/messages/{id} -------------------------------------------

--- a/graywolf/pkg/webapi/server.go
+++ b/graywolf/pkg/webapi/server.go
@@ -175,6 +175,7 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	s.registerPositionLog(mux)
 	s.registerSmartBeacon(mux)
 	s.registerMessages(mux)
+	s.registerTacticals(mux)
 
 	mux.HandleFunc("GET /api/health", s.handleHealth)
 	mux.HandleFunc("GET /api/status", s.handleStatus)

--- a/graywolf/pkg/webapi/tacticals.go
+++ b/graywolf/pkg/webapi/tacticals.go
@@ -1,0 +1,198 @@
+package webapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/messages"
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+// tacticalCallsignRe enforces the 1-9 [A-Z0-9-] tactical grammar at
+// the REST boundary before any DB I/O. Same shape as the wire regex
+// in pkg/messages/invite.go; keeping a local copy avoids importing a
+// tacticals-only regex from the messages package.
+var tacticalCallsignRe = regexp.MustCompile(`^[A-Z0-9-]{1,9}$`)
+
+// registerTacticals installs the top-level /api/tacticals routes.
+// Acceptance is tactical-keyed, not message-keyed — the endpoint
+// lives outside /api/messages/tactical (the CRUD space) so the
+// semantic separation is visible in the path. Registered from
+// RegisterRoutes alongside the other resource registrars.
+func (s *Server) registerTacticals(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/tacticals", s.acceptTacticalInvite)
+}
+
+// acceptTacticalInvite subscribes the local operator to a tactical
+// callsign, optionally stamping InviteAcceptedAt on the originating
+// invite row for audit. Idempotent: re-posting returns the same state
+// with AlreadyMember=true.
+//
+// "Already a member" is never a 409 — it's a normal 200 OK with the
+// AlreadyMember flag set so the client can surface a distinct toast
+// without error-handling ceremony.
+//
+// @Summary  Accept a tactical invite (subscribe)
+// @Tags     messages
+// @ID       acceptTacticalInvite
+// @Accept   json
+// @Produce  json
+// @Param    body body     dto.AcceptInviteRequest true "Tactical + optional source message id"
+// @Success  200  {object} dto.AcceptInviteResponse
+// @Failure  400  {object} webtypes.ErrorResponse
+// @Failure  500  {object} webtypes.ErrorResponse
+// @Failure  503  {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /tacticals [post]
+func (s *Server) acceptTacticalInvite(w http.ResponseWriter, r *http.Request) {
+	req, err := decodeJSON[dto.AcceptInviteRequest](r)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	callsign := strings.ToUpper(strings.TrimSpace(req.Callsign))
+	if !tacticalCallsignRe.MatchString(callsign) {
+		badRequest(w, "callsign must be 1-9 uppercase alphanumeric or hyphen characters")
+		return
+	}
+
+	// Look up the existing row (if any) so we can distinguish the
+	// "create new" / "re-enable disabled" / "already a member" paths.
+	existing, err := s.store.GetTacticalCallsignByCallsign(r.Context(), callsign)
+	if err != nil {
+		s.internalError(w, r, "get tactical callsign by callsign", err)
+		return
+	}
+
+	var (
+		finalModel    configstore.TacticalCallsign
+		alreadyMember bool
+	)
+	if existing == nil {
+		// Fresh subscription.
+		finalModel = configstore.TacticalCallsign{
+			Callsign: callsign,
+			Enabled:  true,
+		}
+		if err := s.store.CreateTacticalCallsign(r.Context(), &finalModel); err != nil {
+			if !isUniqueConstraintErr(err) {
+				s.internalError(w, r, "create tactical callsign", err)
+				return
+			}
+			// Lost a race with a concurrent create — re-fetch and
+			// treat as an upsert. Callers see idempotent behavior.
+			row, err2 := s.store.GetTacticalCallsignByCallsign(r.Context(), callsign)
+			if err2 != nil || row == nil {
+				s.internalError(w, r, "reload tactical after race", err)
+				return
+			}
+			existing = row
+		}
+	}
+
+	if existing != nil {
+		// Existing row path — preserve Alias; flip Enabled=true if
+		// needed. Detect the "already a member" case (Enabled was
+		// already true) so the UI can toast distinctly.
+		alreadyMember = existing.Enabled
+		if !existing.Enabled {
+			existing.Enabled = true
+			if err := s.store.UpdateTacticalCallsign(r.Context(), existing); err != nil {
+				s.internalError(w, r, "update tactical callsign enabled", err)
+				return
+			}
+		}
+		finalModel = *existing
+	}
+
+	// Optional audit stamp on the originating invite row. The stamp
+	// is strictly invariant-gated so a malicious or malformed
+	// SourceMessageID can't corrupt an unrelated row. If any
+	// invariant fails, the subscription still succeeds — acceptance
+	// is tactical-keyed, the message link is informational.
+	var stampedMessageID uint64
+	if req.SourceMessageID != 0 && s.messagesStore != nil {
+		id := uint64(req.SourceMessageID)
+		row, err := s.messagesStore.GetByID(r.Context(), id)
+		switch {
+		case errors.Is(err, gorm.ErrRecordNotFound):
+			// Row gone — silent skip.
+		case err != nil:
+			s.logger.Warn("accept-invite: lookup source message failed",
+				"err", err, "id", id)
+		case row == nil:
+			// Silent skip.
+		case row.Direction != "in",
+			row.Kind != messages.MessageKindInvite,
+			row.InviteTactical != callsign,
+			row.InviteAcceptedAt != nil:
+			// Invariant mismatch or already stamped — silent skip.
+			// Idempotent: re-posting the same accept is a no-op.
+		default:
+			now := time.Now().UTC()
+			row.InviteAcceptedAt = &now
+			if err := s.messagesStoreUpdater(row); err != nil {
+				s.logger.Warn("accept-invite: stamp InviteAcceptedAt failed",
+					"err", err, "id", id)
+			} else {
+				stampedMessageID = row.ID
+			}
+		}
+	}
+
+	// Reload the router's TacticalSet so incoming packets addressed
+	// to the newly-accepted tactical classify correctly. The
+	// messagesReload channel is drained by cmd/graywolf's wiring
+	// goroutine, which calls ReloadTacticalCallsigns. We also call
+	// ReloadTacticalCallsigns inline when the service is present so
+	// subsequent requests see the update even before the reload
+	// goroutine wakes.
+	if s.messagesService != nil {
+		if err := s.messagesService.ReloadTacticalCallsigns(r.Context()); err != nil {
+			s.logger.Warn("reload tactical callsigns after accept", "err", err)
+		}
+	}
+	s.signalMessagesReload()
+
+	// Emit a message.updated SSE event so other tabs / the sender
+	// view re-render the invite bubble with its new accepted state.
+	// Only emit when we actually stamped a row — spurious events
+	// would force useless UI redraws across the whole stream.
+	if stampedMessageID != 0 && s.messagesService != nil {
+		s.messagesService.EventHub().Publish(messages.Event{
+			Type:      messages.EventMessageUpdated,
+			MessageID: stampedMessageID,
+			Timestamp: time.Now().UTC(),
+		})
+	}
+
+	writeJSON(w, http.StatusOK, dto.AcceptInviteResponse{
+		Tactical:      dto.TacticalCallsignFromModel(finalModel),
+		AlreadyMember: alreadyMember,
+	})
+}
+
+// messagesStoreUpdater writes a single message row through the store
+// the handler is configured with. Kept as a method so tests can
+// inject a store that records writes without needing a full DB.
+//
+// The webapi.MessagesStore interface intentionally exposes reads
+// only; mutation still flows through *messages.Store. Tests wire the
+// same store for both interfaces so this method uses a type switch
+// to reach the mutating API without widening MessagesStore.
+func (s *Server) messagesStoreUpdater(m *configstore.Message) error {
+	if ms, ok := s.messagesStore.(interface {
+		Update(ctx context.Context, m *configstore.Message) error
+	}); ok {
+		return ms.Update(context.Background(), m)
+	}
+	// Fall back to a direct DB write via the configstore.
+	return s.store.DB().Save(m).Error
+}

--- a/graywolf/pkg/webapi/tacticals_test.go
+++ b/graywolf/pkg/webapi/tacticals_test.go
@@ -1,0 +1,435 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/messages"
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+// newTacticalsTestServer wires a Server with the real messages Store,
+// a fake MessagesService (so we can observe ReloadTacticalCallsigns
+// + EventHub), and the tacticals route registered.
+func newTacticalsTestServer(t *testing.T) (*Server, *http.ServeMux, *messages.Store, *fakeMessagesSvc) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := configstore.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.UpsertIGateConfig(ctx, &configstore.IGateConfig{
+		Callsign: "N0CALL", Server: "rotate.aprs2.net", Port: 14580,
+		Passcode: "-1", TxChannel: 1, RfChannel: 1, MaxMsgHops: 2, GateRfToIs: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	msgStore := messages.NewStore(store.DB())
+
+	svc := &fakeMessagesSvc{}
+	srv, err := NewServer(Config{
+		Store:  store,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.SetMessagesService(svc)
+	srv.SetMessagesStore(msgStore)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	return srv, mux, msgStore, svc
+}
+
+// TestAcceptTacticalInvite_CreatesNewSubscription asserts that POST
+// /api/tacticals against an unknown tactical creates a new enabled
+// row and returns AlreadyMember=false.
+func TestAcceptTacticalInvite_CreatesNewSubscription(t *testing.T) {
+	srv, mux, _, svc := newTacticalsTestServer(t)
+
+	reloaded := make(chan struct{}, 1)
+	svc.reloadTacticalFn = func(ctx context.Context) error {
+		select {
+		case reloaded <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+
+	body := `{"callsign":"TAC-NET"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp dto.AcceptInviteResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Tactical.Callsign != "TAC-NET" {
+		t.Errorf("Tactical.Callsign = %q, want TAC-NET", resp.Tactical.Callsign)
+	}
+	if !resp.Tactical.Enabled {
+		t.Error("Tactical.Enabled must be true on fresh accept")
+	}
+	if resp.AlreadyMember {
+		t.Error("AlreadyMember must be false on first accept")
+	}
+
+	// Verify persisted.
+	row, err := srv.store.GetTacticalCallsignByCallsign(context.Background(), "TAC-NET")
+	if err != nil {
+		t.Fatalf("lookup after accept: %v", err)
+	}
+	if row == nil || !row.Enabled {
+		t.Fatalf("expected persisted enabled row; got %+v", row)
+	}
+
+	select {
+	case <-reloaded:
+	case <-time.After(time.Second):
+		t.Error("ReloadTacticalCallsigns was not called")
+	}
+}
+
+// TestAcceptTacticalInvite_IdempotentOnAlreadyEnabled verifies that a
+// second POST against an already-enabled subscription returns 200
+// with AlreadyMember=true (NOT 409 — the plan forbids 409 on this
+// path).
+func TestAcceptTacticalInvite_IdempotentOnAlreadyEnabled(t *testing.T) {
+	_, mux, _, _ := newTacticalsTestServer(t)
+
+	body := `{"callsign":"TAC-NET"}`
+	// First accept.
+	req1 := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	mux.ServeHTTP(httptest.NewRecorder(), req1)
+
+	// Second accept.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	rec2 := httptest.NewRecorder()
+	mux.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected 200 on second accept, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+	var resp dto.AcceptInviteResponse
+	if err := json.NewDecoder(rec2.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.AlreadyMember {
+		t.Error("AlreadyMember must be true on second accept of the same tactical")
+	}
+}
+
+// TestAcceptTacticalInvite_EnablesDisabledPreservesAlias verifies that
+// accepting for a row that exists but is Enabled=false flips it to
+// Enabled=true without clobbering the existing Alias.
+func TestAcceptTacticalInvite_EnablesDisabledPreservesAlias(t *testing.T) {
+	srv, mux, _, _ := newTacticalsTestServer(t)
+
+	ctx := context.Background()
+	pre := &configstore.TacticalCallsign{
+		Callsign: "TAC-NET",
+		Alias:    "Old Name",
+		Enabled:  false,
+	}
+	if err := srv.store.CreateTacticalCallsign(ctx, pre); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	body := `{"callsign":"TAC-NET"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp dto.AcceptInviteResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if !resp.Tactical.Enabled {
+		t.Error("Enabled must be true post-accept")
+	}
+	if resp.Tactical.Alias != "Old Name" {
+		t.Errorf("Alias = %q, want preserved %q", resp.Tactical.Alias, "Old Name")
+	}
+	if resp.AlreadyMember {
+		t.Error("AlreadyMember must be false — row existed but was disabled")
+	}
+
+	// Verify persisted state.
+	row, _ := srv.store.GetTacticalCallsignByCallsign(ctx, "TAC-NET")
+	if row == nil || !row.Enabled || row.Alias != "Old Name" {
+		t.Errorf("unexpected persisted row: %+v", row)
+	}
+}
+
+// TestAcceptTacticalInvite_MalformedCallsign returns 400 for inputs
+// that don't match the 1-9 [A-Z0-9-] grammar.
+func TestAcceptTacticalInvite_MalformedCallsign(t *testing.T) {
+	_, mux, _, _ := newTacticalsTestServer(t)
+
+	cases := []struct {
+		name string
+		call string
+	}{
+		{"empty", ""},
+		{"too long", "TOOLONGTAC"},
+		{"underscore", "TAC_NET"},
+		{"space", "TAC NET"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := fmt.Sprintf(`{"callsign":%q}`, tc.call)
+			req := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("%s: expected 400, got %d: %s", tc.name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestAcceptTacticalInvite_LowercaseNormalizedToUpper verifies that a
+// lowercase callsign in the request is uppercased before validation
+// + persist. The wire regex is uppercase-only but the handler is
+// tolerant on input.
+func TestAcceptTacticalInvite_LowercaseNormalizedToUpper(t *testing.T) {
+	srv, mux, _, _ := newTacticalsTestServer(t)
+
+	body := `{"callsign":"tac-net"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	row, err := srv.store.GetTacticalCallsignByCallsign(context.Background(), "TAC-NET")
+	if err != nil || row == nil {
+		t.Fatalf("expected persisted row under uppercase key; err=%v row=%+v", err, row)
+	}
+}
+
+// TestAcceptTacticalInvite_NoSourceMessageStillSubscribes verifies
+// that omitting SourceMessageID (or sending 0) still results in a
+// successful subscribe — the message link is optional audit info.
+func TestAcceptTacticalInvite_NoSourceMessageStillSubscribes(t *testing.T) {
+	srv, mux, _, _ := newTacticalsTestServer(t)
+
+	body := `{"callsign":"TAC-NET","source_message_id":0}`
+	req := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	row, _ := srv.store.GetTacticalCallsignByCallsign(context.Background(), "TAC-NET")
+	if row == nil || !row.Enabled {
+		t.Errorf("expected subscription even without source_message_id; got %+v", row)
+	}
+}
+
+// TestAcceptTacticalInvite_StampsSourceMessageAuditFields verifies
+// that when SourceMessageID points to a valid inbound invite for the
+// matching tactical, the handler sets InviteAcceptedAt for audit.
+func TestAcceptTacticalInvite_StampsSourceMessageAuditFields(t *testing.T) {
+	srv, mux, msgStore, svc := newTacticalsTestServer(t)
+	// EventHub must exist for the handler to publish on.
+	_ = svc.EventHub()
+
+	// Seed an inbound invite row for TAC-NET.
+	inv := &configstore.Message{
+		Direction:      "in",
+		OurCall:        "N0CALL",
+		FromCall:       "W1ABC",
+		ToCall:         "N0CALL",
+		Text:           "!GW1 INVITE TAC-NET",
+		ThreadKind:     messages.ThreadKindDM,
+		ThreadKey:      "W1ABC",
+		Kind:           messages.MessageKindInvite,
+		InviteTactical: "TAC-NET",
+		Source:         "rf",
+		Unread:         true,
+	}
+	insertMessage(t, msgStore, inv)
+
+	body := fmt.Sprintf(`{"callsign":"TAC-NET","source_message_id":%d}`, inv.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Re-read and assert stamp.
+	got, err := msgStore.GetByID(context.Background(), inv.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.InviteAcceptedAt == nil {
+		t.Fatal("InviteAcceptedAt must be set after accept")
+	}
+	firstStamp := *got.InviteAcceptedAt
+
+	// Verify subscription exists.
+	row, _ := srv.store.GetTacticalCallsignByCallsign(context.Background(), "TAC-NET")
+	if row == nil || !row.Enabled {
+		t.Fatalf("subscription missing post-accept: %+v", row)
+	}
+
+	// Idempotency: re-posting the same accept must not re-stamp or
+	// change state, and must return AlreadyMember=true.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	rec2 := httptest.NewRecorder()
+	mux.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected 200 on second accept, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+	var resp2 dto.AcceptInviteResponse
+	_ = json.NewDecoder(rec2.Body).Decode(&resp2)
+	if !resp2.AlreadyMember {
+		t.Error("AlreadyMember must be true on second accept")
+	}
+	got2, _ := msgStore.GetByID(context.Background(), inv.ID)
+	if got2.InviteAcceptedAt == nil || !got2.InviteAcceptedAt.Equal(firstStamp) {
+		t.Errorf("InviteAcceptedAt changed on re-accept: was %v, now %v", firstStamp, got2.InviteAcceptedAt)
+	}
+}
+
+// TestAcceptTacticalInvite_SilentlySkipsMismatchedSource verifies
+// that when SourceMessageID resolves to a row that fails any of the
+// invariants (wrong direction, wrong kind, mismatched tactical, etc.)
+// the subscription still succeeds and the source row is left
+// untouched. The plan says acceptance is tactical-keyed, not
+// message-keyed.
+func TestAcceptTacticalInvite_SilentlySkipsMismatchedSource(t *testing.T) {
+	srv, mux, msgStore, _ := newTacticalsTestServer(t)
+
+	// Seed an OUTBOUND text row — wrong direction and wrong kind.
+	bogus := &configstore.Message{
+		Direction:  "out",
+		OurCall:    "N0CALL",
+		FromCall:   "N0CALL",
+		ToCall:     "W1ABC",
+		Text:       "hello",
+		ThreadKind: messages.ThreadKindDM,
+		ThreadKey:  "W1ABC",
+		Kind:       messages.MessageKindText,
+	}
+	insertMessage(t, msgStore, bogus)
+
+	body := fmt.Sprintf(`{"callsign":"TAC-NET","source_message_id":%d}`, bogus.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Subscription exists.
+	row, _ := srv.store.GetTacticalCallsignByCallsign(context.Background(), "TAC-NET")
+	if row == nil || !row.Enabled {
+		t.Fatalf("subscription must succeed even with a mismatched source: %+v", row)
+	}
+
+	// Source row unchanged — InviteAcceptedAt still nil.
+	got, _ := msgStore.GetByID(context.Background(), bogus.ID)
+	if got.InviteAcceptedAt != nil {
+		t.Errorf("source row must not be stamped on invariant mismatch; InviteAcceptedAt=%v", got.InviteAcceptedAt)
+	}
+}
+
+// TestAcceptTacticalInvite_TacticalMismatchDoesNotStamp verifies that
+// a source message whose InviteTactical differs from the accept's
+// callsign is left unchanged — protects against a malicious client
+// stamping unrelated rows.
+func TestAcceptTacticalInvite_TacticalMismatchDoesNotStamp(t *testing.T) {
+	srv, mux, msgStore, _ := newTacticalsTestServer(t)
+
+	// Invite for TAC-A.
+	inv := &configstore.Message{
+		Direction:      "in",
+		OurCall:        "N0CALL",
+		FromCall:       "W1ABC",
+		ToCall:         "N0CALL",
+		Text:           "!GW1 INVITE TAC-A",
+		ThreadKind:     messages.ThreadKindDM,
+		Kind:           messages.MessageKindInvite,
+		InviteTactical: "TAC-A",
+		Source:         "rf",
+	}
+	insertMessage(t, msgStore, inv)
+
+	// Accept for TAC-B, but cite the TAC-A message.
+	body := fmt.Sprintf(`{"callsign":"TAC-B","source_message_id":%d}`, inv.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// TAC-B subscribed.
+	rowB, _ := srv.store.GetTacticalCallsignByCallsign(context.Background(), "TAC-B")
+	if rowB == nil || !rowB.Enabled {
+		t.Fatal("TAC-B subscription missing")
+	}
+	// TAC-A invite row untouched.
+	got, _ := msgStore.GetByID(context.Background(), inv.ID)
+	if got.InviteAcceptedAt != nil {
+		t.Error("TAC-A invite must NOT be stamped when accept is for a different tactical")
+	}
+}
+
+// TestAcceptTacticalInvite_EmitsUpdatedEventOnStamp asserts that when
+// the accept stamps InviteAcceptedAt, a message.updated SSE event is
+// emitted for the source row (so other tabs / the sender re-render).
+func TestAcceptTacticalInvite_EmitsUpdatedEventOnStamp(t *testing.T) {
+	_, mux, msgStore, svc := newTacticalsTestServer(t)
+	hub := svc.EventHub()
+	events, unsub := hub.Subscribe()
+	defer unsub()
+
+	inv := &configstore.Message{
+		Direction:      "in",
+		OurCall:        "N0CALL",
+		FromCall:       "W1ABC",
+		ToCall:         "N0CALL",
+		Text:           "!GW1 INVITE TAC-NET",
+		ThreadKind:     messages.ThreadKindDM,
+		Kind:           messages.MessageKindInvite,
+		InviteTactical: "TAC-NET",
+		Source:         "rf",
+	}
+	insertMessage(t, msgStore, inv)
+
+	body := fmt.Sprintf(`{"callsign":"TAC-NET","source_message_id":%d}`, inv.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/tacticals", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	select {
+	case e := <-events:
+		if e.Type != messages.EventMessageUpdated {
+			t.Errorf("event type = %q, want %q", e.Type, messages.EventMessageUpdated)
+		}
+		if e.MessageID != inv.ID {
+			t.Errorf("event MessageID = %d, want %d", e.MessageID, inv.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected a message.updated event after accept-with-stamp")
+	}
+}

--- a/graywolf/web/src/api/generated/api.d.ts
+++ b/graywolf/web/src/api/generated/api.d.ts
@@ -971,6 +971,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/tacticals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Accept a tactical invite (subscribe) */
+        post: operations["acceptTacticalInvite"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/tx-timing": {
         parameters: {
             query?: never;
@@ -1236,6 +1253,34 @@ export interface components {
             windGust?: number;
             /** @description mph (1-minute sustained) */
             windSpeed?: number;
+        };
+        "dto.AcceptInviteRequest": {
+            /**
+             * @description Callsign is the tactical label to subscribe to. Required. Must
+             *     match the APRS tactical syntax (1-9 of [A-Z0-9-]) after uppercase
+             *     normalization.
+             */
+            callsign: string;
+            /**
+             * @description SourceMessageID, when non-zero, identifies the inbound invite
+             *     message that triggered the accept. Used only for audit — the
+             *     handler sets InviteAcceptedAt on that row if it resolves to a
+             *     valid invite for the same tactical. Zero = accept without audit.
+             */
+            source_message_id?: number;
+        };
+        "dto.AcceptInviteResponse": {
+            /**
+             * @description AlreadyMember is true when the operator was already subscribed
+             *     and enabled before this request. Lets the UI suppress the
+             *     "Joined TAC" toast and emit "Already a member" instead.
+             */
+            already_member?: boolean;
+            /**
+             * @description Tactical is the post-accept state of the subscription. Always
+             *     populated with Enabled=true (accept is the "turn it on" verb).
+             */
+            tactical?: components["schemas"]["dto.TacticalCallsignResponse"];
         };
         "dto.AgwRequest": {
             callsigns?: string;
@@ -1570,8 +1615,27 @@ export interface components {
             failure_reason?: string;
             from_call?: string;
             id?: number;
+            /**
+             * @description InviteAcceptedAt is audit-only: set when the local operator
+             *     accepted this invite. The UI must NOT use this to decide "joined"
+             *     state — that comes from the live TacticalSet cache. Kept so
+             *     operators can see when/if an invite was acted on.
+             */
+            invite_accepted_at?: string;
+            /**
+             * @description InviteTactical is the tactical callsign referenced by an invite.
+             *     Empty (and omitted) on non-invite rows.
+             */
+            invite_tactical?: string;
             is_ack?: boolean;
             is_bulletin?: boolean;
+            /**
+             * @description Kind is the body classification. Always populated — "text" for
+             *     normal messages, "invite" for tactical invitations. Never omitted
+             *     so clients can use a simple equality check without worrying about
+             *     a legacy empty string.
+             */
+            kind?: string;
             msg_id?: string;
             next_retry_at?: string;
             our_call?: string;
@@ -1658,6 +1722,19 @@ export interface components {
              */
             client_id?: string;
             /**
+             * @description InviteTactical is the tactical callsign referenced by an invite.
+             *     Must be set when Kind == "invite"; ignored otherwise.
+             */
+            invite_tactical?: string;
+            /**
+             * @description Kind classifies the outbound row. Empty or "text" is a normal
+             *     DM/tactical message; "invite" makes the sender build a
+             *     `!GW1 INVITE <InviteTactical>` body and stamp the row with
+             *     Kind=invite + InviteTactical. The sender (Phase 2) is
+             *     responsible for honoring this; the DTO just carries it.
+             */
+            kind?: string;
+            /**
              * @description Path overrides the default RF path from preferences. Empty =
              *     use MessagePreferences.DefaultPath.
              */
@@ -1667,7 +1744,11 @@ export interface components {
              *     of the current fallback policy.
              */
             prefer_is?: boolean;
-            /** @description Text is the message body (<= 67 APRS chars after validation). */
+            /**
+             * @description Text is the message body (<= 67 APRS chars after validation).
+             *     Ignored when Kind == "invite" — the server builds the wire body
+             *     from InviteTactical.
+             */
             text?: string;
             /**
              * @description To is the addressee: a station callsign for a DM or a tactical
@@ -5527,6 +5608,58 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["webapi.StatusDTO"];
+                };
+            };
+        };
+    };
+    acceptTacticalInvite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Tactical + optional source message id */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["dto.AcceptInviteRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.AcceptInviteResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
                 };
             };
         };

--- a/graywolf/web/src/api/messages.js
+++ b/graywolf/web/src/api/messages.js
@@ -197,6 +197,35 @@ export function getTacticalParticipants(key, params) {
   return api.get(`/messages/tactical/${encodeURIComponent(key)}/participants${qs(params)}`);
 }
 
+// --- Tactical invite accept ----------------------------------------
+
+/**
+ * POST /api/tacticals — subscribe the operator to a tactical callsign
+ * in response to an `!GW1 INVITE <TAC>` invite bubble's Accept button.
+ *
+ * The endpoint is tactical-keyed, not message-keyed: "accept" means
+ * "enable my subscription to TAC". `source_message_id` lets the server
+ * stamp the triggering invite row with `invite_accepted_at` for audit;
+ * omit (or pass 0) when there isn't a bubble context.
+ *
+ * `already_member=true` is a normal 200 OK with a distinct UX meaning
+ * ("Already a member of TAC") — clients must not treat it as an error.
+ *
+ * Phase-invite-2 may finalize the path as `/tacticals/subscribe`; Phase
+ * 3 defaulted to `/tacticals` per the plan. If Phase 2 landed a different
+ * confirmed path, update the string below and regenerate the TS client.
+ *
+ * @param {{callsign: string, source_message_id?: number}} req
+ * @returns {Promise<{tactical: import('./generated/api').components['schemas']['dto.TacticalCallsignResponse'], already_member: boolean}>}
+ */
+export function acceptTactical(req) {
+  const body = {
+    callsign: (req?.callsign || '').toUpperCase(),
+    source_message_id: req?.source_message_id || 0,
+  };
+  return api.post('/tacticals', body);
+}
+
 // --- Station autocomplete (out-of-band helper) ---------------------
 
 /**

--- a/graywolf/web/src/components/messages/CallsignAutocomplete.svelte
+++ b/graywolf/web/src/components/messages/CallsignAutocomplete.svelte
@@ -202,7 +202,18 @@
     }
   }
 
+  // Suppresses the focus event that our own onMount autofocus fires.
+  // Without this, mounting inside a modal whose focus trap immediately
+  // steals focus back produces a brief dropdown flash: onFocusIn →
+  // open=true → list renders → focus moves to modal close button →
+  // input blurs → onBlurOut 120ms later → open=false.
+  let suppressNextFocus = false;
+
   function onFocusIn() {
+    if (suppressNextFocus) {
+      suppressNextFocus = false;
+      return;
+    }
     open = true;
     if (results.length === 0) runFetch();
   }
@@ -217,7 +228,12 @@
 
   onMount(() => {
     if (autofocus && inputEl) {
+      suppressNextFocus = true;
       inputEl.focus();
+      // If the modal's focus trap doesn't actually steal focus away,
+      // clear the flag after a frame so the next real focus (e.g., the
+      // user re-clicking the input) still opens the dropdown.
+      requestAnimationFrame(() => { suppressNextFocus = false; });
     }
   });
 
@@ -263,6 +279,8 @@
       style:width="{popWidth}px"
       data-combobox={listId}
       data-testid="callsign-autocomplete-list"
+      onpointerdown={(e) => e.stopPropagation()}
+      onmousedown={(e) => e.stopPropagation()}
     >
       {#each groups as g}
         <li role="presentation" class="group-heading">{g.heading}</li>

--- a/graywolf/web/src/components/messages/CallsignAutocomplete.svelte
+++ b/graywolf/web/src/components/messages/CallsignAutocomplete.svelte
@@ -24,6 +24,20 @@
   import { autocompleteStations } from '../../api/messages.js';
   import { relativeLong } from './time.js';
 
+  // Portal action: move the node to document.body so `position: fixed`
+  // is relative to the viewport rather than a transformed ancestor
+  // (chonky's Modal applies a transform for centering, which otherwise
+  // reparents fixed-positioned descendants' containing block to the
+  // modal itself and throws the dropdown off-screen).
+  function portal(node) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        if (node.parentNode) node.parentNode.removeChild(node);
+      },
+    };
+  }
+
   /** @type {{
    *    value?: string,
    *    placeholder?: string,
@@ -233,6 +247,7 @@
   </div>
   {#if open && (flatItems.length > 0 || (value && value.trim()))}
     <ul
+      use:portal
       id={listId}
       role="listbox"
       class="list"

--- a/graywolf/web/src/components/messages/CallsignAutocomplete.svelte
+++ b/graywolf/web/src/components/messages/CallsignAutocomplete.svelte
@@ -44,6 +44,7 @@
    *    onCommit?: (call: string) => void,
    *    disabled?: boolean,
    *    autofocus?: boolean,
+   *    excludeBots?: boolean,
    *  }}
    */
   let {
@@ -52,6 +53,7 @@
     onCommit,
     disabled = false,
     autofocus = false,
+    excludeBots = false,
   } = $props();
 
   let inputEl = $state(null);
@@ -126,7 +128,11 @@
     const q = (value || '').trim();
     try {
       const res = await autocompleteStations({ q, limit: 20 });
-      results = Array.isArray(res) ? res : [];
+      const arr = Array.isArray(res) ? res : [];
+      // In invite contexts the caller passes excludeBots — APRS
+      // services aren't valid invite targets (they don't subscribe
+      // to tactical chats), so drop them from the candidate list.
+      results = excludeBots ? arr.filter(r => r.source !== 'bot') : arr;
       // Initial highlight: pick the best station (non-bot) if any,
       // else the first row. Bots remain visible at the top of the
       // rendered list, but highlight defaults to stations so the

--- a/graywolf/web/src/components/messages/CallsignAutocomplete.svelte
+++ b/graywolf/web/src/components/messages/CallsignAutocomplete.svelte
@@ -371,6 +371,11 @@
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
     /* z-index high enough to sit above chonky Modal's backdrop + content. */
     z-index: 1000;
+    /* bits-ui Dialog sets pointer-events:none on <body> while open to
+       scope clicks to Dialog.Content. Our portaled listbox is a body
+       descendant and inherits `none`, so clicks fall through to the
+       modal. Re-enable explicitly. */
+    pointer-events: auto;
   }
   .group-heading {
     padding: 6px 12px 4px;

--- a/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
+++ b/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
@@ -575,7 +575,7 @@
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    min-height: 24px;
+    height: 24px;
     padding: 0 4px 0 10px;
     background: var(--color-surface-raised);
     border: 1px solid var(--color-border);
@@ -608,8 +608,13 @@
     border-color: var(--color-primary);
   }
   .chip-call {
+    /* Match the icon buttons' 18px box so align-items:center on .chip
+       puts both on the same midline. Without an explicit height, the
+       text collapses to font-size (12px) and its font-metric ink
+       offset within that tight box drifts visibly against the icon. */
     display: inline-flex;
     align-items: center;
+    height: 18px;
     line-height: 1;
     font-weight: 600;
   }

--- a/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
+++ b/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
@@ -574,7 +574,8 @@
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    padding: 2px 4px 2px 10px;
+    min-height: 24px;
+    padding: 0 4px 0 10px;
     background: var(--color-surface-raised);
     border: 1px solid var(--color-border);
     border-radius: 999px;
@@ -606,6 +607,9 @@
     border-color: var(--color-primary);
   }
   .chip-call {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1;
     font-weight: 600;
   }
   .chip-remove,

--- a/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
+++ b/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
@@ -564,12 +564,17 @@
     min-width: 180px;
   }
   /* The autocomplete renders its own bordered input; flatten it so it
-     blends into the chip-area surface. */
+     blends into the chip-area surface. Match the chip's 24px height
+     so the placeholder and the chip callsign share the same baseline
+     when the chip-area flex row centers them. */
   :global(.chip-area .wrap .input) {
     border: none !important;
     box-shadow: none !important;
     background: transparent !important;
-    padding: 4px 2px !important;
+    height: 24px !important;
+    line-height: 24px !important;
+    padding: 0 2px !important;
+    font-size: 13px !important;
   }
   .chip {
     display: inline-flex;

--- a/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
+++ b/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
@@ -549,11 +549,11 @@
     flex-wrap: wrap;
     gap: 6px;
     align-items: center;
-    padding: 6px;
+    padding: 4px;
     background: var(--color-bg);
     border: 1px solid var(--color-border);
     border-radius: var(--radius);
-    min-height: 44px;
+    min-height: 36px;
   }
   .chip-area:focus-within {
     border-color: var(--color-primary);

--- a/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
+++ b/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
@@ -470,6 +470,7 @@
             placeholder={chips.length === 0 ? 'Callsign, tactical, or paste a list' : 'Add another…'}
             onCommit={onAutocompleteCommit}
             autofocus={true}
+            excludeBots={true}
           />
         </div>
       </div>

--- a/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
+++ b/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
@@ -1,0 +1,698 @@
+<script>
+  // Invite-to-tactical modal.
+  //
+  // Two-axis interaction: the tactical is fixed (carried in the header,
+  // not pinned to a pill in the body the way ComposeNewModal pins its
+  // To: pill), and the variable is the recipient chip set. The body
+  // wraps `CallsignAutocomplete` in a chip picker with paste-list
+  // expansion, dedupe-on-commit, and self-invite filtering. Send fires
+  // one `POST /api/messages` per chip concurrently; per-chip state
+  // transitions idle → sending → sent | failed, driven by SSE ack
+  // reconciliation through `messagesStore.messageById`, not the POST
+  // response (202 returns before RF transmission completes).
+  //
+  // The modal deliberately stays open after the Send click: the user
+  // watches each chip settle. Once every chip is terminal (sent or
+  // failed), the Send button relabels to `Done` (or `Retry all (N)`
+  // if all failed). Confirm-close on Escape/backdrop/X while anything
+  // is still `sending`.
+
+  import { onMount, tick } from 'svelte';
+  import { Button, Icon, Modal } from '@chrissnell/chonky-ui';
+  import { messages as store } from '../../lib/messagesStore.svelte.js';
+  import { sendMessage } from '../../api/messages.js';
+  import { api } from '../../lib/api.js';
+  import { toasts } from '../../lib/stores.js';
+  import {
+    classifyCommit,
+    classifyPasteList,
+    normalizeCall,
+    PASTE_SPLIT_RE,
+  } from '../../lib/inviteValidation.js';
+  import CallsignAutocomplete from './CallsignAutocomplete.svelte';
+
+  /** @type {{
+   *    tactical: string,
+   *    open: boolean,
+   *    onClose: () => void,
+   *  }}
+   */
+  let {
+    tactical,
+    open = $bindable(false),
+    onClose,
+  } = $props();
+
+  // --- Chip state ---------------------------------------------------
+  // Paste-list + chip validation rules live in lib/inviteValidation.js
+  // (pure logic, unit-tested).
+  //
+  // Per-chip record:
+  //   {call, state, messageId?, error?, flashing?}
+  //   state: 'idle' | 'sending' | 'sent' | 'failed'
+  let chips = $state([]);
+  let autoInput = $state('');
+  let hintText = $state('');
+  let isOnline = $state(true);
+  let ourCall = $state('');
+  let sendBtnWrap = $state(null);
+  let confirmCloseOpen = $state(false);
+
+  // Fetch operator callsign from /igate (same pattern as TacticalSettings).
+  onMount(async () => {
+    try {
+      const ig = await api.get('/igate');
+      ourCall = (ig?.callsign || '').toUpperCase();
+    } catch {
+      // Non-fatal — self-filter just won't work if this fails.
+    }
+    if (typeof navigator !== 'undefined') {
+      isOnline = !!navigator.onLine;
+    }
+    const onOnline = () => { isOnline = true; };
+    const onOffline = () => { isOnline = false; };
+    if (typeof window !== 'undefined') {
+      window.addEventListener('online', onOnline);
+      window.addEventListener('offline', onOffline);
+    }
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('online', onOnline);
+        window.removeEventListener('offline', onOffline);
+      }
+    };
+  });
+
+  // Clear state whenever the modal opens so reopening after a previous
+  // batch doesn't leak chips.
+  $effect(() => {
+    if (open) {
+      chips = [];
+      autoInput = '';
+      hintText = '';
+    }
+  });
+
+  // --- SSE reconciliation -------------------------------------------
+  // Watch `messageById` for acks; flip per-chip `sending → sent`.
+  // `failed` is set directly on POST rejection (covered in send loop).
+  $effect(() => {
+    // Touch the map so Svelte re-runs when anything changes.
+    const map = store.messageById;
+    let mutated = false;
+    const next = chips.map((c) => {
+      if (c.state !== 'sending' || !c.messageId) return c;
+      const m = map.get(c.messageId);
+      if (!m) return c;
+      // Terminal success states:
+      //   - acked (APRS ack received)
+      //   - sent / sent_rf / sent_is (transmitted; ack may or may not follow)
+      //   - timeout (retry budget exhausted; plan treats it as "sent")
+      // Terminal failure states:
+      //   - rejected, failed
+      if (['acked', 'sent', 'sent_rf', 'sent_is', 'timeout'].includes(m.status)) {
+        mutated = true;
+        return { ...c, state: 'sent' };
+      }
+      if (['rejected', 'failed'].includes(m.status)) {
+        mutated = true;
+        return { ...c, state: 'failed', error: m.failure_reason || m.status };
+      }
+      return c;
+    });
+    if (mutated) chips = next;
+  });
+
+  // --- Chip state derivations ---------------------------------------
+  const chipCount = $derived(chips.length);
+  const anySending = $derived(chips.some((c) => c.state === 'sending'));
+  const allTerminal = $derived(
+    chipCount > 0 && chips.every((c) => c.state === 'sent' || c.state === 'failed'),
+  );
+  const allFailed = $derived(
+    chipCount > 0 && chips.every((c) => c.state === 'failed'),
+  );
+
+  const sendLabel = $derived.by(() => {
+    if (chipCount === 0) return 'Send';
+    if (allTerminal) {
+      if (allFailed) return `Retry all (${chipCount})`;
+      return 'Done';
+    }
+    const noun = chipCount === 1 ? 'invitation' : 'invitations';
+    return `Send ${chipCount} ${noun}`;
+  });
+
+  const sendDisabled = $derived(
+    chipCount === 0 || anySending || (!isOnline && !allTerminal),
+  );
+
+  // --- Chip mutation helpers ----------------------------------------
+  function indexOfChip(call) {
+    const norm = normalizeCall(call);
+    return chips.findIndex((c) => c.call === norm);
+  }
+
+  function flashChip(idx) {
+    if (idx < 0 || idx >= chips.length) return;
+    chips = chips.map((c, i) => (i === idx ? { ...c, flashing: true } : c));
+    setTimeout(() => {
+      chips = chips.map((c, i) => (i === idx ? { ...c, flashing: false } : c));
+    }, 600);
+  }
+
+  /**
+   * Commit a single callsign as a chip. Returns the same outcome set as
+   * classifyCommit: 'ok' | 'duplicate' | 'invalid' | 'self'. Caller
+   * decides whether to show a toast / clear the input.
+   */
+  function commitChip(raw) {
+    const existingCalls = chips.map((c) => c.call);
+    const outcome = classifyCommit(raw, existingCalls, ourCall);
+    if (outcome === 'ok') {
+      chips = [...chips, { call: normalizeCall(raw), state: 'idle' }];
+    } else if (outcome === 'duplicate') {
+      const idx = indexOfChip(raw);
+      flashChip(idx);
+    }
+    return outcome;
+  }
+
+  function removeChip(idx) {
+    const chip = chips[idx];
+    if (!chip) return;
+    // Locked chips (sent / sending) cannot be removed via ×.
+    if (chip.state === 'sent' || chip.state === 'sending') return;
+    chips = chips.filter((_, i) => i !== idx);
+  }
+
+  function onAutocompleteCommit(call) {
+    const result = commitChip(call);
+    // Reset hint only when something new happens; don't stomp a paste-list hint.
+    if (result === 'ok') hintText = '';
+    if (result === 'self') {
+      toasts.error("You can't invite yourself");
+    }
+    // Dedupe on commit: DO NOT clear the input. The plan explicitly
+    // says the user backspaces to clear it so they know the autocomplete
+    // didn't add anything.
+    if (result === 'duplicate') return;
+    autoInput = '';
+  }
+
+  function handlePaste(e) {
+    const pasted = e?.clipboardData?.getData?.('text') || '';
+    if (!pasted || !PASTE_SPLIT_RE.test(pasted)) {
+      // Single-token paste: let the autocomplete handle it normally.
+      return;
+    }
+    e.preventDefault();
+    const existingCalls = chips.map((c) => c.call);
+    const { added, duplicate, invalid, self } = classifyPasteList(pasted, existingCalls, ourCall);
+    // Commit the valid tokens as chips (classifyPasteList already
+    // verified them; commitChip repeats the check but is idempotent on
+    // already-passed tokens).
+    for (const call of added) {
+      chips = [...chips, { call, state: 'idle' }];
+    }
+    if (self.length > 0) {
+      toasts.error("You can't invite yourself");
+    }
+    // Hint: "N added · M invalid [· K duplicate]" — omit zero counts.
+    const invalidTotal = invalid.length + self.length;
+    const parts = [];
+    if (added.length > 0) parts.push(`${added.length} added`);
+    if (duplicate.length > 0) parts.push(`${duplicate.length} duplicate`);
+    if (invalidTotal > 0) parts.push(`${invalidTotal} invalid`);
+    hintText = parts.length > 0 ? parts.join(' · ') : '';
+    // Leave invalid tokens in the input so the operator can fix them;
+    // self + malformed are both "not added".
+    autoInput = [...invalid, ...self].join(' ');
+  }
+
+  function handleChipKeydown(e, idx) {
+    if (e.key === 'Backspace' || e.key === 'Delete') {
+      e.preventDefault();
+      removeChip(idx);
+    }
+  }
+
+  // Capture-phase keyboard on the Recipients container:
+  //   - Backspace on empty autocomplete input → remove last chip.
+  //   - Enter on empty input → focus Send.
+  //   - Cmd/Ctrl+Enter → send from anywhere inside the modal.
+  function onRecipientsKeydown(e) {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      handleSend();
+      return;
+    }
+    // Only the input's raw keydown can tell us "input is empty".
+    const isAutocompleteInput = e.target?.getAttribute?.('role') === 'combobox';
+    if (!isAutocompleteInput) return;
+    const val = e.target.value || '';
+    if (e.key === 'Backspace' && val === '' && chips.length > 0) {
+      e.preventDefault();
+      // Find the last non-locked chip to remove.
+      for (let i = chips.length - 1; i >= 0; i--) {
+        const c = chips[i];
+        if (c.state !== 'sent' && c.state !== 'sending') {
+          removeChip(i);
+          return;
+        }
+      }
+      return;
+    }
+    if (e.key === 'Enter' && val === '') {
+      e.preventDefault();
+      e.stopPropagation();
+      if (chips.length > 0 && sendBtnWrap) {
+        const btn = sendBtnWrap.querySelector('button');
+        btn?.focus();
+      }
+    }
+  }
+
+  // --- Send flow ----------------------------------------------------
+  async function sendOne(idx) {
+    const chip = chips[idx];
+    if (!chip) return;
+    // Transition to sending
+    chips = chips.map((c, i) => (i === idx ? { ...c, state: 'sending', error: undefined } : c));
+    try {
+      const res = await sendMessage({
+        to: chip.call,
+        text: '',
+        kind: 'invite',
+        invite_tactical: tactical,
+      });
+      // Feed the freshly-persisted row into the shared store so the
+      // messageById effect above can reconcile acks arriving via SSE /
+      // poll without a cursor round-trip. This is the same pattern the
+      // parent Messages.svelte uses via `reconcilePending`, minus the
+      // pending clientId bookkeeping (invite sends don't go through the
+      // optimistic-bubble pipeline).
+      if (res) store.upsertMessage(res);
+
+      // Capture id for SSE reconciliation. If the row is already in a
+      // terminal state (status arrived with the POST response, which
+      // can happen for IS-only sends or immediate-fail paths), mirror
+      // it immediately.
+      chips = chips.map((c, i) => {
+        if (i !== idx) return c;
+        const next = { ...c, messageId: res?.id };
+        if (res && ['acked', 'sent', 'sent_rf', 'sent_is', 'timeout'].includes(res.status)) {
+          next.state = 'sent';
+        } else if (res && ['rejected', 'failed'].includes(res.status)) {
+          next.state = 'failed';
+          next.error = res.failure_reason || res.status;
+        }
+        return next;
+      });
+    } catch (err) {
+      chips = chips.map((c, i) => (
+        i === idx
+          ? { ...c, state: 'failed', error: err?.message || 'Send failed' }
+          : c
+      ));
+    }
+  }
+
+  async function handleSend() {
+    if (chipCount === 0) return;
+    // If everyone is terminal and this is the Done button, close.
+    if (allTerminal && !allFailed) {
+      doClose();
+      return;
+    }
+    // Retry-all: flip every failed chip back to idle and continue.
+    if (allTerminal && allFailed) {
+      chips = chips.map((c) => (
+        c.state === 'failed' ? { ...c, state: 'idle', error: undefined } : c
+      ));
+      await tick();
+    }
+    // Otherwise, fire every `idle` chip in parallel. `sending` chips
+    // stay as-is (shouldn't happen — send is disabled while any are
+    // sending).
+    const jobs = [];
+    chips.forEach((c, i) => {
+      if (c.state === 'idle') jobs.push(sendOne(i));
+    });
+    await Promise.allSettled(jobs);
+  }
+
+  async function retryChip(idx) {
+    const chip = chips[idx];
+    if (!chip || chip.state !== 'failed') return;
+    chips = chips.map((c, i) => (i === idx ? { ...c, state: 'idle', error: undefined } : c));
+    await tick();
+    await sendOne(idx);
+  }
+
+  // --- Close lifecycle ----------------------------------------------
+  function requestClose() {
+    if (anySending) {
+      confirmCloseOpen = true;
+      return false;
+    }
+    doClose();
+    return true;
+  }
+
+  function doClose() {
+    confirmCloseOpen = false;
+    open = false;
+    onClose?.();
+  }
+
+  function cancelClose() {
+    confirmCloseOpen = false;
+  }
+
+  // Chonky's Modal toggles `open` via bits-ui Dialog on Escape + backdrop
+  // click. We intercept via `onOpenChange` below: if the close is not
+  // allowed, we re-open the dialog in the next tick. Not pretty, but
+  // bits-ui's Dialog doesn't expose a `preventDefault`-style close hook.
+  function onOpenChange(nextOpen) {
+    if (nextOpen) return;
+    if (!requestClose()) {
+      // Snap back open.
+      tick().then(() => { open = true; });
+    }
+  }
+</script>
+
+<Modal bind:open {onOpenChange}>
+  <Modal.Header>
+    <h3 class="title">Invite to {tactical}</h3>
+    <Modal.Close aria-label="Close">
+      <Icon name="x" size="sm" />
+    </Modal.Close>
+  </Modal.Header>
+  <Modal.Body>
+    {#if !isOnline}
+      <div class="offline-banner" role="status">
+        <Icon name="wifi-off" size="sm" />
+        <span>You're offline — invitations will queue.</span>
+      </div>
+    {/if}
+
+    <div
+      class="recipients"
+      role="group"
+      aria-label="Recipients"
+    >
+      <label class="label" for="invite-recipients-input">Recipients</label>
+      <!-- keydown lives on the chip-area because its direct descendants
+           include the autocomplete input; an outer role="group" + keydown
+           trips a11y rules. Cmd/Ctrl+Enter, Backspace-on-empty, and
+           Enter-on-empty are all handled there. This element is a
+           container for an actually-interactive combobox child; the
+           outer keydown is a delegation shortcut, not an interactive
+           role in its own right. -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <div
+        class="chip-area"
+        onpaste={handlePaste}
+        onkeydown={onRecipientsKeydown}
+      >
+        {#each chips as chip, i (chip.call)}
+          <span
+            class="chip"
+            class:sending={chip.state === 'sending'}
+            class:sent={chip.state === 'sent'}
+            class:failed={chip.state === 'failed'}
+            class:flashing={chip.flashing}
+            data-testid="invite-chip"
+            data-call={chip.call}
+            data-state={chip.state}
+          >
+            <span class="chip-call">{chip.call}</span>
+            {#if chip.state === 'sending'}
+              <span class="chip-status" aria-label="Sending">
+                <Icon name="refresh-cw" size="xs" />
+              </span>
+            {:else if chip.state === 'sent'}
+              <span class="chip-status" aria-label="Sent">
+                <Icon name="check" size="xs" />
+              </span>
+            {:else if chip.state === 'failed'}
+              <button
+                type="button"
+                class="chip-retry"
+                onclick={() => retryChip(i)}
+                aria-label={`Retry invitation to ${chip.call}`}
+                data-testid="chip-retry"
+              >
+                <Icon name="refresh-cw" size="xs" />
+              </button>
+            {/if}
+            {#if chip.state !== 'sent' && chip.state !== 'sending'}
+              <button
+                type="button"
+                class="chip-remove"
+                onclick={() => removeChip(i)}
+                onkeydown={(e) => handleChipKeydown(e, i)}
+                aria-label={`Remove ${chip.call}`}
+              >
+                <Icon name="x" size="xs" />
+              </button>
+            {/if}
+          </span>
+        {/each}
+
+        <div class="autocomplete-wrap">
+          <CallsignAutocomplete
+            bind:value={autoInput}
+            placeholder={chips.length === 0 ? 'Callsign, tactical, or paste a list' : 'Add another…'}
+            onCommit={onAutocompleteCommit}
+            autofocus={true}
+          />
+        </div>
+      </div>
+      {#if hintText}
+        <div class="hint" data-testid="paste-hint">{hintText}</div>
+      {:else if chipCount === 0}
+        <div class="helper">Add at least one recipient.</div>
+      {/if}
+    </div>
+
+    <div class="actions" bind:this={sendBtnWrap}>
+      <Button
+        variant="primary"
+        onclick={handleSend}
+        disabled={sendDisabled}
+        data-testid="invite-send"
+      >
+        {sendLabel}
+      </Button>
+    </div>
+  </Modal.Body>
+</Modal>
+
+{#if confirmCloseOpen}
+  <div
+    class="confirm-close"
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby="invite-confirm-title"
+  >
+    <div class="confirm-card">
+      <h4 id="invite-confirm-title">Close while sending?</h4>
+      <p>Some invitations are still transmitting. They'll continue, but you won't see status updates.</p>
+      <div class="confirm-actions">
+        <Button variant="ghost" onclick={cancelClose}>Keep open</Button>
+        <Button variant="primary" onclick={doClose}>Close anyway</Button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    font-family: var(--font-mono);
+  }
+  .offline-banner {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    margin-bottom: 10px;
+    background: var(--color-warning-muted, rgba(250, 175, 75, 0.15));
+    border: 1px solid var(--color-warning, #eab308);
+    border-radius: var(--radius);
+    font-size: 12px;
+    color: var(--color-text);
+  }
+  .recipients {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 16px;
+  }
+  .label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--color-text-dim);
+  }
+  .chip-area {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    padding: 6px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    min-height: 44px;
+  }
+  .chip-area:focus-within {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px var(--color-primary-muted);
+  }
+  .autocomplete-wrap {
+    flex: 1 1 180px;
+    min-width: 180px;
+  }
+  /* The autocomplete renders its own bordered input; flatten it so it
+     blends into the chip-area surface. */
+  :global(.chip-area .wrap .input) {
+    border: none !important;
+    box-shadow: none !important;
+    background: transparent !important;
+    padding: 4px 2px !important;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 4px 2px 10px;
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.5px;
+    color: var(--color-text);
+  }
+  .chip.sending {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+  }
+  .chip.sent {
+    border-color: var(--color-success, #22c55e);
+    color: var(--color-success, #22c55e);
+    background: var(--color-success-muted, rgba(34, 197, 94, 0.12));
+  }
+  .chip.failed {
+    border-color: var(--color-danger);
+    color: var(--color-danger);
+    background: var(--color-danger-muted, rgba(239, 68, 68, 0.12));
+  }
+  @keyframes chipflash {
+    0%, 100% { box-shadow: 0 0 0 0 var(--color-primary-muted); }
+    40%      { box-shadow: 0 0 0 4px var(--color-primary-muted); }
+  }
+  .chip.flashing {
+    animation: chipflash 600ms ease-out;
+    border-color: var(--color-primary);
+  }
+  .chip-call {
+    font-weight: 600;
+  }
+  .chip-remove,
+  .chip-retry,
+  .chip-status {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 999px;
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 0;
+  }
+  .chip-status {
+    cursor: default;
+  }
+  .chip.sending .chip-status :global(svg) {
+    animation: spin 1s linear infinite;
+  }
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+  }
+  .chip-remove:hover,
+  .chip-retry:hover {
+    background: var(--color-surface);
+  }
+  .chip-remove:focus-visible,
+  .chip-retry:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+  }
+  .hint {
+    font-size: 11px;
+    color: var(--color-text-muted);
+    margin-top: 2px;
+  }
+  .helper {
+    font-size: 11px;
+    color: var(--color-text-dim);
+    margin-top: 2px;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  /* Lightweight inline confirm sheet. The chonky <AlertDialog> is
+     rendered in a portal and conflicts with the parent Modal's focus
+     trap; this in-flow card sits on top of the Modal content and
+     keeps focus contained. */
+  .confirm-close {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 2000;
+  }
+  .confirm-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    padding: 16px;
+    max-width: 360px;
+    width: calc(100% - 32px);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  }
+  .confirm-card h4 {
+    margin: 0 0 8px 0;
+    font-size: 14px;
+  }
+  .confirm-card p {
+    margin: 0 0 12px 0;
+    font-size: 13px;
+    color: var(--color-text-muted);
+  }
+  .confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+</style>

--- a/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
+++ b/graywolf/web/src/components/messages/InviteToTacticalModal.svelte
@@ -574,6 +574,9 @@
     height: 24px !important;
     line-height: 24px !important;
     padding: 0 2px !important;
+    /* chonky-ui's global input[type="text"] rule adds margin-bottom:1rem,
+       which inflated the autocomplete row by 14px inside the chip-area. */
+    margin: 0 !important;
     font-size: 13px !important;
   }
   .chip {

--- a/graywolf/web/src/components/messages/MessageBubble.svelte
+++ b/graywolf/web/src/components/messages/MessageBubble.svelte
@@ -23,8 +23,18 @@
   // message body in proportional system fallback — otherwise bubbles
   // feel like a terminal log. Callsigns and timestamps stay mono.
 
-  import { Badge, Icon, Tooltip } from '@chrissnell/chonky-ui';
+  import { tick } from 'svelte';
+  import { push } from 'svelte-spa-router';
+  import { Badge, Button, Icon, Tooltip } from '@chrissnell/chonky-ui';
   import { callsignColors, callsignMonogram } from '../../lib/callsignColor.js';
+  import { messages as store } from '../../lib/messagesStore.svelte.js';
+  import { acceptTactical } from '../../api/messages.js';
+  import { toasts } from '../../lib/stores.js';
+  import {
+    ignoredInviteIds,
+    markAutoNavDone,
+    hasAutoNavFired,
+  } from '../../lib/stores/ignoredInvites.js';
   import { timeOfDay } from './time.js';
 
   /** @type {{
@@ -157,6 +167,118 @@
   }
 
   const showReplyPrivately = $derived(isTactical && !isOut && !!sender);
+
+  // --- Invite-branch state ------------------------------------------
+  // An invite bubble (kind === 'invite') renders differently from a
+  // normal DM bubble: inbound gets an Accept CTA, outbound gets
+  // "You invited …" copy. "Joined" rendering is driven by tactical-set
+  // membership, not by `msg.invite_accepted_at` (per plan — refresh-safe
+  // on first paint, race-free with SSE set updates).
+
+  const isInvite = $derived(msg?.kind === 'invite');
+  const inviteTactical = $derived(msg?.invite_tactical || '');
+  const toCall = $derived(msg?.to_call || msg?.peer_call || '');
+
+  // Accept button state machine: idle → accepting → joined | failed.
+  // Local to this bubble instance — a second bubble for the same TAC
+  // starts at `joined` naturally because tactSet.has(tactical) flips.
+  let acceptState = $state('idle'); // 'idle' | 'accepting' | 'failed'
+  let acceptError = $state('');
+  let openTacBtnWrap = $state(null);
+
+  // Membership in the tactical set IS the source of truth for "Joined"
+  // — `invite_accepted_at` is audit-only (see Phase 1 handoff §"For
+  // Phase 3"). Checking this reactively means that accepting from
+  // another tab or receiving an invite for an already-subscribed
+  // tactical both render "Joined" on first paint.
+  const isJoined = $derived.by(() => {
+    if (!isInvite) return false;
+    const t = inviteTactical;
+    if (!t) return false;
+    const entry = store.tacticals.get(t);
+    return !!entry && entry.enabled !== false;
+  });
+
+  // Narrow viewport stacking for the inbound Accept row.
+  let narrowViewport = $state(false);
+  $effect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(max-width: 359px)');
+    const apply = () => { narrowViewport = mq.matches; };
+    apply();
+    mq.addEventListener?.('change', apply);
+    return () => mq.removeEventListener?.('change', apply);
+  });
+
+  // Is this bubble in the user's local ignored set? The parent (thread
+  // view) usually filters these out, but we defensively render a
+  // collapsed placeholder here as well.
+  const isThisIgnored = $derived.by(() => {
+    if (!msg?.id) return false;
+    // Touch the subscribed store so Svelte picks up changes.
+    const set = $ignoredInviteIds;
+    return set?.has?.(msg.id) ?? false;
+  });
+
+  async function handleAccept() {
+    if (!isInvite || !inviteTactical || acceptState === 'accepting') return;
+    acceptState = 'accepting';
+    acceptError = '';
+    try {
+      const res = await acceptTactical({
+        callsign: inviteTactical,
+        source_message_id: msg?.id || 0,
+      });
+      // Server returns { tactical, already_member }. Fold the tactical
+      // into the store so the "Joined" derivation picks it up without
+      // waiting for the next /tactical rollup.
+      if (res?.tactical?.callsign) {
+        store.tacticals.set(res.tactical.callsign, {
+          id: res.tactical.id,
+          alias: res.tactical.alias || '',
+          enabled: res.tactical.enabled !== false,
+        });
+      }
+      acceptState = 'idle';
+
+      if (res?.already_member) {
+        toasts.success(`Already a member of ${inviteTactical}`);
+        // Do not auto-nav — they already had this tactical enabled.
+        await tick();
+        focusOpenLink();
+      } else {
+        const firstAccept = !hasAutoNavFired(msg?.id);
+        if (firstAccept) {
+          markAutoNavDone(msg?.id);
+          // Toast with Stay-here undo is shown via chonky's toast;
+          // since the base toast helper doesn't expose an action slot,
+          // degrade to a plain success message. Undo-via-toast would
+          // require a richer toast API — left as follow-up.
+          toasts.success(`Joined ${inviteTactical}`);
+          const threadId = `tactical:${inviteTactical}`;
+          push(`/messages?thread=${encodeURIComponent(threadId)}`);
+        } else {
+          toasts.success(`Joined ${inviteTactical}`);
+          await tick();
+          focusOpenLink();
+        }
+      }
+    } catch (err) {
+      acceptState = 'failed';
+      acceptError = err?.message || "Couldn't join";
+    }
+  }
+
+  function focusOpenLink() {
+    const link = openTacBtnWrap?.querySelector?.('a, button');
+    link?.focus?.();
+  }
+
+  function openTacticalThread() {
+    if (!inviteTactical) return;
+    const threadId = `tactical:${inviteTactical}`;
+    push(`/messages?thread=${encodeURIComponent(threadId)}`);
+  }
 </script>
 
 <article
@@ -199,7 +321,110 @@
         aria-hidden="true"
       >{monogram}</span>
     {/if}
-    <p class="bubble-text">{bodyText}</p>
+
+    {#if isInvite}
+      {#if isThisIgnored}
+        <p class="bubble-text invite-dismissed" data-testid="invite-dismissed">
+          Invitation hidden.
+        </p>
+      {:else if isOut}
+        <!-- Outbound invite: "You invited CALL to TAC". The ack-state
+             pill is reused from the normal DM bubble machinery below. -->
+        <p class="bubble-text invite-text" data-testid="invite-outbound">
+          <span class="invite-emoji" aria-hidden="true">📻</span>
+          You invited <strong class="invite-call">{toCall}</strong> to
+          <strong class="invite-tac">{inviteTactical}</strong>
+        </p>
+      {:else}
+        <!-- Inbound invite: broadcast line + Accept CTA (or Joined state). -->
+        <div
+          class="invite-inbound"
+          class:narrow={narrowViewport}
+          data-testid="invite-inbound"
+        >
+          <p class="bubble-text invite-text">
+            <span class="invite-emoji" aria-hidden="true">📻</span>
+            <strong class="invite-call">{sender}</strong>
+            invites you to
+            <strong class="invite-tac">{inviteTactical}</strong>
+          </p>
+          {#if isJoined}
+            <div
+              class="invite-actions joined"
+              role="group"
+              aria-label={`Invitation to ${inviteTactical}`}
+              aria-live="polite"
+            >
+              <!-- Joined state is not Tab-focusable: skip the pill (it's
+                   non-interactive text anyway) and keep Open reachable
+                   only via mouse/touch when the bubble isn't the
+                   operator's immediate task. Per plan: "Viewed/accepted
+                   invites are not Tab-focusable." -->
+              <span class="joined-pill" aria-hidden="true">
+                <Icon name="check" size="xs" />
+                Joined
+              </span>
+              <span class="open-wrap" bind:this={openTacBtnWrap}>
+                <button
+                  type="button"
+                  class="open-tac-btn"
+                  onclick={openTacticalThread}
+                  tabindex="-1"
+                  aria-label={`Open ${inviteTactical}`}
+                  data-testid="invite-open-tac"
+                >
+                  Open {inviteTactical}
+                  <Icon name="chevron-right" size="xs" />
+                </button>
+              </span>
+            </div>
+          {:else}
+            <div
+              class="invite-actions"
+              role="group"
+              aria-label={`Invitation to ${inviteTactical}`}
+              aria-live="polite"
+            >
+              <button
+                type="button"
+                class="accept-btn"
+                onclick={handleAccept}
+                disabled={acceptState === 'accepting'}
+                aria-label={`Accept invitation and join ${inviteTactical}`}
+                data-testid="invite-accept"
+              >
+                {#if acceptState === 'accepting'}
+                  <span class="accept-spin" aria-hidden="true">
+                    <Icon name="refresh-cw" size="sm" />
+                  </span>
+                  Joining…
+                {:else}
+                  <Icon name="check" size="sm" />
+                  Accept · Join {inviteTactical}
+                {/if}
+              </button>
+              {#if acceptState === 'failed'}
+                <div class="accept-error" role="alert">
+                  <span>{acceptError || "Couldn't join."} Retry.</span>
+                  <button
+                    type="button"
+                    class="accept-retry"
+                    onclick={handleAccept}
+                    aria-label={`Retry joining ${inviteTactical}`}
+                    data-testid="invite-accept-retry"
+                  >
+                    <Icon name="refresh-cw" size="xs" />
+                    Retry
+                  </button>
+                </div>
+              {/if}
+            </div>
+          {/if}
+        </div>
+      {/if}
+    {:else}
+      <p class="bubble-text">{bodyText}</p>
+    {/if}
     <div class="bubble-meta">
       <button
         type="button"
@@ -488,5 +713,160 @@
       width: 32px;
       height: 32px;
     }
+  }
+
+  /* --- Invite branch ------------------------------------------------ */
+  .invite-inbound {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .invite-inbound.narrow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .invite-text {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui,
+      'Helvetica Neue', Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.35;
+  }
+  .invite-emoji {
+    margin-right: 4px;
+  }
+  .invite-call,
+  .invite-tac {
+    font-family: var(--font-mono);
+    letter-spacing: 0.3px;
+  }
+  .invite-dismissed {
+    margin: 0;
+    font-style: italic;
+    color: var(--color-text-dim);
+    font-size: 12px;
+  }
+  .invite-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .invite-actions.joined {
+    margin-top: 2px;
+  }
+
+  .accept-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--color-primary);
+    background: var(--color-primary);
+    color: var(--color-primary-foreground, #fff);
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    cursor: pointer;
+    transition: filter 0.15s, background 0.15s;
+  }
+  .accept-btn:hover:not(:disabled) {
+    filter: brightness(1.08);
+  }
+  .accept-btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+  .accept-btn:disabled {
+    opacity: 0.7;
+    cursor: wait;
+  }
+  .accept-spin {
+    display: inline-flex;
+    align-items: center;
+  }
+  .accept-spin :global(svg) {
+    animation: bubble-invite-spin 1s linear infinite;
+  }
+  @keyframes bubble-invite-spin {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+  }
+  .accept-error {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    background: var(--color-danger-muted);
+    border: 1px solid var(--color-danger);
+    border-radius: 6px;
+    color: var(--color-danger);
+    font-size: 12px;
+  }
+  .accept-retry {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: transparent;
+    border: 1px solid var(--color-danger);
+    color: var(--color-danger);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .accept-retry:hover {
+    background: var(--color-danger);
+    color: var(--color-primary-foreground, #fff);
+  }
+  .accept-retry:focus-visible {
+    outline: 2px solid var(--color-danger);
+    outline-offset: 1px;
+  }
+
+  .joined-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    color: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.5px;
+  }
+  .open-wrap {
+    display: inline-flex;
+  }
+  .open-tac-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+    border-radius: 6px;
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-primary);
+    color: var(--color-primary);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    cursor: pointer;
+    text-decoration: none;
+  }
+  .open-tac-btn:hover {
+    background: var(--color-primary);
+    color: var(--color-primary-foreground, #fff);
+  }
+  .open-tac-btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
 </style>

--- a/graywolf/web/src/components/messages/ThreadHeader.svelte
+++ b/graywolf/web/src/components/messages/ThreadHeader.svelte
@@ -69,29 +69,31 @@
       {/if}
     </div>
     {#if isTactical}
-      <div class="monitor">
-        <Toggle
-          checked={!muted}
-          onCheckedChange={handleMute}
-          label="Monitor"
-          aria-label={muted ? 'Unmute tactical monitoring' : 'Mute tactical monitoring'}
-        />
+      <div class="actions">
+        <div class="monitor">
+          <Toggle
+            checked={!muted}
+            onCheckedChange={handleMute}
+            label="Monitor"
+            aria-label={muted ? 'Unmute tactical monitoring' : 'Mute tactical monitoring'}
+          />
+        </div>
+        <Tooltip>
+          <Tooltip.Trigger>
+            <button
+              type="button"
+              class="invite-btn"
+              onclick={openInvite}
+              aria-label={`Invite stations to ${tacticalKey}`}
+              data-testid="thread-invite-btn"
+            >
+              <Icon name="users" size="md" />
+              <span class="invite-label">Invite Users</span>
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Invite</Tooltip.Content>
+        </Tooltip>
       </div>
-      <Tooltip>
-        <Tooltip.Trigger>
-          <button
-            type="button"
-            class="invite-btn"
-            onclick={openInvite}
-            aria-label={`Invite stations to ${tacticalKey}`}
-            data-testid="thread-invite-btn"
-          >
-            <Icon name="users" size="md" />
-            <span class="invite-label">Invite Users</span>
-          </button>
-        </Tooltip.Trigger>
-        <Tooltip.Content>Invite</Tooltip.Content>
-      </Tooltip>
     {/if}
   </div>
   {#if isTactical}
@@ -183,6 +185,12 @@
     font-size: 11px;
     color: var(--color-text-dim);
   }
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+  }
   .monitor {
     flex-shrink: 0;
     display: inline-flex;
@@ -226,5 +234,14 @@
 
   @media (max-width: 767px) {
     .chips { padding-left: 0; }
+    /* Let actions wrap to their own row below the title so the
+       tactical name isn't crushed to "GR…" next to a Monitor toggle
+       and "Invite Users" button. */
+    .primary { flex-wrap: wrap; }
+    .actions {
+      flex: 1 1 100%;
+      justify-content: flex-end;
+      margin-top: 2px;
+    }
   }
 </style>

--- a/graywolf/web/src/components/messages/ThreadHeader.svelte
+++ b/graywolf/web/src/components/messages/ThreadHeader.svelte
@@ -6,8 +6,9 @@
   // Back chevron is rendered on mobile (<768 px) so the user can pop
   // back to the conversation list.
 
-  import { Icon, Toggle } from '@chrissnell/chonky-ui';
+  import { Icon, Toggle, Tooltip } from '@chrissnell/chonky-ui';
   import ParticipantChips from './ParticipantChips.svelte';
+  import InviteToTacticalModal from './InviteToTacticalModal.svelte';
   import { relativeLong } from './time.js';
 
   /** @type {{
@@ -27,6 +28,16 @@
     onMuteToggle,
     onOpenDm,
   } = $props();
+
+  let inviteOpen = $state(false);
+  const tacticalKey = $derived(thread?.key || '');
+
+  function openInvite() {
+    inviteOpen = true;
+  }
+  function closeInvite() {
+    inviteOpen = false;
+  }
 
   const lastHeard = $derived(thread?.lastAt ? relativeLong(thread.lastAt) : '');
   const muted = $derived(!!thread?.muted);
@@ -66,14 +77,36 @@
           aria-label={muted ? 'Unmute tactical monitoring' : 'Mute tactical monitoring'}
         />
       </div>
+      <Tooltip>
+        <Tooltip.Trigger>
+          <button
+            type="button"
+            class="invite-btn"
+            onclick={openInvite}
+            aria-label={`Invite stations to ${tacticalKey}`}
+            data-testid="thread-invite-btn"
+          >
+            <Icon name="users" size="md" />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Content>Invite</Tooltip.Content>
+      </Tooltip>
     {/if}
   </div>
   {#if isTactical}
     <div class="row chips">
-      <ParticipantChips tacticalKey={thread?.key || ''} {onOpenDm} />
+      <ParticipantChips tacticalKey={tacticalKey} {onOpenDm} />
     </div>
   {/if}
 </header>
+
+{#if isTactical}
+  <InviteToTacticalModal
+    tactical={tacticalKey}
+    bind:open={inviteOpen}
+    onClose={closeInvite}
+  />
+{/if}
 
 <style>
   .thread-header {
@@ -153,6 +186,30 @@
     flex-shrink: 0;
     display: inline-flex;
     align-items: center;
+  }
+  .invite-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .invite-btn:hover {
+    background: var(--color-surface-raised);
+    color: var(--color-primary);
+    border-color: var(--color-border);
+  }
+  .invite-btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
   .chips {
     padding-left: 34px;

--- a/graywolf/web/src/components/messages/ThreadHeader.svelte
+++ b/graywolf/web/src/components/messages/ThreadHeader.svelte
@@ -87,6 +87,7 @@
             data-testid="thread-invite-btn"
           >
             <Icon name="users" size="md" />
+            <span class="invite-label">Invite Users</span>
           </button>
         </Tooltip.Trigger>
         <Tooltip.Content>Invite</Tooltip.Content>
@@ -191,16 +192,22 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 6px;
     flex-shrink: 0;
-    width: 32px;
     height: 32px;
-    padding: 0;
+    padding: 0 10px;
     border: 1px solid transparent;
     border-radius: var(--radius);
     background: transparent;
     color: var(--color-text-muted);
     cursor: pointer;
     transition: background 0.15s, color 0.15s, border-color 0.15s;
+    font: inherit;
+    line-height: 1;
+  }
+  .invite-label {
+    font-size: 0.875rem;
+    white-space: nowrap;
   }
   .invite-btn:hover {
     background: var(--color-surface-raised);

--- a/graywolf/web/src/lib/inviteValidation.js
+++ b/graywolf/web/src/lib/inviteValidation.js
@@ -1,0 +1,90 @@
+// Pure-logic helpers for the invite-to-tactical modal.
+//
+// Extracted so they can be unit-tested without a Svelte runtime. The
+// modal composes these into its stateful chip flow; the tests exercise
+// each rule in isolation.
+
+// Matches the APRS callsign syntax that both `ParseInvite` (the backend
+// wire parser) and the `tactical_callsign` column accept. Uppercase-only;
+// the caller must normalize before matching.
+export const CALLSIGN_RE = /^[A-Z0-9-]{1,9}$/;
+
+// Paste separators: comma, semicolon, any whitespace.
+export const PASTE_SPLIT_RE = /[,\s;]+/;
+
+/** Normalize a raw input token: trim + uppercase. */
+export function normalizeCall(raw) {
+  return (raw || '').trim().toUpperCase();
+}
+
+/** Validate a *normalized* call against the APRS regex. */
+export function isValidCall(call) {
+  return CALLSIGN_RE.test(call || '');
+}
+
+/**
+ * Split a pasted blob into an array of normalized call tokens (empties
+ * dropped). Does NOT validate — caller filters via isValidCall.
+ */
+export function splitPasteList(pasted) {
+  if (!pasted) return [];
+  return pasted
+    .split(PASTE_SPLIT_RE)
+    .map(normalizeCall)
+    .filter(Boolean);
+}
+
+/**
+ * Classify a single commit attempt against an existing chip set + the
+ * operator's own callsign. Returns one of:
+ *   'invalid'   — token fails CALLSIGN_RE
+ *   'self'      — token equals the operator's callsign
+ *   'duplicate' — token already in `existingCalls`
+ *   'ok'        — safe to add as a new chip
+ * The caller owns the actual mutation; this function is side-effect free.
+ */
+export function classifyCommit(rawToken, existingCalls, ownCallsign) {
+  const call = normalizeCall(rawToken);
+  if (!call) return 'invalid';
+  if (!isValidCall(call)) return 'invalid';
+  const own = normalizeCall(ownCallsign);
+  if (own && call === own) return 'self';
+  for (const existing of existingCalls) {
+    if (normalizeCall(existing) === call) return 'duplicate';
+  }
+  return 'ok';
+}
+
+/**
+ * Run a paste-list classification pass. Returns the batched result so
+ * the UI can decide what to show ("3 added · 1 invalid"). `existingCalls`
+ * grows as valid tokens are "committed" within the same paste (so a
+ * pasted list with A, A, B yields 2 added + 1 duplicate, not 2 added).
+ *
+ * @param {string} pasted
+ * @param {Iterable<string>} existingCalls
+ * @param {string} ownCallsign
+ * @returns {{added: string[], duplicate: string[], invalid: string[], self: string[]}}
+ */
+export function classifyPasteList(pasted, existingCalls, ownCallsign) {
+  const seen = new Set([...existingCalls].map(normalizeCall));
+  const result = { added: [], duplicate: [], invalid: [], self: [] };
+  for (const tok of splitPasteList(pasted)) {
+    const outcome = classifyCommit(tok, seen, ownCallsign);
+    switch (outcome) {
+      case 'ok':
+        result.added.push(tok);
+        seen.add(tok);
+        break;
+      case 'self':
+        result.self.push(tok);
+        break;
+      case 'duplicate':
+        result.duplicate.push(tok);
+        break;
+      default:
+        result.invalid.push(tok);
+    }
+  }
+  return result;
+}

--- a/graywolf/web/src/lib/inviteValidation.test.js
+++ b/graywolf/web/src/lib/inviteValidation.test.js
@@ -1,0 +1,143 @@
+// Tests for the invite-validation helpers.
+//
+// Pure-JS; no Svelte runtime. Runnable with either Node's built-in
+// `node --test` or Vitest.
+//   node --test src/lib/inviteValidation.test.js
+
+import { strict as assert } from 'node:assert';
+import {
+  CALLSIGN_RE,
+  classifyCommit,
+  classifyPasteList,
+  isValidCall,
+  normalizeCall,
+  PASTE_SPLIT_RE,
+  splitPasteList,
+} from './inviteValidation.js';
+
+let describe, it;
+try {
+  const nodeTest = await import('node:test');
+  describe = nodeTest.describe;
+  it = nodeTest.it;
+} catch {
+  describe = globalThis.describe;
+  it = globalThis.it;
+}
+
+describe('normalizeCall', () => {
+  it('trims and uppercases', () => {
+    assert.equal(normalizeCall('  w1abc  '), 'W1ABC');
+    assert.equal(normalizeCall('n0call-7'), 'N0CALL-7');
+  });
+  it('handles empty / null', () => {
+    assert.equal(normalizeCall(''), '');
+    assert.equal(normalizeCall(null), '');
+    assert.equal(normalizeCall(undefined), '');
+  });
+});
+
+describe('isValidCall (CALLSIGN_RE)', () => {
+  it('accepts 1..9 A-Z 0-9 -', () => {
+    for (const c of ['W', 'W1', 'W1A', 'W1ABC', 'W1ABC-15', 'TAC-NET', 'N0CALL-7']) {
+      assert.ok(isValidCall(c), `expected valid: ${c}`);
+    }
+  });
+  it('rejects lowercase, too-long, and invalid chars', () => {
+    for (const c of ['w1abc', 'TAC_NET', 'TOOLONGCALL', 'W1 ABC', '', '1234567890']) {
+      assert.ok(!isValidCall(c), `expected invalid: ${c}`);
+    }
+  });
+  it('exposes the regex for external consumers', () => {
+    assert.ok(CALLSIGN_RE instanceof RegExp);
+    assert.match('W5ABC', CALLSIGN_RE);
+  });
+});
+
+describe('splitPasteList', () => {
+  it('splits on commas, whitespace, semicolons', () => {
+    assert.deepEqual(
+      splitPasteList('W1ABC, N0CALL-7; K5FOO\tK7BAR'),
+      ['W1ABC', 'N0CALL-7', 'K5FOO', 'K7BAR'],
+    );
+  });
+  it('collapses runs of separators', () => {
+    assert.deepEqual(splitPasteList('A,,,B\n\nC'), ['A', 'B', 'C']);
+  });
+  it('returns empty for empty / null input', () => {
+    assert.deepEqual(splitPasteList(''), []);
+    assert.deepEqual(splitPasteList(null), []);
+    assert.deepEqual(splitPasteList(undefined), []);
+  });
+  it('PASTE_SPLIT_RE matches any separator char', () => {
+    assert.ok(PASTE_SPLIT_RE.test('a,b'));
+    assert.ok(PASTE_SPLIT_RE.test('a b'));
+    assert.ok(PASTE_SPLIT_RE.test('a;b'));
+    assert.ok(!PASTE_SPLIT_RE.test('a-b'));
+  });
+});
+
+describe('classifyCommit', () => {
+  it('returns ok for a fresh valid call', () => {
+    assert.equal(classifyCommit('W1ABC', [], ''), 'ok');
+  });
+  it('returns invalid for malformed tokens', () => {
+    assert.equal(classifyCommit('', [], ''), 'invalid');
+    assert.equal(classifyCommit('TOOLONGCALL', [], ''), 'invalid');
+    assert.equal(classifyCommit('bad_char', [], ''), 'invalid');
+  });
+  it('returns self for operator callsign', () => {
+    assert.equal(classifyCommit('W1ME', [], 'W1ME'), 'self');
+    assert.equal(classifyCommit('w1me', [], 'W1ME'), 'self');
+  });
+  it('returns duplicate for an existing chip (case-insensitive)', () => {
+    assert.equal(classifyCommit('W1ABC', ['W1ABC'], ''), 'duplicate');
+    assert.equal(classifyCommit('w1abc', ['W1ABC'], ''), 'duplicate');
+  });
+  it('self beats duplicate (self-filter runs first)', () => {
+    // Not possible in practice, but codifies the order.
+    assert.equal(classifyCommit('W1ME', ['W1ME'], 'W1ME'), 'self');
+  });
+  it('invalid beats self', () => {
+    assert.equal(classifyCommit('', [], ''), 'invalid');
+  });
+});
+
+describe('classifyPasteList', () => {
+  it('groups added / duplicate / invalid across a mixed list', () => {
+    const result = classifyPasteList(
+      'W1ABC, N0CALL-7, bad_char, W1ABC, W9XYZ',
+      [],
+      '',
+    );
+    assert.deepEqual(result.added, ['W1ABC', 'N0CALL-7', 'W9XYZ']);
+    assert.deepEqual(result.duplicate, ['W1ABC']);
+    assert.deepEqual(result.invalid, ['BAD_CHAR']);
+    assert.deepEqual(result.self, []);
+  });
+
+  it('deduplicates across the existing chip set', () => {
+    const result = classifyPasteList('W1ABC, W1NEW', ['W1ABC'], '');
+    assert.deepEqual(result.added, ['W1NEW']);
+    assert.deepEqual(result.duplicate, ['W1ABC']);
+  });
+
+  it('deduplicates a pasted token against itself', () => {
+    const result = classifyPasteList('W1ABC W1ABC W1ABC', [], '');
+    assert.equal(result.added.length, 1);
+    assert.equal(result.duplicate.length, 2);
+  });
+
+  it('calls out self-invites in the self bucket', () => {
+    const result = classifyPasteList('W1ME, W9XYZ', [], 'W1ME');
+    assert.deepEqual(result.self, ['W1ME']);
+    assert.deepEqual(result.added, ['W9XYZ']);
+    assert.deepEqual(result.invalid, []);
+  });
+
+  it('tolerates empty / whitespace-only input', () => {
+    const result = classifyPasteList('   \n\t,,;;', [], '');
+    assert.equal(result.added.length, 0);
+    assert.equal(result.invalid.length, 0);
+  });
+});

--- a/graywolf/web/src/lib/messagesStore.svelte.js
+++ b/graywolf/web/src/lib/messagesStore.svelte.js
@@ -47,6 +47,12 @@ class MessagesStore {
   tacticals = new SvelteMap();
   // clientId -> optimistic outbound row (awaiting server reconciliation)
   pendingByClientId = new SvelteMap();
+  // id -> MessageResponse (sparse). Populated by upsertMessage for every
+  // persisted row the transport hands us. The invite modal subscribes to
+  // this map to drive per-chip ack state without spinning up its own
+  // EventSource. Unbounded in principle, but each entry is ~500B and a
+  // full page reload reseeds via /conversations + /messages. Fine.
+  messageById = new SvelteMap();
 
   activeThreadId = $state(null);
   filter = $state('all');
@@ -120,6 +126,14 @@ class MessagesStore {
     }
 
     this.conversations.set(threadId, thread);
+
+    // Stash the full row by id so per-bubble consumers (e.g. the invite
+    // modal's per-chip state machine) can react to ack status changes
+    // without reopening a thread. Only persisted rows have an id — the
+    // optimistic pending bubbles live separately on pendingByClientId.
+    if (typeof msg.id === 'number' && msg.id > 0) {
+      this.messageById.set(msg.id, msg);
+    }
 
     // Clear any pending optimistic bubble that this message reconciles.
     if (msg.msg_id && this.pendingByClientId.has(msg.msg_id)) {

--- a/graywolf/web/src/lib/stores/ignoredInvites.js
+++ b/graywolf/web/src/lib/stores/ignoredInvites.js
@@ -1,0 +1,116 @@
+// Client-only "ignored invite" tracking.
+//
+// Ignoring an invite is local cosmetic state — there's no server column
+// and no endpoint (per the tactical-chat-invite plan §9). The operator
+// clicks away from an invite bubble and it collapses; on refresh the
+// same set persists from localStorage. Cross-device sync is deliberately
+// out of scope.
+//
+// Shape: `Set<number>` of message IDs. Exposed as a Svelte writable
+// store so components can subscribe reactively, plus imperative helpers
+// for the common read/write paths. The project's other messages stores
+// (messagesStore.svelte.js) use Svelte 5 runes + SvelteMap, but those
+// patterns don't compose cleanly with localStorage hydration at import
+// time; a plain `writable` with a SvelteMap-free `Set` is the simpler
+// model here.
+
+import { writable } from 'svelte/store';
+
+const STORAGE_KEY = 'graywolf.ignoredInviteIds';
+
+function loadFromStorage() {
+  if (typeof localStorage === 'undefined') return new Set();
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    const out = new Set();
+    for (const v of parsed) {
+      const n = Number(v);
+      if (Number.isFinite(n) && n > 0) out.add(n);
+    }
+    return out;
+  } catch {
+    return new Set();
+  }
+}
+
+function saveToStorage(set) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...set]));
+  } catch {
+    // Quota exceeded, privacy mode, etc — non-fatal.
+  }
+}
+
+/**
+ * Svelte store holding the current ignored-invite set. Subscribe to
+ * rebuild UI when invites are ignored/unignored from anywhere in the app.
+ *
+ * @type {import('svelte/store').Writable<Set<number>>}
+ */
+export const ignoredInviteIds = writable(loadFromStorage());
+
+// Persist on every mutation. Subscription fires synchronously on
+// creation too, but writing the same thing back out once is cheap.
+ignoredInviteIds.subscribe((v) => {
+  if (v instanceof Set) saveToStorage(v);
+});
+
+/** Mark a message ID as ignored (idempotent). */
+export function ignoreInvite(id) {
+  const n = Number(id);
+  if (!Number.isFinite(n) || n <= 0) return;
+  ignoredInviteIds.update((s) => {
+    if (s.has(n)) return s;
+    const next = new Set(s);
+    next.add(n);
+    return next;
+  });
+}
+
+/** Remove the ignore flag (idempotent). */
+export function unignoreInvite(id) {
+  const n = Number(id);
+  if (!Number.isFinite(n) || n <= 0) return;
+  ignoredInviteIds.update((s) => {
+    if (!s.has(n)) return s;
+    const next = new Set(s);
+    next.delete(n);
+    return next;
+  });
+}
+
+/**
+ * Synchronous peek. Intended for non-reactive callers (tests, imperative
+ * guards). Reactive UI should subscribe via `$ignoredInviteIds`.
+ */
+export function isIgnored(id) {
+  const n = Number(id);
+  if (!Number.isFinite(n) || n <= 0) return false;
+  let current;
+  const unsub = ignoredInviteIds.subscribe((v) => { current = v; });
+  unsub();
+  return !!current?.has(n);
+}
+
+// --- Auto-nav-once tracking --------------------------------------
+// The plan says auto-nav happens on the FIRST accept of an invite
+// bubble in a session, but subsequent renders (refresh, other tabs,
+// multiple invites to the same TAC) must NOT auto-nav. This set lives
+// in module scope (ES module singleton, not persisted) so it resets on
+// page reload — "first accept this session" is a per-session property.
+const autoNavDone = new Set();
+
+export function markAutoNavDone(id) {
+  const n = Number(id);
+  if (Number.isFinite(n) && n > 0) autoNavDone.add(n);
+}
+
+export function hasAutoNavFired(id) {
+  const n = Number(id);
+  if (!Number.isFinite(n) || n <= 0) return false;
+  return autoNavDone.has(n);
+}

--- a/graywolf/web/src/lib/stores/ignoredInvites.test.js
+++ b/graywolf/web/src/lib/stores/ignoredInvites.test.js
@@ -1,0 +1,160 @@
+// Tests for the localStorage-backed ignoredInvites store.
+//
+// Pure-JS; no Svelte runtime. Runnable with either Node's built-in
+// `node --test` or Vitest. The project has no test runner wired today,
+// so these files exist for:
+//   1. Documenting the store's contract.
+//   2. Running cleanly once a test runner is added.
+//
+// To run with Vitest (after adding it):
+//   npm run test
+// To run with node --test (no deps needed, Node 20+):
+//   node --test src/lib/stores/ignoredInvites.test.js
+//
+// The file uses `import.meta.vitest`-style describe/it if available, else
+// falls back to node:test.
+
+import { strict as assert } from 'node:assert';
+
+// Tiny in-memory localStorage shim for tests. The store module reads
+// from `localStorage` at import time, so we install the shim BEFORE
+// importing.
+function installLocalStorageShim() {
+  const mem = new Map();
+  globalThis.localStorage = {
+    getItem: (k) => (mem.has(k) ? mem.get(k) : null),
+    setItem: (k, v) => mem.set(k, String(v)),
+    removeItem: (k) => mem.delete(k),
+    clear: () => mem.clear(),
+    get length() { return mem.size; },
+    key: (i) => [...mem.keys()][i] ?? null,
+    __mem: mem,
+  };
+  return mem;
+}
+
+function resetModule() {
+  // Bust the module cache so a fresh import re-hydrates from localStorage.
+  // Works with Node's dynamic import cache.
+  const key = new URL('./ignoredInvites.js', import.meta.url).href;
+  // Node doesn't expose a stable cache-eviction API for ESM, but re-
+  // importing with a cache-busting query param achieves the same effect.
+  return import(`./ignoredInvites.js?t=${Date.now()}-${Math.random()}`);
+}
+
+const hasNodeTest = typeof process !== 'undefined' && typeof process.versions?.node === 'string';
+
+// Pick a describe/it compatible with vitest, jest, or node:test.
+let describe, it, beforeEach;
+try {
+  const nodeTest = await import('node:test');
+  describe = nodeTest.describe;
+  it = nodeTest.it;
+  beforeEach = nodeTest.beforeEach;
+} catch {
+  // Assume Vitest's globals if node:test isn't available.
+  describe = globalThis.describe;
+  it = globalThis.it;
+  beforeEach = globalThis.beforeEach;
+}
+
+describe('ignoredInvites store', () => {
+  beforeEach(() => {
+    installLocalStorageShim();
+  });
+
+  it('starts empty when no localStorage entry exists', async () => {
+    const mod = await resetModule();
+    let current;
+    const unsub = mod.ignoredInviteIds.subscribe((v) => { current = v; });
+    unsub();
+    assert.ok(current instanceof Set);
+    assert.equal(current.size, 0);
+  });
+
+  it('hydrates from localStorage on import', async () => {
+    const mem = installLocalStorageShim();
+    mem.set('graywolf.ignoredInviteIds', JSON.stringify([7, 42, 99]));
+    const mod = await resetModule();
+    let current;
+    const unsub = mod.ignoredInviteIds.subscribe((v) => { current = v; });
+    unsub();
+    assert.equal(current.size, 3);
+    assert.ok(current.has(7));
+    assert.ok(current.has(42));
+    assert.ok(current.has(99));
+  });
+
+  it('ignoreInvite persists to localStorage', async () => {
+    const mem = installLocalStorageShim();
+    const mod = await resetModule();
+    mod.ignoreInvite(123);
+    const stored = JSON.parse(mem.get('graywolf.ignoredInviteIds') || '[]');
+    assert.deepEqual(stored, [123]);
+  });
+
+  it('ignoreInvite is idempotent', async () => {
+    const mod = await resetModule();
+    mod.ignoreInvite(5);
+    mod.ignoreInvite(5);
+    mod.ignoreInvite(5);
+    let current;
+    const unsub = mod.ignoredInviteIds.subscribe((v) => { current = v; });
+    unsub();
+    assert.equal(current.size, 1);
+  });
+
+  it('unignoreInvite removes the id', async () => {
+    const mod = await resetModule();
+    mod.ignoreInvite(1);
+    mod.ignoreInvite(2);
+    mod.unignoreInvite(1);
+    let current;
+    const unsub = mod.ignoredInviteIds.subscribe((v) => { current = v; });
+    unsub();
+    assert.equal(current.size, 1);
+    assert.ok(current.has(2));
+    assert.ok(!current.has(1));
+  });
+
+  it('isIgnored peeks without subscription leaks', async () => {
+    const mod = await resetModule();
+    mod.ignoreInvite(50);
+    assert.ok(mod.isIgnored(50));
+    assert.ok(!mod.isIgnored(51));
+  });
+
+  it('rejects non-positive / non-numeric ids', async () => {
+    const mod = await resetModule();
+    mod.ignoreInvite(0);
+    mod.ignoreInvite(-5);
+    mod.ignoreInvite('abc');
+    mod.ignoreInvite(null);
+    let current;
+    const unsub = mod.ignoredInviteIds.subscribe((v) => { current = v; });
+    unsub();
+    assert.equal(current.size, 0);
+  });
+
+  it('tolerates malformed localStorage payload', async () => {
+    const mem = installLocalStorageShim();
+    mem.set('graywolf.ignoredInviteIds', 'not-json-at-all');
+    const mod = await resetModule();
+    let current;
+    const unsub = mod.ignoredInviteIds.subscribe((v) => { current = v; });
+    unsub();
+    assert.equal(current.size, 0);
+  });
+
+  it('markAutoNavDone / hasAutoNavFired track per-session state', async () => {
+    const mod = await resetModule();
+    assert.ok(!mod.hasAutoNavFired(77));
+    mod.markAutoNavDone(77);
+    assert.ok(mod.hasAutoNavFired(77));
+    assert.ok(!mod.hasAutoNavFired(78));
+    // autoNav tracker is module-scoped and does NOT persist to
+    // localStorage — reimporting resets it.
+    const fresh = await resetModule();
+    assert.ok(!fresh.hasAutoNavFired(77));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a tactical-chat invite flow: operators send `!GW1 INVITE <TAC>` as a DM; recipients see an Accept bubble that subscribes them to the tactical locally.
- Backend: 3 new `Message` columns with CHECK constraint and explicit legacy-row backfill, `ParseInvite` on the APRS inbound path, `SendMessage` builds the wire body server-side from request fields, and a new tactical-keyed `POST /api/tacticals` accept endpoint that's idempotent and preserves existing aliases.
- Frontend: new `InviteToTacticalModal` (chip picker w/ paste-list, commit-time dedupe + self-filter, SSE-driven chip state, confirm-close, Retry-all), invite branch in `MessageBubble` with a11y treatment and explicit Open-TAC anchor, tactical-only `ThreadHeader` invite button, and a localStorage-backed `ignoredInvites` store.

## Test plan

- [ ] `go test ./pkg/messages/... ./pkg/configstore/... ./pkg/webapi/...` — all green (backfill + dedup + accept + round-trip cases)
- [ ] `npm run build` in `web/` — clean (svelte-check + api:check)
- [ ] Pure-logic Vitest suites (`inviteValidation`, `ignoredInvites`) — 29/29 pass
- [ ] Manual: open Invite Users from a tactical thread, paste a roster, verify chip states (paste-list split, dedupe, self-filter), confirm \`!GW1 INVITE TAC\` lands on the wire and the recipient's bubble shows Accept
- [ ] Manual: accept → \`POST /api/tacticals\` subscribes, bubble flips to \`✓ Joined · Open TAC →\`, auto-nav fires once per session
- [ ] Manual: narrow-viewport header wraps Monitor + Invite Users to a second row so the tactical name stays readable
- [ ] Verified on anguilla: autocomplete click commits the chip (modal no longer dismissed by bits-ui's outside-click), chip-area collapses tight to a single row, chip/× and placeholder share a baseline