### PR TITLE
gitignore: add go.work / go.work.sum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ target/
 .cursor/
 .vscode/
 .DS_Store
+go.work
+go.work.sum
 aprs-test-tracks/
 .context/
 .claude/


### PR DESCRIPTION
## Summary
- Add `go.work` and `go.work.sum` to `.gitignore` so per-developer Go workspace files don't get committed.

## Why
While doing Plan 2c work I dropped a `go.work` at the repo root linking `./graywolf` and `../graywolf-flare-server` so gopls could index both modules together (silences "not in your workspace" diagnostics). That file is local-only — it varies per checkout depending on which sibling repos exist. Same reasoning as `.cursor/` / `.vscode/`.

## Test plan
- [x] No code changes — gitignore-only.
- [x] `git status` shows nothing else affected.