### PR TITLE
fix(aprs): reject Mic-E packets with SPACE in lon info bytes

### DIFF
--- a/graywolf/pkg/aprs/mice.go
+++ b/graywolf/pkg/aprs/mice.go
@@ -323,11 +323,30 @@ func isMicEHighBit(c byte) bool {
 	return false
 }
 
+// ErrMicELonAmbiguous reports that one of the three longitude bytes is a
+// SPACE (0x20), which APRS101 ch 10 reserves as the "no/ambiguous data"
+// marker for the Mic-E info-field longitude field. Some encoders (Yaesu
+// FT-2D/FT-3D, Kenwood TH-D72) emit this state before GPS lock; the
+// receiver MUST NOT combine the SPACE byte with the destination's
+// longitude offset bit and pretend the result is a position. parseMicE
+// surfaces this as a warn-and-drop rather than plotting the station
+// 8000+ km from its actual location.
+var ErrMicELonAmbiguous = errors.New("mic-e: longitude ambiguous (SPACE in info field)")
+
 // decodeMicELon decodes the 3-byte info-field longitude into decimal
 // degrees and applies the offset / hemisphere.
 func decodeMicELon(b []byte, offset int, sign float64) (float64, error) {
 	if len(b) < 3 {
 		return 0, errors.New("mic-e: lon short")
+	}
+	// APRS101 ch 10: a SPACE (0x20) in any of the three longitude
+	// bytes flags that field as unknown — the convention used when GPS
+	// has not locked or the encoder is otherwise unwilling to assert a
+	// value. Combining it with the dest-byte-4 +100° offset would
+	// otherwise yield lon = (b[0]-28)+100 = 104° from a 0x20 byte and
+	// drop a German station onto Mongolia.
+	if b[0] == ' ' || b[1] == ' ' || b[2] == ' ' {
+		return 0, ErrMicELonAmbiguous
 	}
 	// Degrees byte (0x1C..0x7F after +28 offset).
 	d := int(b[0]) - 28

--- a/graywolf/pkg/aprs/mice_test.go
+++ b/graywolf/pkg/aprs/mice_test.go
@@ -1,6 +1,7 @@
 package aprs
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/chrissnell/graywolf/pkg/ax25"
@@ -124,6 +125,30 @@ func TestParseMicEAltitude(t *testing.T) {
 	}
 	if !pkt.Position.HasAlt || int(pkt.Position.Altitude) != 1234 {
 		t.Errorf("outer position altitude %+v", pkt.Position)
+	}
+}
+
+// TestParseMicEAmbiguousLonRejected covers a DL9DAK packet seen in the
+// wild whose longitude info-field begins with SPACE (0x20). dest "U3SUY8"
+// sets the +100° longitude-offset bit (dest[4]='Y'), so combining the
+// SPACE byte (raw lon=4) with the offset yields 104.96° — a
+// spec-compliant decode that drops the German station onto Mongolia,
+// ~8000 km from its actual position. APRS101 ch 10 reserves SPACE as the
+// ambiguous-data marker for this field, so we refuse to plot it.
+func TestParseMicEAmbiguousLonRejected(t *testing.T) {
+	srcAddr, _ := ax25.ParseAddress("DL9DAK")
+	destAddr, _ := ax25.ParseAddress("U3SUY8")
+	info := []byte{'\'', 0x20, 'U', 'h', 'l', 0x20, 'B', '-', '/', '>'}
+	f, err := ax25.NewUIFrame(srcAddr, destAddr, nil, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkt, err := Parse(f)
+	if err == nil {
+		t.Fatalf("expected error for ambiguous lon, got pkt %+v", pkt.MicE)
+	}
+	if !errors.Is(err, ErrMicELonAmbiguous) {
+		t.Fatalf("wrong error: %v (want ErrMicELonAmbiguous)", err)
 	}
 }
 


### PR DESCRIPTION
APRS101 ch 10 reserves SPACE (0x20) in any of the three Mic-E info-field longitude bytes as the "no usable data" marker emitted by Yaesu / Kenwood radios that beacon before GPS lock. The decoder was treating SPACE as a numeric byte, so a DL9DAK beacon (dest U3SUY8, info "' Uhl B-/>") decoded to 104.96 E and showed up ~8000 km from its actual German location, because dest[4]='Y' also set the +100 offset bit.

Surface ErrMicELonAmbiguous instead; the packet still classifies as Mic-E but parseMicE bails before publishing a position so the station doesn't appear at the wrong spot on the map.