### PR TITLE
fix(app): derive tile-cache-dir from --config when not set (systemd unblock)

### DIFF
--- a/docs/handbook/history-database.html
+++ b/docs/handbook/history-database.html
@@ -134,7 +134,7 @@
 
     <pre><code>[Service]
 ExecStart=
-ExecStart=/usr/bin/graywolf -config /var/lib/graywolf/graywolf.db -history-db /run/graywolf/history.db -modem /usr/bin/graywolf-modem -http 0.0.0.0:8080
+ExecStart=/usr/bin/graywolf -config /var/lib/graywolf/graywolf.db -history-db /run/graywolf/history.db -tile-cache-dir /var/lib/graywolf/tiles -modem /usr/bin/graywolf-modem -http 0.0.0.0:8080
 RuntimeDirectory=graywolf
 RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes</code></pre>

--- a/graywolf/pkg/app/flags.go
+++ b/graywolf/pkg/app/flags.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 // ParseFlags parses the graywolf command-line flags (everything after
@@ -58,9 +59,30 @@ func parseFlagsTo(args []string, w io.Writer) (Config, error) {
 	if leftover := fs.Args(); len(leftover) > 0 {
 		return Config{}, fmt.Errorf("unexpected positional arguments: %v", leftover)
 	}
+	// Derive tile-cache-dir from --config's parent dir when --config was
+	// supplied but --tile-cache-dir was not. Avoids the "./tiles" CWD-
+	// relative trap on systemd installs (CWD is "/", read-only). Operators
+	// using --config /var/lib/graywolf/graywolf.db get
+	// /var/lib/graywolf/tiles automatically.
+	if !flagWasSet(fs, "tile-cache-dir") && flagWasSet(fs, "config") {
+		cfg.TileCacheDir = filepath.Join(filepath.Dir(cfg.DBPath), "tiles")
+	}
 	if err := cfg.Validate(); err != nil {
 		return Config{}, err
 	}
 	return cfg, nil
+}
+
+// flagWasSet reports whether the named flag was explicitly set on the
+// command line. fs.Visit only iterates flags actually passed by the
+// user, so a flag inheriting its default value is not visited.
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	set := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			set = true
+		}
+	})
+	return set
 }
 

--- a/graywolf/pkg/app/flags_test.go
+++ b/graywolf/pkg/app/flags_test.go
@@ -86,6 +86,38 @@ func TestParseFlags_TileCacheDirOverride(t *testing.T) {
 	}
 }
 
+// TestParseFlags_TileCacheDirDerivedFromConfig pins the systemd-friendly
+// behavior: when the operator passes -config to relocate the SQLite DB,
+// the tile cache co-locates next to it instead of inheriting the
+// CWD-relative ./tiles default (which fails under systemd where CWD
+// is /, read-only).
+func TestParseFlags_TileCacheDirDerivedFromConfig(t *testing.T) {
+	cfg, err := ParseFlags([]string{"-config", "/var/lib/graywolf/graywolf.db"})
+	if err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	want := "/var/lib/graywolf/tiles"
+	if cfg.TileCacheDir != want {
+		t.Errorf("TileCacheDir: got %q, want %q", cfg.TileCacheDir, want)
+	}
+}
+
+// TestParseFlags_TileCacheDirExplicitWinsOverConfig confirms an explicit
+// -tile-cache-dir flag is honored even when -config is also set, so an
+// operator who deliberately wants tiles elsewhere keeps that ability.
+func TestParseFlags_TileCacheDirExplicitWinsOverConfig(t *testing.T) {
+	cfg, err := ParseFlags([]string{
+		"-config", "/var/lib/graywolf/graywolf.db",
+		"-tile-cache-dir", "/elsewhere/tiles",
+	})
+	if err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if cfg.TileCacheDir != "/elsewhere/tiles" {
+		t.Errorf("TileCacheDir: got %q, want %q", cfg.TileCacheDir, "/elsewhere/tiles")
+	}
+}
+
 func TestParseFlagsErrors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/packaging/aur/graywolf-aprs.service
