### PR TITLE
ui(map): fix layer toggles, restore Leaflet styling, mount on style.load

### DIFF
--- a/graywolf/web/src/lib/map/maplibre-map.svelte
+++ b/graywolf/web/src/lib/map/maplibre-map.svelte
@@ -244,7 +244,19 @@
         // Style may be mid-swap; ignore.
       }
     });
-    map.once('load', () => oncreate?.(map));
+    // Mount the operator's data layers (stations, trails, weather,
+    // my-position) as soon as the style *spec* is parsed -- do NOT wait
+    // for the basemap's `load`, which only fires after every basemap
+    // source has completed its first fetch. If maps.nw5w.com is slow,
+    // unreachable, or its tiles.json hangs, `load` never fires and the
+    // operator's stations silently fail to appear on what is otherwise
+    // a working map. style.load fires as soon as `style._loaded` flips
+    // true, which is all addSource/addLayer/Marker.addTo need.
+    if (map.style?._loaded) {
+      oncreate?.(map);
+    } else {
+      map.once('style.load', () => oncreate?.(map));
+    }
     if (typeof window !== 'undefined') window.__gwMap = map;
   });
 


### PR DESCRIPTION
## Summary

- Fix Svelte 5 \$effect dependency tracking on layer toggle checkboxes; the optional-chain was short-circuiting the dep read so stations/trails/weather/my-position toggles silently did nothing.
- Rebuild the trails layer with the legacy Leaflet styling: per-callsign 7-color palette, fading per-segment opacity, white-filled colored dots with click-for-popup, hover tooltips, and clickable digi path links.
- Rebuild the weather layer using DOM markers with the legacy `wx-text` chip styling instead of MapLibre symbol-layer text.
- Mount operator data layers (stations, trails, weather, my-position) on `style.load` instead of `load`. The `load` event waits for every basemap source's first fetch to complete, so a slow/unreachable basemap tiles.json would silently prevent stations from ever appearing on what looked like a working map. `style.load` fires once the style spec is parsed, which is all addSource/addLayer/Marker.addTo actually need. Likely latent since the maplibre-gl v5 upgrade; surfaced when the upstream tile source got slow enough to mask it.

## Test plan

- [ ] Layer toggle checkboxes flip stations/trails/weather/my-position visibility on click
- [ ] Trails render with per-callsign colored polylines, fading-opacity segments, and white-filled colored dots with click-for-popup
- [ ] Weather chips render above stations with the legacy `wx-text` styling
- [ ] Stations and overlays appear even when the basemap tiles.json is slow or degraded
- [ ] `svelte-check` reports 0 errors