### PR TITLE
Allow messaging own base callsign when operating under a different SSID

### DIFF
--- a/pkg/webapi/messages.go
+++ b/pkg/webapi/messages.go
@@ -266,7 +266,7 @@ func (s *Server) sendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	to := strings.ToUpper(strings.TrimSpace(req.To))
-	if baseCall(to) != "" && baseCall(ourCall) != "" && baseCall(to) == baseCall(ourCall) {
+	if to != "" && ourCall != "" && to == ourCall {
 		badRequest(w, "cannot send a message to our own callsign")
 		return
 	}

--- a/pkg/webapi/messages_test.go
+++ b/pkg/webapi/messages_test.go
@@ -339,6 +339,73 @@ func TestSendMessage_LoopbackGuard(t *testing.T) {
 	}
 }
 
+// TestSendMessage_AllowsCrossSSID asserts the loopback guard compares
+// full callsigns (SSID included). When our station is W6XYZ-10, sending
+// to bare W6XYZ — a separate APRS station — must be permitted.
+func TestSendMessage_AllowsCrossSSID(t *testing.T) {
+	sentCh := make(chan messages.SendMessageRequest, 1)
+	svc := &fakeMessagesSvc{
+		sendFn: func(ctx context.Context, req messages.SendMessageRequest) (*configstore.Message, error) {
+			sentCh <- req
+			return &configstore.Message{
+				ID:         7,
+				Direction:  "out",
+				OurCall:    req.OurCall,
+				FromCall:   req.OurCall,
+				ToCall:     req.To,
+				Text:       req.Text,
+				ThreadKind: messages.ThreadKindDM,
+				ThreadKey:  req.To,
+				MsgID:      "001",
+				CreatedAt:  time.Now(),
+				AckState:   messages.AckStateNone,
+			}, nil
+		},
+	}
+	srv, mux, _ := newMessagesTestServer(t, svc)
+	if err := srv.store.UpsertStationConfig(context.Background(), configstore.StationConfig{Callsign: "W6XYZ-10"}); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"to":"W6XYZ","text":"hi"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for cross-SSID send, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got := <-sentCh
+	if got.To != "W6XYZ" || got.OurCall != "W6XYZ-10" {
+		t.Errorf("unexpected send req: %+v", got)
+	}
+}
+
+// TestSendMessage_BlocksExactSSIDMatch asserts the loopback guard still
+// blocks when the destination is an exact match for our callsign with
+// SSID — true loopback to ourselves.
+func TestSendMessage_BlocksExactSSIDMatch(t *testing.T) {
+	svc := &fakeMessagesSvc{
+		sendFn: func(ctx context.Context, req messages.SendMessageRequest) (*configstore.Message, error) {
+			t.Error("service SendMessage must NOT be called for exact loopback")
+			return nil, nil
+		},
+	}
+	srv, mux, _ := newMessagesTestServer(t, svc)
+	if err := srv.store.UpsertStationConfig(context.Background(), configstore.StationConfig{Callsign: "W6XYZ-10"}); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"to":"W6XYZ-10","text":"hi"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for exact-SSID loopback, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestSendMessage_MissingStationCallsign(t *testing.T) {
 	svc := &fakeMessagesSvc{
 		sendFn: func(ctx context.Context, req messages.SendMessageRequest) (*configstore.Message, error) {


### PR DESCRIPTION
Previously, the loopback guard in the send-message handler stripped SSIDs before comparing the destination callsign against our own. This caused a false positive when, for example, graywolf is configured as LLXLLL-10 and the operator tries to send a message to LLXLLL (a separate station, e.g. using APRSdroid). Both reduced to LLXLLL and the request was rejected with "cannot send a message to our own callsign."

The fix compares the full callsigns, SSID included. A message is only blocked if the destination exactly matches our configured callsign — cross-SSID messages are allowed through.

Full disclosure: I used AI to make this change. Feel free to reject or update as needed. Just something I was hoping to get fixed.

by the way - loving this software!