+++ b/packaging/aur/graywolf-aprs.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/graywolf -config /var/lib/graywolf-aprs/graywolf.db -history-db /var/lib/graywolf-aprs/graywolf-history.db -modem /usr/bin/graywolf-modem -http 0.0.0.0:8080
+ExecStart=/usr/bin/graywolf -config /var/lib/graywolf-aprs/graywolf.db -history-db /var/lib/graywolf-aprs/graywolf-history.db -tile-cache-dir /var/lib/graywolf-aprs/tiles -modem /usr/bin/graywolf-modem -http 0.0.0.0:8080
 Restart=on-failure
 RestartSec=5
 

--- a/packaging/nsis/RUNNING-AS-A-SERVICE.md
+++ b/packaging/nsis/RUNNING-AS-A-SERVICE.md
@@ -20,6 +20,7 @@ choco install nssm
 nssm install Graywolf "C:\Program Files\Graywolf\graywolf.exe" `
   -config "C:\ProgramData\Graywolf\graywolf.db" `
   -history-db "C:\ProgramData\Graywolf\graywolf-history.db" `
+  -tile-cache-dir "C:\ProgramData\Graywolf\tiles" `
   -modem "C:\Program Files\Graywolf\graywolf-modem.exe" `
   -http 127.0.0.1:8080
 
@@ -36,7 +37,7 @@ policy on its own.
 
 ```powershell
 sc.exe create Graywolf `
-  binPath= "\"C:\Program Files\Graywolf\graywolf.exe\" -config \"C:\ProgramData\Graywolf\graywolf.db\" -history-db \"C:\ProgramData\Graywolf\graywolf-history.db\" -modem \"C:\Program Files\Graywolf\graywolf-modem.exe\" -http 127.0.0.1:8080" `
+  binPath= "\"C:\Program Files\Graywolf\graywolf.exe\" -config \"C:\ProgramData\Graywolf\graywolf.db\" -history-db \"C:\ProgramData\Graywolf\graywolf-history.db\" -tile-cache-dir \"C:\ProgramData\Graywolf\tiles\" -modem \"C:\Program Files\Graywolf\graywolf-modem.exe\" -http 127.0.0.1:8080" `
   start= auto `
   DisplayName= "Graywolf APRS"
 

--- a/packaging/systemd/graywolf.service
+++ b/packaging/systemd/graywolf.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/graywolf -config /var/lib/graywolf/graywolf.db -history-db /var/lib/graywolf/graywolf-history.db -modem /usr/bin/graywolf-modem -http 0.0.0.0:8080
+ExecStart=/usr/bin/graywolf -config /var/lib/graywolf/graywolf.db -history-db /var/lib/graywolf/graywolf-history.db -tile-cache-dir /var/lib/graywolf/tiles -modem /usr/bin/graywolf-modem -http 0.0.0.0:8080
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary

Hotfix: graywolf fails to start under systemd with `mkdir ./tiles: read-only file system`. The `--tile-cache-dir` flag defaulted to `./tiles` (CWD-relative); systemd runs services with CWD `/`, which is read-only on most distros. This blocks the service in a restart loop.

The fix derives `--tile-cache-dir` from `--config`'s parent directory when `--config` is supplied but `--tile-cache-dir` is not. Operators with `-config /var/lib/graywolf/graywolf.db` automatically get tiles at `/var/lib/graywolf/tiles`. Explicit `--tile-cache-dir` still wins when supplied. Dev mode (no flags) keeps the original `./tiles` default.

## Test plan

- [x] New unit tests cover (a) derived path when only --config is set, (b) explicit --tile-cache-dir wins over the derivation, plus the existing default + override tests
- [ ] On the affected box: pull main, restart the systemd unit. Confirm `/var/lib/graywolf/tiles` is created and the service stays up.