### PR TITLE
ui(map): fix layer toggles + restore Leaflet-style trails/weather

### DIFF
--- a/graywolf/web/src/lib/map/layers/trails.js
+++ b/graywolf/web/src/lib/map/layers/trails.js
@@ -1,55 +1,271 @@
-// Trails: a single MapLibre line layer fed by a GeoJSON source whose
-// features are the per-station position histories. Newest position is
-// positions[0]; we emit coordinates in time order (newest-first is fine
-// since LineString rendering is order-agnostic for visual appearance).
+// Trails: per-callsign colored polylines + circle dots at historical
+// position fixes, mirroring the legacy Leaflet TrailLayer styling.
 //
-// Stations with fewer than 2 positions are skipped (no trail to draw).
-// Z-order: MapLibre canvas layers always render below DOM-based markers
-// (the stations layer), so the trail line naturally sits beneath the
-// station icons without explicit beforeLayerId placement.
+// - 7-color deterministic palette keyed off callsign hash.
+// - Per-segment fading opacity: newest segment ~0.9, oldest ~0.3.
+// - White-filled colored dots at every previous fix (positions[1..]).
+//   positions[0] is intentionally NOT dotted -- the station icon already
+//   sits there.
+// - Click a dot for a popup carrying that fix's packet metadata
+//   (timestamp, coords, speed/course/alt, via, path, comment).
+// - Hover a line or dot for a small callsign tooltip.
+//
+// Implementation:
+//   * One LineString feature per segment with `color` + `opacity`
+//     properties read by paint expressions, so a single line layer
+//     handles every callsign.
+//   * Two circle layers backed by a shared point source: an invisible
+//     fat hit zone (radius 12) so dots are easy to click on touch, and
+//     the visible 3px dot on top.
+//   * Path arrays are JSON-stringified into the feature properties so
+//     they survive the GeoJSON round-trip; we parse them back on click.
+//
+// MapLibre canvas layers always render below DOM-based markers, so the
+// trail line and dots naturally sit beneath the station icons without
+// explicit beforeLayerId placement.
 
-const SOURCE_ID = 'gw-trails';
-const LAYER_ID = 'gw-trails-line';
+import maplibregl from 'maplibre-gl';
+import { esc, timeAgo, fmtLat, fmtLon, viaCls, viaText } from '../popup-helpers.js';
 
