### PR TITLE
fix(maps): align Register button and switch to chonky Radio

### DIFF
--- a/graywolf/web/src/lib/maps/styles.css
+++ b/graywolf/web/src/lib/maps/styles.css
@@ -40,6 +40,23 @@
   }
 }
 
+/* maps-row-aligned: variant of .maps-row used by the registration form
+ * where the row holds a single-line input + single-line button. Stretches
+ * children to equal heights so the chonky Button and Input visually align. */
+@media (min-width: 600px) {
+  .maps-row-aligned {
+    align-items: stretch;
+  }
+}
+
+/* Wrap div around the callsign Input grows to fill the row on desktop;
+ * the chonky button keeps its natural width. min-width: 0 prevents the
+ * input from overflowing its container in flex layouts. */
+.maps-callsign-input {
+  flex: 1;
+  min-width: 0;
+}
+
 :global(.maps-cta) {
   /* Primary CTA spans the row on mobile, sits inline on tablet+. */
   width: 100%;
@@ -53,7 +70,7 @@
 
 /* iOS Safari auto-zooms <input> with font-size <16px. chonky-ui's --text-base
  * is 0.9rem (~14.4px), so force 16px on the callsign input to suppress zoom. */
-:global(.maps-input-label input) {
+:global(.maps-callsign-input input) {
   font-size: 16px;
 }
 
@@ -116,64 +133,33 @@
   user-select: all;
 }
 
-.radio-group {
-  border: none;
-  margin: 0;
-  padding: 0;
+/* Source radio group uses chonky-ui Radio components. The sublabel is rendered
+ * outside the Radio (chonky's Radio takes a single label prop, no children)
+ * and indented to align under the label text rather than the radio dot. */
+:global(.source-radio-group) {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 16px;
 }
-.radio-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 12px;
-  min-height: 44px;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-}
-.radio-row:hover:not(.disabled) {
-  background: var(--bg-hover);
-  border-color: var(--accent);
-}
-.radio-row.disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-.radio-row input[type="radio"] {
-  width: 20px;
-  height: 20px;
-  margin-top: 2px;
-  accent-color: var(--accent);
-  flex-shrink: 0;
-}
-.radio-text {
+
+.source-radio-row {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
-.radio-label {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-.radio-sublabel {
+
+.source-sublabel {
+  margin: 0 0 0 32px;
   font-size: 13px;
   color: var(--text-muted);
+  line-height: 1.4;
 }
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+
+@media (max-width: 480px) {
+  .source-sublabel {
+    margin-left: 28px;
+    font-size: 12px;
+  }
 }
 
 .source-offline-hint {

--- a/graywolf/web/src/routes/MapsSettings.svelte
+++ b/graywolf/web/src/routes/MapsSettings.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import { Box, Button, Input, Toggle } from '@chrissnell/chonky-ui';
+  import { Box, Button, Input, Toggle, Radio, RadioGroup } from '@chrissnell/chonky-ui';
   import { mapsState, ISSUES_URL } from '../lib/settings/maps-store.svelte.js';
   import { validateCallsign } from '../lib/maps/callsign.js';
   import { downloadsState } from '../lib/maps/downloads-store.svelte.js';
@@ -173,10 +173,11 @@
   </Box>
 
   <Box title="Register this device">
-    <div class="maps-row">
-      <label class="maps-input-label">
-        <span class="maps-input-label-text">Your callsign</span>
+    <label for="maps-callsign-input" class="maps-input-label-text">Your callsign</label>
+    <div class="maps-row maps-row-aligned">
+      <div class="maps-callsign-input">
         <Input
+          id="maps-callsign-input"
           type="text"
           placeholder="N5XXX"
           bind:value={callsignInput}
@@ -186,7 +187,7 @@
           inputmode="text"
           disabled={!consented}
         />
-      </label>
+      </div>
       <Button
         class="maps-cta"
         variant="primary"
@@ -272,23 +273,22 @@
 {/if}
 
 <Box title="Map source">
-  <fieldset class="radio-group">
-    <legend class="visually-hidden">Choose a basemap source</legend>
+  <RadioGroup
+    value={mapsState.source}
+    onValueChange={onSourceChange}
+    name="map-source"
+    class="source-radio-group"
+    aria-label="Choose a basemap source"
+  >
     {#each sources as src}
-      <label class="radio-row" class:disabled={isDisabled(src)}>
-        <input
-          type="radio"
-          name="map-source"
+      <div class="source-radio-row">
+        <Radio
           value={src.value}
-          checked={mapsState.source === src.value}
+          label={src.label}
           disabled={isDisabled(src)}
-          onchange={(e) => onSourceChange(e.currentTarget.value)}
         />
-        <span class="radio-text">
-          <span class="radio-label">{src.label}</span>
-          <span class="radio-sublabel">{src.sublabel}</span>
-        </span>
-      </label>
+        <p class="source-sublabel">{src.sublabel}</p>
+      </div>
       {#if src.value === 'graywolf' && mapsState.source === 'graywolf' && downloadsState.completed.size > 0}
         <p class="source-offline-hint">
           Using offline tiles for {downloadsState.completed.size}
@@ -297,7 +297,7 @@
         </p>
       {/if}
     {/each}
-  </fieldset>
+  </RadioGroup>
 </Box>
 
 {#if mapsState.registered}
@@ -367,13 +367,9 @@
 <style>
   @import '../lib/maps/styles.css';
 
-  .maps-input-label {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    flex: 1;
-  }
   .maps-input-label-text {
+    display: block;
+    margin-bottom: 4px;
     font-size: 13px;
     font-weight: 600;
     color: var(--text-secondary);


### PR DESCRIPTION
## Summary

Three Maps Settings polish issues from operator feedback:

1. **Register button vertical alignment** — the input was nested in a flex-column label that also held a label-text element above it, making the column taller than the button. With `align-items: end`, the button bottom-aligned to the column's bottom and visually offset below the input center. Fixed by hoisting "Your callsign" out of the row as a standalone `<label for=...>` above; the row now contains just `<Input>` + `<Button>`, both stretched to equal height at \`min-width: 600px\`.

2. **Radio buttons not vertically aligned** — the previous HTML `<input type="radio">` with `margin-top: 2px` and a flex column for label+sublabel had alignment drift across rows. Fixed by switching to chonky-ui `Radio` + `RadioGroup` (alignment handled by chonky internally).

3. **Yellow-filled radio looked non-standard** — chonky's `Radio` provides the project's standard radio styling, matching what's used in Beacons and Digipeater pages.

The sublabel under each radio renders as a separate `<p class="source-sublabel">` indented below the chonky Radio's label. Existing `sources` array, `onSourceChange`, `isDisabled` logic, and the offline-coverage hint are all unchanged.

## Test plan

- [ ] Open `/preferences/maps` on a fresh server. Tick "I understand and agree" — Register button should be vertically aligned (centered/stretched) with the input
- [ ] Confirm the OSM and Graywolf radios match the visual style of radios on Beacons/Digipeater pages
- [ ] Sublabel under each radio renders below the radio's label (not under the dot, not floating)
- [ ] Graywolf radio is disabled (greyed out) until registered
- [ ] At 320px and 375px viewport, layout still works (radios stack, Register button remains tappable)