### PR TITLE
flareschema: wire schema package + modem --list-audio/--list-usb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +193,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "coreaudio-rs"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,7 +234,7 @@ dependencies = [
  "jni",
  "js-sys",
  "libc",
- "mach2",
+ "mach2 0.5.0",
  "ndk",
  "ndk-context",
  "num-derive",
@@ -430,6 +452,7 @@ dependencies = [
  "gpiocdev-uapi",
  "hidapi",
  "nix",
+ "nusb",
  "prost",
  "prost-build",
  "serde",
@@ -504,6 +527,16 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2 0.4.3",
 ]
 
 [[package]]
@@ -617,6 +650,12 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -626,6 +665,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mach2"
@@ -729,6 +777,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "nusb"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f861541f15de120eae5982923d073bfc0c1a65466561988c82d6e197734c19e"
+dependencies = [
+ "atomic-waker",
+ "core-foundation",
+ "core-foundation-sys",
+ "futures-core",
+ "io-kit-sys",
+ "libc",
+ "log",
+ "once_cell",
+ "rustix 0.38.44",
+ "slab",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1028,6 +1095,19 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1035,7 +1115,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1135,7 +1215,7 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1537,6 +1617,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1561,6 +1659,37 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
@@ -1569,7 +1698,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.53.1",
  "windows_i686_msvc 0.53.1",
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
@@ -1593,6 +1722,18 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
@@ -1602,6 +1743,18 @@ name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1617,9 +1770,27 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -1635,6 +1806,18 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
@@ -1644,6 +1827,18 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1659,6 +1854,18 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
@@ -1668,6 +1875,18 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ SWAGGER_UI_VENDOR := $(DOCS_HANDBOOK)/vendor/swagger-ui
 # api-client-check guards catch.
 GENERATED_SPEC_FILES := $(DOCS_GEN_DIR)/swagger.json $(DOCS_GEN_DIR)/swagger.yaml $(WEB_DIR)/src/api/generated/api.d.ts
 
-.PHONY: all build release test bench clean clean-web distclean check fmt lint doc run-bench proto go-build go-test go-fuzz web graywolf version bump-minor bump-point bump-beta handbook-sync docs docs-api-html docs-check docs-lint api-client api-client-check install-hooks
+.PHONY: all build release test bench clean clean-web distclean check fmt lint doc run-bench proto go-build go-test go-fuzz web graywolf version bump-minor bump-point bump-beta handbook-sync docs docs-api-html docs-check docs-lint api-client api-client-check flareschema install-hooks
 
 all: release web
 	mkdir -p bin
@@ -306,6 +306,18 @@ api-client-check: $(NODE_STAMP)
 			exit 1; \
 		fi; \
 		echo "api-client-check: generated client matches committed copy."
+
+# --- Flare schema --------------------------------------------------------
+#
+# `make flareschema` regenerates docs/flareschema/v1.json from the Go
+# source of pkg/flareschema. The committed file is what the flare-server
+# uses for input validation in CI.
+
+.PHONY: flareschema
+flareschema:
+	@echo ">> regenerating docs/flareschema/v1.json"
+	@cd graywolf && go run ./cmd/flareschema-gen > ../docs/flareschema/v1.json
+	@echo ">> docs/flareschema/v1.json updated"
 
 # --- Git hooks -----------------------------------------------------------
 #

--- a/docs/flareschema/v1.json
+++ b/docs/flareschema/v1.json
@@ -1,0 +1,638 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/chrissnell/graywolf/pkg/flareschema/flare",
+  "$ref": "#/$defs/Flare",
+  "$defs": {
+    "AudioDevice": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "direction": {
+          "type": "string"
+        },
+        "is_default": {
+          "type": "boolean"
+        },
+        "supported_configs": {
+          "items": {
+            "$ref": "#/$defs/AudioStreamConfigRange"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "direction",
+        "is_default"
+      ]
+    },
+    "AudioDevices": {
+      "properties": {
+        "hosts": {
+          "items": {
+            "$ref": "#/$defs/AudioHost"
+          },
+          "type": "array"
+        },
+        "issues": {
+          "items": {
+            "$ref": "#/$defs/CollectorIssue"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "hosts"
+      ]
+    },
+    "AudioHost": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "is_default": {
+          "type": "boolean"
+        },
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/AudioDevice"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "is_default",
+        "devices"
+      ]
+    },
+    "AudioStreamConfigRange": {
+      "properties": {
+        "channels": {
+          "type": "integer"
+        },
+        "min_sample_rate_hz": {
+          "type": "integer"
+        },
+        "max_sample_rate_hz": {
+          "type": "integer"
+        },
+        "sample_format": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "channels",
+        "min_sample_rate_hz",
+        "max_sample_rate_hz",
+        "sample_format"
+      ]
+    },
+    "CM108Device": {
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "product": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "path",
+        "vendor",
+        "product",
+        "description"
+      ]
+    },
+    "CM108Devices": {
+      "properties": {
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/CM108Device"
+          },
+          "type": "array"
+        },
+        "issues": {
+          "items": {
+            "$ref": "#/$defs/CollectorIssue"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "devices"
+      ]
+    },
+    "CollectorIssue": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "kind",
+        "message"
+      ]
+    },
+    "ConfigItem": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "key",
+        "value"
+      ]
+    },
+    "ConfigSection": {
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "#/$defs/ConfigItem"
+          },
+          "type": "array"
+        },
+        "issues": {
+          "items": {
+            "$ref": "#/$defs/CollectorIssue"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "items"
+      ]
+    },
+    "Flare": {
+      "properties": {
+        "schema_version": {
+          "type": "integer"
+        },
+        "user": {
+          "$ref": "#/$defs/User"
+        },
+        "meta": {
+          "$ref": "#/$defs/Meta"
+        },
+        "config": {
+          "$ref": "#/$defs/ConfigSection"
+        },
+        "system": {
+          "$ref": "#/$defs/System"
+        },
+        "service_status": {
+          "$ref": "#/$defs/ServiceStatus"
+        },
+        "ptt": {
+          "$ref": "#/$defs/PTTSection"
+        },
+        "gps": {
+          "$ref": "#/$defs/GPSSection"
+        },
+        "audio_devices": {
+          "$ref": "#/$defs/AudioDevices"
+        },
+        "usb_topology": {
+          "$ref": "#/$defs/USBTopology"
+        },
+        "cm108": {
+          "$ref": "#/$defs/CM108Devices"
+        },
+        "logs": {
+          "$ref": "#/$defs/LogsSection"
+        }
+      },
+      "type": "object",
+      "required": [
+        "schema_version",
+        "user",
+        "meta",
+        "config",
+        "system",
+        "service_status",
+        "ptt",
+        "gps",
+        "audio_devices",
+        "usb_topology",
+        "cm108",
+        "logs"
+      ]
+    },
+    "GPSCandidate": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "product": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "permissions": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        },
+        "reachable": {
+          "type": "boolean"
+        },
+        "accessible": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "required": [
+        "kind"
+      ]
+    },
+    "GPSSection": {
+      "properties": {
+        "candidates": {
+          "items": {
+            "$ref": "#/$defs/GPSCandidate"
+          },
+          "type": "array"
+        },
+        "issues": {
+          "items": {
+            "$ref": "#/$defs/CollectorIssue"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "candidates"
+      ]
+    },
+    "LogEntry": {
+      "properties": {
+        "ts_ns": {
+          "type": "integer"
+        },
+        "level": {
+          "type": "string"
+        },
+        "component": {
+          "type": "string"
+        },
+        "msg": {
+          "type": "string"
+        },
+        "attrs": {
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "required": [
+        "ts_ns",
+        "level",
+        "component",
+        "msg"
+      ]
+    },
+    "LogsSection": {
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "entries": {
+          "items": {
+            "$ref": "#/$defs/LogEntry"
+          },
+          "type": "array"
+        },
+        "issues": {
+          "items": {
+            "$ref": "#/$defs/CollectorIssue"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "source",
+        "entries"
+      ]
+    },
+    "Meta": {
+      "properties": {
+        "schema_version": {
+          "type": "integer"
+        },
+        "graywolf_version": {
+          "type": "string"
+        },
+        "graywolf_commit": {
+          "type": "string"
+        },
+        "graywolf_modem_version": {
+          "type": "string"
+        },
+        "graywolf_modem_commit": {
+          "type": "string"
+        },
+        "hostname_hash": {
+          "type": "string"
+        },
+        "submitted_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "type": "object",
+      "required": [
+        "schema_version",
+        "graywolf_version",
+        "submitted_at"
+      ]
+    },
+    "NetworkInterface": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "mac_oui": {
+          "type": "string"
+        },
+        "up": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "up"
+      ]
+    },
+    "PTTCandidate": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "product": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "permissions": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        },
+        "accessible": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "required": [
+        "kind"
+      ]
+    },
+    "PTTSection": {
+      "properties": {
+        "candidates": {
+          "items": {
+            "$ref": "#/$defs/PTTCandidate"
+          },
+          "type": "array"
+        },
+        "issues": {
+          "items": {
+            "$ref": "#/$defs/CollectorIssue"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "candidates"
+      ]
+    },
+    "ServiceStatus": {
+      "properties": {
+        "manager": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string"
+        },
+        "is_active": {
+          "type": "boolean"
+        },
+        "is_failed": {
+          "type": "boolean"
+        },
+        "restart_count": {
+          "type": "integer"
+        },
+        "issues": {
+          "items": {
+            "$ref": "#/$defs/CollectorIssue"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "is_active",
+        "is_failed"
+      ]
+    },
+    "System": {
+      "properties": {
+        "os": {
+          "type": "string"
+        },
+        "os_pretty": {
+          "type": "string"
+        },
+        "kernel": {
+          "type": "string"
+        },
+        "arch": {
+          "type": "string"
+        },
+        "is_raspberry_pi": {
+          "type": "boolean"
+        },
+        "pi_model": {
+          "type": "string"
+        },
+        "groups": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ntp_synchronized": {
+          "type": "boolean"
+        },
+        "udev_rules_present": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "network_interfaces": {
+          "items": {
+            "$ref": "#/$defs/NetworkInterface"
+          },
+          "type": "array"
+        },
+        "issues": {
+          "items": {
+            "$ref": "#/$defs/CollectorIssue"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "os",
+        "arch"
+      ]
+    },
+    "USBDevice": {
+      "properties": {
+        "bus_number": {
+          "type": "integer"
+        },
+        "port_path": {
+          "type": "string"
+        },
+        "vendor_id": {
+          "type": "string"
+        },
+        "product_id": {
+          "type": "string"
+        },
+        "vendor_name": {
+          "type": "string"
+        },
+        "product_name": {
+          "type": "string"
+        },
+        "manufacturer": {
+          "type": "string"
+        },
+        "serial": {
+          "type": "string"
+        },
+        "class": {
+          "type": "string"
+        },
+        "subclass": {
+          "type": "string"
+        },
+        "usb_version": {
+          "type": "string"
+        },
+        "speed": {
+          "type": "string"
+        },
+        "max_power_ma": {
+          "type": "integer"
+        },
+        "hub_power_source": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "bus_number",
+        "vendor_id",
+        "product_id"
+      ]
+    },
+    "USBTopology": {
+      "properties": {
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/USBDevice"
+          },
+          "type": "array"
+        },
+        "issues": {
+          "items": {
+            "$ref": "#/$defs/CollectorIssue"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "devices"
+      ]
+    },
+    "User": {
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "radio_model": {
+          "type": "string"
+        },
+        "audio_interface": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -42,6 +42,9 @@ Crate name: `graywolf-demod`. Binary: `graywolf-modem`. Source:
 | GPIO chardev v2 PTT (Linux gpiocdev) | `tx/ptt_gpio_linux.rs` |
 | rigctld TCP PTT (`T 1\n` / `T 0\n`) | `tx/ptt_rigctld.rs` |
 | CM108 HID enumeration (`--list-cm108`) | `cm108.rs` |
+| `--list-audio` JSON enumerator (cpal hosts/devices) | `src/audio/soundcard.rs` (`listing` module), `src/list_audio.rs` |
+| `--list-usb` JSON enumerator (nusb tree walk) | `src/list_usb.rs` |
+| Modem CLI dispatch + flag handlers | `src/bin/graywolf_modem.rs` |
 | IPC framing | `ipc/framing.rs` |
 | IPC server (UDS / Windows TCP) | `ipc/server.rs` |
 | Generated proto types | `ipc/proto.rs` (re-exports `OUT_DIR/graywolf.rs`) |
@@ -110,6 +113,21 @@ The split is enforced by [invariant 9](invariants.md).
 | `app/{aprsfanout,rxfanout}` | RX fanout to digipeater / KISS broadcast / APRS submit |
 | `app/{auth_store,gpsmanager,adapters,wiring,modem,flags,config,shutdown,platform_*}` | Wiring helpers |
 | `internal/{backoff,dedup,ratelimit,testsync,testtx}` | Internal utilities |
+
+## Wire schema (Go)
+
+Canonical struct tree for the flare wire payload — the contract between
+`graywolf flare` (Plan 2b) and graywolf-flare-server (Plan 2c).
+
+| Concern | File |
+|---|---|
+| Top-level `Flare` struct | [`../../graywolf/pkg/flareschema/flare.go`](../../graywolf/pkg/flareschema/flare.go) |
+| `SchemaVersion` constant + `Unmarshal` | [`../../graywolf/pkg/flareschema/version.go`](../../graywolf/pkg/flareschema/version.go), [`../../graywolf/pkg/flareschema/unmarshal.go`](../../graywolf/pkg/flareschema/unmarshal.go) |
+| Per-section types | `audio.go`, `usb.go`, `cm108.go`, `system.go`, `devices.go`, `logs.go`, `config.go`, `user.go`, `issue.go` |
+| Sample fixture (round-trip + schema gen) | [`../../graywolf/pkg/flareschema/sample.go`](../../graywolf/pkg/flareschema/sample.go) |
+| Cross-language convergence test | [`../../graywolf/pkg/flareschema/convergence_test.go`](../../graywolf/pkg/flareschema/convergence_test.go) |
+| JSON Schema generator | [`../../graywolf/cmd/flareschema-gen/main.go`](../../graywolf/cmd/flareschema-gen/main.go) |
+| Generated JSON Schema document | [`../../docs/flareschema/v1.json`](../../docs/flareschema/v1.json) |
 
 ## Web UI (`graywolf/web/`)
 

--- a/docs/wiki/glossary.md
+++ b/docs/wiki/glossary.md
@@ -85,3 +85,10 @@ background, the operator handbook is the starting point.
 | `notes.yaml` | The in-app release-notes data file (embedded into the Go binary). | [`../../graywolf/pkg/releasenotes/notes.yaml`](../../graywolf/pkg/releasenotes/notes.yaml) |
 | `VERSION` | Repo-root authoritative version file. Read by Makefile and Rust `build.rs`. | [`../../VERSION`](../../VERSION) |
 | `graywolf.db` / `graywolf-history.db` / `graywolf-logs.db` | Config, history, and log-ring SQLite files at runtime (gitignored). | see [system-topology.md](system-topology.md) |
+
+## Diagnostics
+
+| Term | In this project | Pointer |
+|---|---|---|
+| Flare | A schema-versioned diagnostic submission carrying a graywolf user's config, hardware, devices, and recent logs. Sent by `graywolf flare` (Plan 2b) to `graywolf-flare-server` (Plan 2c). | [`../../.context/2026-04-25-graywolf-flare-system-design.md`](../../.context/2026-04-25-graywolf-flare-system-design.md) |
+| Wire schema (flareschema) | The canonical Go struct tree at `graywolf/pkg/flareschema/` defining the JSON document a flare submission carries. | [`../../graywolf/pkg/flareschema/`](../../graywolf/pkg/flareschema/), [`../../docs/flareschema/v1.json`](../../docs/flareschema/v1.json) |

--- a/docs/wiki/system-topology.md
+++ b/docs/wiki/system-topology.md
@@ -75,6 +75,30 @@ Operator handbook page for the history DB: [`../handbook/history-database.html`]
 
 Path policy (resolved in [`pkg/logbuffer/path.go`](../../graywolf/pkg/logbuffer/path.go)): on Raspberry Pi or SD-card-rooted hosts, and when the operator passes `--logbuffer-ramdisk`, the ring lives on tmpfs (`/run/graywolf/` preferred, `/dev/shm/graywolf/` fallback) so we don't burn flash. Everywhere else it sits next to `graywolf.db`. Ring size defaults to 2000 rows on tmpfs and 5000 on disk; the `LogBufferConfig.MaxRows` configstore singleton overrides that, with `0` disabling persistence entirely. The buffer feeds the future `graywolf flare` diagnostic submission CLI.
 
+## Wire schema (flare submission contract)
+
+The `graywolf flare` CLI (Plan 2b) and `graywolf-flare-server` (Plan 2c)
+exchange a schema-versioned JSON document. The canonical struct tree
+lives in graywolf at [`../../graywolf/pkg/flareschema/`](../../graywolf/pkg/flareschema/);
+the JSON Schema generated from it commits to
+[`../../docs/flareschema/v1.json`](../../docs/flareschema/v1.json) and is
+regenerated via `make flareschema`.
+
+graywolf-flare-server lives in its own repo and depends on this package
+through go.mod — locally via a `replace` directive pointing at this
+worktree, and in CI pinned to a tagged graywolf version. Bumping
+`SchemaVersion` is therefore a coordinated change across both repos plus
+a new committed `docs/flareschema/v<N>.json`.
+
+`graywolf-modem` participates in the contract through its `--list-audio`
+and `--list-usb` flags ([`../../graywolf-modem/src/list_audio.rs`](../../graywolf-modem/src/list_audio.rs),
+[`../../graywolf-modem/src/list_usb.rs`](../../graywolf-modem/src/list_usb.rs)),
+whose stdout JSON unmarshals directly into `flareschema.AudioDevices`
+and `flareschema.USBTopology`. The cross-language guard is the
+convergence test in [`../../graywolf/pkg/flareschema/convergence_test.go`](../../graywolf/pkg/flareschema/convergence_test.go),
+which runs the modem binary at test time and parses its stdout into the
+schema types.
+
 ## External services
 
 | Service | Purpose | Code | Handbook |

--- a/graywolf-modem/Cargo.toml
+++ b/graywolf-modem/Cargo.toml
@@ -12,6 +12,10 @@ cpal = "0.17"
 hidapi = "2.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# USB topology enumeration for `--list-audio`'s sibling --list-usb.
+# Pure-Rust, no libusb dependency, and works cross-platform without
+# requiring privileged kernel APIs.
+nusb = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 # Direct POSIX access for serial PTT: fcntl::open + libc TIOCMSET ioctls.

--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -954,3 +954,177 @@ mod tests {
         }
     }
 }
+
+/// Read-only enumeration of every cpal host's input + output devices.
+///
+/// Used by the `--list-audio` CLI subcommand. No streams are constructed
+/// here — every call walks the host iterator and reads supported config
+/// ranges, nothing more. Safe to call from a one-shot binary path that
+/// exits immediately after.
+///
+/// The output structures mirror the Go-side `flareschema.AudioDevices`
+/// shape so the JSON serialization is the contract.
+pub mod listing {
+    use cpal::traits::{DeviceTrait, HostTrait};
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    pub struct AudioDevices {
+        pub hosts: Vec<AudioHost>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub issues: Vec<CollectorIssue>,
+    }
+
+    #[derive(Serialize)]
+    pub struct AudioHost {
+        pub id: String,
+        pub name: String,
+        pub is_default: bool,
+        pub devices: Vec<AudioDevice>,
+    }
+
+    #[derive(Serialize)]
+    pub struct AudioDevice {
+        pub name: String,
+        pub direction: String,
+        pub is_default: bool,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub supported_configs: Vec<AudioStreamConfigRange>,
+    }
+
+    #[derive(Serialize)]
+    pub struct AudioStreamConfigRange {
+        pub channels: u16,
+        pub min_sample_rate_hz: u32,
+        pub max_sample_rate_hz: u32,
+        pub sample_format: String,
+    }
+
+    #[derive(Serialize)]
+    pub struct CollectorIssue {
+        pub kind: String,
+        pub message: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub path: Option<String>,
+    }
+
+    pub fn enumerate() -> AudioDevices {
+        let mut hosts_out = Vec::new();
+        let mut issues = Vec::new();
+
+        let default_host_id = cpal::default_host().id();
+
+        for host_id in cpal::available_hosts() {
+            let host = match cpal::host_from_id(host_id) {
+                Ok(h) => h,
+                Err(e) => {
+                    issues.push(CollectorIssue {
+                        kind: "host_init_failed".into(),
+                        message: format!("{}: {}", host_id.name(), e),
+                        path: None,
+                    });
+                    continue;
+                }
+            };
+
+            let default_input = host
+                .default_input_device()
+                .and_then(|d| d.name().ok());
+            let default_output = host
+                .default_output_device()
+                .and_then(|d| d.name().ok());
+
+            let mut devices = Vec::new();
+            collect_devices(
+                &host,
+                "input",
+                default_input.as_deref(),
+                &mut devices,
+                &mut issues,
+            );
+            collect_devices(
+                &host,
+                "output",
+                default_output.as_deref(),
+                &mut devices,
+                &mut issues,
+            );
+
+            hosts_out.push(AudioHost {
+                id: host_id.name().to_lowercase(),
+                name: host_id.name().to_string(),
+                is_default: host_id == default_host_id,
+                devices,
+            });
+        }
+
+        AudioDevices {
+            hosts: hosts_out,
+            issues,
+        }
+    }
+
+    fn collect_devices(
+        host: &cpal::Host,
+        direction: &str,
+        default_name: Option<&str>,
+        devices: &mut Vec<AudioDevice>,
+        issues: &mut Vec<CollectorIssue>,
+    ) {
+        let iter = match direction {
+            "input" => host.input_devices(),
+            "output" => host.output_devices(),
+            _ => unreachable!(),
+        };
+        let iter = match iter {
+            Ok(it) => it,
+            Err(e) => {
+                issues.push(CollectorIssue {
+                    kind: "enumerate_failed".into(),
+                    message: format!("{} {}: {}", host.id().name(), direction, e),
+                    path: None,
+                });
+                return;
+            }
+        };
+
+        for dev in iter {
+            let name = dev.name().unwrap_or_else(|_| "<unknown>".to_string());
+            let is_default = default_name.map(|d| d == name).unwrap_or(false);
+
+            let configs = match direction {
+                "input" => dev.supported_input_configs().map(|i| i.collect::<Vec<_>>()),
+                "output" => dev.supported_output_configs().map(|i| i.collect::<Vec<_>>()),
+                _ => unreachable!(),
+            };
+            let configs = configs.unwrap_or_default();
+
+            let mut ranges = Vec::with_capacity(configs.len());
+            for c in configs {
+                ranges.push(AudioStreamConfigRange {
+                    channels: c.channels(),
+                    min_sample_rate_hz: c.min_sample_rate(),
+                    max_sample_rate_hz: c.max_sample_rate(),
+                    sample_format: format_sample_format(c.sample_format()),
+                });
+            }
+
+            devices.push(AudioDevice {
+                name,
+                direction: direction.to_string(),
+                is_default,
+                supported_configs: ranges,
+            });
+        }
+    }
+
+    fn format_sample_format(f: cpal::SampleFormat) -> String {
+        match f {
+            cpal::SampleFormat::I16 => "i16",
+            cpal::SampleFormat::U16 => "u16",
+            cpal::SampleFormat::F32 => "f32",
+            other => return format!("{:?}", other).to_lowercase(),
+        }
+        .to_string()
+    }
+}

--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -1027,12 +1027,18 @@ pub mod listing {
                 }
             };
 
+            // cpal deprecated `.name()` in favor of `.description()`,
+            // which returns a structured DeviceDescription. We carry
+            // its `.name()` field (an owned String) on the wire — the
+            // JSON field stays `name` for the schema contract.
             let default_input = host
                 .default_input_device()
-                .and_then(|d| d.name().ok());
+                .and_then(|d| d.description().ok())
+                .map(|desc| desc.name().to_string());
             let default_output = host
                 .default_output_device()
-                .and_then(|d| d.name().ok());
+                .and_then(|d| d.description().ok())
+                .map(|desc| desc.name().to_string());
 
             let mut devices = Vec::new();
             collect_devices(
@@ -1089,7 +1095,10 @@ pub mod listing {
         };
 
         for dev in iter {
-            let name = dev.name().unwrap_or_else(|_| "<unknown>".to_string());
+            let name = dev
+                .description()
+                .map(|d| d.name().to_string())
+                .unwrap_or_else(|_| "<unknown>".to_string());
             let is_default = default_name.map(|d| d == name).unwrap_or(false);
 
             let configs = match direction {

--- a/graywolf-modem/src/bin/graywolf_modem.rs
+++ b/graywolf-modem/src/bin/graywolf_modem.rs
@@ -15,6 +15,16 @@
 //!                                    devices as a JSON array and exit.
 //!                                    Used by the Go parent on macOS and
 //!                                    Windows where sysfs is unavailable.
+//!     graywolf-modem --list-audio    Enumerate cpal hosts + input/output
+//!                                    devices + supported config ranges
+//!                                    as JSON and exit. Used by the
+//!                                    `graywolf flare` CLI to capture the
+//!                                    audio stack from the same crate the
+//!                                    modem uses at runtime.
+//!     graywolf-modem --list-usb      Enumerate the USB device tree
+//!                                    (bus/port path, vendor/product
+//!                                    strings, hub power source,
+//!                                    bMaxPower, speed) as JSON and exit.
 //!
 //! On Unix the IPC listener is a Unix domain socket at the given path. On
 //! Windows it is a TCP socket on 127.0.0.1 with an OS-assigned port; the
@@ -51,6 +61,11 @@ fn main() -> ExitCode {
                 return ExitCode::from(1);
             }
         }
+    }
+
+    if args.len() == 2 && args[1] == "--list-audio" {
+        println!("{}", graywolf_demod::list_audio::run());
+        return ExitCode::SUCCESS;
     }
 
     let server = bind_server(&args);

--- a/graywolf-modem/src/bin/graywolf_modem.rs
+++ b/graywolf-modem/src/bin/graywolf_modem.rs
@@ -68,6 +68,11 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
+    if args.len() == 2 && args[1] == "--list-usb" {
+        println!("{}", graywolf_demod::list_usb::run());
+        return ExitCode::SUCCESS;
+    }
+
     let server = bind_server(&args);
     let server = match server {
         Ok(s) => s,

--- a/graywolf-modem/src/lib.rs
+++ b/graywolf-modem/src/lib.rs
@@ -95,6 +95,7 @@ pub mod fx25;
 pub mod il2p;
 pub mod tx;
 pub mod cm108;
+pub mod list_audio;
 
 /// Base semver string ("0.7.13"), injected at build time from the repo's
 /// VERSION file (via the GRAYWOLF_VERSION env var set by the Makefile / CI).

--- a/graywolf-modem/src/lib.rs
+++ b/graywolf-modem/src/lib.rs
@@ -96,6 +96,7 @@ pub mod il2p;
 pub mod tx;
 pub mod cm108;
 pub mod list_audio;
+pub mod list_usb;
 
 /// Base semver string ("0.7.13"), injected at build time from the repo's
 /// VERSION file (via the GRAYWOLF_VERSION env var set by the Makefile / CI).

--- a/graywolf-modem/src/list_audio.rs
+++ b/graywolf-modem/src/list_audio.rs
@@ -1,0 +1,24 @@
+//! `--list-audio` subcommand: emit cpal host/device topology as JSON
+//! matching `graywolf/pkg/flareschema.AudioDevices`. Used by the future
+//! `graywolf flare` CLI to capture the audio stack from the same crate
+//! the modem uses at runtime, so reports never disagree with what the
+//! modem actually sees.
+
+use crate::audio::soundcard::listing;
+
+/// Run the enumeration and return the JSON string. Errors are baked
+/// into the AudioDevices.issues field, never returned out — `--list-*`
+/// flags must always emit a parseable document.
+pub fn run() -> String {
+    let result = listing::enumerate();
+    serde_json::to_string(&result).unwrap_or_else(|e| {
+        // Catastrophic only if AudioDevices itself becomes unserializable;
+        // emit a minimal valid document so the Go side's Unmarshal still
+        // succeeds and the issue lands in the issues array of an empty
+        // enumeration.
+        format!(
+            "{{\"hosts\":[],\"issues\":[{{\"kind\":\"json_marshal_failed\",\"message\":{:?}}}]}}",
+            e.to_string()
+        )
+    })
+}

--- a/graywolf-modem/src/list_usb.rs
+++ b/graywolf-modem/src/list_usb.rs
@@ -1,0 +1,170 @@
+//! `--list-usb` subcommand: emit a USB device tree as JSON matching
+//! `graywolf/pkg/flareschema.USBTopology`. Used by the future
+//! `graywolf flare` CLI to capture USB topology from the same crate the
+//! modem uses at runtime so audio/HID/USB enumeration cannot disagree.
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct USBTopology {
+    devices: Vec<USBDevice>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    issues: Vec<CollectorIssue>,
+}
+
+#[derive(Serialize)]
+struct USBDevice {
+    bus_number: u32,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    port_path: String,
+    vendor_id: String,
+    product_id: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    vendor_name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    product_name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    manufacturer: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    serial: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    class: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    subclass: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    usb_version: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    speed: String,
+    #[serde(skip_serializing_if = "is_zero")]
+    max_power_ma: u32,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    hub_power_source: String,
+}
+
+#[derive(Serialize)]
+struct CollectorIssue {
+    kind: String,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+}
+
+fn is_zero(v: &u32) -> bool {
+    *v == 0
+}
+
+/// Run the enumeration. Always emits a parseable JSON document — every
+/// failure is recorded as an issue rather than thrown out of the binary,
+/// so the Go-side collector sees a structured response in every case.
+pub fn run() -> String {
+    let mut topology = USBTopology {
+        devices: Vec::new(),
+        issues: Vec::new(),
+    };
+
+    let iter = match nusb::list_devices() {
+        Ok(it) => it,
+        Err(e) => {
+            topology.issues.push(CollectorIssue {
+                kind: "list_devices_failed".into(),
+                message: format!("{}", e),
+                path: None,
+            });
+            return marshal(&topology);
+        }
+    };
+
+    for d in iter {
+        // nusb 0.1.14 does not expose a portable port-chain accessor.
+        // The platform-specific accessors are:
+        //   * Linux/Android: `sysfs_path()` (full chain in the path)
+        //   * macOS: `location_id()` (encodes the hub chain in nibbles)
+        //   * Windows: `port_number()` (single u32)
+        // For now, fall back to the portable `device_address()` so the
+        // field is populated on every platform; the JSON tag stays
+        // `port_path` so the Go-side wire contract (USBDevice.PortPath)
+        // is unchanged. A richer multi-segment chain is a follow-up
+        // that walks the parent device tree per platform.
+        let port_path = port_path_for(&d);
+
+        topology.devices.push(USBDevice {
+            bus_number: d.bus_number() as u32,
+            port_path,
+            vendor_id: format!("{:04x}", d.vendor_id()),
+            product_id: format!("{:04x}", d.product_id()),
+            vendor_name: String::new(), // not exposed by nusb without descriptor read
+            product_name: d.product_string().unwrap_or_default().to_string(),
+            manufacturer: d.manufacturer_string().unwrap_or_default().to_string(),
+            serial: d.serial_number().unwrap_or_default().to_string(),
+            class: format!("{:02x}", d.class()),
+            subclass: format!("{:02x}", d.subclass()),
+            // nusb 0.1.14 renamed `usb_version()` to `device_version()`;
+            // the JSON field stays `usb_version` (Go-side wire contract).
+            usb_version: format_bcd(d.device_version()),
+            speed: format_speed(d.speed()),
+            // bMaxPower / hub power source require a descriptor read
+            // which on some platforms requires open(); leave them unset
+            // when nusb's DeviceInfo doesn't surface them. Reading from
+            // sysfs on Linux or IOKit on macOS is a follow-up.
+            max_power_ma: 0,
+            hub_power_source: String::new(),
+        });
+    }
+
+    marshal(&topology)
+}
+
+fn marshal(t: &USBTopology) -> String {
+    serde_json::to_string(t).unwrap_or_else(|e| {
+        format!(
+            "{{\"devices\":[],\"issues\":[{{\"kind\":\"json_marshal_failed\",\"message\":{:?}}}]}}",
+            e.to_string()
+        )
+    })
+}
+
+fn format_bcd(bcd: u16) -> String {
+    let major = (bcd >> 8) & 0xff;
+    let minor = bcd & 0xff;
+    format!("{:x}.{:02x}", major, minor)
+}
+
+/// Render a stable per-device locator string for the `port_path` JSON
+/// field. nusb 0.1.x's portable `DeviceInfo` only exposes
+/// `device_address()` cross-platform; richer hub chains live behind
+/// platform-specific accessors and are a follow-up.
+fn port_path_for(d: &nusb::DeviceInfo) -> String {
+    #[cfg(target_os = "macos")]
+    {
+        // macOS location IDs encode the full hub chain in 4-bit
+        // nibbles (e.g. 0x14310000 → root 1, hub 4, port 3, port 1).
+        // Render as zero-padded 8-digit hex to match Apple's
+        // System Information display.
+        return format!("{:08x}", d.location_id());
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return d.port_number().to_string();
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        // Linux + everything else: the device address is unique per
+        // bus and the simplest portable identifier nusb exposes.
+        return d.device_address().to_string();
+    }
+}
+
+fn format_speed(s: Option<nusb::Speed>) -> String {
+    match s {
+        Some(nusb::Speed::Low) => "low".into(),
+        Some(nusb::Speed::Full) => "full".into(),
+        Some(nusb::Speed::High) => "high".into(),
+        Some(nusb::Speed::Super) => "super".into(),
+        Some(nusb::Speed::SuperPlus) => "super_plus".into(),
+        None => "unknown".into(),
+        // Future nusb versions may add variants; collapse them to
+        // "unknown" rather than a debug-formatted string so the
+        // operator UI's drop-down list stays curated.
+        Some(_) => "unknown".into(),
+    }
+}

--- a/graywolf-modem/src/list_usb.rs
+++ b/graywolf-modem/src/list_usb.rs
@@ -98,9 +98,14 @@ pub fn run() -> String {
             serial: d.serial_number().unwrap_or_default().to_string(),
             class: format!("{:02x}", d.class()),
             subclass: format!("{:02x}", d.subclass()),
-            // nusb 0.1.14 renamed `usb_version()` to `device_version()`;
-            // the JSON field stays `usb_version` (Go-side wire contract).
-            usb_version: format_bcd(d.device_version()),
+            // usb_version (bcdUSB, the USB protocol version) is not
+            // exposed by nusb 0.1.x's portable DeviceInfo —
+            // device_version() returns bcdDevice (firmware revision),
+            // a different descriptor field. Leave the JSON field
+            // omitted (skip_serializing_if drops the empty string)
+            // until a per-platform collector reads bcdUSB from sysfs
+            // (Linux), IOKit (macOS), or SetupAPI (Windows).
+            usb_version: String::new(),
             speed: format_speed(d.speed()),
             // bMaxPower / hub power source require a descriptor read
             // which on some platforms requires open(); leave them unset
@@ -121,12 +126,6 @@ fn marshal(t: &USBTopology) -> String {
             e.to_string()
         )
     })
-}
-
-fn format_bcd(bcd: u16) -> String {
-    let major = (bcd >> 8) & 0xff;
-    let minor = bcd & 0xff;
-    format!("{:x}.{:02x}", major, minor)
 }
 
 /// Render a stable per-device locator string for the `port_path` JSON

--- a/graywolf-modem/src/list_usb.rs
+++ b/graywolf-modem/src/list_usb.rs
@@ -128,29 +128,33 @@ fn marshal(t: &USBTopology) -> String {
     })
 }
 
-/// Render a stable per-device locator string for the `port_path` JSON
-/// field. nusb 0.1.x's portable `DeviceInfo` only exposes
-/// `device_address()` cross-platform; richer hub chains live behind
-/// platform-specific accessors and are a follow-up.
+// Render a stable per-device locator string for the `port_path` JSON
+// field. nusb 0.1.x's portable `DeviceInfo` only exposes
+// `device_address()` cross-platform; richer hub chains live behind
+// platform-specific accessors and are a follow-up.
+//
+// One impl per target OS keeps each fn body to a single trailing
+// expression (no `return`, no clippy::needless_return) while the
+// dead branches stay out of the compiled binary.
+#[cfg(target_os = "macos")]
 fn port_path_for(d: &nusb::DeviceInfo) -> String {
-    #[cfg(target_os = "macos")]
-    {
-        // macOS location IDs encode the full hub chain in 4-bit
-        // nibbles (e.g. 0x14310000 → root 1, hub 4, port 3, port 1).
-        // Render as zero-padded 8-digit hex to match Apple's
-        // System Information display.
-        return format!("{:08x}", d.location_id());
-    }
-    #[cfg(target_os = "windows")]
-    {
-        return d.port_number().to_string();
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        // Linux + everything else: the device address is unique per
-        // bus and the simplest portable identifier nusb exposes.
-        return d.device_address().to_string();
-    }
+    // macOS location IDs encode the full hub chain in 4-bit nibbles
+    // (e.g. 0x14310000 → root 1, hub 4, port 3, port 1). Render as
+    // zero-padded 8-digit hex to match Apple's System Information
+    // display.
+    format!("{:08x}", d.location_id())
+}
+
+#[cfg(target_os = "windows")]
+fn port_path_for(d: &nusb::DeviceInfo) -> String {
+    d.port_number().to_string()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn port_path_for(d: &nusb::DeviceInfo) -> String {
+    // Linux + everything else: the device address is unique per
+    // bus and the simplest portable identifier nusb exposes.
+    d.device_address().to_string()
 }
 
 fn format_speed(s: Option<nusb::Speed>) -> String {

--- a/graywolf/cmd/flareschema-gen/main.go
+++ b/graywolf/cmd/flareschema-gen/main.go
@@ -3,9 +3,15 @@
 // Makefile's `flareschema` target.
 //
 // Stable output: invopop/jsonschema walks struct fields in declaration
-// order, and we explicitly disable additional-properties so the schema
-// matches Go's encoding/json behaviour. Re-running the generator
-// against an unchanged Go source tree yields a byte-identical document.
+// order, so re-running the generator against an unchanged Go source
+// tree yields a byte-identical document.
+//
+// Forward-compatibility: AllowAdditionalProperties is enabled so older
+// receivers don't reject payloads from newer client builds carrying an
+// extra field before the server's migration path runs. The version
+// gate (SchemaVersion / ErrUnsupportedSchemaVersion in the schema
+// package) is what enforces compatibility, not a strict-properties
+// schema check.
 package main
 
 import (

--- a/graywolf/cmd/flareschema-gen/main.go
+++ b/graywolf/cmd/flareschema-gen/main.go
@@ -1,0 +1,42 @@
+// Command flareschema-gen prints the JSON Schema document for the
+// flareschema.Flare struct to stdout. Wired into the top-level
+// Makefile's `flareschema` target.
+//
+// Stable output: invopop/jsonschema walks struct fields in declaration
+// order, and we explicitly disable additional-properties so the schema
+// matches Go's encoding/json behaviour. Re-running the generator
+// against an unchanged Go source tree yields a byte-identical document.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/invopop/jsonschema"
+
+	"github.com/chrissnell/graywolf/pkg/flareschema"
+)
+
+func main() {
+	r := &jsonschema.Reflector{
+		// Allow additional fields so older client builds emitting an
+		// extra (forward-compatible) property don't fail validation
+		// before the server's migration path runs.
+		AllowAdditionalProperties: true,
+		// Inline definitions: the operator UI's generated schema viewer
+		// is happier with one self-contained document than with $ref
+		// chains.
+		ExpandedStruct: false,
+	}
+	schema := r.Reflect(&flareschema.Flare{})
+	out, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "flareschema-gen: marshal: %v\n", err)
+		os.Exit(1)
+	}
+	if _, err := os.Stdout.Write(append(out, '\n')); err != nil {
+		fmt.Fprintf(os.Stderr, "flareschema-gen: write: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/graywolf/go.mod
+++ b/graywolf/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/glebarez/go-sqlite v1.21.2
 	github.com/glebarez/sqlite v1.11.0
+	github.com/invopop/jsonschema v0.14.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/warthog618/go-gpiocdev v0.9.1
@@ -17,7 +18,9 @@ require (
 )
 
 require (
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/creack/goselect v0.1.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -28,10 +31,12 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	modernc.org/libc v1.22.5 // indirect

--- a/graywolf/go.sum
+++ b/graywolf/go.sum
@@ -1,5 +1,9 @@
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
@@ -19,6 +23,8 @@ github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 h1:Xim43kblpZXfIBQsbu
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
+github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
@@ -35,6 +41,8 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
+github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -64,6 +72,8 @@ go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/graywolf/pkg/flareschema/audio.go
+++ b/graywolf/pkg/flareschema/audio.go
@@ -1,0 +1,46 @@
+package flareschema
+
+// AudioDevices is the top-level shape emitted by
+// `graywolf-modem --list-audio`. It is also the schema attached to the
+// flare's audio_devices section.
+//
+// Multi-host: cpal exposes one Host per audio API on the platform (ALSA,
+// PulseAudio, JACK on Linux; CoreAudio on macOS; WASAPI on Windows). We
+// iterate available_hosts() so a JACK-on-Linux user's report carries
+// both ALSA and JACK devices, not whichever host the modem picked at
+// runtime.
+type AudioDevices struct {
+	Hosts  []AudioHost      `json:"hosts"`
+	Issues []CollectorIssue `json:"issues,omitempty"`
+}
+
+// AudioHost is one cpal host. ID is the cpal-internal host identifier
+// (e.g. "alsa", "jack", "coreaudio"); Name is the display name from the
+// host trait. IsDefault marks the host cpal::default_host() picked.
+type AudioHost struct {
+	ID        string        `json:"id"`
+	Name      string        `json:"name"`
+	IsDefault bool          `json:"is_default"`
+	Devices   []AudioDevice `json:"devices"`
+}
+
+// AudioDevice is one cpal device under a host. Direction is "input" or
+// "output". IsDefault marks the host's default-input / default-output
+// pick (each direction has its own default).
+type AudioDevice struct {
+	Name             string                   `json:"name"`
+	Direction        string                   `json:"direction"`
+	IsDefault        bool                     `json:"is_default"`
+	SupportedConfigs []AudioStreamConfigRange `json:"supported_configs,omitempty"`
+}
+
+// AudioStreamConfigRange flattens cpal::SupportedStreamConfigRange into
+// a JSON-friendly shape. Channels is fixed (cpal reports per-config
+// channel count), but sample rate is a range. SampleFormat is one of
+// "i16", "u16", "f32" (the cpal SampleFormat variants).
+type AudioStreamConfigRange struct {
+	Channels        uint16 `json:"channels"`
+	MinSampleRateHz uint32 `json:"min_sample_rate_hz"`
+	MaxSampleRateHz uint32 `json:"max_sample_rate_hz"`
+	SampleFormat    string `json:"sample_format"`
+}

--- a/graywolf/pkg/flareschema/audio_test.go
+++ b/graywolf/pkg/flareschema/audio_test.go
@@ -1,0 +1,76 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAudioDevicesJSONShape(t *testing.T) {
+	in := AudioDevices{
+		Hosts: []AudioHost{
+			{
+				ID:        "alsa",
+				Name:      "ALSA",
+				IsDefault: true,
+				Devices: []AudioDevice{
+					{
+						Name:      "default",
+						Direction: "input",
+						IsDefault: true,
+						SupportedConfigs: []AudioStreamConfigRange{
+							{
+								Channels:        1,
+								MinSampleRateHz: 48000,
+								MaxSampleRateHz: 48000,
+								SampleFormat:    "i16",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"hosts":[`,
+		`"id":"alsa"`,
+		`"name":"ALSA"`,
+		`"is_default":true`,
+		`"devices":[`,
+		`"name":"default"`,
+		`"direction":"input"`,
+		`"supported_configs":[`,
+		`"channels":1`,
+		`"min_sample_rate_hz":48000`,
+		`"max_sample_rate_hz":48000`,
+		`"sample_format":"i16"`,
+	} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("got %s, missing %s", b, want)
+		}
+	}
+}
+
+func TestAudioDevicesRoundTrip(t *testing.T) {
+	in := AudioDevices{
+		Hosts: []AudioHost{
+			{ID: "coreaudio", Name: "CoreAudio", IsDefault: true},
+		},
+		Issues: []CollectorIssue{{Kind: "host_init_failed", Message: "JACK server not running"}},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out AudioDevices
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Hosts) != 1 || out.Hosts[0].ID != "coreaudio" || len(out.Issues) != 1 {
+		t.Fatalf("round trip mismatch: %+v", out)
+	}
+}

--- a/graywolf/pkg/flareschema/cm108.go
+++ b/graywolf/pkg/flareschema/cm108.go
@@ -1,0 +1,21 @@
+package flareschema
+
+// CM108Device matches the shape emitted by `graywolf-modem --list-cm108`
+// today (graywolf-modem/src/cm108.rs:11). Field names and JSON tags MUST
+// stay in lockstep with that file — this is the cross-language contract
+// for the existing flag, not a new one.
+type CM108Device struct {
+	Path        string `json:"path"`
+	Vendor      string `json:"vendor"`
+	Product     string `json:"product"`
+	Description string `json:"description"`
+}
+
+// CM108Devices wraps the modem's bare array output into the same
+// section-with-issues shape every other flare section uses, so the
+// operator UI can render it uniformly. The collector side fills Devices
+// from the modem's array output and Issues from any exec failure.
+type CM108Devices struct {
+	Devices []CM108Device    `json:"devices"`
+	Issues  []CollectorIssue `json:"issues,omitempty"`
+}

--- a/graywolf/pkg/flareschema/cm108_test.go
+++ b/graywolf/pkg/flareschema/cm108_test.go
@@ -1,0 +1,49 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The shape of a single CM108 device must match what enumerate_cm108()
+// in graywolf-modem/src/cm108.rs already emits today. Keep this test
+// in sync with that file's Cm108Device struct.
+func TestCM108DeviceMatchesExistingModemOutput(t *testing.T) {
+	d := CM108Device{
+		Path:        "0001:0008:03",
+		Vendor:      "0d8c",
+		Product:     "0012",
+		Description: "CM108 Audio Controller",
+	}
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"path":"0001:0008:03","vendor":"0d8c","product":"0012","description":"CM108 Audio Controller"}`
+	if string(b) != want {
+		t.Fatalf("got %s\nwant %s", b, want)
+	}
+}
+
+func TestCM108DevicesUnmarshalArrayShape(t *testing.T) {
+	// graywolf-modem --list-cm108 today emits a JSON array, not an
+	// object. The flare collector wraps it into CM108Devices on the Go
+	// side. Confirm we can drive the wrap from the modem-shaped array.
+	raw := []byte(`[{"path":"a","vendor":"0d8c","product":"0012","description":"x"}]`)
+	var arr []CM108Device
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		t.Fatalf("unmarshal array: %v", err)
+	}
+	if len(arr) != 1 || arr[0].Path != "a" {
+		t.Fatalf("got %+v", arr)
+	}
+	wrap := CM108Devices{Devices: arr}
+	out, err := json.Marshal(wrap)
+	if err != nil {
+		t.Fatalf("marshal wrap: %v", err)
+	}
+	if !strings.Contains(string(out), `"devices":[`) {
+		t.Fatalf("got %s; expected wrap to expose a devices array", out)
+	}
+}

--- a/graywolf/pkg/flareschema/config.go
+++ b/graywolf/pkg/flareschema/config.go
@@ -1,0 +1,20 @@
+package flareschema
+
+// ConfigItem is one row of the configstore dump after scrubbing. Values
+// that the scrubber decided to suppress are written as the literal
+// string "[REDACTED]" — that placeholder lives in the value field so the
+// operator UI doesn't need a separate "redacted" flag column.
+type ConfigItem struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// ConfigSection is the top-level "config" object on a flare. Items
+// preserve the order the configstore emitted them so resubmit diffs stay
+// stable across re-runs. Issues records collector failures (e.g.
+// "configstore unreadable") so a flare without config remains useful for
+// system+device debugging.
+type ConfigSection struct {
+	Items  []ConfigItem     `json:"items"`
+	Issues []CollectorIssue `json:"issues,omitempty"`
+}

--- a/graywolf/pkg/flareschema/config_test.go
+++ b/graywolf/pkg/flareschema/config_test.go
@@ -1,0 +1,61 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestConfigItemRoundTrip(t *testing.T) {
+	in := ConfigItem{Key: "ptt.device", Value: "/dev/ttyUSB0"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != `{"key":"ptt.device","value":"/dev/ttyUSB0"}` {
+		t.Fatalf("got %s", b)
+	}
+	var out ConfigItem
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round trip: in=%+v out=%+v", in, out)
+	}
+}
+
+func TestConfigSectionOrderPreserved(t *testing.T) {
+	s := ConfigSection{
+		Items: []ConfigItem{
+			{Key: "ptt.device", Value: "/dev/ttyUSB0"},
+			{Key: "aprs.callsign", Value: "N0CALL"},
+			{Key: "aprs.password", Value: "[REDACTED]"},
+		},
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got ConfigSection
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Items) != 3 {
+		t.Fatalf("len = %d, want 3", len(got.Items))
+	}
+	if got.Items[0].Key != "ptt.device" || got.Items[2].Key != "aprs.password" {
+		t.Fatalf("order not preserved: %+v", got.Items)
+	}
+}
+
+func TestConfigSectionEmptyIssuesOmitted(t *testing.T) {
+	s := ConfigSection{Items: []ConfigItem{{Key: "k", Value: "v"}}}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// "issues" must be absent when empty (omitempty contract).
+	if strings.Contains(string(b), `"issues"`) {
+		t.Fatalf("got %s; issues should be omitempty when empty", b)
+	}
+}

--- a/graywolf/pkg/flareschema/convergence_test.go
+++ b/graywolf/pkg/flareschema/convergence_test.go
@@ -114,3 +114,40 @@ func TestConvergenceListAudio(t *testing.T) {
 		t.Fatalf("both hosts and issues nil; document was empty")
 	}
 }
+
+func TestConvergenceListUSB(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows runners don't ship the modem binary in this matrix")
+	}
+	bin := findModemBinary(t)
+	if bin == "" {
+		t.Skip("graywolf-modem binary not found; build with `cargo build --release` to enable")
+	}
+
+	stdout, err := runModemListing(bin, "--list-usb")
+	if err != nil {
+		t.Fatalf("--list-usb: %v", err)
+	}
+
+	var got USBTopology
+	if err := json.Unmarshal(stdout, &got); err != nil {
+		t.Fatalf("unmarshal --list-usb output into USBTopology: %v\nstdout:\n%s", err, stdout)
+	}
+
+	// Re-marshal/re-parse to ensure the document round-trips cleanly.
+	rt, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	var second USBTopology
+	if err := json.Unmarshal(rt, &second); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+
+	// Sanity: the document must always have a devices field, even if
+	// empty (omitempty is intentionally not set on USBTopology.Devices).
+	// Hosts with no USB visibility report it via the issues channel.
+	if got.Devices == nil && got.Issues == nil {
+		t.Fatalf("both devices and issues nil; document was empty")
+	}
+}

--- a/graywolf/pkg/flareschema/convergence_test.go
+++ b/graywolf/pkg/flareschema/convergence_test.go
@@ -1,6 +1,7 @@
 package flareschema
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
@@ -9,6 +10,17 @@ import (
 	"runtime"
 	"testing"
 )
+
+// strictDecode runs json.Unmarshal with DisallowUnknownFields so any
+// field the Rust side emits that isn't named on the Go side fails the
+// test. encoding/json's default ignores unknown fields silently, which
+// would let a Rust-side rename (e.g. `channels` → `channel_count`)
+// pass — defeating the convergence-test contract.
+func strictDecode(data []byte, v interface{}) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	return dec.Decode(v)
+}
 
 // repoRoot walks up looking for graywolf-modem/Cargo.toml — the same
 // marker the modembridge integration tests use to locate the workspace
@@ -92,20 +104,21 @@ func TestConvergenceListAudio(t *testing.T) {
 	}
 
 	var got AudioDevices
-	if err := json.Unmarshal(stdout, &got); err != nil {
-		t.Fatalf("unmarshal --list-audio output into AudioDevices: %v\nstdout:\n%s", err, stdout)
+	if err := strictDecode(stdout, &got); err != nil {
+		t.Fatalf("strict-decode --list-audio output into AudioDevices: %v\nstdout:\n%s", err, stdout)
 	}
 
-	// Round-trip the parsed value back to JSON and re-parse so a stray
-	// extra field on the Rust side gets surfaced. encoding/json is lossy
-	// on unknown fields by default; we want this to be a contract test.
+	// Round-trip strict: confirm the parsed value re-encodes to a shape
+	// the strict decoder also accepts. Combined with the first strict
+	// decode, this catches both (a) Rust emitting a field Go doesn't know
+	// and (b) Go marshaling a field Go can't subsequently round-trip.
 	roundTrip, err := json.Marshal(got)
 	if err != nil {
 		t.Fatalf("re-marshal: %v", err)
 	}
 	var second AudioDevices
-	if err := json.Unmarshal(roundTrip, &second); err != nil {
-		t.Fatalf("re-parse: %v", err)
+	if err := strictDecode(roundTrip, &second); err != nil {
+		t.Fatalf("strict re-parse: %v", err)
 	}
 
 	// Sanity: the document must be well-formed even on hosts with no
@@ -130,18 +143,18 @@ func TestConvergenceListUSB(t *testing.T) {
 	}
 
 	var got USBTopology
-	if err := json.Unmarshal(stdout, &got); err != nil {
-		t.Fatalf("unmarshal --list-usb output into USBTopology: %v\nstdout:\n%s", err, stdout)
+	if err := strictDecode(stdout, &got); err != nil {
+		t.Fatalf("strict-decode --list-usb output into USBTopology: %v\nstdout:\n%s", err, stdout)
 	}
 
-	// Re-marshal/re-parse to ensure the document round-trips cleanly.
+	// Round-trip strict: see TestConvergenceListAudio for rationale.
 	rt, err := json.Marshal(got)
 	if err != nil {
 		t.Fatalf("re-marshal: %v", err)
 	}
 	var second USBTopology
-	if err := json.Unmarshal(rt, &second); err != nil {
-		t.Fatalf("re-parse: %v", err)
+	if err := strictDecode(rt, &second); err != nil {
+		t.Fatalf("strict re-parse: %v", err)
 	}
 
 	// Sanity: the document must always have a devices field, even if

--- a/graywolf/pkg/flareschema/convergence_test.go
+++ b/graywolf/pkg/flareschema/convergence_test.go
@@ -1,0 +1,116 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// repoRoot walks up looking for graywolf-modem/Cargo.toml — the same
+// marker the modembridge integration tests use to locate the workspace
+// root. Returns "" when no marker is found, which the test interprets as
+// a skip signal.
+func repoRoot() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "graywolf-modem", "Cargo.toml")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// findModemBinary returns the path to a runnable graywolf-modem binary,
+// or "" with a skip reason. Lookup order:
+//  1. CI-built sibling (<repo>/bin/graywolf-modem)
+//  2. cargo-built workspace artifact (<repo>/target/release/graywolf-modem)
+//  3. $PATH
+//
+// We do NOT cargo-build the modem from this test; the build-tag-gated
+// fallback lives in modembridge's integration_test.go and is invoked
+// from explicit integration runs only.
+func findModemBinary(t *testing.T) string {
+	t.Helper()
+
+	root := repoRoot()
+	if root != "" {
+		ciBin := filepath.Join(root, "bin", "graywolf-modem")
+		if _, err := os.Stat(ciBin); err == nil {
+			return ciBin
+		}
+		releaseBin := filepath.Join(root, "target", "release", "graywolf-modem")
+		if _, err := os.Stat(releaseBin); err == nil {
+			return releaseBin
+		}
+	}
+	if path, err := exec.LookPath("graywolf-modem"); err == nil {
+		return path
+	}
+	return ""
+}
+
+// runModemListing executes graywolf-modem with one of the --list-* flags
+// and returns its stdout. Errors are returned verbatim so the caller can
+// distinguish "binary missing" from "binary present but failed".
+func runModemListing(bin, flag string) ([]byte, error) {
+	cmd := exec.Command(bin, flag)
+	out, err := cmd.Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return nil, errors.New("graywolf-modem " + flag + " failed: " + string(ee.Stderr))
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+func TestConvergenceListAudio(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows runners don't ship the modem binary in this matrix")
+	}
+	bin := findModemBinary(t)
+	if bin == "" {
+		t.Skip("graywolf-modem binary not found; build with `cargo build --release` to enable")
+	}
+
+	stdout, err := runModemListing(bin, "--list-audio")
+	if err != nil {
+		t.Fatalf("--list-audio: %v", err)
+	}
+
+	var got AudioDevices
+	if err := json.Unmarshal(stdout, &got); err != nil {
+		t.Fatalf("unmarshal --list-audio output into AudioDevices: %v\nstdout:\n%s", err, stdout)
+	}
+
+	// Round-trip the parsed value back to JSON and re-parse so a stray
+	// extra field on the Rust side gets surfaced. encoding/json is lossy
+	// on unknown fields by default; we want this to be a contract test.
+	roundTrip, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	var second AudioDevices
+	if err := json.Unmarshal(roundTrip, &second); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+
+	// Sanity: the document must be well-formed even on hosts with no
+	// audio devices. issues is the catch-all in that case.
+	if got.Hosts == nil && got.Issues == nil {
+		t.Fatalf("both hosts and issues nil; document was empty")
+	}
+}

--- a/graywolf/pkg/flareschema/devices.go
+++ b/graywolf/pkg/flareschema/devices.go
@@ -1,0 +1,53 @@
+package flareschema
+
+// PTTCandidate is one device the PTT enumerator considered. The exact
+// fields populated depend on Kind:
+//   - "serial":     Path, Vendor, Product, Description, Permissions, Owner, Group
+//   - "cm108_hid":  Path, Vendor, Product, Description (interface number lives in CM108Devices)
+//   - "gpio_chip":  Path, Description; Permissions+Owner+Group when readable
+//   - "parport":    Path, Description
+//
+// Accessible is the result of an actual open-for-write probe — it is the
+// most actionable bit for triage because "user is not in dialout/gpio"
+// shows up here as Accessible=false even when Permissions/Owner/Group
+// look right.
+type PTTCandidate struct {
+	Kind        string `json:"kind"`
+	Path        string `json:"path,omitempty"`
+	Vendor      string `json:"vendor,omitempty"`
+	Product     string `json:"product,omitempty"`
+	Description string `json:"description,omitempty"`
+	Permissions string `json:"permissions,omitempty"`
+	Owner       string `json:"owner,omitempty"`
+	Group       string `json:"group,omitempty"`
+	Accessible  bool   `json:"accessible,omitempty"`
+}
+
+// PTTSection wraps the candidate list with an issues slice for collector
+// failures (e.g. /dev/parport* unreadable).
+type PTTSection struct {
+	Candidates []PTTCandidate   `json:"candidates"`
+	Issues     []CollectorIssue `json:"issues,omitempty"`
+}
+
+// GPSCandidate is a serial device that looked GPS-ish, or the gpsd
+// socket. Kind is "serial" or "gpsd_socket". Reachable applies only to
+// the socket case (was it accepting connections at probe time).
+type GPSCandidate struct {
+	Kind        string `json:"kind"`
+	Path        string `json:"path,omitempty"`
+	Vendor      string `json:"vendor,omitempty"`
+	Product     string `json:"product,omitempty"`
+	Description string `json:"description,omitempty"`
+	Permissions string `json:"permissions,omitempty"`
+	Owner       string `json:"owner,omitempty"`
+	Group       string `json:"group,omitempty"`
+	Reachable   bool   `json:"reachable,omitempty"`
+	Accessible  bool   `json:"accessible,omitempty"`
+}
+
+// GPSSection wraps the candidate list with an issues slice.
+type GPSSection struct {
+	Candidates []GPSCandidate   `json:"candidates"`
+	Issues     []CollectorIssue `json:"issues,omitempty"`
+}

--- a/graywolf/pkg/flareschema/devices_test.go
+++ b/graywolf/pkg/flareschema/devices_test.go
@@ -1,0 +1,77 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPTTCandidateJSON(t *testing.T) {
+	c := PTTCandidate{
+		Kind:        "serial",
+		Path:        "/dev/ttyUSB0",
+		Vendor:      "0403",
+		Product:     "6001",
+		Description: "FT232R USB UART",
+		Permissions: "crw-rw----",
+		Owner:       "root",
+		Group:       "dialout",
+		Accessible:  true,
+	}
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"kind":"serial"`,
+		`"path":"/dev/ttyUSB0"`,
+		`"vendor":"0403"`,
+		`"product":"6001"`,
+		`"description":"FT232R USB UART"`,
+		`"permissions":"crw-rw----"`,
+		`"owner":"root"`,
+		`"group":"dialout"`,
+		`"accessible":true`,
+	} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("got %s, missing %s", b, want)
+		}
+	}
+}
+
+func TestPTTSectionWithIssues(t *testing.T) {
+	s := PTTSection{
+		Candidates: []PTTCandidate{{Kind: "serial", Path: "/dev/ttyUSB0"}},
+		Issues:     []CollectorIssue{{Kind: "permission_denied", Path: "/sys/class/gpio/export"}},
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"candidates":[`) || !strings.Contains(string(b), `"issues":[`) {
+		t.Fatalf("got %s; expected both candidates and issues arrays", b)
+	}
+}
+
+func TestGPSCandidateJSON(t *testing.T) {
+	c := GPSCandidate{
+		Kind:       "gpsd_socket",
+		Path:       "/var/run/gpsd.sock",
+		Reachable:  true,
+		Accessible: true,
+	}
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"kind":"gpsd_socket"`,
+		`"path":"/var/run/gpsd.sock"`,
+		`"reachable":true`,
+		`"accessible":true`,
+	} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("got %s, missing %s", b, want)
+		}
+	}
+}

--- a/graywolf/pkg/flareschema/doc.go
+++ b/graywolf/pkg/flareschema/doc.go
@@ -1,0 +1,25 @@
+// Package flareschema is the canonical Go definition of the graywolf
+// flare wire payload — the schema-versioned JSON document that the
+// "graywolf flare" CLI submits to graywolf-flare-server.
+//
+// Contract:
+//   - SchemaVersion is a monotonic integer; the server accepts and
+//     migrates older versions for as long as the build supports them.
+//   - Every collector section carries its own []CollectorIssue so a
+//     failure in one domain never aborts the whole submission.
+//   - Sub-struct field tags ("json:...,omitempty" where appropriate)
+//     are part of the wire contract; renaming or retagging requires a
+//     SchemaVersion bump and a corresponding entry in
+//     docs/flareschema/.
+//
+// Cross-repo use:
+//
+// The graywolf-flare-server lives in its own git repo
+// (~/dev/graywolf-flare-server). It depends on this package via go.mod;
+// during local dev it uses a `replace` directive pointing at this
+// worktree, and CI pins to a tagged graywolf version so the schema and
+// the server can never silently disagree.
+//
+// Design: .context/2026-04-25-graywolf-flare-system-design.md
+//         § "Subsystem 2 — graywolf flare CLI" → "Wire Schema".
+package flareschema

--- a/graywolf/pkg/flareschema/flare.go
+++ b/graywolf/pkg/flareschema/flare.go
@@ -1,0 +1,29 @@
+package flareschema
+
+// Flare is the top-level wire payload posted to
+// /api/v1/submit on graywolf-flare-server.
+//
+// Field order in this struct is the canonical wire order. encoding/json
+// preserves struct order on Marshal, so the resulting JSON is stable
+// across builds — important for diffing across resubmits in the operator
+// UI and for human-readable dry-run output.
+//
+// schema_version is duplicated here at the top level (and lives inside
+// Meta as well). The top-level field is the contract surface every
+// receiver checks first; Meta.SchemaVersion mirrors it so a flare
+// payload separated from its envelope (e.g. a dry-run save-to-file the
+// operator emails) is still self-describing.
+type Flare struct {
+	SchemaVersion int           `json:"schema_version"`
+	User          User          `json:"user"`
+	Meta          Meta          `json:"meta"`
+	Config        ConfigSection `json:"config"`
+	System        System        `json:"system"`
+	ServiceStatus ServiceStatus `json:"service_status"`
+	PTT           PTTSection    `json:"ptt"`
+	GPS           GPSSection    `json:"gps"`
+	AudioDevices  AudioDevices  `json:"audio_devices"`
+	USBTopology   USBTopology   `json:"usb_topology"`
+	CM108         CM108Devices  `json:"cm108"`
+	Logs          LogsSection   `json:"logs"`
+}

--- a/graywolf/pkg/flareschema/flare_test.go
+++ b/graywolf/pkg/flareschema/flare_test.go
@@ -1,0 +1,56 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFlareTopLevelTags(t *testing.T) {
+	f := BuildSampleFlare()
+	b, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"schema_version": 1`,
+		`"user":`,
+		`"meta":`,
+		`"config":`,
+		`"system":`,
+		`"service_status":`,
+		`"ptt":`,
+		`"gps":`,
+		`"audio_devices":`,
+		`"usb_topology":`,
+		`"cm108":`,
+		`"logs":`,
+	} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("missing top-level field %s in:\n%s", want, b)
+		}
+	}
+}
+
+func TestFlareRoundTrip(t *testing.T) {
+	in := BuildSampleFlare()
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out Flare
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round trip lost data:\nin:  %+v\nout: %+v", in, out)
+	}
+}
+
+func TestFlareSchemaVersionFieldEqualsConst(t *testing.T) {
+	f := BuildSampleFlare()
+	if f.SchemaVersion != SchemaVersion {
+		t.Fatalf("BuildSampleFlare().SchemaVersion = %d, want %d", f.SchemaVersion, SchemaVersion)
+	}
+}

--- a/graywolf/pkg/flareschema/issue.go
+++ b/graywolf/pkg/flareschema/issue.go
@@ -1,0 +1,17 @@
+package flareschema
+
+// CollectorIssue is appended to a section's Issues slice when a collector
+// hits a recoverable problem (missing permission, absent dependency,
+// unparseable system file). It is intentionally shape-stable across
+// sections so the operator UI can render every section's issues with one
+// component.
+//
+// Kind is a short snake_case tag (e.g. "permission_denied",
+// "modem_unavailable", "parse_failed") that the operator UI groups by.
+// Message is a free-text human-readable explanation. Path is the
+// filesystem path or device the collector tripped over, when applicable.
+type CollectorIssue struct {
+	Kind    string `json:"kind"`
+	Message string `json:"message"`
+	Path    string `json:"path,omitempty"`
+}

--- a/graywolf/pkg/flareschema/issue_test.go
+++ b/graywolf/pkg/flareschema/issue_test.go
@@ -1,0 +1,34 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCollectorIssueJSONShape(t *testing.T) {
+	in := CollectorIssue{
+		Kind:    "permission_denied",
+		Message: "open /sys/class/gpio/export: permission denied",
+		Path:    "/sys/class/gpio/export",
+	}
+	got, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"kind":"permission_denied","message":"open /sys/class/gpio/export: permission denied","path":"/sys/class/gpio/export"}`
+	if string(got) != want {
+		t.Fatalf("got %s\nwant %s", got, want)
+	}
+}
+
+func TestCollectorIssueOmitsEmptyPath(t *testing.T) {
+	in := CollectorIssue{Kind: "modem_unavailable", Message: "exec: no such file"}
+	got, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"kind":"modem_unavailable","message":"exec: no such file"}`
+	if string(got) != want {
+		t.Fatalf("got %s\nwant %s (path with omitempty must drop)", got, want)
+	}
+}

--- a/graywolf/pkg/flareschema/logs.go
+++ b/graywolf/pkg/flareschema/logs.go
@@ -1,0 +1,28 @@
+package flareschema
+
+// LogEntry mirrors one row of the logbuffer ring (graywolf-logs.db).
+// The shape matches pkg/logbuffer's persisted columns one-for-one:
+// ts_ns is unix nanoseconds, Level is "DEBUG"|"INFO"|"WARN"|"ERROR",
+// Component is the dotted slog group chain.
+//
+// Attrs is map[string]any (not json.RawMessage) so the operator UI can
+// render it as a key/value table without re-parsing JSON. Empty maps are
+// dropped via omitempty so a record with no attrs doesn't carry an extra
+// "attrs":{} on the wire.
+type LogEntry struct {
+	TsNs      int64          `json:"ts_ns"`
+	Level     string         `json:"level"`
+	Component string         `json:"component"`
+	Msg       string         `json:"msg"`
+	Attrs     map[string]any `json:"attrs,omitempty"`
+}
+
+// LogsSection is the top-level "logs" object on a flare. Source documents
+// where the rows came from ("graywolf-logs.db", "journalctl",
+// "Console.app", "EventLog") so a future operator can identify the
+// collector path even after schema evolution.
+type LogsSection struct {
+	Source  string           `json:"source"`
+	Entries []LogEntry       `json:"entries"`
+	Issues  []CollectorIssue `json:"issues,omitempty"`
+}

--- a/graywolf/pkg/flareschema/logs_test.go
+++ b/graywolf/pkg/flareschema/logs_test.go
@@ -1,0 +1,61 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestLogEntryShape(t *testing.T) {
+	e := LogEntry{
+		TsNs:      1714069200000000000,
+		Level:     "INFO",
+		Component: "ptt",
+		Msg:       "asserted PTT",
+		Attrs:     map[string]any{"device": "/dev/ttyUSB0"},
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"ts_ns":1714069200000000000`,
+		`"level":"INFO"`,
+		`"component":"ptt"`,
+		`"msg":"asserted PTT"`,
+		`"attrs":{"device":"/dev/ttyUSB0"}`,
+	} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("got %s, missing %s", b, want)
+		}
+	}
+}
+
+func TestLogEntryNoAttrsOmitted(t *testing.T) {
+	e := LogEntry{TsNs: 1, Level: "INFO", Component: "boot", Msg: "started"}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), `"attrs"`) {
+		t.Fatalf("got %s; attrs should be omitempty when nil", b)
+	}
+}
+
+func TestLogsSectionRoundTrip(t *testing.T) {
+	in := LogsSection{
+		Source:  "graywolf-logs.db",
+		Entries: []LogEntry{{TsNs: 1, Level: "INFO", Component: "boot", Msg: "started"}},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out LogsSection
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Source != in.Source || len(out.Entries) != 1 {
+		t.Fatalf("round trip mismatch: in=%+v out=%+v", in, out)
+	}
+}

--- a/graywolf/pkg/flareschema/sample.go
+++ b/graywolf/pkg/flareschema/sample.go
@@ -1,0 +1,120 @@
+package flareschema
+
+import "time"
+
+// BuildSampleFlare returns a fully populated Flare suitable for round
+// trip tests, schema-generation tooling, and dev fixtures. Every section
+// has at least one item AND at least one CollectorIssue so the schema
+// generator visits every branch of the struct tree, and so the
+// round-trip test exercises every field's JSON tags.
+//
+// The sample is deliberately deterministic — no random or time-based
+// values — so committing the generated schema document doesn't churn on
+// each regeneration.
+func BuildSampleFlare() Flare {
+	submittedAt := time.Date(2026, 4, 25, 18, 30, 0, 0, time.UTC)
+	return Flare{
+		SchemaVersion: SchemaVersion,
+		User: User{
+			Email:          "user@example.com",
+			Notes:          "PTT not keying when transmitting via the AGW interface",
+			RadioModel:     "FT-991A",
+			AudioInterface: "Digirig",
+		},
+		Meta: Meta{
+			SchemaVersion:        SchemaVersion,
+			GraywolfVersion:      "0.43.2",
+			GraywolfCommit:       "abc1234",
+			GraywolfModemVersion: "0.11.4",
+			GraywolfModemCommit:  "def5678",
+			HostnameHash:         "1a2b3c4d",
+			SubmittedAt:          submittedAt,
+		},
+		Config: ConfigSection{
+			Items: []ConfigItem{
+				{Key: "ptt.device", Value: "/dev/ttyUSB0"},
+				{Key: "aprs.callsign", Value: "N0CALL"},
+				{Key: "aprs.password", Value: "[REDACTED]"},
+			},
+			Issues: []CollectorIssue{
+				{Kind: "key_dropped", Message: "aprs.passcode dropped per scrub policy"},
+			},
+		},
+		System: System{
+			OS:                "linux",
+			OSPretty:          "Debian GNU/Linux 12 (bookworm)",
+			Kernel:            "6.1.0-13-arm64",
+			Arch:              "arm64",
+			IsRaspberryPi:     true,
+			PiModel:           "Raspberry Pi 4 Model B Rev 1.4",
+			Groups:            []string{"audio", "dialout", "gpio"},
+			NTPSynchronized:   true,
+			UdevRulesPresent:  []string{"99-graywolf.rules"},
+			NetworkInterfaces: []NetworkInterface{{Name: "wlan0", MACOUI: "b8:27:eb", Up: true}},
+			Issues:            []CollectorIssue{{Kind: "udev_check", Message: "/etc/udev/rules.d not readable", Path: "/etc/udev/rules.d"}},
+		},
+		ServiceStatus: ServiceStatus{
+			Manager:      "systemd",
+			Unit:         "graywolf.service",
+			IsActive:     true,
+			IsFailed:     false,
+			RestartCount: 2,
+			Issues:       []CollectorIssue{{Kind: "systemctl_unavailable", Message: "systemctl exited 1 on cold-boot probe"}},
+		},
+		PTT: PTTSection{
+			Candidates: []PTTCandidate{
+				{Kind: "serial", Path: "/dev/ttyUSB0", Vendor: "0403", Product: "6001", Description: "FT232R USB UART", Permissions: "crw-rw----", Owner: "root", Group: "dialout", Accessible: true},
+				{Kind: "cm108_hid", Path: "0001:0008:03", Vendor: "0d8c", Product: "0012", Description: "CM108 Audio Controller", Accessible: false},
+			},
+			Issues: []CollectorIssue{{Kind: "permission_denied", Path: "/sys/class/gpio/export"}},
+		},
+		GPS: GPSSection{
+			Candidates: []GPSCandidate{
+				{Kind: "gpsd_socket", Path: "/var/run/gpsd.sock", Reachable: true, Accessible: true},
+			},
+			Issues: []CollectorIssue{{Kind: "scan_partial", Message: "skipped /dev/ttyACM* (no read permission)"}},
+		},
+		AudioDevices: AudioDevices{
+			Hosts: []AudioHost{
+				{
+					ID: "alsa", Name: "ALSA", IsDefault: true,
+					Devices: []AudioDevice{
+						{
+							Name: "default", Direction: "input", IsDefault: true,
+							SupportedConfigs: []AudioStreamConfigRange{
+								{Channels: 1, MinSampleRateHz: 48000, MaxSampleRateHz: 48000, SampleFormat: "i16"},
+							},
+						},
+					},
+				},
+			},
+			Issues: []CollectorIssue{{Kind: "host_init_failed", Message: "JACK server not running"}},
+		},
+		USBTopology: USBTopology{
+			Devices: []USBDevice{
+				{
+					BusNumber: 1, PortPath: "1-1.4.2",
+					VendorID: "0d8c", ProductID: "0012",
+					VendorName: "C-Media Electronics, Inc.", ProductName: "CM108 Audio Controller",
+					Manufacturer: "C-Media",
+					Class:        "00", Subclass: "00", USBVersion: "2.00",
+					Speed: "full", MaxPowerMA: 100, HubPowerSource: "bus",
+				},
+			},
+			Issues: []CollectorIssue{{Kind: "hub_power_unreadable", Message: "/sys/bus/usb/devices/1-1/bMaxPower not readable"}},
+		},
+		CM108: CM108Devices{
+			Devices: []CM108Device{
+				{Path: "0001:0008:03", Vendor: "0d8c", Product: "0012", Description: "CM108 Audio Controller"},
+			},
+			Issues: []CollectorIssue{{Kind: "modem_warning", Message: "interface_number unknown on macOS host"}},
+		},
+		Logs: LogsSection{
+			Source: "graywolf-logs.db",
+			Entries: []LogEntry{
+				{TsNs: 1714069200000000000, Level: "INFO", Component: "ptt", Msg: "asserted PTT", Attrs: map[string]any{"device": "/dev/ttyUSB0"}},
+			},
+			Issues: []CollectorIssue{{Kind: "log_capture_partial", Message: "ring contained fewer rows than requested"}},
+		},
+	}
+}

--- a/graywolf/pkg/flareschema/system.go
+++ b/graywolf/pkg/flareschema/system.go
@@ -1,0 +1,53 @@
+package flareschema
+
+// System is the OS + hardware + identity snapshot collected at flare
+// time. Field set is the union across Linux, macOS, and Windows; per-OS
+// collectors populate the subset they can fill in and leave the rest at
+// zero. omitempty on the platform-conditional fields keeps macOS/Windows
+// payloads from carrying noisy "is_raspberry_pi=false" defaults.
+//
+// Privacy: hostnames are SHA256-truncated-to-8 before they reach this
+// struct (see Meta.HostnameHash). Network interfaces carry the MAC OUI
+// only — never the full address — to identify the hardware vendor without
+// the per-device suffix.
+type System struct {
+	OS                string             `json:"os"`
+	OSPretty          string             `json:"os_pretty,omitempty"`
+	Kernel            string             `json:"kernel,omitempty"`
+	Arch              string             `json:"arch"`
+	IsRaspberryPi     bool               `json:"is_raspberry_pi,omitempty"`
+	PiModel           string             `json:"pi_model,omitempty"`
+	Groups            []string           `json:"groups,omitempty"`
+	NTPSynchronized   bool               `json:"ntp_synchronized,omitempty"`
+	UdevRulesPresent  []string           `json:"udev_rules_present,omitempty"`
+	NetworkInterfaces []NetworkInterface `json:"network_interfaces,omitempty"`
+	Issues            []CollectorIssue   `json:"issues,omitempty"`
+}
+
+// NetworkInterface carries the OUI-only identity of a NIC. The full MAC
+// is intentionally not represented here; the OUI alone is enough to
+// identify USB-Ethernet adapters or Pi-built-in NICs.
+type NetworkInterface struct {
+	Name   string `json:"name"`
+	MACOUI string `json:"mac_oui,omitempty"`
+	Up     bool   `json:"up"`
+}
+
+// ServiceStatus reports the platform's view of the graywolf service.
+// Manager is one of "systemd", "launchd", "sc" (Windows), or empty when
+// no service supervisor is detected. Empty Manager + a populated Issues
+// slice is the "graywolf is being run interactively" case.
+//
+// IsActive and IsFailed are NOT omitempty: false is a diagnostically
+// load-bearing value (the operator wants to see "service is not
+// running" surfaced explicitly, not inferred from absence). When no
+// supervisor is detected, the operator UI keys off Manager == "" and
+// ignores these fields.
+type ServiceStatus struct {
+	Manager      string           `json:"manager,omitempty"`
+	Unit         string           `json:"unit,omitempty"`
+	IsActive     bool             `json:"is_active"`
+	IsFailed     bool             `json:"is_failed"`
+	RestartCount int              `json:"restart_count,omitempty"`
+	Issues       []CollectorIssue `json:"issues,omitempty"`
+}

--- a/graywolf/pkg/flareschema/system_test.go
+++ b/graywolf/pkg/flareschema/system_test.go
@@ -1,0 +1,86 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSystemFullJSON(t *testing.T) {
+	s := System{
+		OS:               "linux",
+		OSPretty:         "Debian GNU/Linux 12 (bookworm)",
+		Kernel:           "6.1.0-13-arm64",
+		Arch:             "arm64",
+		IsRaspberryPi:    true,
+		PiModel:          "Raspberry Pi 4 Model B Rev 1.4",
+		Groups:           []string{"audio", "dialout", "gpio"},
+		NTPSynchronized:  true,
+		UdevRulesPresent: []string{"99-graywolf.rules"},
+		NetworkInterfaces: []NetworkInterface{
+			{Name: "wlan0", MACOUI: "b8:27:eb", Up: true},
+		},
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"os":"linux"`,
+		`"os_pretty":"Debian GNU/Linux 12 (bookworm)"`,
+		`"kernel":"6.1.0-13-arm64"`,
+		`"arch":"arm64"`,
+		`"is_raspberry_pi":true`,
+		`"pi_model":"Raspberry Pi 4 Model B Rev 1.4"`,
+		`"groups":["audio","dialout","gpio"]`,
+		`"ntp_synchronized":true`,
+		`"udev_rules_present":["99-graywolf.rules"]`,
+		`"name":"wlan0"`,
+		`"mac_oui":"b8:27:eb"`,
+		`"up":true`,
+	} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("got %s, missing %s", b, want)
+		}
+	}
+}
+
+func TestSystemRoundTrip(t *testing.T) {
+	in := System{OS: "darwin", Arch: "arm64", Issues: []CollectorIssue{{Kind: "parse_failed", Message: "sw_vers parse error"}}}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out System
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.OS != in.OS || out.Arch != in.Arch || len(out.Issues) != 1 || out.Issues[0].Kind != "parse_failed" {
+		t.Fatalf("round trip mismatch: %+v vs %+v", in, out)
+	}
+}
+
+func TestServiceStatusJSON(t *testing.T) {
+	s := ServiceStatus{
+		Manager:      "systemd",
+		Unit:         "graywolf.service",
+		IsActive:     true,
+		IsFailed:     false,
+		RestartCount: 2,
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"manager":"systemd"`,
+		`"unit":"graywolf.service"`,
+		`"is_active":true`,
+		`"is_failed":false`,
+		`"restart_count":2`,
+	} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("got %s, missing %s", b, want)
+		}
+	}
+}

--- a/graywolf/pkg/flareschema/unmarshal.go
+++ b/graywolf/pkg/flareschema/unmarshal.go
@@ -1,0 +1,30 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Unmarshal decodes a flare payload, rejecting payloads whose
+// schema_version is greater than this build's SchemaVersion. Older
+// payloads pass through unchanged — migrating them is the receiver's
+// job, not this package's.
+//
+// The two-pass decode is deliberate: peeking at the version header
+// first lets us return ErrUnsupportedSchemaVersion before attempting to
+// fit a future-shaped payload into our current Flare struct, which
+// would otherwise produce confusing partial-decode results.
+func Unmarshal(data []byte) (*Flare, error) {
+	var hdr versionHeader
+	if err := json.Unmarshal(data, &hdr); err != nil {
+		return nil, fmt.Errorf("flareschema: decode version header: %w", err)
+	}
+	if hdr.SchemaVersion > SchemaVersion {
+		return nil, ErrUnsupportedSchemaVersion{Got: hdr.SchemaVersion}
+	}
+	var f Flare
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("flareschema: decode payload: %w", err)
+	}
+	return &f, nil
+}

--- a/graywolf/pkg/flareschema/unmarshal_test.go
+++ b/graywolf/pkg/flareschema/unmarshal_test.go
@@ -1,0 +1,17 @@
+package flareschema
+
+import "testing"
+
+func TestSchemaVersionIsOne(t *testing.T) {
+	if SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d, want 1 — bumping is a deliberate, schema-doc-updating change", SchemaVersion)
+	}
+}
+
+func TestErrUnsupportedSchemaVersionMessage(t *testing.T) {
+	err := ErrUnsupportedSchemaVersion{Got: 99}
+	want := "flareschema: unsupported schema_version 99 (this build supports up to 1)"
+	if err.Error() != want {
+		t.Fatalf("Error() = %q, want %q", err.Error(), want)
+	}
+}

--- a/graywolf/pkg/flareschema/unmarshal_test.go
+++ b/graywolf/pkg/flareschema/unmarshal_test.go
@@ -1,6 +1,10 @@
 package flareschema
 
-import "testing"
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
 
 func TestSchemaVersionIsOne(t *testing.T) {
 	if SchemaVersion != 1 {
@@ -13,5 +17,64 @@ func TestErrUnsupportedSchemaVersionMessage(t *testing.T) {
 	want := "flareschema: unsupported schema_version 99 (this build supports up to 1)"
 	if err.Error() != want {
 		t.Fatalf("Error() = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestUnmarshalHappyPath(t *testing.T) {
+	in := BuildSampleFlare()
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out, err := Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.SchemaVersion != SchemaVersion {
+		t.Fatalf("got version %d, want %d", out.SchemaVersion, SchemaVersion)
+	}
+	if out.User.Email != in.User.Email {
+		t.Fatalf("got email %q, want %q", out.User.Email, in.User.Email)
+	}
+}
+
+func TestUnmarshalRejectsForwardVersion(t *testing.T) {
+	raw := []byte(`{"schema_version": 99}`)
+	_, err := Unmarshal(raw)
+	if err == nil {
+		t.Fatal("Unmarshal accepted forward version; want ErrUnsupportedSchemaVersion")
+	}
+	var verr ErrUnsupportedSchemaVersion
+	if !errors.As(err, &verr) {
+		t.Fatalf("got %T; want ErrUnsupportedSchemaVersion", err)
+	}
+	if verr.Got != 99 {
+		t.Fatalf("verr.Got = %d, want 99", verr.Got)
+	}
+}
+
+func TestUnmarshalAcceptsOlderVersion(t *testing.T) {
+	// SchemaVersion is 1, so this exercises the "0 < SchemaVersion"
+	// path without requiring a real legacy doc. The contract is that
+	// Unmarshal does NOT reject older payloads — migration is the
+	// caller's job.
+	raw := []byte(`{"schema_version": 0, "meta": {"schema_version": 0, "graywolf_version": "old"}}`)
+	out, err := Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("Unmarshal rejected older version: %v", err)
+	}
+	if out.SchemaVersion != 0 {
+		t.Fatalf("SchemaVersion = %d, want 0 (round-tripped)", out.SchemaVersion)
+	}
+}
+
+func TestUnmarshalRejectsInvalidJSON(t *testing.T) {
+	_, err := Unmarshal([]byte(`{not json`))
+	if err == nil {
+		t.Fatal("Unmarshal accepted invalid JSON")
+	}
+	var verr ErrUnsupportedSchemaVersion
+	if errors.As(err, &verr) {
+		t.Fatalf("got version error for invalid JSON; want a generic decode error")
 	}
 }

--- a/graywolf/pkg/flareschema/usb.go
+++ b/graywolf/pkg/flareschema/usb.go
@@ -1,0 +1,41 @@
+package flareschema
+
+// USBTopology is the top-level shape emitted by
+// `graywolf-modem --list-usb`. It walks every device the kernel exposes
+// and records the minimum needed to diagnose:
+//   - "is the radio interface plugged in" (vendor/product strings)
+//   - "is it on a powered hub" (hub_power_source, max_power_ma)
+//   - "is it negotiating a sane speed" (speed, usb_version)
+//   - "what bus position" (port_path) so two identical devices can be
+//     told apart between resubmits
+type USBTopology struct {
+	Devices []USBDevice      `json:"devices"`
+	Issues  []CollectorIssue `json:"issues,omitempty"`
+}
+
+// USBDevice is one device entry in the topology. Vendor/product IDs are
+// rendered as zero-padded 4-digit lowercase hex (e.g. "0d8c") to match
+// the convention used by the rest of graywolf's USB-aware code (see
+// existing graywolf-modem CM108Device.vendor at cm108.rs:52).
+//
+// Speed is one of "low", "full", "high", "super", "super_plus", or
+// "unknown" — the nusb Speed enum collapsed to lower-snake-case.
+//
+// HubPowerSource is "bus", "self", or "unknown" — readable from the hub
+// descriptor only on Linux today; macOS/Windows leave it as "unknown".
+type USBDevice struct {
+	BusNumber      int    `json:"bus_number"`
+	PortPath       string `json:"port_path,omitempty"`
+	VendorID       string `json:"vendor_id"`
+	ProductID      string `json:"product_id"`
+	VendorName     string `json:"vendor_name,omitempty"`
+	ProductName    string `json:"product_name,omitempty"`
+	Manufacturer   string `json:"manufacturer,omitempty"`
+	Serial         string `json:"serial,omitempty"`
+	Class          string `json:"class,omitempty"`
+	Subclass       string `json:"subclass,omitempty"`
+	USBVersion     string `json:"usb_version,omitempty"`
+	Speed          string `json:"speed,omitempty"`
+	MaxPowerMA     int    `json:"max_power_ma,omitempty"`
+	HubPowerSource string `json:"hub_power_source,omitempty"`
+}

--- a/graywolf/pkg/flareschema/usb_test.go
+++ b/graywolf/pkg/flareschema/usb_test.go
@@ -1,0 +1,68 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestUSBTopologyJSONShape(t *testing.T) {
+	in := USBTopology{
+		Devices: []USBDevice{
+			{
+				BusNumber:      1,
+				PortPath:       "1-1.4.2",
+				VendorID:       "0d8c",
+				ProductID:      "0012",
+				VendorName:     "C-Media Electronics, Inc.",
+				ProductName:    "CM108 Audio Controller",
+				Manufacturer:   "C-Media",
+				Class:          "00",
+				Subclass:       "00",
+				USBVersion:     "2.00",
+				Speed:          "full",
+				MaxPowerMA:     100,
+				HubPowerSource: "bus",
+			},
+		},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"devices":[`,
+		`"bus_number":1`,
+		`"port_path":"1-1.4.2"`,
+		`"vendor_id":"0d8c"`,
+		`"product_id":"0012"`,
+		`"vendor_name":"C-Media Electronics, Inc."`,
+		`"product_name":"CM108 Audio Controller"`,
+		`"manufacturer":"C-Media"`,
+		`"class":"00"`,
+		`"subclass":"00"`,
+		`"usb_version":"2.00"`,
+		`"speed":"full"`,
+		`"max_power_ma":100`,
+		`"hub_power_source":"bus"`,
+	} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("got %s, missing %s", b, want)
+		}
+	}
+}
+
+func TestUSBTopologyRoundTrip(t *testing.T) {
+	in := USBTopology{Devices: []USBDevice{{VendorID: "0bda", ProductID: "8153"}}}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out USBTopology
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Devices) != 1 || out.Devices[0].VendorID != "0bda" {
+		t.Fatalf("round trip mismatch: %+v", out)
+	}
+}

--- a/graywolf/pkg/flareschema/user.go
+++ b/graywolf/pkg/flareschema/user.go
@@ -1,0 +1,31 @@
+package flareschema
+
+import "time"
+
+// User holds the optional free-form fields the operator gave the CLI via
+// flags. Every field is omitempty — a user submitting anonymously sends
+// {} here.
+type User struct {
+	Email          string `json:"email,omitempty"`
+	Notes          string `json:"notes,omitempty"`
+	RadioModel     string `json:"radio_model,omitempty"`
+	AudioInterface string `json:"audio_interface,omitempty"`
+}
+
+// Meta carries provenance for the submission: which graywolf and
+// graywolf-modem build produced it, the schema version of the payload,
+// the (irreversible, hashed) hostname, and the submission timestamp.
+//
+// Both the Go binary and the Rust binary carry their own version+commit
+// because a "dev-install mismatch" — operator running a freshly built Go
+// graywolf against a stale graywolf-modem — is a known support pattern
+// that we want to spot in the UI without extra collector logic.
+type Meta struct {
+	SchemaVersion        int       `json:"schema_version"`
+	GraywolfVersion      string    `json:"graywolf_version"`
+	GraywolfCommit       string    `json:"graywolf_commit,omitempty"`
+	GraywolfModemVersion string    `json:"graywolf_modem_version,omitempty"`
+	GraywolfModemCommit  string    `json:"graywolf_modem_commit,omitempty"`
+	HostnameHash         string    `json:"hostname_hash,omitempty"`
+	SubmittedAt          time.Time `json:"submitted_at"`
+}

--- a/graywolf/pkg/flareschema/user_test.go
+++ b/graywolf/pkg/flareschema/user_test.go
@@ -1,0 +1,71 @@
+package flareschema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUserJSONOmitsEmpty(t *testing.T) {
+	u := User{}
+	got, err := json.Marshal(u)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(got) != `{}` {
+		t.Fatalf("got %s, want {} (every User field is omitempty)", got)
+	}
+}
+
+func TestUserJSONFull(t *testing.T) {
+	u := User{
+		Email:          "user@example.com",
+		Notes:          "PTT not keying",
+		RadioModel:     "FT-991A",
+		AudioInterface: "Digirig",
+	}
+	got, err := json.Marshal(u)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"email":"user@example.com"`,
+		`"notes":"PTT not keying"`,
+		`"radio_model":"FT-991A"`,
+		`"audio_interface":"Digirig"`,
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("got %s, missing %s", got, want)
+		}
+	}
+}
+
+func TestMetaCarriesBothBinaryVersions(t *testing.T) {
+	m := Meta{
+		SchemaVersion:        1,
+		GraywolfVersion:      "0.43.2",
+		GraywolfCommit:       "abc1234",
+		GraywolfModemVersion: "0.11.4",
+		GraywolfModemCommit:  "def5678",
+		HostnameHash:         "1a2b3c4d",
+		SubmittedAt:          time.Date(2026, 4, 25, 18, 30, 0, 0, time.UTC),
+	}
+	got, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"schema_version":1`,
+		`"graywolf_version":"0.43.2"`,
+		`"graywolf_commit":"abc1234"`,
+		`"graywolf_modem_version":"0.11.4"`,
+		`"graywolf_modem_commit":"def5678"`,
+		`"hostname_hash":"1a2b3c4d"`,
+		`"submitted_at":"2026-04-25T18:30:00Z"`,
+	} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("got %s, missing %s", got, want)
+		}
+	}
+}

--- a/graywolf/pkg/flareschema/version.go
+++ b/graywolf/pkg/flareschema/version.go
@@ -1,0 +1,29 @@
+package flareschema
+
+import "fmt"
+
+// SchemaVersion is the wire schema version this build emits and accepts.
+// Bumping requires:
+//   - committing a new docs/flareschema/v<N>.json
+//   - documenting the migration in the flare-server's release notes
+//   - leaving the prior version's accept path in place until that build
+//     is no longer in production
+const SchemaVersion = 1
+
+// ErrUnsupportedSchemaVersion is returned by Unmarshal when the payload's
+// schema_version is greater than this build's SchemaVersion. Older
+// versions are intentionally not rejected here — the server is responsible
+// for migrating them up.
+type ErrUnsupportedSchemaVersion struct {
+	Got int
+}
+
+func (e ErrUnsupportedSchemaVersion) Error() string {
+	return fmt.Sprintf("flareschema: unsupported schema_version %d (this build supports up to %d)", e.Got, SchemaVersion)
+}
+
+// versionHeader is the minimal shape Unmarshal peeks at before deciding
+// whether to deserialize the rest of the payload.
+type versionHeader struct {
+	SchemaVersion int `json:"schema_version"`
+}


### PR DESCRIPTION
## Summary

Plan 2a of the flare diagnostic system: lands the canonical Go struct tree for the future flare wire payload, plus the two graywolf-modem CLI flags whose JSON output the Go side will consume. **No operator-facing feature yet** — the `graywolf flare` CLI subcommand and the collector code that POPULATES a flare are Plan 2b; the flare-server is Plan 2c. This PR only locks the contract and proves it cross-language.

## What's new (developer-facing)

- **`graywolf/pkg/flareschema/`** — top-level `Flare` struct composing every section (`User`, `Meta`, `ConfigSection`, `System`, `ServiceStatus`, `PTTSection`, `GPSSection`, `AudioDevices`, `USBTopology`, `CM108Devices`, `LogsSection`). Each section carries its own `[]CollectorIssue` so a failure in one domain never aborts the whole submission. `Unmarshal()` rejects only forward `schema_version` mismatches via a typed `ErrUnsupportedSchemaVersion`; older payloads pass through for server-side migration.
- **`graywolf/cmd/flareschema-gen/`** + **`make flareschema`** — generates `docs/flareschema/v1.json` from the struct tree via `github.com/invopop/jsonschema`. Output is byte-stable across runs; the file is committed.
- **`graywolf-modem --list-audio`** — walks `cpal::available_hosts()` and emits host/device/config-range topology matching `flareschema.AudioDevices`.
- **`graywolf-modem --list-usb`** — walks `nusb::list_devices()` (new dep `nusb = "0.1"`) and emits USB topology matching `flareschema.USBTopology`.
- **Convergence test** — `convergence_test.go` shells out to the modem release binary for both new flags and strict-decodes stdout into the corresponding Go types. Tag drift between Rust serde output and Go struct tags fails CI.
- **Wiki** — new `Wire schema (Go)` section in `code-map.md`, new `Wire schema (flare submission contract)` section in `system-topology.md`, new `Diagnostics` table in `glossary.md`.

## Notable design points

- Per-collector failure model: every section has its own `Issues []CollectorIssue`; no global issues bag on `Flare`.
- `SchemaVersion = 1` is integer-monotonic. Bumping requires a new `docs/flareschema/v<N>.json` plus coordinated server-side migration.
- Both binary versions (Go + Rust) and commits live in `Meta` so dev-install mismatches surface in the operator UI without extra collector logic.
- `AllowAdditionalProperties: true` in the schema generator: receivers must accept newer-build payloads carrying an extra field. The version gate is what enforces compatibility, not strict-properties validation.

## Known limitations (intentional, deferred to Plan 2b/2c follow-up)

- `usb_version` is omitted from `--list-usb` output: nusb 0.1.x's `device_version()` returns bcdDevice (firmware), not the bcdUSB protocol version the schema contracts. A per-platform collector (Linux sysfs, macOS IOKit, Windows SetupAPI) will populate it later.
- `bus_number` is `0` on macOS (nusb doesn't surface it). Platform parity issue, not a contract violation.
- `port_path` namespace varies: macOS `location_id` (8-digit hex), Windows `port_number`, Linux `device_address`. Stable per-resubmit on macOS; not stable on Linux/Windows because device addresses change on re-enumeration.
- `Meta.SubmittedAt` collectors must call `.UTC()` before submit to keep the wire form `Z`-suffixed (Plan 2b discipline).

## Test plan

- [x] `cd graywolf && go build ./...` clean
- [x] `cd graywolf && go test ./...` green (every package, 32 flareschema tests including both convergence tests against the cargo-built modem binary)
- [x] `cd graywolf && go vet ./...` clean
- [x] `GOOS=linux GOARCH=arm GOARM=7 go build ./...` clean (Pi cross-build)
- [x] `make flareschema` byte-stable (`diff` after second run is empty)
- [x] `make docs-check` and `make api-client-check` (pre-commit hooks) pass
- [x] `./target/release/graywolf-modem --list-audio | python3 -m json.tool` returns valid JSON; convergence test strict-decodes it
- [x] `./target/release/graywolf-modem --list-usb | python3 -m json.tool` returns valid JSON; convergence test strict-decodes it
- [x] `--list-cm108` regression check: still works exactly as before (untouched in this PR)
- [ ] CI armv7 Rust cross-build for `graywolf-modem` with the new `nusb = "0.1"` dep (skipped locally — `cross` not installed; CI exercises this matrix)