-export function mountTrailsLayer(map, getStations) {
-  if (!map.getSource(SOURCE_ID)) {
-    map.addSource(SOURCE_ID, {
+const LINE_SOURCE_ID = 'gw-trails-lines';
+const DOT_SOURCE_ID = 'gw-trails-dots';
+const LINE_LAYER_ID = 'gw-trails-line';
+const DOT_HIT_LAYER_ID = 'gw-trails-dot-hit';
+const DOT_LAYER_ID = 'gw-trails-dot';
+
+// Dark saturated palette that pops on the basemap. Order kept stable so
+// a given callsign always maps to the same color across sessions.
+const TRAIL_COLORS = [
+  '#2b6cb0', // dark blue
+  '#6b21a8', // dark purple
+  '#4a9e3f', // lime green
+  '#b5247a', // hot pink
+  '#1a8a9a', // teal
+  '#b45309', // dark amber
+  '#be123c', // crimson
+];
+
+function trailColor(callsign) {
+  let h = 0;
+  for (let i = 0; i < callsign.length; i++) {
+    h = (h * 31 + callsign.charCodeAt(i)) | 0;
+  }
+  const idx = ((h % TRAIL_COLORS.length) + TRAIL_COLORS.length) % TRAIL_COLORS.length;
+  return TRAIL_COLORS[idx];
+}
+
+export function mountTrailsLayer(map, getStations, opts = {}) {
+  const { hasStation = () => false, focusStation = () => {} } = opts;
+
+  if (!map.getSource(LINE_SOURCE_ID)) {
+    map.addSource(LINE_SOURCE_ID, {
       type: 'geojson',
       data: { type: 'FeatureCollection', features: [] },
     });
   }
-  if (!map.getLayer(LAYER_ID)) {
+  if (!map.getSource(DOT_SOURCE_ID)) {
+    map.addSource(DOT_SOURCE_ID, {
+      type: 'geojson',
+      data: { type: 'FeatureCollection', features: [] },
+    });
+  }
+  if (!map.getLayer(LINE_LAYER_ID)) {
     map.addLayer({
-      id: LAYER_ID,
+      id: LINE_LAYER_ID,
       type: 'line',
-      source: SOURCE_ID,
+      source: LINE_SOURCE_ID,
+      layout: { 'line-cap': 'round', 'line-join': 'round' },
       paint: {
-        'line-color': '#3fb950',
-        'line-width': 2,
-        'line-opacity': 0.65,
+        'line-color': ['get', 'color'],
+        'line-width': 4,
+        'line-opacity': ['get', 'opacity'],
       },
     });
   }
+  if (!map.getLayer(DOT_HIT_LAYER_ID)) {
+    map.addLayer({
+      id: DOT_HIT_LAYER_ID,
+      type: 'circle',
+      source: DOT_SOURCE_ID,
+      paint: {
+        'circle-radius': 12,
+        'circle-color': '#000',
+        'circle-opacity': 0,
+      },
+    });
+  }
+  if (!map.getLayer(DOT_LAYER_ID)) {
+    map.addLayer({
+      id: DOT_LAYER_ID,
+      type: 'circle',
+      source: DOT_SOURCE_ID,
+      paint: {
+        'circle-radius': 3,
+        'circle-color': '#ffffff',
+        'circle-stroke-color': ['get', 'color'],
+        'circle-stroke-width': 2,
+        'circle-opacity': ['get', 'opacity'],
+        'circle-stroke-opacity': ['get', 'opacity'],
+      },
+    });
+  }
+
+  let popup = null;
+  let hoverPopup = null;
+
+  function clearHoverTooltip() {
+    if (hoverPopup) { hoverPopup.remove(); hoverPopup = null; }
+  }
+
+  function showHoverTooltip(callsign, lngLat) {
+    if (hoverPopup) {
+      hoverPopup.setLngLat(lngLat).setText(callsign);
+      return;
+    }
+    hoverPopup = new maplibregl.Popup({
+      offset: 8,
+      closeButton: false,
+      closeOnClick: false,
+      className: 'gw-trail-tooltip',
+    })
+      .setLngLat(lngLat)
+      .setText(callsign)
+      .addTo(map);
+  }
+
+  function openDotPopup(props, lngLat) {
+    if (popup) popup.remove();
+    const html = renderDotPopup(props, hasStation);
+    popup = new maplibregl.Popup({
+      offset: 12,
+      closeButton: true,
+      closeOnClick: true,
+      maxWidth: '320px',
+      className: 'gw-station-popup',
+    })
+      .setLngLat(lngLat)
+      .setHTML(html)
+      .addTo(map);
+    popup.on('close', () => { popup = null; });
+
+    // Wire path-link clicks so clicking a digi callsign in the path
+    // re-focuses the map on it.
+    const el = popup.getElement();
+    if (el) {
+      el.addEventListener('click', (ev) => {
+        const link = ev.target && ev.target.closest && ev.target.closest('.path-link');
+        if (!link) return;
+        ev.preventDefault();
+        const cs = link.dataset.callsign;
+        if (cs) focusStation(cs);
+      });
+    }
+  }
+
+  function onDotClick(e) {
+    const f = e.features && e.features[0];
+    if (!f) return;
+    openDotPopup(f.properties, f.geometry.coordinates);
+  }
+
+  function onHoverEnter(e) {
+    const f = e.features && e.features[0];
+    if (!f) return;
+    map.getCanvas().style.cursor = 'pointer';
+    showHoverTooltip(f.properties.callsign, e.lngLat);
+  }
+
+  function onHoverMove(e) {
+    const f = e.features && e.features[0];
+    if (!f) { clearHoverTooltip(); return; }
+    showHoverTooltip(f.properties.callsign, e.lngLat);
+  }
+
+  function onHoverLeave() {
+    map.getCanvas().style.cursor = '';
+    clearHoverTooltip();
+  }
+
+  map.on('click', DOT_LAYER_ID, onDotClick);
+  map.on('click', DOT_HIT_LAYER_ID, onDotClick);
+  map.on('mouseenter', DOT_HIT_LAYER_ID, onHoverEnter);
+  map.on('mousemove', DOT_HIT_LAYER_ID, onHoverMove);
+  map.on('mouseleave', DOT_HIT_LAYER_ID, onHoverLeave);
+  map.on('mouseenter', LINE_LAYER_ID, onHoverEnter);
+  map.on('mousemove', LINE_LAYER_ID, onHoverMove);
+  map.on('mouseleave', LINE_LAYER_ID, onHoverLeave);
 
   function refresh() {
     const stations = getStations();
     if (!stations) return;
 
-    const features = [];
+    const lineFeatures = [];
+    const dotFeatures = [];
+
     for (const [callsign, s] of stations) {
-      const points = s.positions;
-      if (!points || points.length < 2) continue;
-      features.push({
-        type: 'Feature',
-        geometry: {
-          type: 'LineString',
-          coordinates: points.map((p) => [p.lon, p.lat]),
-        },
-        properties: { callsign },
-      });
+      const pts = s.positions;
+      if (!pts || pts.length < 2) continue;
+      const color = trailColor(callsign);
+      const segCount = pts.length - 1;
+
+      for (let i = 0; i < segCount; i++) {
+        const opacity = Math.max(0.9 - (i / segCount) * 0.6, 0.3);
+        lineFeatures.push({
+          type: 'Feature',
+          geometry: {
+            type: 'LineString',
+            coordinates: [
+              [pts[i].lon, pts[i].lat],
+              [pts[i + 1].lon, pts[i + 1].lat],
+            ],
+          },
+          properties: { callsign, color, opacity },
+        });
+      }
+
+      for (let i = 1; i < pts.length; i++) {
+        const p = pts[i];
+        const opacity = Math.max(0.9 - ((i - 1) / segCount) * 0.5, 0.4);
+        dotFeatures.push({
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [p.lon, p.lat] },
+          properties: {
+            callsign,
+            color,
+            opacity,
+            timestamp: p.timestamp,
+            lat: p.lat,
+            lon: p.lon,
+            alt_m: p.alt_m == null ? null : p.alt_m,
+            has_alt: !!p.has_alt,
+            speed_kt: p.speed_kt || 0,
+            course: p.course == null ? null : p.course,
+            channel: p.channel || 0,
+            via: p.via || '',
+            hops: p.hops || 0,
+            direction: p.direction || 'RX',
+            comment: p.comment || '',
+            // Stringify so the array survives any GeoJSON round-trip;
+            // parsed back in renderDotPopup.
+            path: JSON.stringify(p.path || []),
+          },
+        });
+      }
     }
-    const src = map.getSource(SOURCE_ID);
-    if (src) src.setData({ type: 'FeatureCollection', features });
+
+    map.getSource(LINE_SOURCE_ID)?.setData({ type: 'FeatureCollection', features: lineFeatures });
+    map.getSource(DOT_SOURCE_ID)?.setData({ type: 'FeatureCollection', features: dotFeatures });
+  }
+
+  function setVisible(visible) {
+    const value = visible ? 'visible' : 'none';
+    for (const id of [LINE_LAYER_ID, DOT_HIT_LAYER_ID, DOT_LAYER_ID]) {
+      if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', value);
+    }
+    if (!visible) {
+      if (popup) { popup.remove(); popup = null; }
+      clearHoverTooltip();
+    }
   }
 
   function destroy() {
@@ -57,16 +273,85 @@ export function mountTrailsLayer(map, getStations) {
     // map.remove() may already have torn down internal state. Guard --
     // if the map is gone, the layer/source went with it.
     try {
-      if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
-      if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
+      map.off('click', DOT_LAYER_ID, onDotClick);
+      map.off('click', DOT_HIT_LAYER_ID, onDotClick);
+      map.off('mouseenter', DOT_HIT_LAYER_ID, onHoverEnter);
+      map.off('mousemove', DOT_HIT_LAYER_ID, onHoverMove);
+      map.off('mouseleave', DOT_HIT_LAYER_ID, onHoverLeave);
+      map.off('mouseenter', LINE_LAYER_ID, onHoverEnter);
+      map.off('mousemove', LINE_LAYER_ID, onHoverMove);
+      map.off('mouseleave', LINE_LAYER_ID, onHoverLeave);
+      if (popup) { popup.remove(); popup = null; }
+      clearHoverTooltip();
+      for (const id of [DOT_LAYER_ID, DOT_HIT_LAYER_ID, LINE_LAYER_ID]) {
+        if (map.getLayer(id)) map.removeLayer(id);
+      }
+      for (const id of [DOT_SOURCE_ID, LINE_SOURCE_ID]) {
+        if (map.getSource(id)) map.removeSource(id);
+      }
     } catch { /* map already removed */ }
   }
 
-  function setVisible(visible) {
-    if (map.getLayer(LAYER_ID)) {
-      map.setLayoutProperty(LAYER_ID, 'visibility', visible ? 'visible' : 'none');
-    }
+  return { refresh, destroy, setVisible };
+}
+
+// Trail-dot popup uses per-position metadata so it reflects the packet
+// state at the time this fix was reported, not the station's current
+// state. Mirrors the legacy Leaflet trail dot popup.
+function renderDotPopup(props, hasStation) {
+  const ago = timeAgo(props.timestamp);
+  const dir = props.direction || 'RX';
+  const dirCls = dir === 'RX' ? 'b-rx' : dir === 'TX' ? 'b-tx' : 'b-is';
+
+  let html = `<div class="stn-popup">`;
+  html += `<div class="stn-hdr">`;
+  html += `<span class="stn-call">${esc(props.callsign)}</span>`;
+  if (dir !== 'IS') {
+    html += `<span class="badge ${dirCls}">${esc(dir)}</span>`;
+  }
+  html += `</div>`;
+  html += `<div class="stn-sub">${ago}`;
+  if (props.channel) html += ` &middot; Ch ${props.channel}`;
+  html += `</div>`;
+  html += `<div class="stn-sep"></div>`;
+  html += `<div class="stn-coords">${fmtLat(Number(props.lat))} ${fmtLon(Number(props.lon))}</div>`;
+
+  const meta = [];
+  const speedKt = Number(props.speed_kt) || 0;
+  if (speedKt > 0) meta.push(`${Math.round(speedKt * 1.15078)}mph`);
+  if (props.course !== null && props.course !== '' && props.course !== undefined) {
+    meta.push(`${props.course}°`);
+  }
+  if (props.has_alt) {
+    const altM = Number(props.alt_m);
+    if (!Number.isNaN(altM)) meta.push(`alt ${Math.round(altM * 3.28084)} ft`);
+  }
+  if (meta.length) html += `<div class="stn-meta">${meta.join(' · ')}</div>`;
+
+  // viaCls/viaText want { via, hops } -- the per-fix props already have
+  // these flat, so just pass props directly.
+  const viaShim = { via: props.via, hops: Number(props.hops) || 0 };
+  html += `<div class="stn-via ${viaCls(viaShim)}">${viaText(viaShim)}</div>`;
+
+  let path = [];
+  try { path = JSON.parse(props.path || '[]'); } catch { path = []; }
+  if ((Number(props.hops) || 0) > 0 && path.length) {
+    const pathHtml = path.map((call) => {
+      const clean = call.replace('*', '');
+      const suffix = call.endsWith('*') ? '*' : '';
+      if (hasStation(clean)) {
+        return `<a class="path-link" href="#" data-callsign="${esc(clean)}">${esc(clean)}${suffix}</a>`;
+      }
+      return esc(call);
+    }).join(',');
+    html += `<div class="stn-path">${pathHtml}</div>`;
   }
 
-  return { refresh, destroy, setVisible };
+  if (props.comment) {
+    html += `<div class="stn-sep"></div>`;
+    html += `<div class="stn-comment">${esc(props.comment)}</div>`;
+  }
+
+  html += `</div>`;
+  return html;
 }

--- a/graywolf/web/src/lib/map/layers/weather.js
+++ b/graywolf/web/src/lib/map/layers/weather.js
@@ -1,16 +1,25 @@
-// Weather labels for stations whose latest packet included weather
-// telemetry. Renders as a MapLibre symbol layer; canvas symbols sit
-// below the DOM-based station markers, and we offset the text upward
-// so it shows above the station icon (matching the legacy Leaflet
-// overlay's iconAnchor: [40, -14]).
+// Weather labels: per-station DOM marker with the legacy Leaflet
+// wx-text chip styling. Floats above the station icon, anchored at the
+// chip's bottom so its position relative to the station stays stable
+// across zoom levels.
+//
+// Implementation parallels stations.js: keep a Map<callsign, marker>
+// in sync with the data store. The weather layer reads s.weather from
+// the stations Map (the data store also keeps a separate weather
+// SvelteMap, but stations[callsign].weather is the canonical view).
+//
+// Why DOM over symbol layer: the legacy wx-text chip has a translucent
+// dark background, muted-dim text, and a thin border. MapLibre's
+// symbol layer can't paint a backing rectangle behind text -- it can
+// only halo. A DOM marker reproduces the chip exactly and toggles via
+// element.style.display, matching the stations and my-position layers.
 //
 // Field names match WeatherDTO in pkg/webapi/stations.go: temp_f,
 // wind_mph, wind_dir. Unit conversion honors unitsState.isMetric.
 
+import maplibregl from 'maplibre-gl';
 import { unitsState } from '../../settings/units-store.svelte.js';
 
-const SOURCE_ID = 'gw-weather';
-const LAYER_ID = 'gw-weather-labels';
 const KMH_PER_MPH = 1.60934;
 
 function cardinal(deg) {
@@ -35,33 +44,25 @@ function formatLabel(wx, isMetric) {
 }
 
 export function mountWeatherLayer(map, getStations) {
-  if (!map.getSource(SOURCE_ID)) {
-    map.addSource(SOURCE_ID, {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: [] },
-    });
-  }
-  if (!map.getLayer(LAYER_ID)) {
-    map.addLayer({
-      id: LAYER_ID,
-      type: 'symbol',
-      source: SOURCE_ID,
-      layout: {
-        'text-field': ['get', 'label'],
-        'text-size': 11,
-        'text-anchor': 'bottom',
-        // Lift the label above the station icon. Negative Y in
-        // text-offset means upward in MapLibre's symbol coordinates.
-        'text-offset': [0, -2.4],
-        'text-allow-overlap': true,
-        'text-ignore-placement': true,
-      },
-      paint: {
-        'text-color': '#ffffff',
-        'text-halo-color': 'rgba(0, 0, 0, 0.7)',
-        'text-halo-width': 1.2,
-      },
-    });
+  // callsign → { marker, label, lat, lon }
+  const markers = new Map();
+
+  function createMarker(label, lat, lon) {
+    const root = document.createElement('div');
+    root.className = 'wx-label';
+    const text = document.createElement('div');
+    text.className = 'wx-text';
+    text.textContent = label;
+    root.appendChild(text);
+
+    // Anchor 'bottom' + small upward offset so the chip floats above
+    // the 21x21 station icon (which sits centered on the lat/lon, so
+    // its top is ~10.5px above it). 14px offset leaves a hairline gap.
+    return new maplibregl.Marker({
+      element: root,
+      anchor: 'bottom',
+      offset: [0, -14],
+    }).setLngLat([lon, lat]).addTo(map);
   }
 
   function refresh() {
@@ -69,37 +70,71 @@ export function mountWeatherLayer(map, getStations) {
     if (!stations) return;
 
     const isMetric = unitsState.isMetric;
-    const features = [];
+    const seen = new Set();
+
     for (const [callsign, s] of stations) {
       if (!s.weather) continue;
       const pos = s.positions && s.positions[0];
       if (!pos) continue;
       const label = formatLabel(s.weather, isMetric);
       if (!label) continue;
-      features.push({
-        type: 'Feature',
-        geometry: { type: 'Point', coordinates: [pos.lon, pos.lat] },
-        properties: { callsign, label },
-      });
+
+      seen.add(callsign);
+      const entry = markers.get(callsign);
+      if (!entry) {
+        const marker = createMarker(label, pos.lat, pos.lon);
+        markers.set(callsign, { marker, label, lat: pos.lat, lon: pos.lon });
+      } else {
+        // Cheap change detection: skip the DOM/setLngLat work when
+        // nothing meaningful moved. The text node only updates when
+        // the formatted label actually changes (units toggle, fresh
+        // weather packet).
+        if (entry.lat !== pos.lat || entry.lon !== pos.lon) {
+          entry.marker.setLngLat([pos.lon, pos.lat]);
+          entry.lat = pos.lat;
+          entry.lon = pos.lon;
+        }
+        if (entry.label !== label) {
+          const textEl = entry.marker.getElement().querySelector('.wx-text');
+          if (textEl) textEl.textContent = label;
+          entry.label = label;
+        }
+      }
     }
-    const src = map.getSource(SOURCE_ID);
-    if (src) src.setData({ type: 'FeatureCollection', features });
+
+    // Drop markers whose station no longer reports weather (or fell
+    // out of the timerange / bbox).
+    for (const [callsign, entry] of markers) {
+      if (!seen.has(callsign)) {
+        entry.marker.remove();
+        markers.delete(callsign);
+      }
+    }
   }
+
+  let visible = true;
+  function setVisible(next) {
+    visible = !!next;
+    const display = visible ? '' : 'none';
+    for (const { marker } of markers.values()) {
+      marker.getElement().style.display = display;
+    }
+  }
+
+  // Wrap refresh so newly-minted markers honor the current visibility.
+  const wrappedRefresh = () => {
+    refresh();
+    if (!visible) {
+      for (const { marker } of markers.values()) {
+        marker.getElement().style.display = 'none';
+      }
+    }
+  };
 
   function destroy() {
-    // Map may already be torn down by the shell's onDestroy; guard so
-    // a stale removal call doesn't throw and abort sibling cleanups.
-    try {
-      if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
-      if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
-    } catch { /* map already removed */ }
+    for (const { marker } of markers.values()) marker.remove();
+    markers.clear();
   }
 
-  function setVisible(visible) {
-    if (map.getLayer(LAYER_ID)) {
-      map.setLayoutProperty(LAYER_ID, 'visibility', visible ? 'visible' : 'none');
-    }
-  }
-
-  return { refresh, destroy, setVisible };
+  return { refresh: wrappedRefresh, destroy, setVisible };
 }

--- a/graywolf/web/src/routes/LiveMapV2.svelte
+++ b/graywolf/web/src/routes/LiveMapV2.svelte
@@ -142,11 +142,23 @@
     coordText = `${fmtLat(lat)} ${fmtLon(lon)} · ${toMaidenhead(lat, lon)}`;
   }
 
+  function focusStation(callsign) {
+    const target = dataStore.stations.get(callsign);
+    if (!target) return;
+    const tpos = target.positions && target.positions[0];
+    if (!tpos) return;
+    mapRef?.panTo([tpos.lon, tpos.lat]);
+    if (mapRef) openStationPopup(mapRef, target);
+  }
+
   function onMapReady(map) {
     mapRef = map;
     // Trails first so the line sits beneath the (DOM) station markers
     // and below the weather labels in symbol-layer order.
-    trailsLayer = mountTrailsLayer(map, () => dataStore.stations);
+    trailsLayer = mountTrailsLayer(map, () => dataStore.stations, {
+      hasStation: (callsign) => dataStore.stations.has(callsign),
+      focusStation,
+    });
     weatherLayer = mountWeatherLayer(map, () => dataStore.stations);
     hoverPathLayer = mountHoverPathLayer(map, () => {
       const my = dataStore.myPosition;
@@ -213,20 +225,28 @@
     if (myPositionLayer) myPositionLayer.refresh();
   });
 
-  // Push the layer toggles into the layer modules. Each module no-ops
-  // safely before the layer is actually mounted (effect re-fires after
-  // onMapReady).
+  // Push the layer toggles into the layer modules. We MUST read the
+  // reactive value before the optional-chain so Svelte 5 tracks it as a
+  // dependency on the initial run. With `layer?.setVisible(toggle)`, if
+  // `layer` is null on first run (mount before onMapReady), the RHS is
+  // short-circuited and `toggle` is never read — the effect ends up with
+  // zero deps and never re-fires when the operator clicks a checkbox.
+  // Reading `toggle` into a const first guarantees the dep is registered.
   $effect(() => {
-    stationsLayer?.setVisible(layerToggles.stations);
+    const v = layerToggles.stations;
+    stationsLayer?.setVisible(v);
   });
   $effect(() => {
-    trailsLayer?.setVisible(layerToggles.trails);
+    const v = layerToggles.trails;
+    trailsLayer?.setVisible(v);
   });
   $effect(() => {
-    weatherLayer?.setVisible(layerToggles.weather);
+    const v = layerToggles.weather;
+    weatherLayer?.setVisible(v);
   });
   $effect(() => {
-    myPositionLayer?.setVisible(layerToggles.myPosition);
+    const v = layerToggles.myPosition;
+    myPositionLayer?.setVisible(v);
   });
 
   // Push the timerange into the data store.
@@ -737,6 +757,44 @@
   :global(.stn-popup .b-rx) { background: rgba(63, 185, 80, 0.15); color: var(--color-success); }
   :global(.stn-popup .b-tx) { background: rgba(210, 153, 34, 0.15); color: var(--color-warning); }
   :global(.stn-popup .b-is) { background: rgba(195, 155, 255, 0.15); color: #c39bff; }
+
+  /* Weather label chip -- ports the legacy Leaflet wx-label/wx-text
+     styling. The marker root is a maplibregl.Marker (DOM-based) so
+     these have to be :global. */
+  :global(.wx-label) {
+    background: none !important;
+    border: none !important;
+    pointer-events: none;
+  }
+  :global(.wx-text) {
+    background: rgba(22, 27, 34, 0.85);
+    color: var(--color-text-dim);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 1px 4px;
+    border-radius: 3px;
+    white-space: nowrap;
+    text-align: center;
+  }
+
+  /* Trail hover tooltip: small dim chip with the callsign, tip-less and
+     non-interactive. Distinct from station popups so it doesn't pull
+     theme styling for the close button etc. */
+  :global(.gw-trail-tooltip .maplibregl-popup-content) {
+    background: rgba(22, 27, 34, 0.85);
+    color: #e0e0e0;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 3px;
+    padding: 1px 6px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 700;
+    box-shadow: none;
+    pointer-events: none;
+  }
+  :global(.gw-trail-tooltip .maplibregl-popup-tip) {
+    display: none;
+  }
 
   /* Own position marker -- iOS Maps "blue dot" look: white ring around a
      solid blue core, with a soft blue halo. The MapLibre marker DOM is


### PR DESCRIPTION
## Summary

Four reported map regressions, one root cause for the toggles plus two visual rebuilds.

- **Toggles (stations / trails / weather / my-position) all do nothing.** Svelte 5 \`\$effect\` tracks reactive reads at runtime; the LHS-null short-circuit in \`layer?.setVisible(layerToggles.X)\` meant \`layerToggles.X\` was never read on the initial run, the effect tracked zero deps, and clicking a checkbox never re-fired it. Read the toggle into a const before the optional-chain.
- **Trails look nothing like Leaflet.** Replace the single uniform green line with the old \`TrailLayer\` styling: 7-color deterministic per-callsign palette, per-segment fading opacity 0.9 -> 0.3, white-filled colored dots at every previous fix, click popup with that fix's packet metadata (timestamp, coords, speed/course/alt, via, path with clickable digi links, comment), and a callsign tooltip on hover. Two GeoJSON sources + data-driven paint, plus a fat invisible hit-zone circle behind each dot for touch.
- **Weather labels look bad.** Drop the bright-white-on-black-halo MapLibre symbol layer and port the legacy \`wx-label\` / \`wx-text\` chip back as DOM-based \`maplibregl.Marker\` entries anchored above each station. Restore the matching \`:global\` CSS in \`LiveMapV2.svelte\`.

## Test plan

- [ ] Live map loads and renders trails as colored fading polylines (one color per callsign)
- [ ] Click a trail dot -> popup shows that fix's packet metadata
- [ ] Hover a trail line or dot -> small callsign tooltip
- [ ] Weather labels render as the dark translucent chip above each station icon (matches legacy Leaflet)
- [ ] Stations toggle hides/shows station markers
- [ ] Trails toggle hides/shows trail lines + dots
- [ ] Weather toggle hides/shows weather chips
- [ ] My Position toggle hides/shows the blue dot
- [ ] Toggle off, wait for a data refresh, toggle on -> layer comes back