### PR TITLE
auth(maps): switch tile/tilejson auth to ?t= URL token

### DIFF
--- a/graywolf/pkg/mapscache/manager.go
+++ b/graywolf/pkg/mapscache/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -215,14 +216,17 @@ func (m *Manager) run(ctx context.Context, a *activeDownload) {
 	}()
 
 	tok := m.tokenProvider(ctx)
-	url := fmt.Sprintf("%s/download/state/%s.pmtiles", m.mapsBaseURL, a.slug)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	base := fmt.Sprintf("%s/download/state/%s.pmtiles", m.mapsBaseURL, a.slug)
+	fullURL := base
+	if tok != "" {
+		q := url.Values{}
+		q.Set("t", tok)
+		fullURL = base + "?" + q.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
 	if err != nil {
 		m.fail(ctx, a.slug, err)
 		return
-	}
-	if tok != "" {
-		req.Header.Set("Authorization", "Bearer "+tok)
 	}
 	resp, err := m.httpClient.Do(req)
 	if err != nil {

--- a/graywolf/pkg/mapscache/manager_test.go
+++ b/graywolf/pkg/mapscache/manager_test.go
@@ -33,8 +33,11 @@ func newTestManager(t *testing.T, upstreamHandler http.Handler) (*Manager, *conf
 func TestManager_HappyPath(t *testing.T) {
 	body := strings.Repeat("X", 64*1024) // 64 KB
 	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer test-token" {
-			t.Errorf("expected bearer token; got %q", r.Header.Get("Authorization"))
+		if got := r.URL.Query().Get("t"); got != "test-token" {
+			t.Errorf("expected t=test-token query param; got %q", got)
+		}
+		if h := r.Header.Get("Authorization"); h != "" {
+			t.Errorf("expected no Authorization header; got %q", h)
 		}
 		w.Header().Set("Content-Length", "65536")
 		w.Header().Set("Content-Type", "application/vnd.pmtiles")

--- a/graywolf/web/src/lib/map/maplibre-map.svelte
+++ b/graywolf/web/src/lib/map/maplibre-map.svelte
@@ -47,11 +47,11 @@
     const federated = createFederatedProtocol({
       completedSlugsProvider: () => downloadsState.completed,
       fetchOnline: async (z, x, y, signal) => {
-        const url = `https://maps.nw5w.com/${z}/${x}/${y}.mvt`;
-        const headers = bearerToken
-          ? { Authorization: `Bearer ${bearerToken}` }
-          : {};
-        const res = await fetch(url, { headers, signal });
+        const base = `https://maps.nw5w.com/${z}/${x}/${y}.mvt`;
+        const url = bearerToken
+          ? `${base}?t=${encodeURIComponent(bearerToken)}`
+          : base;
+        const res = await fetch(url, { signal });
         if (!res.ok) {
           throw new Error(`tile ${z}/${x}/${y} fetch failed: ${res.status}`);
         }
@@ -132,17 +132,32 @@
     return osmRasterStyle();
   }
 
-  // transformRequest: attach Bearer token to maps.nw5w.com requests
-  // EXCEPT /style/* (must stay anonymous to keep CF edge cache shared).
+  // transformRequest: attach the bearer token as ?t=<token> on
+  // maps.nw5w.com tile and tiles.json requests. URL-token auth keeps
+  // requests CORS-simple (no preflight) and lets the worker share its
+  // CF edge cache across operators (cache key is the canonical URL,
+  // stripped of ?t=). /style/* stays anonymous; /download/ keeps the
+  // Authorization-header path for any future browser-initiated download.
   function transformRequest(url) {
-    if (
-      url.startsWith('https://maps.nw5w.com/') &&
-      !url.startsWith('https://maps.nw5w.com/style/') &&
-      bearerToken
-    ) {
-      return { url, headers: { Authorization: `Bearer ${bearerToken}` } };
+    if (url.startsWith('https://maps.nw5w.com/download/')) {
+      if (bearerToken) {
+        return { url, headers: { Authorization: `Bearer ${bearerToken}` } };
+      }
+      return { url };
+    }
+    if (url.startsWith('https://maps.nw5w.com/style/')) {
+      return { url };
+    }
+    if (url.startsWith('https://maps.nw5w.com/') && bearerToken) {
+      return { url: appendToken(url, bearerToken) };
     }
     return { url };
+  }
+
+  function appendToken(url, token) {
+    const u = new URL(url);
+    u.searchParams.set('t', token);
+    return u.toString();
   }
 
   // Sync the in-memory token from the server. revealToken() hits the


### PR DESCRIPTION
## Summary
- **Web client**: `transformRequest` and `fetchOnline` (gw-tile protocol) now append `?t=<token>` instead of sending `Authorization: Bearer …`. Eliminates the per-tile CORS preflight that was queuing/canceling tile fetches under rapid zoom (HAR capture: 302/389 tile GETs canceled, 0/85 z=13 GETs ever completed). `/style/*` stays anonymous; `/download/` keeps the Authorization-header path for any future browser-initiated download.
- **Go state-pmtiles downloader** (`pkg/mapscache/manager.go`): builds the URL with `?t=<token>` via `url.Values` and no longer sets the `Authorization` header. Required because the maps worker is dropping `Authorization` support entirely.
- **Test** (`pkg/mapscache/manager_test.go`): asserts the `?t=` query param plus a regression guard that no `Authorization` header is sent.

Plan: `graywolf/.context/2026-04-27-url-token-auth-client.md`. Coordinated with the worker change in `~/dev/graywolf-maps/.context/2026-04-27-url-token-auth-tiles-worker.md`.

## Why URL token (not cookies)
- CORS-simple, no preflight, ever.
- Worker keys CF edge cache by canonical URL (no `?t=`) so two operators with different tokens hit the same cached response — cookies + `Access-Control-Allow-Origin: <origin>` would have fragmented the cache per operator hostname.
- Token isn't leaked via `Referer` (Referer carries the originating page URL, not the request URL).

## Coordination
- **Deploy together**: the worker no longer accepts `Authorization`, so any caller still on the bearer header gets a 401. Single-operator topology makes a brief 401 window between worker deploy and graywolf rebuild acceptable.
- **Worker readiness check before merge**:
  - `curl -i 'https://maps.nw5w.com/9/107/195.mvt?t=<token>'` → 200
  - `curl -i 'https://maps.nw5w.com/9/107/195.mvt'` → 401
  - `curl -sI 'https://maps.nw5w.com/9/107/195.mvt?t=anything'` twice → second one `cf-cache-status: HIT`

## Test plan
- [x] `go test ./pkg/mapscache/...` passes
- [x] `go build ./...` clean
- [x] `npm run build` (vite) clean
- [ ] DevTools Network shows zero `OPTIONS` preflights on `/{z}/{x}/{y}.mvt` URLs
- [ ] Tile and tiles.json URLs include `?t=…`; `/style/*` URLs do not
- [ ] Limon/CO → z16 → z9 zoom-burst no longer leaves blank tile patches
- [ ] State download (e.g. `POST /api/maps/downloads/colorado`) still succeeds end-to-end