### PR TITLE
Outbound Actions: Messages drawer for firing @@<otp>#cmd at remote stations

### DIFF
--- a/docs/handbook/actions.html
+++ b/docs/handbook/actions.html
@@ -532,11 +532,13 @@ https://hass.local:8123/api/services/light/turn_on?room={{arg.room}}
     </p>
 
     <p class="note">
-      <strong>Want to fire these from another graywolf?</strong> Copy
-      the <strong>Secret Key</strong> shown in the reveal panel into
-      the receiving operator&rsquo;s Messages &rarr; Remote Actions
-      drawer (Manage secrets &rarr; New Secret &rarr; Secret Key).
-      Same string, two sides. See
+      <strong>Want to let another graywolf fire these?</strong> Copy
+      the <strong>Secret Key</strong> shown in the reveal panel and
+      send it (over a trusted side channel) to the operator at the
+      other graywolf &mdash; the one who wants to fire this Action
+      remotely. They paste it into <em>their</em> Messages &rarr;
+      Remote Actions drawer (Manage secrets &rarr; New Secret &rarr;
+      Secret Key). Same string, two sides. See
       <a href="remote-actions.html">Remote Actions</a>.
     </p>
 

--- a/docs/handbook/actions.html
+++ b/docs/handbook/actions.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
@@ -530,6 +531,15 @@ https://hass.local:8123/api/services/light/turn_on?room={{arg.room}}
       single-operator station.
     </p>
 
+    <p class="note">
+      <strong>Want to fire these from another graywolf?</strong> Copy
+      the <strong>Secret Key</strong> shown in the reveal panel into
+      the receiving operator&rsquo;s Messages &rarr; Remote Actions
+      drawer (Manage secrets &rarr; New Secret &rarr; Secret Key).
+      Same string, two sides. See
+      <a href="remote-actions.html">Remote Actions</a>.
+    </p>
+
     <h2>Authenticator apps</h2>
 
     <p>
@@ -843,9 +853,9 @@ https://hass.local:8123/api/services/light/turn_on?room={{arg.room}}
         <span class="label">Previous</span>
         Messaging
       </a>
-      <a href="livemap.html" class="next">
+      <a href="remote-actions.html" class="next">
         <span class="label">Next</span>
-        Live Map
+        Remote Actions
       </a>
     </nav>
   </main>

--- a/docs/handbook/actions.html
+++ b/docs/handbook/actions.html
@@ -509,7 +509,7 @@ https://hass.local:8123/api/services/light/turn_on?room={{arg.room}}
         (see the next section), or
       </li>
       <li>
-        <strong>Copy the base32 secret</strong> shown on the right and
+        <strong>Copy the Secret Key</strong> shown on the right and
         type/paste it into your authenticator manually.
       </li>
     </ol>
@@ -535,7 +535,7 @@ https://hass.local:8123/api/services/light/turn_on?room={{arg.room}}
     <p>
       Any standard TOTP authenticator works. The QR code in the reveal
       panel encodes the standard <code>otpauth://</code> URI, and the
-      base32 secret is plain RFC 4648.
+      Secret Key is plain RFC 4648 base32.
     </p>
 
     <ul>
@@ -543,12 +543,12 @@ https://hass.local:8123/api/services/light/turn_on?room={{arg.room}}
         <strong>Google Authenticator</strong> &mdash; tap
         <em>+</em> &rarr; <em>Scan a QR code</em>, point the camera at
         the panel, done. Or <em>+</em> &rarr; <em>Enter a setup key</em>
-        and paste the base32 string.
+        and paste the Secret Key.
       </li>
       <li>
         <strong>Authy</strong> &mdash; <em>Add Account</em> &rarr;
         <em>Scan QR Code</em>, or
-        <em>Enter Code Manually</em> for the base32 string. Authy
+        <em>Enter Code Manually</em> and paste the Secret Key. Authy
         backs the account up to its cloud; if you do not want that,
         prefer Google Authenticator or 1Password.
       </li>
@@ -562,7 +562,7 @@ https://hass.local:8123/api/services/light/turn_on?room={{arg.room}}
       <li>
         <strong>Bitwarden, KeePassXC, etc.</strong> &mdash; any TOTP-aware
         password manager works the same way; either scan the QR or
-        paste the base32 secret.
+        paste the Secret Key.
       </li>
     </ul>
 

--- a/docs/handbook/agwpe.html
+++ b/docs/handbook/agwpe.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/architecture.html
+++ b/docs/handbook/architecture.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/audio.html
+++ b/docs/handbook/audio.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/ax25-terminal.html
+++ b/docs/handbook/ax25-terminal.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/beacons.html
+++ b/docs/handbook/beacons.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/callsign.html
+++ b/docs/handbook/callsign.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/channels.html
+++ b/docs/handbook/channels.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/configurations.html
+++ b/docs/handbook/configurations.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/digipeater.html
+++ b/docs/handbook/digipeater.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/gps.html
+++ b/docs/handbook/gps.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/history-database.html
+++ b/docs/handbook/history-database.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/igate.html
+++ b/docs/handbook/igate.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/index.html
+++ b/docs/handbook/index.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/installation.html
+++ b/docs/handbook/installation.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/kiss.html
+++ b/docs/handbook/kiss.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/livemap.html
+++ b/docs/handbook/livemap.html
@@ -38,6 +38,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/logs.html
+++ b/docs/handbook/logs.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/maps.html
+++ b/docs/handbook/maps.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/messaging.html
+++ b/docs/handbook/messaging.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
@@ -326,6 +327,23 @@
       Stations on stricter clients may truncate or drop anything past 67
       bytes, so leave it off unless you&rsquo;ve confirmed it works on
       both ends.
+    </p>
+
+    <h2>Firing remote Actions from a thread</h2>
+
+    <p>
+      DM threads show a zap icon (<span class="kbd">&#9889;</span>) in
+      the thread header. Tapping it opens the
+      <a href="remote-actions.html">Remote Actions</a> drawer: a
+      side-panel for firing operator-curated
+      <code>@@&lt;otp&gt;#&lt;action&gt;</code> macros at the remote
+      station whose callsign owns the thread. Inbound replies that
+      arrive within 60 seconds of an outbound fire and start with a
+      status keyword (<code>ok</code>, <code>error</code>,
+      <code>bad_otp</code>, ...) get a small zap badge in the bubble
+      footer so you can correlate the reply with what you sent. The
+      icon is omitted on tactical (multi-recipient) threads, where an
+      OTP-protected fire to many callsigns at once would be a footgun.
     </p>
 
     <h2>Edge cases</h2>

--- a/docs/handbook/monitoring.html
+++ b/docs/handbook/monitoring.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/preferences.html
+++ b/docs/handbook/preferences.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/ptt.html
+++ b/docs/handbook/ptt.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/remote-actions.html
+++ b/docs/handbook/remote-actions.html
@@ -317,9 +317,12 @@
         name on the receiver.
       </li>
       <li>
-        <strong><code>replay</code>.</strong> You fired the same OTP
-        twice within its 30-second window. Wait for the tile&rsquo;s
-        cooldown countdown to clear and try again.
+        <strong><code>bad_otp</code> on rapid re-fire.</strong> The
+        receiver rejects the same OTP twice within its 30-second
+        window (replay protection). Wait for the tile&rsquo;s cooldown
+        countdown to clear and try again. Distinguishable from a
+        mistyped Secret Key in that it only happens on the second of
+        two fast clicks; a mistyped key fails every time.
       </li>
       <li>
         <strong>SEND disabled with a tooltip.</strong> The assembled

--- a/docs/handbook/remote-actions.html
+++ b/docs/handbook/remote-actions.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Remote Actions &mdash; Graywolf Handbook</title>
+  <link rel="stylesheet" href="handbook.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="index.html" class="site-logo">
+      <img src="img/graywolf-logo.svg" alt="" />
+      <span>graywolf <span class="handbook-label">handbook</span></span>
+    </a>
+    <div class="header-actions">
+      <button class="theme-toggle" aria-label="Toggle theme">[ dark ]</button>
+    </div>
+  </div>
+</header>
+
+<div class="layout">
+  <aside class="sidebar">
+    <nav>
+      <div class="sidebar-section">Getting Started</div>
+      <a href="index.html">Introduction</a>
+      <a href="installation.html">Installation</a>
+      <a href="callsign.html">Station Callsign</a>
+      <div class="sidebar-section">Radio</div>
+      <a href="audio.html">Audio Devices</a>
+      <a href="channels.html">Radio Channels</a>
+      <a href="ptt.html">Push-to-Talk</a>
+      <div class="sidebar-section">APRS</div>
+      <a href="beacons.html">Beacons</a>
+      <a href="digipeater.html">Digipeater</a>
+      <a href="igate.html">iGate</a>
+      <a href="messaging.html">Messaging</a>
+      <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
+      <a href="livemap.html">Live Map</a>
+      <div class="sidebar-section">Packet</div>
+      <a href="ax25-terminal.html">AX.25 Terminal</a>
+      <div class="sidebar-section">Interfaces</div>
+      <a href="kiss.html">KISS TNC</a>
+      <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
+      <a href="agwpe.html">AGWPE</a>
+      <a href="gps.html">GPS</a>
+      <div class="sidebar-section">Operations</div>
+      <a href="history-database.html">Position Log</a>
+      <a href="logs.html">Logs</a>
+      <a href="monitoring.html">Monitoring</a>
+      <a href="simulation.html">Simulation</a>
+      <a href="maps.html">Maps</a>
+      <a href="preferences.html">Preferences</a>
+      <a href="architecture.html">Architecture</a>
+      <div class="sidebar-section">Reference</div>
+      <a href="configurations.html">Known-Working Configs</a>
+      <a href="api.html">REST API Reference</a>
+    </nav>
+  </aside>
+
+  <main class="content">
+    <h1>Remote Actions</h1>
+    <p class="subtitle">Send <code>@@&lt;otp&gt;#&lt;action&gt;</code> commands at another station from inside Messages</p>
+
+    <p>
+      A <strong>Remote Action</strong> is the outbound side of the same
+      grammar described on the <a href="actions.html">Actions</a> page.
+      Where Actions defines what your station will <em>run</em> when an
+      <code>@@</code>-prefixed message arrives, Remote Actions lets you
+      <em>send</em> those messages at someone else&rsquo;s station from
+      inside Messages &mdash; either by tapping a saved macro tile or by
+      typing a one-off command.
+    </p>
+
+    <p>
+      Both sides have to be set up. The receiving station must already
+      have a matching Action defined; this page covers the sender side
+      and walks through the credential copy-paste between the two.
+    </p>
+
+    <h2>Two sides, one secret</h2>
+
+    <p>
+      OTP-protected Actions use a shared <strong>Secret Key</strong> &mdash;
+      the standard RFC 4648 base32 string a TOTP authenticator app
+      consumes. The receiving station generates that Secret Key when
+      the operator creates the credential on its Actions page; the
+      sending station stores the same Secret Key in the Remote Actions
+      drawer. From then on, both sides compute the same six-digit code
+      from the wall clock and the receiver accepts it.
+    </p>
+
+    <p>
+      There is no key exchange protocol &mdash; operators copy and paste
+      the Secret Key over a side channel they trust (signal, email,
+      voice over the air, paper handoff). Treat it like an SSH key.
+    </p>
+
+    <p class="note">
+      <strong>Same string, two sides.</strong> The value labelled
+      <em>Secret Key</em> in the receiver&rsquo;s reveal panel and the
+      value labelled <em>Secret Key</em> in the sender&rsquo;s
+      <em>New Secret</em> dialog are the same string. If you mistype
+      one character, every fire returns <code>bad_otp</code>.
+    </p>
+
+    <h2>Setting up the credential &mdash; receiver side</h2>
+
+    <p>
+      On the <em>receiving</em> station (the one whose action you want
+      to fire):
+    </p>
+
+    <ol>
+      <li>
+        Open <strong>Actions</strong> in the sidebar.
+      </li>
+      <li>
+        In the <strong>OTP Credentials</strong> table, click
+        <strong>+ New Credential</strong>.
+      </li>
+      <li>
+        Name the credential after the operator who will be allowed to
+        fire it (e.g. <code>NW5W</code>) and submit.
+      </li>
+      <li>
+        The reveal panel appears. <strong>Copy the Secret Key</strong>
+        from the right side &mdash; the long base32 string, not the
+        QR code. The page warns that this is the only time the value
+        is shown.
+      </li>
+      <li>
+        Bind the credential to the Action whose name the sender will
+        type &mdash; e.g. <code>unlock</code> &mdash; via that Action&rsquo;s
+        <em>OTP credential</em> field with <em>Require OTP</em> on.
+      </li>
+    </ol>
+
+    <p>
+      Send the Secret Key to the sender over a trusted channel.
+    </p>
+
+    <h2>Setting up the credential &mdash; sender side</h2>
+
+    <p>
+      On the <em>sending</em> station (the one this page is on):
+    </p>
+
+    <ol>
+      <li>
+        Open <strong>Messages</strong> in the sidebar.
+      </li>
+      <li>
+        Open a DM thread to the receiving callsign. (Tactical,
+        multi-recipient threads do not show the zap icon &mdash; an
+        OTP-protected fire to many callsigns at once would be an
+        operational footgun.)
+      </li>
+      <li>
+        Click the zap icon (<span class="kbd">&#9889;</span>) in the
+        thread header to open the <strong>Remote Actions</strong>
+        drawer. The drawer anchors right on desktop and slides up
+        from the bottom on mobile.
+      </li>
+      <li>
+        Click <strong>Manage secrets...</strong> (under the OTP
+        picker, or via the top-level Messages overflow menu).
+      </li>
+      <li>
+        Click <strong>+ New Secret</strong>. Give it a name that
+        identifies the remote station &mdash; e.g.
+        <code>NW5W OTP</code>.
+      </li>
+      <li>
+        Paste the <strong>Secret Key</strong> you copied from the
+        receiver into the Secret Key field. Whitespace is tolerated;
+        case does not matter.
+      </li>
+      <li>
+        Save.
+      </li>
+    </ol>
+
+    <p>
+      The new secret now appears in the OTP picker on every macro you
+      create against any thread.
+    </p>
+
+    <h2>Creating macros</h2>
+
+    <p>
+      A <strong>macro</strong> is a saved tile that fires a specific
+      action against a specific remote station with a specific argument
+      list. Macros are scoped per thread &mdash; the macros you create
+      while the drawer is open against <code>NW5W-9</code> only show
+      up on threads to <code>NW5W-9</code>.
+    </p>
+
+    <ol>
+      <li>
+        Open the drawer on the target thread.
+      </li>
+      <li>
+        Click <strong>Edit macros</strong> at the bottom of the
+        drawer.
+      </li>
+      <li>
+        Click <strong>+ Add new macro</strong>. Fill in:
+        <ul>
+          <li><strong>Label</strong> &mdash; what the tile says (e.g. <code>unlock front</code>).</li>
+          <li><strong>Action</strong> &mdash; the action name as defined on the receiver (e.g. <code>unlock</code>).</li>
+          <li><strong>Args</strong> &mdash; space-separated <code>k=v</code> pairs, or empty.</li>
+          <li><strong>OTP Secret</strong> &mdash; pick the credential you saved above, or leave blank for <em>manual OTP</em> (you&rsquo;ll be prompted to type a code at fire time, useful for actions on receivers where the operator types the code from a phone authenticator).</li>
+        </ul>
+      </li>
+      <li>
+        Save. The tile appears in fire mode and is reorderable by
+        drag.
+      </li>
+    </ol>
+
+    <p>
+      Deleting a credential demotes its bound macros to manual-OTP
+      rather than deleting them, so you can rotate a Secret Key without
+      losing the macro layout.
+    </p>
+
+    <h2>Firing</h2>
+
+    <p>
+      Two ways to send a Remote Action:
+    </p>
+
+    <ul>
+      <li>
+        <strong>Tap a tile.</strong> The frontend asks the backend for
+        a fresh six-digit OTP from the bound credential, assembles
+        <code>@@&lt;digits&gt;#&lt;action&gt; [args]</code>, and posts
+        it through the same send path as a hand-typed line in the
+        thread. The outbound bubble looks identical to a normal
+        message because it <em>is</em> a normal message &mdash; only
+        the body differs.
+      </li>
+      <li>
+        <strong>Free-form sender.</strong> The drawer&rsquo;s text
+        field at the bottom lets you type an action name + args
+        without saving a macro. Pick an OTP secret (or <em>manual
+        OTP</em>), type the line, send.
+      </li>
+    </ul>
+
+    <p>
+      The SEND button greys out when the assembled wire string would
+      exceed the APRS frame budget (67 characters by default; 200 if
+      you have <em>Allow long APRS messages</em> enabled in
+      Preferences). Shorten args to enable the button.
+    </p>
+
+    <p>
+      A short cooldown countdown sits on each tile right after a fire
+      &mdash; the receiver&rsquo;s replay ring will reject the same OTP
+      twice in the same 30-second TOTP step, and the cooldown is the
+      UI&rsquo;s polite reminder of that.
+    </p>
+
+    <h2>Reading replies</h2>
+
+    <p>
+      Inbound text from the same callsign within 60 seconds of an
+      outbound fire that begins with one of these status keywords gets
+      a zap-tagged badge in the bubble footer:
+    </p>
+
+    <div class="box">
+      <div class="box-body">
+        <p>
+          <code>ok</code> &middot; <code>error:</code> &middot;
+          <code>bad_otp</code> &middot; <code>bad_arg</code> &middot;
+          <code>denied</code> &middot; <code>unknown</code> &middot;
+          <code>disabled</code> &middot; <code>busy</code> &middot;
+          <code>rate_limited</code> &middot; <code>timeout</code>
+          &middot; <code>no_credential</code>
+        </p>
+      </div>
+    </div>
+
+    <p>
+      Inbound text within the same 60-second window that does
+      <em>not</em> begin with a status keyword stays a normal chat
+      bubble. The trade-off is intentional: a free-form remark from
+      the peer that happens to start with <code>ok</code> will be
+      mis-badged, but unrelated chat will not be. False negatives are
+      preferred over false positives.
+    </p>
+
+    <h2>Troubleshooting</h2>
+
+    <ul>
+      <li>
+        <strong><code>bad_otp</code> reply.</strong> The two stations&rsquo;
+        clocks differ by more than one TOTP step (30 s). Sync NTP on
+        both. If you just rotated the Secret Key on the receiver,
+        update the matching secret in the sender&rsquo;s credentials
+        modal &mdash; one mistyped character produces this every time.
+      </li>
+      <li>
+        <strong><code>denied</code>.</strong> The receiver&rsquo;s
+        Action has a sender allowlist that excludes your callsign. The
+        operator on the receiver side has to add you.
+      </li>
+      <li>
+        <strong><code>unknown</code>.</strong> The action name is
+        misspelled, the Action has been deleted on the receiver, or
+        the Action is disabled. Check the macro label vs. the Action
+        name on the receiver.
+      </li>
+      <li>
+        <strong><code>replay</code>.</strong> You fired the same OTP
+        twice within its 30-second window. Wait for the tile&rsquo;s
+        cooldown countdown to clear and try again.
+      </li>
+      <li>
+        <strong>SEND disabled with a tooltip.</strong> The assembled
+        line exceeds the APRS frame budget. Shorten args or enable
+        <em>Allow long APRS messages</em> on the
+        <a href="preferences.html">Preferences</a> page (200-char
+        frames, only safe when both stations support it).
+      </li>
+      <li>
+        <strong>No zap icon on a thread.</strong> Tactical (multi-
+        recipient) threads omit the icon by design. Open or create a
+        DM to that callsign instead.
+      </li>
+      <li>
+        <strong>Reply has no zap badge.</strong> Either the inbound
+        arrived more than 60 s after the fire, or its first word is
+        not in the status-prefix allowlist. Both are normal.
+      </li>
+    </ul>
+
+    <h2>Related</h2>
+
+    <ul>
+      <li><a href="actions.html">Actions</a> &mdash; the inbound side: defining actions, OTP credentials, sender allowlists, and reply formats on the receiving station.</li>
+      <li><a href="messaging.html">Messaging</a> &mdash; how DM and tactical threads work; long-message mode; preferences.</li>
+    </ul>
+
+    <nav class="page-nav">
+      <a href="actions.html">
+        <span class="label">Previous</span>
+        Actions
+      </a>
+      <a href="livemap.html" class="next">
+        <span class="label">Next</span>
+        Live Map
+      </a>
+    </nav>
+  </main>
+</div>
+
+<footer class="site-footer">
+  graywolf &middot; modern APRS station
+</footer>
+
+<script src="handbook.js"></script>
+</body>
+</html>

--- a/docs/handbook/remote-kiss-tnc.html
+++ b/docs/handbook/remote-kiss-tnc.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/simulation.html
+++ b/docs/handbook/simulation.html
@@ -37,6 +37,7 @@
       <a href="igate.html">iGate</a>
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -23,6 +23,7 @@ roles.
 - [`invariants.md`](invariants.md) -- cross-cutting "if X then also Y" rules with reasons.
 - [`glossary.md`](glossary.md) -- domain terms as graywolf uses them, with source pointers.
 - [`actions.md`](actions.md) -- the `@@`-prefixed APRS Actions subsystem: trigger surface, classifier topology, source-aware reply, lifecycle, schema.
+- [`remote-actions.md`](remote-actions.md) -- outbound Actions: macro + remote-OTP credential CRUD; the Messages drawer that fires `@@<otp>#<action>` at remote stations.
 
 ## Maintenance
 

--- a/docs/wiki/actions.md
+++ b/docs/wiki/actions.md
@@ -230,3 +230,7 @@ results.
 - Outbound counterpart (macro/credential CRUD + Messages drawer):
   [`remote-actions.md`](remote-actions.md). The two subsystems share
   only `parser.go` (exported `ValidActionName`, `MaxActionNameLen`).
+  Operator-facing invariant: the **Secret Key** value shown in the
+  inbound credential UI here is the *same string* the sender pastes
+  into the outbound `EditCredentialModal` — there is no key exchange,
+  operators copy-paste the value over a side channel they trust.

--- a/docs/wiki/actions.md
+++ b/docs/wiki/actions.md
@@ -227,3 +227,6 @@ results.
 - The `@@` sentinel is the sole hot-path discriminator; if you add
   another trigger, update this page and `pkg/actions/classifier.go`
   in the same change.
+- Outbound counterpart (macro/credential CRUD + Messages drawer):
+  [`remote-actions.md`](remote-actions.md). The two subsystems share
+  only `parser.go` (exported `ValidActionName`, `MaxActionNameLen`).

--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -182,6 +182,8 @@ and embedded via `go:embed all:dist` -- see [invariant 12](invariants.md).
 | `src/lib/stores/terminal.svelte.js` | Sidebar-facing summary: unread-bytes total across non-focused sessions for the Sidebar `NotificationBadge` |
 | `public/fonts/saucecodepro-nerd/` | SauceCodePro Nerd Font face declarations for the terminal viewport. Ships with `local()` fallbacks; the woff2 binaries are pending vendoring (see `VERSION.txt` in that directory) |
 | `src/components/` | Reusable: ConfirmDialog, DataTable, FormField, Modal, NewsPopup, PacketLogViewer, PageHeader, ReleaseNoteCard, Sidebar, StationCallsignBanner, SymbolPicker, UpdateAvailableBanner |
+| `src/components/messages/remote_actions/` | Outbound Actions UI: `RemoteActionsDrawer` (zap-icon-anchored thread drawer), `MacroTile` + `MacroEditRow` (fire / edit modes), `FreeFormSender` (ad-hoc `@@<otp>#cmd`), `CredentialsModal` + `EditCredentialModal` + `CredentialPicker` (TOTP secret CRUD), `ReplyBubbleAdornment` (zap-tagged inbound badge). See [`remote-actions.md`](remote-actions.md). |
+| `src/lib/remote_actions/` | Outbound Actions client lib: typed API wrapper, reactive store (Svelte 5 runes singleton), TOTP countdown timer, reply correlation (60s window + status-prefix allowlist), wire-string assembler + send helper that piggy-backs on `POST /api/messages`. |
 | `src/lib/map/` | MapLibre integration (data-store, map-store, layers, sources, popups, APRS icons) |
 | `src/lib/maps/` | Offline-maps client glue (downloads-store, state-bounds, state-list, state-picker) |
 | `src/lib/settings/` | Reactive prefs stores (units, maps, messages-preferences, theme) |

--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -77,6 +77,7 @@ The TX-funnel rule lives in [invariant 16](invariants.md).
 | `igate/filters` | IS->RF rule engine (priority-ordered, deny by default) | [`../handbook/igate.html`](../handbook/igate.html) |
 | `messages` | APRS messaging domain: router, store (GORM), sender, retry, invite, tactical_set, bots, preferences, event_hub, local_tx_ring | [`../handbook/messaging.html`](../handbook/messaging.html) |
 | `actions` | `@@`-prefixed APRS message Actions: classifier, parser, OTP verifier, per-Action runner with rate limit + queue, command/webhook executors, source-aware reply, audit pruner | [`actions.md`](actions.md) |
+| `remoteactions` | OUTBOUND counterpart: macro + remote-OTP credential stores, base32/target-call/action-name validators, RFC 6238 TOTP generator, service composition root. Sibling, not fork, of `pkg/actions/` (shares only the wire grammar via exported `actions.ValidActionName`). | [`remote-actions.md`](remote-actions.md) |
 | `gps` | GPSD client + serial NMEA reader + cache + station-position layered cache + enumerate | [`../handbook/gps.html`](../handbook/gps.html) |
 | `callsign` | Callsign parsing, N0CALL detection, APRS-IS passcode | [`../handbook/preferences.html`](../handbook/preferences.html) |
 | `stationcache` | Heard-station cache (memory + persistent) and APRS-extract helpers | (no dedicated page) |
@@ -85,7 +86,7 @@ The TX-funnel rule lives in [invariant 16](invariants.md).
 
 | Package | Purpose | Handbook |
 |---|---|---|
-| `configstore` | SQLite config DB (GORM, glebarez/sqlite, pure Go); migrations, seeds, models. Actions tables live here too: `actions`, `otp_credentials`, `action_listener_addressees`, `action_invocations` (migration 15, raw SQL — not AutoMigrate; see [`actions.md`](actions.md)) | [`../handbook/preferences.html`](../handbook/preferences.html) |
+| `configstore` | SQLite config DB (GORM, glebarez/sqlite, pure Go); migrations, seeds, models. Actions tables live here too: `actions`, `otp_credentials`, `action_listener_addressees`, `action_invocations` (migration 15, raw SQL — not AutoMigrate; see [`actions.md`](actions.md)). Outbound Actions adds `remote_otp_credentials`, `remote_action_macros` (migration 16, raw SQL with FK ON DELETE SET NULL; see [`remote-actions.md`](remote-actions.md)). | [`../handbook/preferences.html`](../handbook/preferences.html) |
 | `historydb` | Position-history SQLite (separate DB, schema bootstrapped on `Open`) | [`../handbook/history-database.html`](../handbook/history-database.html) |
 | `packetlog` | In-memory ring of RX/TX/IS packet records with filter-query API. Live-tail fan-out (`Subscribe`) is in `subscribe.go`; per-subscriber bounded channel, drop-on-full -- backs the AX.25 terminal raw-tail mode and any future live monitor pages. | [`../handbook/monitoring.html`](../handbook/monitoring.html) |
 | `metrics` | Prometheus metrics + helper to fold Rust-side StatusUpdate into them | [`../handbook/monitoring.html`](../handbook/monitoring.html) |

--- a/docs/wiki/remote-actions.md
+++ b/docs/wiki/remote-actions.md
@@ -1,0 +1,117 @@
+# Remote Actions (outbound) subsystem
+
+Operator-curated affordance that turns the same `@@<otp>#<action>` wire
+grammar into outbound traffic: the operator picks a remote station in
+Messages, fires a saved macro (or types a free-form action), and the
+Messages send path delivers `@@<otp>#<action> [k=v ...]` to that
+station. The remote side runs the inbound [Actions
+subsystem](actions.md); this side just composes and sends.
+
+Lives in [`../../pkg/remoteactions/`](../../pkg/remoteactions/) with
+persistence in [`../../pkg/configstore/`](../../pkg/configstore/) and
+wiring in [`../../pkg/app/wiring.go`](../../pkg/app/wiring.go). REST
+handlers under
+[`../../pkg/webapi/remote_actions_*.go`](../../pkg/webapi/). UI lives
+under `web/src/components/messages/remote_actions/`.
+
+## Sibling, not fork
+
+`pkg/remoteactions/` is a **sibling** of `pkg/actions/`, not a fork.
+The two share **only the wire grammar** — `pkg/actions/parser.go`
+exports `ValidActionName` and `MaxActionNameLen`, which
+`pkg/remoteactions/validate.go` consumes so outbound macro creation
+rejects names the receiver would refuse. There is no runtime coupling:
+- Inbound classifier never reads remote credentials or macros.
+- Outbound macro fires never enter the inbound classifier.
+
+## Wire grammar (recap)
+
+```
+@@<otp>#<action> [k=v ...]
+```
+
+Same grammar as inbound. `<otp>` is six digits or empty when the
+remote Action has `otp_required=false`. The outbound side does not
+know the remote Action's `otp_required` value, so the operator picks
+"manual OTP" (omit) vs. "use credential" (six digits stamped from a
+TOTP secret) per macro.
+
+## Hot path
+
+```
+operator clicks macro tile
+  -> pkg/remoteactions store loads macro + (optional) credential
+  -> POST /api/remote-actions/otp/{credId} -> RFC 6238 TOTP code
+  -> frontend assembles "@@<digits>#<name> [args]"
+  -> POST /api/messages (existing send path; identical to typed lines)
+  -> pkg/messages.Service.SendMessage -> RF/IS as configured
+```
+
+The macro fire is **indistinguishable on the wire from a hand-typed
+line**. There is no `Source: macro` flag in the messages table; the
+auditor sees one outbound message of kind `text`.
+
+## Schema (migration 16)
+
+`pkg/configstore/migrate_remote_actions.go`. Two tables, raw SQL so
+the FK and the index can be expressed precisely:
+
+| Table | Columns | Notes |
+|---|---|---|
+| `remote_otp_credentials` | `id`, `name` (UNIQUE), `secret_b32`, `algorithm`, `digits`, `period`, `created_at`, `last_used_at` | TOTP secret stored plaintext per the single-user-station design. `secret_b32` is never echoed back after Create. |
+| `remote_action_macros` | `id`, `target_call`, `label`, `action_name`, `args_string`, `remote_otp_credential_id` (nullable FK), `position`, `created_at`, `updated_at` | `target_call` indexed for per-thread lookup. FK has `ON DELETE SET NULL` — deleting a credential demotes its macros to "manual OTP" instead of orphaning them. |
+
+The two matching Go models in
+[`../../pkg/remoteactions/models.go`](../../pkg/remoteactions/models.go)
+are intentionally **NOT** registered with AutoMigrate; migration 16 is
+the single source of truth.
+
+Migration version 16 follows version 15 (inbound `actions_tables`).
+See [`code-map.md`](code-map.md#configstore) for the full migration
+ledger.
+
+## REST surface
+
+All routes under `/api/remote-actions/`. Op IDs in
+[`../../pkg/webapi/docs/op_ids.go`](../../pkg/webapi/docs/op_ids.go);
+swagger tag `remote-actions`.
+
+| Method | Path | Op ID | Notes |
+|---|---|---|---|
+| GET | `/api/remote-actions/credentials` | `listRemoteOTPCredentials` | Wire shape strips `secret_b32`. `used_by[]` carries distinct target callsigns of bound macros (single scan via `CredStore.UsedBy`). |
+| POST | `/api/remote-actions/credentials` | `createRemoteOTPCredential` | Validates base32 (case-insensitive, whitespace tolerated); 409 on UNIQUE name collision. |
+| PUT | `/api/remote-actions/credentials/{id}` | `updateRemoteOTPCredential` | Empty `secret_b32` leaves stored secret untouched. 404 when row gone. 409 on name collision. |
+| DELETE | `/api/remote-actions/credentials/{id}` | `deleteRemoteOTPCredential` | 409 when `len(used_by) > 0`. |
+| GET | `/api/remote-actions/macros?target=CALL` | `listRemoteActionMacros` | Target uppercased server-side. Sorted by `position ASC, id ASC`. |
+| POST | `/api/remote-actions/macros` | `createRemoteActionMacro` | Validates target callsign + action name + args length. |
+| PUT | `/api/remote-actions/macros/{id}` | `updateRemoteActionMacro` | Partial update with mixed semantics — see DTO doc on `RemoteActionMacroRequest`. **Position is ignored on PUT**; `/macros/reorder` is the sole owner of ordering. |
+| DELETE | `/api/remote-actions/macros/{id}` | `deleteRemoteActionMacro` | 204 on success. |
+| POST | `/api/remote-actions/macros/reorder` | `reorderRemoteActionMacros` | Body `{target_call, ids[]}`. Each id must resolve to a macro for that target; an unknown id rolls the transaction back and returns 400. |
+| POST | `/api/remote-actions/otp/{credId}` | `generateRemoteOTPCode` | Returns `{code, expires_at}` (RFC3339 UTC, inclusive upper edge of current TOTP step). Bumps `last_used_at` (non-fatal on error). |
+
+## Wiring
+
+`pkg/app/wiring.go`:
+
+1. `wireRemoteActions(ctx)` — runs after `wireActions`. Failure is
+   non-fatal: logs and returns nil so the rest of the app boots. The
+   webapi handlers fall back to 503 via `requireRemoteActions` when
+   `App.remoteActions` is nil.
+2. `apiSrv.SetRemoteActions(a.remoteActions)` — runs before
+   `apiSrv.RegisterRoutes(apiMux)` so handlers see the service on
+   the first request.
+
+The composition root (`pkg/remoteactions/Service`) holds two stores
+(`CredStore`, `MacroStore`) and a logger. There is no goroutine, no
+scheduler, no inbound hook — outbound fires are synchronous and
+piggy-back on `pkg/messages`.
+
+## Cross-references
+
+- Inbound counterpart: [`actions.md`](actions.md)
+- Messages send path: see [`code-map.md`](code-map.md) row `messages`
+- Single-user-station design rationale (plaintext secrets, no rate
+  limit on OTP generate): consistent with inbound `otp_credentials`
+  table.
+- Original design intent: `docs/superpowers/specs/2026-05-03-messages-action-sender-design.md`,
+  Phase A plan `docs/superpowers/plans/2026-05-03-messages-action-sender.md`.

--- a/pkg/actions/parser.go
+++ b/pkg/actions/parser.go
@@ -48,7 +48,7 @@ func Parse(body string) (*ParsedInvocation, error) {
 	if len(action) > MaxActionNameLen {
 		return nil, fmt.Errorf("%w: action name exceeds %d chars", ErrParse, MaxActionNameLen)
 	}
-	if !validActionName(action) {
+	if !ValidActionName(action) {
 		return nil, fmt.Errorf("%w: action name contains invalid characters", ErrParse)
 	}
 	args, err := parseArgs(argTail)
@@ -58,9 +58,11 @@ func Parse(body string) (*ParsedInvocation, error) {
 	return &ParsedInvocation{OTPDigits: otp, Action: action, Args: args}, nil
 }
 
-// validActionName enforces the spec charset for action names:
-// letters, digits, dot, dash, underscore. ASCII only, case-sensitive.
-func validActionName(s string) bool {
+// ValidActionName reports whether s is a legal action name. Mirrors the
+// inbound parser's grammar so outbound macro creation rejects names the
+// receiver would refuse. Charset: ASCII letters, digits, dot, dash,
+// underscore. Case-sensitive.
+func ValidActionName(s string) bool {
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		switch {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chrissnell/graywolf/pkg/metrics"
 	"github.com/chrissnell/graywolf/pkg/modembridge"
 	"github.com/chrissnell/graywolf/pkg/packetlog"
+	"github.com/chrissnell/graywolf/pkg/remoteactions"
 	"github.com/chrissnell/graywolf/pkg/stationcache"
 	"github.com/chrissnell/graywolf/pkg/txgovernor"
 	"github.com/chrissnell/graywolf/pkg/updatescheck"
@@ -140,6 +141,11 @@ type App struct {
 	// inbox and into the Actions executor pipeline. nil until wireActions
 	// runs; the rxfanout + IS hooks tolerate nil.
 	actions *actions.Service
+
+	// remoteActions is the outbound-Actions service: macro and remote-OTP
+	// credential CRUD plus the OTP generator. nil until wireRemoteActions
+	// runs; webapi handlers fall back to 503 when nil.
+	remoteActions *remoteactions.Service
 
 	// resolvedModem is the absolute path to the graywolf-modem binary
 	// after running through ResolveModemPath. Retained so diagnostic

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -37,6 +37,7 @@ import (
 	"github.com/chrissnell/graywolf/pkg/modembridge"
 	"github.com/chrissnell/graywolf/pkg/packetlog"
 	"github.com/chrissnell/graywolf/pkg/pttdevice"
+	"github.com/chrissnell/graywolf/pkg/remoteactions"
 	"github.com/chrissnell/graywolf/pkg/stationcache"
 	"github.com/chrissnell/graywolf/pkg/txgovernor"
 	"github.com/chrissnell/graywolf/pkg/updatescheck"
@@ -422,6 +423,13 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 	// is hooked into the rxfanout + IS paths in dispatchRxFrame and
 	// onIGateIsRxPacket.
 	if err := a.wireActions(ctx); err != nil {
+		return err
+	}
+
+	// --- Outbound Actions service -------------------------------------
+	// Owns macro + remote-OTP credential CRUD. Failure is non-fatal;
+	// webapi handlers fall back to 503 when a.remoteActions stays nil.
+	if err := a.wireRemoteActions(ctx); err != nil {
 		return err
 	}
 
@@ -832,6 +840,26 @@ func (a *App) wireActions(ctx context.Context) error {
 	return nil
 }
 
+// wireRemoteActions constructs the outbound-Actions service. Failure
+// is non-fatal (matches wireActions); the REST handlers fall back to
+// 503 when a.remoteActions is nil.
+//
+// Ordering: runs after wireActions because both touch the same DB,
+// keeping the wireup chain visually grouped. There is no runtime
+// dependency on the inbound actions service.
+func (a *App) wireRemoteActions(ctx context.Context) error {
+	svc, err := remoteactions.NewService(remoteactions.ServiceConfig{
+		DB:     a.store.DB(),
+		Logger: a.logger.With("component", "remoteactions"),
+	})
+	if err != nil {
+		a.logger.Error("remoteactions service init", "err", err)
+		return nil
+	}
+	a.remoteActions = svc
+	return nil
+}
+
 // wireAGW constructs a.agwServer from configstore. A disabled or
 // missing AGW config leaves a.agwServer nil. The agwReload channel is
 // created unconditionally so an initially-disabled AGW can be toggled
@@ -1014,6 +1042,13 @@ func (a *App) wireHTTP(ctx context.Context) error {
 	// the test-fire endpoint returns 503.
 	if a.actions != nil {
 		apiSrv.SetActionsService(a.actions)
+	}
+
+	// Outbound Actions: macro + remote-OTP credential CRUD plus the
+	// OTP generator. Nil disables the /api/remote-actions/* endpoints
+	// (handlers return 503 via requireRemoteActions).
+	if a.remoteActions != nil {
+		apiSrv.SetRemoteActions(a.remoteActions)
 	}
 
 	// Construct the GitHub-update checker and install it on the webapi

--- a/pkg/configstore/migrate.go
+++ b/pkg/configstore/migrate.go
@@ -141,6 +141,16 @@ type migration struct {
 //	    AutoMigrate list — this migration is the single source of truth
 //	    for their schema. See
 //	    docs/superpowers/plans/2026-05-02-graywolf-actions.md Phase A.
+//	16 — remote_actions_tables: create the outbound-Actions feature
+//	    tables (remote_otp_credentials, remote_action_macros) via raw
+//	    SQL so remote_action_macros.remote_otp_credential_id can declare
+//	    FOREIGN KEY ... ON DELETE SET NULL and the target_call index can
+//	    be created precisely. The two matching Go models in
+//	    pkg/remoteactions/models.go are intentionally NOT added to the
+//	    AutoMigrate list — this migration is the single source of truth
+//	    for their schema. See
+//	    docs/superpowers/plans/2026-05-03-messages-action-sender.md
+//	    Phase A.
 var schemaMigrations = []migration{
 	{version: 1, name: "beacon_compress_default", phase: postAutoMigrate, run: migrateBeaconCompressDefault},
 	{version: 2, name: "channel_device_fields", phase: preAutoMigrate, run: migrateChannelDeviceFields},
@@ -157,6 +167,7 @@ var schemaMigrations = []migration{
 	{version: 13, name: "messages_config_singleton", phase: postAutoMigrate, run: migrateMessagesConfigCopyFromIgate},
 	{version: 14, name: "ax25_terminal_tables", phase: postAutoMigrate, run: migrateAX25TerminalTables},
 	{version: 15, name: "actions_tables", phase: postAutoMigrate, run: migrateActionsTables},
+	{version: 16, name: "remote_actions_tables", phase: postAutoMigrate, run: migrateRemoteActionsTables},
 }
 
 // runMigrations applies every pending migration in the given phase,

--- a/pkg/configstore/migrate_remote_actions.go
+++ b/pkg/configstore/migrate_remote_actions.go
@@ -1,0 +1,53 @@
+package configstore
+
+import "gorm.io/gorm"
+
+// migrateRemoteActionsTables creates the outbound-Actions feature tables
+// (remote_otp_credentials, remote_action_macros) using raw SQL so the
+// FK ON DELETE SET NULL clause and the target_call index can be
+// expressed precisely. The two matching Go models live in
+// pkg/remoteactions/models.go and are intentionally NOT added to the
+// AutoMigrate list — this migration is the single source of truth.
+//
+// FK rationale: a macro keeps its row when the bound credential is
+// deleted; remote_otp_credential_id falls to NULL and the UI shows the
+// macro as "manual OTP" rather than orphaning it.
+//
+// secret_b32 is plaintext per the single-user-station design (same
+// rationale as otp_credentials for inbound Actions; see
+// pkg/configstore/migrate_actions.go).
+func migrateRemoteActionsTables(tx *gorm.DB) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS remote_otp_credentials (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE,
+			secret_b32 TEXT NOT NULL,
+			algorithm TEXT NOT NULL DEFAULT 'sha1',
+			digits INTEGER NOT NULL DEFAULT 6,
+			period INTEGER NOT NULL DEFAULT 30,
+			created_at DATETIME NOT NULL,
+			last_used_at DATETIME
+		)`,
+		`CREATE TABLE IF NOT EXISTS remote_action_macros (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_call TEXT NOT NULL,
+			label TEXT NOT NULL,
+			action_name TEXT NOT NULL,
+			args_string TEXT NOT NULL DEFAULT '',
+			remote_otp_credential_id INTEGER,
+			position INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			FOREIGN KEY (remote_otp_credential_id)
+				REFERENCES remote_otp_credentials(id) ON DELETE SET NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_remote_action_macros_target_call
+			ON remote_action_macros(target_call)`,
+	}
+	for _, s := range stmts {
+		if err := tx.Exec(s).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/configstore/migrate_remote_actions_test.go
+++ b/pkg/configstore/migrate_remote_actions_test.go
@@ -1,0 +1,76 @@
+package configstore
+
+import (
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestMigrateRemoteActionsTables(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := migrateRemoteActionsTables(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	for _, table := range []string{"remote_otp_credentials", "remote_action_macros"} {
+		var n int
+		if err := db.Raw(
+			"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?",
+			table,
+		).Scan(&n).Error; err != nil {
+			t.Fatalf("probe %s: %v", table, err)
+		}
+		if n != 1 {
+			t.Fatalf("table %s missing", table)
+		}
+	}
+	var idx int
+	if err := db.Raw(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_remote_action_macros_target_call'",
+	).Scan(&idx).Error; err != nil {
+		t.Fatalf("probe idx: %v", err)
+	}
+	if idx != 1 {
+		t.Fatalf("expected target_call index")
+	}
+}
+
+func TestMigrateRemoteActionsForeignKeySetNull(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("fk on: %v", err)
+	}
+	if err := migrateRemoteActionsTables(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := db.Exec(
+		`INSERT INTO remote_otp_credentials (name, secret_b32, algorithm, digits, period, created_at)
+		 VALUES ('NW5W OTP', 'JBSWY3DPEHPK3PXP', 'sha1', 6, 30, datetime('now'))`,
+	).Error; err != nil {
+		t.Fatalf("insert cred: %v", err)
+	}
+	if err := db.Exec(
+		`INSERT INTO remote_action_macros (target_call, label, action_name, args_string, remote_otp_credential_id, position, created_at, updated_at)
+		 VALUES ('KK7XYZ-9', 'unlock', 'unlock', 'door=front', 1, 0, datetime('now'), datetime('now'))`,
+	).Error; err != nil {
+		t.Fatalf("insert macro: %v", err)
+	}
+	if err := db.Exec("DELETE FROM remote_otp_credentials WHERE id = 1").Error; err != nil {
+		t.Fatalf("delete cred: %v", err)
+	}
+	var fk *uint
+	if err := db.Raw(
+		"SELECT remote_otp_credential_id FROM remote_action_macros WHERE id = 1",
+	).Scan(&fk).Error; err != nil {
+		t.Fatalf("scan fk: %v", err)
+	}
+	if fk != nil {
+		t.Fatalf("expected NULL after FK ON DELETE SET NULL, got %v", *fk)
+	}
+}

--- a/pkg/remoteactions/doc.go
+++ b/pkg/remoteactions/doc.go
@@ -1,0 +1,21 @@
+// Package remoteactions implements the OUTBOUND half of the Actions
+// feature: operator-curated macros and TOTP credentials used to fire
+// `@@<otp>#<action> [k=v ...]` invocations at remote stations from
+// inside Messages.
+//
+// This package is a sibling of pkg/actions/ (the inbound Actions
+// runner), not a fork. The two share nothing at runtime: outbound
+// macros never enter the inbound classifier, and inbound invocations
+// never read remote credentials. They share only the wire grammar,
+// which is owned by pkg/actions/parser.go and re-used here for
+// validation parity.
+//
+// Schema: see migration 16 in pkg/configstore/migrate_remote_actions.go.
+// Models in this package's models.go are the in-memory shape; they are
+// intentionally NOT registered with AutoMigrate.
+//
+// Composition root: Service (service.go), constructed from
+// pkg/app/wiring.go after the messages.Service is wired. Failure to
+// construct is non-fatal — the REST handlers return 503 and the UI
+// drawer reads as empty.
+package remoteactions

--- a/pkg/remoteactions/models.go
+++ b/pkg/remoteactions/models.go
@@ -1,0 +1,54 @@
+package remoteactions
+
+import "time"
+
+// RemoteOTPCredential is one named TOTP secret used to fire macros at a
+// remote station. Stored plaintext per the single-user-station design;
+// the REST list endpoints scrub SecretB32 from the wire shape.
+//
+// Name follows the convention "<CALLSIGN> OTP" (e.g. "NW5W OTP") but
+// the column is just UNIQUE TEXT — operators can use whatever string
+// they want.
+//
+// Algorithm/Digits/Period default at the SQL layer (sha1 / 6 / 30) so
+// a row inserted with zero values still works.
+type RemoteOTPCredential struct {
+	ID         uint   `gorm:"primaryKey"`
+	Name       string `gorm:"uniqueIndex;size:64;not null"`
+	SecretB32  string `gorm:"size:128;not null"`
+	Algorithm  string `gorm:"size:16;not null;default:'sha1'"`
+	Digits     int    `gorm:"not null;default:6"`
+	Period     int    `gorm:"not null;default:30"`
+	CreatedAt  time.Time
+	LastUsedAt *time.Time
+}
+
+func (*RemoteOTPCredential) TableName() string { return "remote_otp_credentials" }
+
+// RemoteActionMacro is one saved (target, action, args, optional
+// credential) tuple shown as a tile in the Messages drawer.
+//
+// TargetCall is uppercased on write (validate.go); the column is plain
+// TEXT with an index so per-thread lookup is a single seek.
+//
+// RemoteOTPCredentialID is nullable: when nil the macro fires in
+// manual-OTP mode (operator types six digits before SEND). When set,
+// the FK has ON DELETE SET NULL — deleting a credential demotes its
+// macros instead of cascading.
+//
+// Position is the drag-reorder index, low first. Conflicts (two
+// macros for the same target with the same position) are resolved by
+// the store's reorder helper, not at the SQL layer.
+type RemoteActionMacro struct {
+	ID                    uint   `gorm:"primaryKey"`
+	TargetCall            string `gorm:"size:9;not null;index:idx_remote_action_macros_target_call"`
+	Label                 string `gorm:"size:64;not null"`
+	ActionName            string `gorm:"size:32;not null"`
+	ArgsString            string `gorm:"type:text;not null;default:''"`
+	RemoteOTPCredentialID *uint  `gorm:"column:remote_otp_credential_id"`
+	Position              int    `gorm:"not null;default:0"`
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+}
+
+func (*RemoteActionMacro) TableName() string { return "remote_action_macros" }

--- a/pkg/remoteactions/models_test.go
+++ b/pkg/remoteactions/models_test.go
@@ -1,0 +1,29 @@
+package remoteactions
+
+import (
+	"testing"
+	"time"
+)
+
+func TestModelTableNames(t *testing.T) {
+	if (&RemoteOTPCredential{}).TableName() != "remote_otp_credentials" {
+		t.Fatalf("RemoteOTPCredential.TableName mismatch")
+	}
+	if (&RemoteActionMacro{}).TableName() != "remote_action_macros" {
+		t.Fatalf("RemoteActionMacro.TableName mismatch")
+	}
+}
+
+func TestModelZeroValues(t *testing.T) {
+	c := RemoteOTPCredential{Name: "NW5W OTP", SecretB32: "JBSWY3DPEHPK3PXP", CreatedAt: time.Now()}
+	if c.Algorithm != "" || c.Digits != 0 || c.Period != 0 {
+		t.Fatalf("model defaults should be zero-valued; DB defaults set them")
+	}
+	m := RemoteActionMacro{TargetCall: "KK7XYZ-9", Label: "x", ActionName: "x"}
+	if m.Position != 0 {
+		t.Fatalf("Position zero")
+	}
+	if m.RemoteOTPCredentialID != nil {
+		t.Fatalf("FK should be nil")
+	}
+}

--- a/pkg/remoteactions/otp.go
+++ b/pkg/remoteactions/otp.go
@@ -1,0 +1,76 @@
+package remoteactions
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+)
+
+// Generate computes the current TOTP code for cred at the given moment
+// and returns (code, nextStepBoundary). The next-step time is the
+// inclusive upper edge of the current TOTP window — used by the UI
+// countdown so the picker shows "next in Ns" without a separate query.
+//
+// Defaults for zero-valued fields:
+//
+//	Algorithm "" -> SHA1
+//	Digits   0  -> 6
+//	Period   0  -> 30
+//
+// SecretB32 may be lowercase or include whitespace; the function
+// normalizes via NormalizeBase32Secret. An invalid secret returns an
+// error rather than silently substituting.
+func Generate(cred *RemoteOTPCredential, now time.Time) (string, time.Time, error) {
+	if cred == nil {
+		return "", time.Time{}, fmt.Errorf("remoteactions: nil credential")
+	}
+	secret, err := NormalizeBase32Secret(cred.SecretB32)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("secret: %w", err)
+	}
+	algo := otpAlgorithm(cred.Algorithm)
+	digits := otpDigits(cred.Digits)
+	period := uint(cred.Period)
+	if period == 0 {
+		period = 30
+	}
+	code, err := totp.GenerateCodeCustom(secret, now.UTC(), totp.ValidateOpts{
+		Period:    period,
+		Digits:    digits,
+		Algorithm: algo,
+	})
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("totp: %w", err)
+	}
+	stepSec := int64(period)
+	curStep := now.Unix() / stepSec
+	next := time.Unix((curStep+1)*stepSec, 0).UTC()
+	return code, next, nil
+}
+
+func otpAlgorithm(s string) otp.Algorithm {
+	switch strings.ToUpper(s) {
+	case "", "SHA1":
+		return otp.AlgorithmSHA1
+	case "SHA256":
+		return otp.AlgorithmSHA256
+	case "SHA512":
+		return otp.AlgorithmSHA512
+	default:
+		return otp.AlgorithmSHA1
+	}
+}
+
+func otpDigits(n int) otp.Digits {
+	switch n {
+	case 0, 6:
+		return otp.DigitsSix
+	case 8:
+		return otp.DigitsEight
+	default:
+		return otp.DigitsSix
+	}
+}

--- a/pkg/remoteactions/otp_test.go
+++ b/pkg/remoteactions/otp_test.go
@@ -1,0 +1,71 @@
+package remoteactions
+
+import (
+	"testing"
+	"time"
+)
+
+// RFC 6238 Appendix B reference values for the SHA1 secret
+// "12345678901234567890" (base32: GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ).
+func TestGenerateSHA1Vectors(t *testing.T) {
+	cred := &RemoteOTPCredential{
+		SecretB32: "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ",
+		Algorithm: "sha1",
+		Digits:    8,
+		Period:    30,
+	}
+	cases := []struct {
+		t    int64
+		want string
+	}{
+		{59, "94287082"},
+		{1111111109, "07081804"},
+		{1111111111, "14050471"},
+		{1234567890, "89005924"},
+		{2000000000, "69279037"},
+	}
+	for _, tc := range cases {
+		got, _, err := Generate(cred, time.Unix(tc.t, 0))
+		if err != nil {
+			t.Fatalf("generate t=%d: %v", tc.t, err)
+		}
+		if got != tc.want {
+			t.Fatalf("t=%d got %s want %s", tc.t, got, tc.want)
+		}
+	}
+}
+
+func TestGenerateNextStep(t *testing.T) {
+	cred := &RemoteOTPCredential{
+		SecretB32: "JBSWY3DPEHPK3PXP",
+		Algorithm: "sha1",
+		Digits:    6,
+		Period:    30,
+	}
+	// At t=10, next step boundary is t=30.
+	_, next, err := Generate(cred, time.Unix(10, 0))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if next.Unix() != 30 {
+		t.Fatalf("next = %d, want 30", next.Unix())
+	}
+	// At t=30 (boundary), next step is t=60.
+	_, next, _ = Generate(cred, time.Unix(30, 0))
+	if next.Unix() != 60 {
+		t.Fatalf("next = %d, want 60", next.Unix())
+	}
+}
+
+func TestGenerateDefaultsForZeroFields(t *testing.T) {
+	// A row inserted via Create with zero Algorithm/Digits/Period
+	// should still produce a six-digit SHA1/30s code.
+	cred := &RemoteOTPCredential{SecretB32: "JBSWY3DPEHPK3PXP"}
+	got, _, err := Generate(cred, time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 6 {
+		t.Fatalf("got %s, want 6 digits", got)
+	}
+}

--- a/pkg/remoteactions/service.go
+++ b/pkg/remoteactions/service.go
@@ -1,0 +1,49 @@
+package remoteactions
+
+import (
+	"errors"
+	"log/slog"
+
+	"gorm.io/gorm"
+)
+
+// Service is the composition root for the outbound-Actions package.
+// It owns the two stores and exposes them to REST handlers via Creds()
+// and Macros(). One instance per graywolf process.
+//
+// Failure to construct (currently only "DB == nil") is non-fatal at
+// the wiring layer; the REST handlers fall back to 503 when the
+// service is missing.
+type Service struct {
+	db     *gorm.DB
+	creds  *CredStore
+	macros *MacroStore
+	logger *slog.Logger
+}
+
+// ServiceConfig wires the service to its dependencies.
+type ServiceConfig struct {
+	DB     *gorm.DB     // required
+	Logger *slog.Logger // optional; nil -> slog.Default()
+}
+
+// NewService constructs the service. Returns an error when DB is nil
+// so the wiring layer can log and skip rather than panic.
+func NewService(cfg ServiceConfig) (*Service, error) {
+	if cfg.DB == nil {
+		return nil, errors.New("remoteactions: ServiceConfig.DB required")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{
+		db:     cfg.DB,
+		creds:  NewCredStore(cfg.DB),
+		macros: NewMacroStore(cfg.DB),
+		logger: logger,
+	}, nil
+}
+
+func (s *Service) Creds() *CredStore   { return s.creds }
+func (s *Service) Macros() *MacroStore { return s.macros }

--- a/pkg/remoteactions/service_test.go
+++ b/pkg/remoteactions/service_test.go
@@ -1,0 +1,52 @@
+package remoteactions
+
+import (
+	"context"
+	"testing"
+)
+
+func TestServiceConstruction(t *testing.T) {
+	db := newTestDB(t)
+	svc, err := NewService(ServiceConfig{DB: db})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if svc.Creds() == nil || svc.Macros() == nil {
+		t.Fatalf("sub-stores not exposed")
+	}
+}
+
+func TestServiceRequiresDB(t *testing.T) {
+	if _, err := NewService(ServiceConfig{}); err == nil {
+		t.Fatalf("expected error for nil DB")
+	}
+}
+
+func TestServiceFireRoundtrip(t *testing.T) {
+	db := newTestDB(t)
+	svc, _ := NewService(ServiceConfig{DB: db})
+	ctx := context.Background()
+
+	cred := &RemoteOTPCredential{Name: "NW5W OTP", SecretB32: "JBSWY3DPEHPK3PXP"}
+	if err := svc.Creds().Create(ctx, cred); err != nil {
+		t.Fatalf("create cred: %v", err)
+	}
+	macro := &RemoteActionMacro{
+		TargetCall:            "KK7XYZ-9",
+		Label:                 "unlock front",
+		ActionName:            "unlock",
+		ArgsString:            "door=front",
+		RemoteOTPCredentialID: &cred.ID,
+	}
+	if err := svc.Macros().Create(ctx, macro); err != nil {
+		t.Fatalf("create macro: %v", err)
+	}
+
+	got, err := svc.Macros().ListByTarget(ctx, "KK7XYZ-9")
+	if err != nil || len(got) != 1 {
+		t.Fatalf("list: %v, %d rows", err, len(got))
+	}
+	if got[0].RemoteOTPCredentialID == nil || *got[0].RemoteOTPCredentialID != cred.ID {
+		t.Fatalf("FK lost in round-trip")
+	}
+}

--- a/pkg/remoteactions/store_creds.go
+++ b/pkg/remoteactions/store_creds.go
@@ -1,0 +1,109 @@
+package remoteactions
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// CredStore is the persistence layer for RemoteOTPCredential rows.
+// One instance per Service; safe for concurrent use (delegates to
+// gorm.DB which is goroutine-safe).
+type CredStore struct {
+	db *gorm.DB
+}
+
+func NewCredStore(db *gorm.DB) *CredStore { return &CredStore{db: db} }
+
+// Create inserts a new credential, stamping CreatedAt to time.Now().UTC().
+// Returns the unique-constraint error from SQLite verbatim when Name
+// collides; callers map that to HTTP 409.
+func (s *CredStore) Create(ctx context.Context, c *RemoteOTPCredential) error {
+	if c == nil {
+		return errors.New("remoteactions: nil credential")
+	}
+	c.CreatedAt = time.Now().UTC()
+	return s.db.WithContext(ctx).Create(c).Error
+}
+
+// Get fetches by primary key. Returns gorm.ErrRecordNotFound (use
+// errors.Is) when missing.
+func (s *CredStore) Get(ctx context.Context, id uint) (*RemoteOTPCredential, error) {
+	var c RemoteOTPCredential
+	if err := s.db.WithContext(ctx).First(&c, id).Error; err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// List returns every credential ordered by Name. The list is small (one
+// or two per remote station the operator interacts with) so a full
+// scan is fine.
+func (s *CredStore) List(ctx context.Context) ([]RemoteOTPCredential, error) {
+	var out []RemoteOTPCredential
+	if err := s.db.WithContext(ctx).Order("name").Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Update writes the row identified by c.ID. The fields touched are
+// Name, SecretB32, Algorithm, Digits, Period — caller is responsible
+// for validation. CreatedAt and LastUsedAt are not modified.
+func (s *CredStore) Update(ctx context.Context, c *RemoteOTPCredential) error {
+	if c == nil || c.ID == 0 {
+		return errors.New("remoteactions: nil credential or zero id")
+	}
+	return s.db.WithContext(ctx).Model(&RemoteOTPCredential{}).
+		Where("id = ?", c.ID).
+		Updates(map[string]any{
+			"name":       c.Name,
+			"secret_b32": c.SecretB32,
+			"algorithm":  c.Algorithm,
+			"digits":     c.Digits,
+			"period":     c.Period,
+		}).Error
+}
+
+// Delete removes the credential. Macros bound to it have their
+// remote_otp_credential_id nulled by the FK ON DELETE SET NULL.
+func (s *CredStore) Delete(ctx context.Context, id uint) error {
+	return s.db.WithContext(ctx).Delete(&RemoteOTPCredential{}, id).Error
+}
+
+// TouchLastUsed records the most recent moment a credential generated
+// a TOTP code. UTC always; the UI sorts the picker by this column so
+// recently-used credentials float to the top.
+func (s *CredStore) TouchLastUsed(ctx context.Context, id uint, when time.Time) error {
+	return s.db.WithContext(ctx).Model(&RemoteOTPCredential{}).
+		Where("id = ?", id).
+		Update("last_used_at", when.UTC()).Error
+}
+
+// UsedBy returns a map of credential id -> distinct uppercased target
+// callsigns whose macros reference it. One scan over the macros table;
+// the REST list endpoint joins this map onto the credential rows so
+// the deletion gate ("Unbind from N macro(s) first") can render
+// without a per-credential query.
+func (s *CredStore) UsedBy(ctx context.Context) (map[uint][]string, error) {
+	type row struct {
+		CredID     uint
+		TargetCall string
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("remote_action_macros").
+		Select("DISTINCT remote_otp_credential_id AS cred_id, target_call").
+		Where("remote_otp_credential_id IS NOT NULL").
+		Order("target_call").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := map[uint][]string{}
+	for _, r := range rows {
+		out[r.CredID] = append(out[r.CredID], r.TargetCall)
+	}
+	return out, nil
+}

--- a/pkg/remoteactions/store_creds.go
+++ b/pkg/remoteactions/store_creds.go
@@ -51,12 +51,14 @@ func (s *CredStore) List(ctx context.Context) ([]RemoteOTPCredential, error) {
 
 // Update writes the row identified by c.ID. The fields touched are
 // Name, SecretB32, Algorithm, Digits, Period — caller is responsible
-// for validation. CreatedAt and LastUsedAt are not modified.
+// for validation. CreatedAt and LastUsedAt are not modified. Returns
+// gorm.ErrRecordNotFound when no row matches c.ID so callers can map
+// to HTTP 404.
 func (s *CredStore) Update(ctx context.Context, c *RemoteOTPCredential) error {
 	if c == nil || c.ID == 0 {
 		return errors.New("remoteactions: nil credential or zero id")
 	}
-	return s.db.WithContext(ctx).Model(&RemoteOTPCredential{}).
+	res := s.db.WithContext(ctx).Model(&RemoteOTPCredential{}).
 		Where("id = ?", c.ID).
 		Updates(map[string]any{
 			"name":       c.Name,
@@ -64,7 +66,14 @@ func (s *CredStore) Update(ctx context.Context, c *RemoteOTPCredential) error {
 			"algorithm":  c.Algorithm,
 			"digits":     c.Digits,
 			"period":     c.Period,
-		}).Error
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 // Delete removes the credential. Macros bound to it have their

--- a/pkg/remoteactions/store_creds_test.go
+++ b/pkg/remoteactions/store_creds_test.go
@@ -1,0 +1,170 @@
+package remoteactions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("fk on: %v", err)
+	}
+	stmts := []string{
+		`CREATE TABLE remote_otp_credentials (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE,
+			secret_b32 TEXT NOT NULL,
+			algorithm TEXT NOT NULL DEFAULT 'sha1',
+			digits INTEGER NOT NULL DEFAULT 6,
+			period INTEGER NOT NULL DEFAULT 30,
+			created_at DATETIME NOT NULL,
+			last_used_at DATETIME
+		)`,
+		`CREATE TABLE remote_action_macros (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_call TEXT NOT NULL,
+			label TEXT NOT NULL,
+			action_name TEXT NOT NULL,
+			args_string TEXT NOT NULL DEFAULT '',
+			remote_otp_credential_id INTEGER,
+			position INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			FOREIGN KEY (remote_otp_credential_id)
+				REFERENCES remote_otp_credentials(id) ON DELETE SET NULL
+		)`,
+		`CREATE INDEX idx_remote_action_macros_target_call
+			ON remote_action_macros(target_call)`,
+	}
+	for _, s := range stmts {
+		if err := db.Exec(s).Error; err != nil {
+			t.Fatalf("schema: %v", err)
+		}
+	}
+	return db
+}
+
+func TestCredStoreCreateGetList(t *testing.T) {
+	db := newTestDB(t)
+	cs := NewCredStore(db)
+	ctx := context.Background()
+
+	c := &RemoteOTPCredential{Name: "NW5W OTP", SecretB32: "JBSWY3DPEHPK3PXP"}
+	if err := cs.Create(ctx, c); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if c.ID == 0 || c.CreatedAt.IsZero() {
+		t.Fatalf("Create did not stamp id/createdAt: %+v", c)
+	}
+
+	got, err := cs.Get(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "NW5W OTP" || got.SecretB32 != "JBSWY3DPEHPK3PXP" {
+		t.Fatalf("get returned %+v", got)
+	}
+
+	list, err := cs.List(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("list length = %d", len(list))
+	}
+}
+
+func TestCredStoreUniqueName(t *testing.T) {
+	db := newTestDB(t)
+	cs := NewCredStore(db)
+	ctx := context.Background()
+	if err := cs.Create(ctx, &RemoteOTPCredential{Name: "dup", SecretB32: "JBSWY3DPEHPK3PXP"}); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	err := cs.Create(ctx, &RemoteOTPCredential{Name: "dup", SecretB32: "JBSWY3DPEHPK3PXP"})
+	if err == nil {
+		t.Fatalf("expected unique constraint error")
+	}
+}
+
+func TestCredStoreUpdateAndTouch(t *testing.T) {
+	db := newTestDB(t)
+	cs := NewCredStore(db)
+	ctx := context.Background()
+	c := &RemoteOTPCredential{Name: "NW5W OTP", SecretB32: "JBSWY3DPEHPK3PXP"}
+	if err := cs.Create(ctx, c); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	c.Name = "NW5W repeater"
+	if err := cs.Update(ctx, c); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, _ := cs.Get(ctx, c.ID)
+	if got.Name != "NW5W repeater" {
+		t.Fatalf("Update did not persist: %+v", got)
+	}
+	when := time.Now().UTC().Truncate(time.Second)
+	if err := cs.TouchLastUsed(ctx, c.ID, when); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	got, _ = cs.Get(ctx, c.ID)
+	if got.LastUsedAt == nil || !got.LastUsedAt.Equal(when) {
+		t.Fatalf("TouchLastUsed did not stamp; got %v want %v", got.LastUsedAt, when)
+	}
+}
+
+func TestCredStoreUsedBy(t *testing.T) {
+	db := newTestDB(t)
+	cs := NewCredStore(db)
+	ms := NewMacroStore(db)
+	ctx := context.Background()
+
+	c := &RemoteOTPCredential{Name: "NW5W OTP", SecretB32: "JBSWY3DPEHPK3PXP"}
+	if err := cs.Create(ctx, c); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	for _, target := range []string{"KK7XYZ-9", "KK7XYZ-9", "W7ABC"} {
+		m := &RemoteActionMacro{
+			TargetCall:            target,
+			Label:                 "x",
+			ActionName:            "x",
+			RemoteOTPCredentialID: &c.ID,
+		}
+		if err := ms.Create(ctx, m); err != nil {
+			t.Fatalf("macro: %v", err)
+		}
+	}
+	usedBy, err := cs.UsedBy(ctx)
+	if err != nil {
+		t.Fatalf("usedBy: %v", err)
+	}
+	got := usedBy[c.ID]
+	if len(got) != 2 || got[0] == got[1] {
+		t.Fatalf("expected 2 distinct targets, got %v", got)
+	}
+}
+
+func TestCredStoreDelete(t *testing.T) {
+	db := newTestDB(t)
+	cs := NewCredStore(db)
+	ctx := context.Background()
+	c := &RemoteOTPCredential{Name: "NW5W OTP", SecretB32: "JBSWY3DPEHPK3PXP"}
+	if err := cs.Create(ctx, c); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := cs.Delete(ctx, c.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := cs.Get(ctx, c.ID); err == nil {
+		t.Fatalf("expected not-found after delete")
+	}
+}

--- a/pkg/remoteactions/store_macros.go
+++ b/pkg/remoteactions/store_macros.go
@@ -1,0 +1,103 @@
+package remoteactions
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// MacroStore is the persistence layer for RemoteActionMacro rows.
+// One instance per Service; safe for concurrent use.
+type MacroStore struct {
+	db *gorm.DB
+}
+
+func NewMacroStore(db *gorm.DB) *MacroStore { return &MacroStore{db: db} }
+
+// Create inserts a new macro, stamping CreatedAt and UpdatedAt.
+// TargetCall must already be uppercased — validation lives in the
+// caller (validate.go).
+func (s *MacroStore) Create(ctx context.Context, m *RemoteActionMacro) error {
+	if m == nil {
+		return errors.New("remoteactions: nil macro")
+	}
+	now := time.Now().UTC()
+	m.CreatedAt = now
+	m.UpdatedAt = now
+	return s.db.WithContext(ctx).Create(m).Error
+}
+
+// Get fetches by primary key. Returns gorm.ErrRecordNotFound when missing.
+func (s *MacroStore) Get(ctx context.Context, id uint) (*RemoteActionMacro, error) {
+	var m RemoteActionMacro
+	if err := s.db.WithContext(ctx).First(&m, id).Error; err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// ListByTarget returns macros for one peer, ordered by Position
+// ascending then ID ascending (tie-break for ties; defensive against
+// reorder races).
+func (s *MacroStore) ListByTarget(ctx context.Context, targetCall string) ([]RemoteActionMacro, error) {
+	var out []RemoteActionMacro
+	if err := s.db.WithContext(ctx).
+		Where("target_call = ?", targetCall).
+		Order("position ASC, id ASC").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Update writes Label, ActionName, ArgsString, RemoteOTPCredentialID,
+// Position, and bumps UpdatedAt. TargetCall is intentionally NOT
+// updatable — the drawer is per-thread; moving a macro between targets
+// is a delete+create.
+func (s *MacroStore) Update(ctx context.Context, m *RemoteActionMacro) error {
+	if m == nil || m.ID == 0 {
+		return errors.New("remoteactions: nil macro or zero id")
+	}
+	m.UpdatedAt = time.Now().UTC()
+	return s.db.WithContext(ctx).Model(&RemoteActionMacro{}).
+		Where("id = ?", m.ID).
+		Updates(map[string]any{
+			"label":                    m.Label,
+			"action_name":              m.ActionName,
+			"args_string":              m.ArgsString,
+			"remote_otp_credential_id": m.RemoteOTPCredentialID,
+			"position":                 m.Position,
+			"updated_at":               m.UpdatedAt,
+		}).Error
+}
+
+// Delete removes one macro by id.
+func (s *MacroStore) Delete(ctx context.Context, id uint) error {
+	return s.db.WithContext(ctx).Delete(&RemoteActionMacro{}, id).Error
+}
+
+// Reorder rewrites the Position column of every macro for one
+// targetCall to match the supplied id order (index 0 -> position 0,
+// index 1 -> position 1, ...). Runs in a single transaction so partial
+// failure leaves the existing order intact. Macros for the target that
+// are NOT in `ids` are left alone — defensive against a stale UI list
+// that lost a macro the operator deleted on another tab.
+func (s *MacroStore) Reorder(ctx context.Context, targetCall string, ids []uint) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		now := time.Now().UTC()
+		for i, id := range ids {
+			res := tx.Model(&RemoteActionMacro{}).
+				Where("id = ? AND target_call = ?", id, targetCall).
+				Updates(map[string]any{
+					"position":   i,
+					"updated_at": now,
+				})
+			if res.Error != nil {
+				return res.Error
+			}
+		}
+		return nil
+	})
+}

--- a/pkg/remoteactions/store_macros.go
+++ b/pkg/remoteactions/store_macros.go
@@ -55,13 +55,14 @@ func (s *MacroStore) ListByTarget(ctx context.Context, targetCall string) ([]Rem
 // Update writes Label, ActionName, ArgsString, RemoteOTPCredentialID,
 // Position, and bumps UpdatedAt. TargetCall is intentionally NOT
 // updatable — the drawer is per-thread; moving a macro between targets
-// is a delete+create.
+// is a delete+create. Returns gorm.ErrRecordNotFound when no row
+// matches m.ID so callers can map to HTTP 404.
 func (s *MacroStore) Update(ctx context.Context, m *RemoteActionMacro) error {
 	if m == nil || m.ID == 0 {
 		return errors.New("remoteactions: nil macro or zero id")
 	}
 	m.UpdatedAt = time.Now().UTC()
-	return s.db.WithContext(ctx).Model(&RemoteActionMacro{}).
+	res := s.db.WithContext(ctx).Model(&RemoteActionMacro{}).
 		Where("id = ?", m.ID).
 		Updates(map[string]any{
 			"label":                    m.Label,
@@ -70,7 +71,14 @@ func (s *MacroStore) Update(ctx context.Context, m *RemoteActionMacro) error {
 			"remote_otp_credential_id": m.RemoteOTPCredentialID,
 			"position":                 m.Position,
 			"updated_at":               m.UpdatedAt,
-		}).Error
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 // Delete removes one macro by id.
@@ -78,12 +86,19 @@ func (s *MacroStore) Delete(ctx context.Context, id uint) error {
 	return s.db.WithContext(ctx).Delete(&RemoteActionMacro{}, id).Error
 }
 
+// ErrReorderUnknownID is returned when Reorder receives an id that
+// does not name a macro for the supplied targetCall (deleted, wrong
+// target, or never existed). Mapped to HTTP 400 by the handler.
+var ErrReorderUnknownID = errors.New("remoteactions: reorder list contains unknown id")
+
 // Reorder rewrites the Position column of every macro for one
 // targetCall to match the supplied id order (index 0 -> position 0,
-// index 1 -> position 1, ...). Runs in a single transaction so partial
-// failure leaves the existing order intact. Macros for the target that
-// are NOT in `ids` are left alone — defensive against a stale UI list
-// that lost a macro the operator deleted on another tab.
+// index 1 -> position 1, ...). Runs in a single transaction so any
+// failure rolls the change back atomically. Every id in ids must
+// resolve to a row for targetCall: an unknown id returns
+// ErrReorderUnknownID and rolls back. Macros for the target that are
+// NOT in ids keep their prior position — caller is responsible for
+// passing the full live id set if it wants total reordering.
 func (s *MacroStore) Reorder(ctx context.Context, targetCall string, ids []uint) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		now := time.Now().UTC()
@@ -96,6 +111,9 @@ func (s *MacroStore) Reorder(ctx context.Context, targetCall string, ids []uint)
 				})
 			if res.Error != nil {
 				return res.Error
+			}
+			if res.RowsAffected == 0 {
+				return ErrReorderUnknownID
 			}
 		}
 		return nil

--- a/pkg/remoteactions/store_macros_test.go
+++ b/pkg/remoteactions/store_macros_test.go
@@ -1,0 +1,92 @@
+package remoteactions
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMacroStoreCreateListByTarget(t *testing.T) {
+	db := newTestDB(t)
+	ms := NewMacroStore(db)
+	ctx := context.Background()
+
+	for i, tgt := range []string{"KK7XYZ-9", "W7ABC", "KK7XYZ-9"} {
+		m := &RemoteActionMacro{
+			TargetCall: tgt,
+			Label:      "macro",
+			ActionName: "act",
+			Position:   i,
+		}
+		if err := ms.Create(ctx, m); err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+	}
+
+	got, err := ms.ListByTarget(ctx, "KK7XYZ-9")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 KK7XYZ-9 macros, got %d", len(got))
+	}
+	if got[0].Position > got[1].Position {
+		t.Fatalf("not sorted by position: %+v", got)
+	}
+}
+
+func TestMacroStoreUpdate(t *testing.T) {
+	db := newTestDB(t)
+	ms := NewMacroStore(db)
+	ctx := context.Background()
+	m := &RemoteActionMacro{TargetCall: "KK7XYZ-9", Label: "old", ActionName: "x"}
+	if err := ms.Create(ctx, m); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	m.Label = "new"
+	m.ArgsString = "door=front"
+	if err := ms.Update(ctx, m); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, _ := ms.Get(ctx, m.ID)
+	if got.Label != "new" || got.ArgsString != "door=front" {
+		t.Fatalf("update did not persist: %+v", got)
+	}
+}
+
+func TestMacroStoreReorder(t *testing.T) {
+	db := newTestDB(t)
+	ms := NewMacroStore(db)
+	ctx := context.Background()
+	var ids []uint
+	for i := 0; i < 3; i++ {
+		m := &RemoteActionMacro{TargetCall: "K", Label: "x", ActionName: "x", Position: i}
+		if err := ms.Create(ctx, m); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		ids = append(ids, m.ID)
+	}
+	// reverse
+	if err := ms.Reorder(ctx, "K", []uint{ids[2], ids[1], ids[0]}); err != nil {
+		t.Fatalf("reorder: %v", err)
+	}
+	got, _ := ms.ListByTarget(ctx, "K")
+	if got[0].ID != ids[2] || got[2].ID != ids[0] {
+		t.Fatalf("reorder did not stick: %+v", got)
+	}
+}
+
+func TestMacroStoreDelete(t *testing.T) {
+	db := newTestDB(t)
+	ms := NewMacroStore(db)
+	ctx := context.Background()
+	m := &RemoteActionMacro{TargetCall: "K", Label: "x", ActionName: "x"}
+	if err := ms.Create(ctx, m); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := ms.Delete(ctx, m.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := ms.Get(ctx, m.ID); err == nil {
+		t.Fatalf("expected not-found")
+	}
+}

--- a/pkg/remoteactions/validate.go
+++ b/pkg/remoteactions/validate.go
@@ -1,0 +1,115 @@
+package remoteactions
+
+import (
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/chrissnell/graywolf/pkg/actions"
+)
+
+// MaxActionNameLen mirrors the inbound parser's hard limit.
+const MaxActionNameLen = actions.MaxActionNameLen
+
+// MaxLabelLen is the macro tile label cap. Roughly fits a one-line
+// drawer button on mobile.
+const MaxLabelLen = 64
+
+// MaxArgsStringLen is a generous cap on the args portion of a macro.
+// The wire-format budget check happens at fire time; this is a
+// belt-and-suspenders ceiling on what the DB will store.
+const MaxArgsStringLen = 200
+
+// ValidateActionName accepts a name that the inbound parser would
+// also accept. Empty string is rejected.
+func ValidateActionName(s string) error {
+	if s == "" {
+		return errors.New("action name required")
+	}
+	if len(s) > MaxActionNameLen {
+		return fmt.Errorf("action name exceeds %d chars", MaxActionNameLen)
+	}
+	if !actions.ValidActionName(s) {
+		return errors.New("action name has invalid characters")
+	}
+	return nil
+}
+
+// ValidateBase32Secret reports whether s decodes as a base32 TOTP
+// secret. Whitespace and padding are tolerated; case is normalized.
+// Length must be at least 16 chars after normalization (covers all
+// RFC 6238 secret lengths used in practice — 80 bits = 16 base32 chars
+// for SHA1; longer for SHA256/SHA512).
+func ValidateBase32Secret(s string) error {
+	norm, err := NormalizeBase32Secret(s)
+	if err != nil {
+		return err
+	}
+	if len(norm) < 16 {
+		return errors.New("secret too short")
+	}
+	return nil
+}
+
+// NormalizeBase32Secret strips whitespace, uppercases, and validates
+// that the result decodes as base32 (with or without padding). Returns
+// the uppercased no-whitespace form on success — this is the form
+// stored in the SecretB32 column.
+func NormalizeBase32Secret(s string) (string, error) {
+	clean := strings.ToUpper(strings.ReplaceAll(s, " ", ""))
+	clean = strings.TrimRight(clean, "=")
+	if clean == "" {
+		return "", errors.New("secret required")
+	}
+	// Re-pad to a multiple of 8 for decode validation.
+	padded := clean
+	if pad := (8 - len(clean)%8) % 8; pad > 0 {
+		padded = clean + strings.Repeat("=", pad)
+	}
+	if _, err := base32.StdEncoding.DecodeString(padded); err != nil {
+		return "", fmt.Errorf("invalid base32: %w", err)
+	}
+	return clean, nil
+}
+
+// NormalizeTargetCall uppercases and validates a target callsign.
+// Accepts the same shape as APRS addressees: 1..6 alphanumeric base
+// call, optional `-` SSID of 1..2 chars. Total max 9 chars (callsign-
+// SSID with separator).
+func NormalizeTargetCall(s string) (string, error) {
+	clean := strings.ToUpper(strings.TrimSpace(s))
+	if clean == "" {
+		return "", errors.New("target callsign required")
+	}
+	if len(clean) > 9 {
+		return "", errors.New("target callsign too long")
+	}
+	base, ssid, hasSSID := strings.Cut(clean, "-")
+	if base == "" || len(base) > 6 {
+		return "", errors.New("base callsign 1..6 chars")
+	}
+	if !isAlnumASCII(base) {
+		return "", errors.New("base callsign letters/digits only")
+	}
+	if hasSSID {
+		if len(ssid) < 1 || len(ssid) > 2 || !isAlnumASCII(ssid) {
+			return "", errors.New("ssid 1..2 alphanumeric")
+		}
+	}
+	return clean, nil
+}
+
+func isAlnumASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z':
+		case c >= 'a' && c <= 'z':
+		case c >= '0' && c <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/remoteactions/validate_test.go
+++ b/pkg/remoteactions/validate_test.go
@@ -1,0 +1,57 @@
+package remoteactions
+
+import "testing"
+
+func TestValidateBase32Secret(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"JBSWY3DPEHPK3PXP", true},
+		{"jbswy3dpehpk3pxp", true},     // lowercase accepted, uppercased on store
+		{"JBSWY3DPEHPK3PXP====", true}, // padding tolerated
+		{"JBSWY 3DPEH PK3PX P", true},  // whitespace tolerated
+		{"", false},
+		{"!!!!!!!!", false},
+		{"JBSW", false}, // too short for any sane TOTP
+	}
+	for _, tc := range cases {
+		got := ValidateBase32Secret(tc.in)
+		if (got == nil) != tc.want {
+			t.Fatalf("ValidateBase32Secret(%q) err=%v want valid=%v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeBase32Secret(t *testing.T) {
+	got, err := NormalizeBase32Secret(" jbswy 3dpehpk3pxp ")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != "JBSWY3DPEHPK3PXP" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestValidateTargetCall(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  string
+		valid bool
+	}{
+		{"kk7xyz-9", "KK7XYZ-9", true},
+		{"NW5W", "NW5W", true},
+		{"", "", false},
+		{"toolongcall-99", "", false},
+		{"BAD/CHAR", "", false},
+	}
+	for _, tc := range cases {
+		got, err := NormalizeTargetCall(tc.in)
+		if (err == nil) != tc.valid {
+			t.Fatalf("NormalizeTargetCall(%q) err=%v want valid=%v", tc.in, err, tc.valid)
+		}
+		if tc.valid && got != tc.want {
+			t.Fatalf("NormalizeTargetCall(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/webapi/docs/cmd/tagify/main.go
+++ b/pkg/webapi/docs/cmd/tagify/main.go
@@ -58,6 +58,7 @@ var tagOrder = []tagEntry{
 	{"preferences", "Operator display preferences stored server-side (units, etc.)."},
 	{"maps", "Offline PMTiles map downloads: per-state download lifecycle and status."},
 	{"actions", "On-air remote command/webhook execution: action definitions, OTP credentials, listener addressees, audit log, and operator test-fire."},
+	{"remote-actions", "Outbound Actions: operator-curated macros plus remote-station TOTP credentials used to fire @@<otp>#<action> invocations from inside Messages."},
 
 	// --- Admin / auth / health ------------------------------------------
 	{"auth", "Session login, logout, and first-user setup."},

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -5962,6 +5962,135 @@
                 }
             }
         },
+        "/remote-actions/macros": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "remote-actions"
+                ],
+                "summary": "List remote action macros for one target",
+                "operationId": "listRemoteActionMacros",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target callsign (uppercased server-side)",
+                        "name": "target",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.RemoteActionMacro"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "remote-actions"
+                ],
+                "summary": "Create remote action macro",
+                "operationId": "createRemoteActionMacro",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.RemoteActionMacro"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/remote-actions/macros/reorder": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "remote-actions"
+                ],
+                "summary": "Reorder remote action macros for one target",
+                "operationId": "reorderRemoteActionMacros",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/remote-actions/macros/{id}": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "remote-actions"
+                ],
+                "summary": "Update remote action macro",
+                "operationId": "updateRemoteActionMacro",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.RemoteActionMacro"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "remote-actions"
+                ],
+                "summary": "Delete remote action macro",
+                "operationId": "deleteRemoteActionMacro",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/smart-beacon": {
             "get": {
                 "security": [
@@ -9219,6 +9348,38 @@
                 },
                 "schema_version": {
                     "type": "integer"
+                }
+            }
+        },
+        "dto.RemoteActionMacro": {
+            "type": "object",
+            "properties": {
+                "action_name": {
+                    "type": "string"
+                },
+                "args_string": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "integer"
+                },
+                "remote_otp_credential_id": {
+                    "type": "integer"
+                },
+                "target_call": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -99,6 +99,10 @@
             "description": "On-air remote command/webhook execution: action definitions, OTP credentials, listener addressees, audit log, and operator test-fire."
         },
         {
+            "name": "remote-actions",
+            "description": "Outbound Actions: operator-curated macros plus remote-station TOTP credentials used to fire @@\u003cotp\u003e#\u003caction\u003e invocations from inside Messages."
+        },
+        {
             "name": "auth",
             "description": "Session login, logout, and first-user setup."
         },
@@ -5849,6 +5853,115 @@
                 }
             }
         },
+        "/remote-actions/credentials": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "remote-actions"
+                ],
+                "summary": "List remote OTP credentials",
+                "operationId": "listRemoteOTPCredentials",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.RemoteOTPCredential"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "remote-actions"
+                ],
+                "summary": "Create remote OTP credential",
+                "operationId": "createRemoteOTPCredential",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.RemoteOTPCredential"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/remote-actions/credentials/{id}": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "remote-actions"
+                ],
+                "summary": "Update remote OTP credential",
+                "operationId": "updateRemoteOTPCredential",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.RemoteOTPCredential"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "remote-actions"
+                ],
+                "summary": "Delete remote OTP credential",
+                "operationId": "deleteRemoteOTPCredential",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/smart-beacon": {
             "get": {
                 "security": [
@@ -9106,6 +9219,38 @@
                 },
                 "schema_version": {
                     "type": "integer"
+                }
+            }
+        },
+        "dto.RemoteOTPCredential": {
+            "type": "object",
+            "properties": {
+                "algorithm": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "digits": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "last_used_at": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "period": {
+                    "type": "integer"
+                },
+                "used_by": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -6091,6 +6091,41 @@
                 }
             }
         },
+        "/remote-actions/otp/{id}": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "remote-actions"
+                ],
+                "summary": "Generate one-shot TOTP code for a remote credential",
+                "operationId": "generateRemoteOTPCode",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Credential id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.RemoteOTPCode"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/smart-beacon": {
             "get": {
                 "security": [
@@ -9379,6 +9414,17 @@
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.RemoteOTPCode": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "expires_at": {
                     "type": "string"
                 }
             }

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -1799,6 +1799,27 @@ definitions:
       schema_version:
         type: integer
     type: object
+  dto.RemoteActionMacro:
+    properties:
+      action_name:
+        type: string
+      args_string:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: integer
+      label:
+        type: string
+      position:
+        type: integer
+      remote_otp_credential_id:
+        type: integer
+      target_call:
+        type: string
+      updated_at:
+        type: string
+    type: object
   dto.RemoteOTPCredential:
     properties:
       algorithm:
@@ -6444,6 +6465,91 @@ paths:
           schema:
             $ref: '#/definitions/webtypes.ErrorResponse'
       summary: Update remote OTP credential
+      tags:
+        - remote-actions
+  /remote-actions/macros:
+    get:
+      operationId: listRemoteActionMacros
+      parameters:
+        - description: Target callsign (uppercased server-side)
+          in: query
+          name: target
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/dto.RemoteActionMacro'
+            type: array
+      summary: List remote action macros for one target
+      tags:
+        - remote-actions
+    post:
+      consumes:
+        - application/json
+      operationId: createRemoteActionMacro
+      produces:
+        - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.RemoteActionMacro'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      summary: Create remote action macro
+      tags:
+        - remote-actions
+  /remote-actions/macros/{id}:
+    delete:
+      operationId: deleteRemoteActionMacro
+      responses:
+        "204":
+          description: No Content
+      summary: Delete remote action macro
+      tags:
+        - remote-actions
+    put:
+      consumes:
+        - application/json
+      operationId: updateRemoteActionMacro
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.RemoteActionMacro'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      summary: Update remote action macro
+      tags:
+        - remote-actions
+  /remote-actions/macros/reorder:
+    post:
+      consumes:
+        - application/json
+      operationId: reorderRemoteActionMacros
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      summary: Reorder remote action macros for one target
       tags:
         - remote-actions
   /smart-beacon:

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -1799,6 +1799,27 @@ definitions:
       schema_version:
         type: integer
     type: object
+  dto.RemoteOTPCredential:
+    properties:
+      algorithm:
+        type: string
+      created_at:
+        type: string
+      digits:
+        type: integer
+      id:
+        type: integer
+      last_used_at:
+        type: string
+      name:
+        type: string
+      period:
+        type: integer
+      used_by:
+        items:
+          type: string
+        type: array
+    type: object
   dto.SendMessageRequest:
     properties:
       channel:
@@ -2716,6 +2737,8 @@ tags:
     description: 'Offline PMTiles map downloads: per-state download lifecycle and status.'
   - name: actions
     description: 'On-air remote command/webhook execution: action definitions, OTP credentials, listener addressees, audit log, and operator test-fire.'
+  - name: remote-actions
+    description: 'Outbound Actions: operator-curated macros plus remote-station TOTP credentials used to fire @@<otp>#<action> invocations from inside Messages.'
   - name: auth
     description: Session login, logout, and first-user setup.
   - name: version
@@ -6351,6 +6374,78 @@ paths:
       summary: List unseen release notes for the caller
       tags:
         - release-notes
+  /remote-actions/credentials:
+    get:
+      operationId: listRemoteOTPCredentials
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/dto.RemoteOTPCredential'
+            type: array
+      summary: List remote OTP credentials
+      tags:
+        - remote-actions
+    post:
+      consumes:
+        - application/json
+      operationId: createRemoteOTPCredential
+      produces:
+        - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.RemoteOTPCredential'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      summary: Create remote OTP credential
+      tags:
+        - remote-actions
+  /remote-actions/credentials/{id}:
+    delete:
+      operationId: deleteRemoteOTPCredential
+      responses:
+        "204":
+          description: No Content
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      summary: Delete remote OTP credential
+      tags:
+        - remote-actions
+    put:
+      consumes:
+        - application/json
+      operationId: updateRemoteOTPCredential
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.RemoteOTPCredential'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      summary: Update remote OTP credential
+      tags:
+        - remote-actions
   /smart-beacon:
     get:
       description: |-

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -1820,6 +1820,13 @@ definitions:
       updated_at:
         type: string
     type: object
+  dto.RemoteOTPCode:
+    properties:
+      code:
+        type: string
+      expires_at:
+        type: string
+    type: object
   dto.RemoteOTPCredential:
     properties:
       algorithm:
@@ -6550,6 +6557,29 @@ paths:
           schema:
             $ref: '#/definitions/webtypes.ErrorResponse'
       summary: Reorder remote action macros for one target
+      tags:
+        - remote-actions
+  /remote-actions/otp/{id}:
+    post:
+      operationId: generateRemoteOTPCode
+      parameters:
+        - description: Credential id
+          in: path
+          name: id
+          required: true
+          type: integer
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.RemoteOTPCode'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      summary: Generate one-shot TOTP code for a remote credential
       tags:
         - remote-actions
   /smart-beacon:

--- a/pkg/webapi/docs/op_ids.go
+++ b/pkg/webapi/docs/op_ids.go
@@ -381,3 +381,21 @@ const (
 	OpGetOTPCredential         = "getOTPCredential"
 	OpDeleteOTPCredential      = "deleteOTPCredential"
 )
+
+// Remote Actions resource — /api/remote-actions/* — outbound
+// Actions feature. Operator-curated macros + remote-station TOTP
+// credentials used to fire @@<otp>#<action> invocations from inside
+// Messages. Wire shape: pkg/webapi/dto/remote_actions.go. Composition
+// root: pkg/remoteactions/.
+const (
+	OpListRemoteOTPCredentials  = "listRemoteOTPCredentials"
+	OpCreateRemoteOTPCredential = "createRemoteOTPCredential"
+	OpUpdateRemoteOTPCredential = "updateRemoteOTPCredential"
+	OpDeleteRemoteOTPCredential = "deleteRemoteOTPCredential"
+	OpListRemoteActionMacros    = "listRemoteActionMacros"
+	OpCreateRemoteActionMacro   = "createRemoteActionMacro"
+	OpUpdateRemoteActionMacro   = "updateRemoteActionMacro"
+	OpDeleteRemoteActionMacro   = "deleteRemoteActionMacro"
+	OpReorderRemoteActionMacros = "reorderRemoteActionMacros"
+	OpGenerateRemoteOTPCode     = "generateRemoteOTPCode"
+)

--- a/pkg/webapi/dto/remote_actions.go
+++ b/pkg/webapi/dto/remote_actions.go
@@ -46,6 +46,15 @@ type RemoteActionMacro struct {
 
 // RemoteActionMacroRequest is the create / update body. TargetCall is
 // uppercased on the server; clients may send any case.
+//
+// Update (PUT) semantics:
+//
+//   - Label, ActionName: gated — empty string leaves the field unchanged.
+//   - ArgsString, RemoteOTPCredentialID: always overwrite. Empty string
+//     clears args; nil unbinds the credential. Clients must send the
+//     full update body.
+//   - Position: ignored on PUT. The /macros/reorder endpoint is the
+//     sole owner of macro ordering.
 type RemoteActionMacroRequest struct {
 	TargetCall            string `json:"target_call"`
 	Label                 string `json:"label"`

--- a/pkg/webapi/dto/remote_actions.go
+++ b/pkg/webapi/dto/remote_actions.go
@@ -1,0 +1,74 @@
+// Package dto wire shapes for the outbound Actions feature.
+package dto
+
+// RemoteOTPCredential is the safe wire shape for a remote-station TOTP
+// secret. SecretB32 is intentionally absent — it is only echoed back
+// at create time via RemoteOTPCredentialCreated, and never retrievable
+// thereafter.
+//
+// UsedBy is the list of distinct uppercased target callsigns whose
+// macros reference this credential. The credential cannot be deleted
+// while non-empty (HTTP 409); the UI surfaces "Unbind from N macro(s)
+// first" using its length.
+type RemoteOTPCredential struct {
+	ID         uint     `json:"id"`
+	Name       string   `json:"name"`
+	Algorithm  string   `json:"algorithm"`
+	Digits     int      `json:"digits"`
+	Period     int      `json:"period"`
+	CreatedAt  string   `json:"created_at"`
+	LastUsedAt *string  `json:"last_used_at,omitempty"`
+	UsedBy     []string `json:"used_by"`
+}
+
+// RemoteOTPCredentialRequest is the create / update body. Algorithm,
+// Digits, Period are optional on create; the server fills sha1/6/30.
+type RemoteOTPCredentialRequest struct {
+	Name      string `json:"name"`
+	SecretB32 string `json:"secret_b32"`
+	Algorithm string `json:"algorithm,omitempty"`
+	Digits    int    `json:"digits,omitempty"`
+	Period    int    `json:"period,omitempty"`
+}
+
+// RemoteActionMacro is the wire shape of one saved macro.
+type RemoteActionMacro struct {
+	ID                    uint   `json:"id"`
+	TargetCall            string `json:"target_call"`
+	Label                 string `json:"label"`
+	ActionName            string `json:"action_name"`
+	ArgsString            string `json:"args_string"`
+	RemoteOTPCredentialID *uint  `json:"remote_otp_credential_id,omitempty"`
+	Position              int    `json:"position"`
+	CreatedAt             string `json:"created_at"`
+	UpdatedAt             string `json:"updated_at"`
+}
+
+// RemoteActionMacroRequest is the create / update body. TargetCall is
+// uppercased on the server; clients may send any case.
+type RemoteActionMacroRequest struct {
+	TargetCall            string `json:"target_call"`
+	Label                 string `json:"label"`
+	ActionName            string `json:"action_name"`
+	ArgsString            string `json:"args_string"`
+	RemoteOTPCredentialID *uint  `json:"remote_otp_credential_id,omitempty"`
+	Position              int    `json:"position"`
+}
+
+// RemoteActionMacroReorderRequest is the body of POST
+// /api/remote-actions/macros/reorder. The IDs list defines the new
+// order: index 0 -> position 0, etc. Macros for the target that are
+// not in the list are left unchanged.
+type RemoteActionMacroReorderRequest struct {
+	TargetCall string `json:"target_call"`
+	IDs        []uint `json:"ids"`
+}
+
+// RemoteOTPCode is the response from POST /api/remote-actions/otp/{credId}.
+// ExpiresAt is RFC3339 UTC and marks the inclusive upper edge of the
+// step that produced this code. The drawer uses (ExpiresAt - now) as
+// the countdown source.
+type RemoteOTPCode struct {
+	Code      string `json:"code"`
+	ExpiresAt string `json:"expires_at"`
+}

--- a/pkg/webapi/remote_actions_creds.go
+++ b/pkg/webapi/remote_actions_creds.go
@@ -1,0 +1,15 @@
+package webapi
+
+import "net/http"
+
+// requireRemoteActions writes 503 and returns false when the outbound
+// Actions service is not wired (typically because the messages.Service
+// failed to construct, or NewService returned an error). Handlers call
+// this before touching s.remoteActions.
+func (s *Server) requireRemoteActions(w http.ResponseWriter) bool {
+	if s.remoteActions == nil {
+		serviceUnavailable(w, "remote actions service not configured")
+		return false
+	}
+	return true
+}

--- a/pkg/webapi/remote_actions_creds.go
+++ b/pkg/webapi/remote_actions_creds.go
@@ -1,15 +1,246 @@
 package webapi
 
-import "net/http"
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/chrissnell/graywolf/pkg/remoteactions"
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
 
 // requireRemoteActions writes 503 and returns false when the outbound
-// Actions service is not wired (typically because the messages.Service
-// failed to construct, or NewService returned an error). Handlers call
-// this before touching s.remoteActions.
+// Actions service is not wired. Handlers call this before touching
+// s.remoteActions.
 func (s *Server) requireRemoteActions(w http.ResponseWriter) bool {
 	if s.remoteActions == nil {
 		serviceUnavailable(w, "remote actions service not configured")
 		return false
 	}
 	return true
+}
+
+// registerRemoteActionsCreds installs /api/remote-actions/credentials.
+func (s *Server) registerRemoteActionsCreds(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/remote-actions/credentials", s.listRemoteOTPCredentials)
+	mux.HandleFunc("POST /api/remote-actions/credentials", s.createRemoteOTPCredential)
+	mux.HandleFunc("PUT /api/remote-actions/credentials/{id}", s.updateRemoteOTPCredential)
+	mux.HandleFunc("DELETE /api/remote-actions/credentials/{id}", s.deleteRemoteOTPCredential)
+}
+
+// listRemoteOTPCredentials returns every credential WITHOUT the secret.
+// UsedBy is populated by a single scan of the macros table.
+//
+//	@Summary	List remote OTP credentials
+//	@Tags		remote-actions
+//	@ID			listRemoteOTPCredentials
+//	@Produce	json
+//	@Success	200	{array}	dto.RemoteOTPCredential
+//	@Router		/remote-actions/credentials [get]
+func (s *Server) listRemoteOTPCredentials(w http.ResponseWriter, r *http.Request) {
+	if !s.requireRemoteActions(w) {
+		return
+	}
+	rows, err := s.remoteActions.Creds().List(r.Context())
+	if err != nil {
+		s.internalError(w, r, "list remote creds", err)
+		return
+	}
+	usedBy, err := s.remoteActions.Creds().UsedBy(r.Context())
+	if err != nil {
+		s.internalError(w, r, "lookup used-by", err)
+		return
+	}
+	out := make([]dto.RemoteOTPCredential, 0, len(rows))
+	for i := range rows {
+		out = append(out, remoteCredToDTO(&rows[i], usedBy[rows[i].ID]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// createRemoteOTPCredential validates and stores a new credential.
+//
+//	@Summary	Create remote OTP credential
+//	@Tags		remote-actions
+//	@ID			createRemoteOTPCredential
+//	@Accept		json
+//	@Produce	json
+//	@Success	201	{object}	dto.RemoteOTPCredential
+//	@Failure	400	{object}	webtypes.ErrorResponse
+//	@Failure	409	{object}	webtypes.ErrorResponse
+//	@Router		/remote-actions/credentials [post]
+func (s *Server) createRemoteOTPCredential(w http.ResponseWriter, r *http.Request) {
+	if !s.requireRemoteActions(w) {
+		return
+	}
+	var in dto.RemoteOTPCredentialRequest
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		badRequest(w, "invalid JSON")
+		return
+	}
+	if in.Name == "" {
+		badRequest(w, "name required")
+		return
+	}
+	secret, err := remoteactions.NormalizeBase32Secret(in.SecretB32)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	row := &remoteactions.RemoteOTPCredential{
+		Name:      in.Name,
+		SecretB32: secret,
+		Algorithm: defaultStr(in.Algorithm, "sha1"),
+		Digits:    defaultInt(in.Digits, 6),
+		Period:    defaultInt(in.Period, 30),
+	}
+	if err := s.remoteActions.Creds().Create(r.Context(), row); err != nil {
+		if isUniqueConstraintErr(err) {
+			conflict(w, "name already exists")
+			return
+		}
+		s.internalError(w, r, "create remote cred", err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, remoteCredToDTO(row, nil))
+}
+
+// updateRemoteOTPCredential updates name / secret / algorithm fields.
+// SecretB32 is optional in the body; an empty string leaves the stored
+// secret untouched.
+//
+//	@Summary	Update remote OTP credential
+//	@Tags		remote-actions
+//	@ID			updateRemoteOTPCredential
+//	@Accept		json
+//	@Produce	json
+//	@Success	200	{object}	dto.RemoteOTPCredential
+//	@Failure	400	{object}	webtypes.ErrorResponse
+//	@Failure	404	{object}	webtypes.ErrorResponse
+//	@Router		/remote-actions/credentials/{id} [put]
+func (s *Server) updateRemoteOTPCredential(w http.ResponseWriter, r *http.Request) {
+	if !s.requireRemoteActions(w) {
+		return
+	}
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid id")
+		return
+	}
+	cur, err := s.remoteActions.Creds().Get(r.Context(), uint(id))
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			notFound(w)
+			return
+		}
+		s.internalError(w, r, "get remote cred", err)
+		return
+	}
+	var in dto.RemoteOTPCredentialRequest
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		badRequest(w, "invalid JSON")
+		return
+	}
+	if in.Name != "" {
+		cur.Name = in.Name
+	}
+	if in.SecretB32 != "" {
+		norm, err := remoteactions.NormalizeBase32Secret(in.SecretB32)
+		if err != nil {
+			badRequest(w, err.Error())
+			return
+		}
+		cur.SecretB32 = norm
+	}
+	if in.Algorithm != "" {
+		cur.Algorithm = in.Algorithm
+	}
+	if in.Digits != 0 {
+		cur.Digits = in.Digits
+	}
+	if in.Period != 0 {
+		cur.Period = in.Period
+	}
+	if err := s.remoteActions.Creds().Update(r.Context(), cur); err != nil {
+		if isUniqueConstraintErr(err) {
+			conflict(w, "name already exists")
+			return
+		}
+		s.internalError(w, r, "update remote cred", err)
+		return
+	}
+	usedBy, _ := s.remoteActions.Creds().UsedBy(r.Context())
+	writeJSON(w, http.StatusOK, remoteCredToDTO(cur, usedBy[cur.ID]))
+}
+
+// deleteRemoteOTPCredential rejects with 409 when the credential is
+// still bound to one or more macros (UsedBy length > 0). The UI uses
+// the same property to disable the Delete button.
+//
+//	@Summary	Delete remote OTP credential
+//	@Tags		remote-actions
+//	@ID			deleteRemoteOTPCredential
+//	@Success	204
+//	@Failure	409	{object}	webtypes.ErrorResponse
+//	@Router		/remote-actions/credentials/{id} [delete]
+func (s *Server) deleteRemoteOTPCredential(w http.ResponseWriter, r *http.Request) {
+	if !s.requireRemoteActions(w) {
+		return
+	}
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid id")
+		return
+	}
+	usedBy, err := s.remoteActions.Creds().UsedBy(r.Context())
+	if err != nil {
+		s.internalError(w, r, "usedBy", err)
+		return
+	}
+	if len(usedBy[uint(id)]) > 0 {
+		conflict(w, "credential is bound to one or more macros")
+		return
+	}
+	if err := s.remoteActions.Creds().Delete(r.Context(), uint(id)); err != nil {
+		s.internalError(w, r, "delete remote cred", err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func remoteCredToDTO(c *remoteactions.RemoteOTPCredential, usedBy []string) dto.RemoteOTPCredential {
+	d := dto.RemoteOTPCredential{
+		ID:        c.ID,
+		Name:      c.Name,
+		Algorithm: c.Algorithm,
+		Digits:    c.Digits,
+		Period:    c.Period,
+		CreatedAt: c.CreatedAt.UTC().Format(time.RFC3339),
+		UsedBy:    usedBy,
+	}
+	if c.LastUsedAt != nil {
+		t := c.LastUsedAt.UTC().Format(time.RFC3339)
+		d.LastUsedAt = &t
+	}
+	if d.UsedBy == nil {
+		d.UsedBy = []string{}
+	}
+	return d
+}
+
+func defaultStr(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
+}
+
+func defaultInt(n, def int) int {
+	if n == 0 {
+		return def
+	}
+	return n
 }

--- a/pkg/webapi/remote_actions_creds.go
+++ b/pkg/webapi/remote_actions_creds.go
@@ -169,6 +169,10 @@ func (s *Server) updateRemoteOTPCredential(w http.ResponseWriter, r *http.Reques
 			conflict(w, "name already exists")
 			return
 		}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			notFound(w)
+			return
+		}
 		s.internalError(w, r, "update remote cred", err)
 		return
 	}

--- a/pkg/webapi/remote_actions_creds_test.go
+++ b/pkg/webapi/remote_actions_creds_test.go
@@ -59,6 +59,73 @@ func TestCreateRemoteOTPCredentialRejectsBadSecret(t *testing.T) {
 	}
 }
 
+// TestUpdateCredEmptySecretLeavesSecretAlone: PUT with SecretB32=""
+// must NOT clear the stored secret. The DTO doc says empty leaves it
+// untouched; this test pins that contract.
+func TestUpdateCredEmptySecretLeavesSecretAlone(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body, _ := json.Marshal(dto.RemoteOTPCredentialRequest{
+		Name: "NW5W OTP", SecretB32: "JBSWY3DPEHPK3PXP",
+	})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("POST", "/api/remote-actions/credentials", bytes.NewReader(body)))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed: %d", rr.Code)
+	}
+
+	// PUT with new name only; secret_b32 omitted/empty.
+	body, _ = json.Marshal(dto.RemoteOTPCredentialRequest{
+		Name: "renamed",
+	})
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("PUT", "/api/remote-actions/credentials/1", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update: %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	got, err := srv.remoteActions.Creds().Get(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.SecretB32 != "JBSWY3DPEHPK3PXP" {
+		t.Fatalf("secret was rewritten: %q", got.SecretB32)
+	}
+	if got.Name != "renamed" {
+		t.Fatalf("name not applied: %q", got.Name)
+	}
+}
+
+// TestUpdateCredDuplicateNameReturns409: PUT that collides with
+// another credential's UNIQUE name must return 409.
+func TestUpdateCredDuplicateNameReturns409(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	for _, name := range []string{"first", "second"} {
+		body, _ := json.Marshal(dto.RemoteOTPCredentialRequest{
+			Name: name, SecretB32: "JBSWY3DPEHPK3PXP",
+		})
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("POST", "/api/remote-actions/credentials", bytes.NewReader(body)))
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("seed %s: %d", name, rr.Code)
+		}
+	}
+
+	body, _ := json.Marshal(dto.RemoteOTPCredentialRequest{Name: "first"})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("PUT", "/api/remote-actions/credentials/2", bytes.NewReader(body)))
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestDeleteRemoteOTPCredentialBlockedWhenInUse(t *testing.T) {
 	srv, cleanup := newTestServerWithRemoteActions(t)
 	defer cleanup()

--- a/pkg/webapi/remote_actions_creds_test.go
+++ b/pkg/webapi/remote_actions_creds_test.go
@@ -1,0 +1,85 @@
+package webapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/remoteactions"
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+func TestCreateAndListRemoteOTPCredential(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body, _ := json.Marshal(dto.RemoteOTPCredentialRequest{
+		Name:      "NW5W OTP",
+		SecretB32: "JBSWY3DPEHPK3PXP",
+	})
+	req := httptest.NewRequest("POST", "/api/remote-actions/credentials", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create status %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/remote-actions/credentials", nil)
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list status %d", rr.Code)
+	}
+	var got []dto.RemoteOTPCredential
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "NW5W OTP" {
+		t.Fatalf("unexpected list: %+v", got)
+	}
+}
+
+func TestCreateRemoteOTPCredentialRejectsBadSecret(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body, _ := json.Marshal(dto.RemoteOTPCredentialRequest{Name: "x", SecretB32: "!!!"})
+	req := httptest.NewRequest("POST", "/api/remote-actions/credentials", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDeleteRemoteOTPCredentialBlockedWhenInUse(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	// seed a credential and bind a macro to it
+	cred := &remoteactions.RemoteOTPCredential{Name: "NW5W OTP", SecretB32: "JBSWY3DPEHPK3PXP"}
+	if err := srv.remoteActions.Creds().Create(t.Context(), cred); err != nil {
+		t.Fatalf("seed cred: %v", err)
+	}
+	if err := srv.remoteActions.Macros().Create(t.Context(), &remoteactions.RemoteActionMacro{
+		TargetCall: "KK7XYZ-9", Label: "x", ActionName: "x",
+		RemoteOTPCredentialID: &cred.ID,
+	}); err != nil {
+		t.Fatalf("seed macro: %v", err)
+	}
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/remote-actions/credentials/1", nil)
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/pkg/webapi/remote_actions_macros.go
+++ b/pkg/webapi/remote_actions_macros.go
@@ -1,0 +1,223 @@
+package webapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/chrissnell/graywolf/pkg/remoteactions"
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+func (s *Server) registerRemoteActionsMacros(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/remote-actions/macros", s.listRemoteActionMacros)
+	mux.HandleFunc("POST /api/remote-actions/macros", s.createRemoteActionMacro)
+	mux.HandleFunc("PUT /api/remote-actions/macros/{id}", s.updateRemoteActionMacro)
+	mux.HandleFunc("DELETE /api/remote-actions/macros/{id}", s.deleteRemoteActionMacro)
+	mux.HandleFunc("POST /api/remote-actions/macros/reorder", s.reorderRemoteActionMacros)
+}
+
+//	@Summary	List remote action macros for one target
+//	@Tags		remote-actions
+//	@ID			listRemoteActionMacros
+//	@Param		target	query	string	true	"Target callsign (uppercased server-side)"
+//	@Produce	json
+//	@Success	200	{array}	dto.RemoteActionMacro
+//	@Router		/remote-actions/macros [get]
+func (s *Server) listRemoteActionMacros(w http.ResponseWriter, r *http.Request) {
+	if !s.requireRemoteActions(w) {
+		return
+	}
+	target := r.URL.Query().Get("target")
+	if target == "" {
+		badRequest(w, "target query parameter required")
+		return
+	}
+	norm, err := remoteactions.NormalizeTargetCall(target)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	rows, err := s.remoteActions.Macros().ListByTarget(r.Context(), norm)
+	if err != nil {
+		s.internalError(w, r, "list macros", err)
+		return
+	}
+	out := make([]dto.RemoteActionMacro, 0, len(rows))
+	for i := range rows {
+		out = append(out, remoteMacroToDTO(&rows[i]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+//	@Summary	Create remote action macro
+//	@Tags		remote-actions
+//	@ID			createRemoteActionMacro
+//	@Accept		json
+//	@Produce	json
+//	@Success	201	{object}	dto.RemoteActionMacro
+//	@Failure	400	{object}	webtypes.ErrorResponse
+//	@Router		/remote-actions/macros [post]
+func (s *Server) createRemoteActionMacro(w http.ResponseWriter, r *http.Request) {
+	if !s.requireRemoteActions(w) {
+		return
+	}
+	var in dto.RemoteActionMacroRequest
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		badRequest(w, "invalid JSON")
+		return
+	}
+	target, err := remoteactions.NormalizeTargetCall(in.TargetCall)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	if err := remoteactions.ValidateActionName(in.ActionName); err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	if in.Label == "" {
+		badRequest(w, "label required")
+		return
+	}
+	if len(in.ArgsString) > remoteactions.MaxArgsStringLen {
+		badRequest(w, "args_string too long")
+		return
+	}
+	row := &remoteactions.RemoteActionMacro{
+		TargetCall:            target,
+		Label:                 in.Label,
+		ActionName:            in.ActionName,
+		ArgsString:            in.ArgsString,
+		RemoteOTPCredentialID: in.RemoteOTPCredentialID,
+		Position:              in.Position,
+	}
+	if err := s.remoteActions.Macros().Create(r.Context(), row); err != nil {
+		s.internalError(w, r, "create macro", err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, remoteMacroToDTO(row))
+}
+
+//	@Summary	Update remote action macro
+//	@Tags		remote-actions
+//	@ID			updateRemoteActionMacro
+//	@Accept		json
+//	@Produce	json
+//	@Success	200	{object}	dto.RemoteActionMacro
+//	@Failure	400	{object}	webtypes.ErrorResponse
+//	@Failure	404	{object}	webtypes.ErrorResponse
+//	@Router		/remote-actions/macros/{id} [put]
+func (s *Server) updateRemoteActionMacro(w http.ResponseWriter, r *http.Request) {
+	if !s.requireRemoteActions(w) {
+		return
+	}
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid id")
+		return
+	}
+	cur, err := s.remoteActions.Macros().Get(r.Context(), uint(id))
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			notFound(w)
+			return
+		}
+		s.internalError(w, r, "get macro", err)
+		return
+	}
+	var in dto.RemoteActionMacroRequest
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		badRequest(w, "invalid JSON")
+		return
+	}
+	if in.Label != "" {
+		cur.Label = in.Label
+	}
+	if in.ActionName != "" {
+		if err := remoteactions.ValidateActionName(in.ActionName); err != nil {
+			badRequest(w, err.Error())
+			return
+		}
+		cur.ActionName = in.ActionName
+	}
+	// ArgsString allowed to clear — distinguish absent from empty by
+	// requiring callers to send the full update body. Empty string is
+	// a valid value (no args).
+	cur.ArgsString = in.ArgsString
+	cur.RemoteOTPCredentialID = in.RemoteOTPCredentialID
+	if in.Position != 0 || cur.Position != 0 {
+		cur.Position = in.Position
+	}
+	if err := s.remoteActions.Macros().Update(r.Context(), cur); err != nil {
+		s.internalError(w, r, "update macro", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, remoteMacroToDTO(cur))
+}
+
+//	@Summary	Delete remote action macro
+//	@Tags		remote-actions
+//	@ID			deleteRemoteActionMacro
+//	@Success	204
+//	@Router		/remote-actions/macros/{id} [delete]
+func (s *Server) deleteRemoteActionMacro(w http.ResponseWriter, r *http.Request) {
+	if !s.requireRemoteActions(w) {
+		return
+	}
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid id")
+		return
+	}
+	if err := s.remoteActions.Macros().Delete(r.Context(), uint(id)); err != nil {
+		s.internalError(w, r, "delete macro", err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+//	@Summary	Reorder remote action macros for one target
+//	@Tags		remote-actions
+//	@ID			reorderRemoteActionMacros
+//	@Accept		json
+//	@Success	204
+//	@Failure	400	{object}	webtypes.ErrorResponse
+//	@Router		/remote-actions/macros/reorder [post]
+func (s *Server) reorderRemoteActionMacros(w http.ResponseWriter, r *http.Request) {
+	if !s.requireRemoteActions(w) {
+		return
+	}
+	var in dto.RemoteActionMacroReorderRequest
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		badRequest(w, "invalid JSON")
+		return
+	}
+	target, err := remoteactions.NormalizeTargetCall(in.TargetCall)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	if err := s.remoteActions.Macros().Reorder(r.Context(), target, in.IDs); err != nil {
+		s.internalError(w, r, "reorder macros", err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func remoteMacroToDTO(m *remoteactions.RemoteActionMacro) dto.RemoteActionMacro {
+	return dto.RemoteActionMacro{
+		ID:                    m.ID,
+		TargetCall:            m.TargetCall,
+		Label:                 m.Label,
+		ActionName:            m.ActionName,
+		ArgsString:            m.ArgsString,
+		RemoteOTPCredentialID: m.RemoteOTPCredentialID,
+		Position:              m.Position,
+		CreatedAt:             m.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:             m.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}

--- a/pkg/webapi/remote_actions_macros.go
+++ b/pkg/webapi/remote_actions_macros.go
@@ -144,15 +144,20 @@ func (s *Server) updateRemoteActionMacro(w http.ResponseWriter, r *http.Request)
 		}
 		cur.ActionName = in.ActionName
 	}
-	// ArgsString allowed to clear — distinguish absent from empty by
-	// requiring callers to send the full update body. Empty string is
-	// a valid value (no args).
+	// ArgsString and RemoteOTPCredentialID always overwrite. Empty
+	// string clears args; nil unbinds the credential. Callers must
+	// send the full update body (see RemoteActionMacroRequest doc).
 	cur.ArgsString = in.ArgsString
 	cur.RemoteOTPCredentialID = in.RemoteOTPCredentialID
-	if in.Position != 0 || cur.Position != 0 {
-		cur.Position = in.Position
-	}
+	// Position is intentionally not touched here: drag-reorder is the
+	// one path that should rewrite ordering, via POST /macros/reorder.
+	// A partial PUT that omits position (zero value) must not silently
+	// demote the macro.
 	if err := s.remoteActions.Macros().Update(r.Context(), cur); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			notFound(w)
+			return
+		}
 		s.internalError(w, r, "update macro", err)
 		return
 	}
@@ -202,6 +207,10 @@ func (s *Server) reorderRemoteActionMacros(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if err := s.remoteActions.Macros().Reorder(r.Context(), target, in.IDs); err != nil {
+		if errors.Is(err, remoteactions.ErrReorderUnknownID) {
+			badRequest(w, "reorder list contains an unknown macro id")
+			return
+		}
 		s.internalError(w, r, "reorder macros", err)
 		return
 	}

--- a/pkg/webapi/remote_actions_macros_test.go
+++ b/pkg/webapi/remote_actions_macros_test.go
@@ -1,0 +1,94 @@
+package webapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+func TestCreateAndListRemoteActionMacros(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body, _ := json.Marshal(dto.RemoteActionMacroRequest{
+		TargetCall: "kk7xyz-9", // lowercase: server must uppercase
+		Label:      "unlock front",
+		ActionName: "unlock",
+		ArgsString: "door=front",
+	})
+	req := httptest.NewRequest("POST", "/api/remote-actions/macros", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/remote-actions/macros?target=KK7XYZ-9", nil)
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list: %d", rr.Code)
+	}
+	var got []dto.RemoteActionMacro
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if len(got) != 1 || got[0].TargetCall != "KK7XYZ-9" {
+		t.Fatalf("unexpected: %+v", got)
+	}
+}
+
+func TestCreateMacroRejectsInvalidActionName(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body, _ := json.Marshal(dto.RemoteActionMacroRequest{
+		TargetCall: "K", Label: "x", ActionName: "bad/name",
+	})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/remote-actions/macros", bytes.NewReader(body))
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestReorderMacros(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	for i, lbl := range []string{"a", "b", "c"} {
+		body, _ := json.Marshal(dto.RemoteActionMacroRequest{
+			TargetCall: "K", Label: lbl, ActionName: "x", Position: i,
+		})
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/remote-actions/macros", bytes.NewReader(body))
+		mux.ServeHTTP(rr, req)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("seed %d: %d", i, rr.Code)
+		}
+	}
+	body, _ := json.Marshal(dto.RemoteActionMacroReorderRequest{TargetCall: "K", IDs: []uint{3, 2, 1}})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/remote-actions/macros/reorder", bytes.NewReader(body))
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("reorder: %d body=%s", rr.Code, rr.Body.String())
+	}
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/remote-actions/macros?target=K", nil)
+	mux.ServeHTTP(rr, req)
+	var got []dto.RemoteActionMacro
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if got[0].ID != 3 || got[2].ID != 1 {
+		t.Fatalf("reorder did not stick: %+v", got)
+	}
+}

--- a/pkg/webapi/remote_actions_macros_test.go
+++ b/pkg/webapi/remote_actions_macros_test.go
@@ -92,3 +92,103 @@ func TestReorderMacros(t *testing.T) {
 		t.Fatalf("reorder did not stick: %+v", got)
 	}
 }
+
+// TestReorderRejectsUnknownID: a stale UI list with a non-existent
+// macro id must roll back the transaction and return 400.
+func TestReorderRejectsUnknownID(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	for _, lbl := range []string{"a", "b"} {
+		body, _ := json.Marshal(dto.RemoteActionMacroRequest{
+			TargetCall: "K", Label: lbl, ActionName: "x",
+		})
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("POST", "/api/remote-actions/macros", bytes.NewReader(body)))
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("seed: %d", rr.Code)
+		}
+	}
+	body, _ := json.Marshal(dto.RemoteActionMacroReorderRequest{
+		TargetCall: "K", IDs: []uint{2, 999, 1}, // 999 doesn't exist
+	})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("POST", "/api/remote-actions/macros/reorder", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestUpdateMacroPreservesPosition: partial PUT without Position must
+// not demote a macro to position 0. Reorder is the only path that
+// rewrites ordering.
+func TestUpdateMacroPreservesPosition(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body, _ := json.Marshal(dto.RemoteActionMacroRequest{
+		TargetCall: "K", Label: "x", ActionName: "x", Position: 7,
+	})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("POST", "/api/remote-actions/macros", bytes.NewReader(body)))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed: %d", rr.Code)
+	}
+
+	// PUT with only Label change; Position omitted (zero in JSON).
+	body, _ = json.Marshal(dto.RemoteActionMacroRequest{
+		TargetCall: "K", Label: "renamed", ActionName: "x",
+	})
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("PUT", "/api/remote-actions/macros/1", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update: %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("GET", "/api/remote-actions/macros?target=K", nil))
+	var got []dto.RemoteActionMacro
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if len(got) != 1 || got[0].Position != 7 || got[0].Label != "renamed" {
+		t.Fatalf("position changed or label not applied: %+v", got)
+	}
+}
+
+// TestUpdateMacroClearsArgsString: PUT with ArgsString="" clears the
+// stored args, per the documented "always overwrite" rule.
+func TestUpdateMacroClearsArgsString(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body, _ := json.Marshal(dto.RemoteActionMacroRequest{
+		TargetCall: "K", Label: "x", ActionName: "x", ArgsString: "door=front",
+	})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("POST", "/api/remote-actions/macros", bytes.NewReader(body)))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed: %d", rr.Code)
+	}
+
+	body, _ = json.Marshal(dto.RemoteActionMacroRequest{
+		TargetCall: "K", Label: "x", ActionName: "x", ArgsString: "",
+	})
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("PUT", "/api/remote-actions/macros/1", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update: %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("GET", "/api/remote-actions/macros?target=K", nil))
+	var got []dto.RemoteActionMacro
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if got[0].ArgsString != "" {
+		t.Fatalf("expected cleared args, got %q", got[0].ArgsString)
+	}
+}

--- a/pkg/webapi/remote_actions_otp.go
+++ b/pkg/webapi/remote_actions_otp.go
@@ -1,0 +1,64 @@
+package webapi
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/chrissnell/graywolf/pkg/remoteactions"
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+func (s *Server) registerRemoteActionsOTP(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/remote-actions/otp/{id}", s.generateRemoteOTPCode)
+}
+
+// generateRemoteOTPCode computes the current TOTP code for the named
+// credential and bumps last_used_at. Response carries the next step
+// boundary so the UI countdown is driven by server time, not local
+// clock drift.
+//
+//	@Summary	Generate one-shot TOTP code for a remote credential
+//	@Tags		remote-actions
+//	@ID			generateRemoteOTPCode
+//	@Produce	json
+//	@Param		id	path		int	true	"Credential id"
+//	@Success	200	{object}	dto.RemoteOTPCode
+//	@Failure	404	{object}	webtypes.ErrorResponse
+//	@Router		/remote-actions/otp/{id} [post]
+func (s *Server) generateRemoteOTPCode(w http.ResponseWriter, r *http.Request) {
+	if !s.requireRemoteActions(w) {
+		return
+	}
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid id")
+		return
+	}
+	cred, err := s.remoteActions.Creds().Get(r.Context(), uint(id))
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			notFound(w)
+			return
+		}
+		s.internalError(w, r, "get cred", err)
+		return
+	}
+	now := time.Now().UTC()
+	code, expires, err := remoteactions.Generate(cred, now)
+	if err != nil {
+		s.internalError(w, r, "totp generate", err)
+		return
+	}
+	if err := s.remoteActions.Creds().TouchLastUsed(r.Context(), cred.ID, now); err != nil {
+		// Non-fatal — log then carry on. The code is still correct;
+		// LastUsedAt drift only affects picker sort.
+		s.logger.Warn("touch last_used_at", "id", cred.ID, "err", err)
+	}
+	writeJSON(w, http.StatusOK, dto.RemoteOTPCode{
+		Code:      code,
+		ExpiresAt: expires.Format(time.RFC3339),
+	})
+}

--- a/pkg/webapi/remote_actions_otp_test.go
+++ b/pkg/webapi/remote_actions_otp_test.go
@@ -1,0 +1,59 @@
+package webapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/remoteactions"
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+func TestGenerateRemoteOTPCode(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	cred := &remoteactions.RemoteOTPCredential{Name: "NW5W OTP", SecretB32: "JBSWY3DPEHPK3PXP"}
+	if err := srv.remoteActions.Creds().Create(t.Context(), cred); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/remote-actions/otp/1", nil)
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	var got dto.RemoteOTPCode
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Code) != 6 {
+		t.Fatalf("code = %q", got.Code)
+	}
+	if got.ExpiresAt == "" {
+		t.Fatalf("expires_at empty")
+	}
+
+	// last_used_at must have been bumped
+	refresh, _ := srv.remoteActions.Creds().Get(t.Context(), 1)
+	if refresh.LastUsedAt == nil {
+		t.Fatalf("LastUsedAt not stamped")
+	}
+}
+
+func TestGenerateRemoteOTPCodeNotFound(t *testing.T) {
+	srv, cleanup := newTestServerWithRemoteActions(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/remote-actions/otp/999", nil)
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status %d", rr.Code)
+	}
+}

--- a/pkg/webapi/remote_actions_test_helpers.go
+++ b/pkg/webapi/remote_actions_test_helpers.go
@@ -1,0 +1,66 @@
+package webapi
+
+import (
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/chrissnell/graywolf/pkg/remoteactions"
+)
+
+// newTestServerWithRemoteActions builds a *Server wired with a fresh
+// in-memory SQLite that has only the remote-actions tables. The
+// existing test helpers in this package construct the full configstore
+// and are too heavy for the focused remote-actions tests.
+func newTestServerWithRemoteActions(t *testing.T) (*Server, func()) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("fk on: %v", err)
+	}
+	for _, s := range []string{
+		`CREATE TABLE remote_otp_credentials (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE,
+			secret_b32 TEXT NOT NULL,
+			algorithm TEXT NOT NULL DEFAULT 'sha1',
+			digits INTEGER NOT NULL DEFAULT 6,
+			period INTEGER NOT NULL DEFAULT 30,
+			created_at DATETIME NOT NULL,
+			last_used_at DATETIME
+		)`,
+		`CREATE TABLE remote_action_macros (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_call TEXT NOT NULL,
+			label TEXT NOT NULL,
+			action_name TEXT NOT NULL,
+			args_string TEXT NOT NULL DEFAULT '',
+			remote_otp_credential_id INTEGER,
+			position INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			FOREIGN KEY (remote_otp_credential_id)
+				REFERENCES remote_otp_credentials(id) ON DELETE SET NULL
+		)`,
+	} {
+		if err := db.Exec(s).Error; err != nil {
+			t.Fatalf("schema: %v", err)
+		}
+	}
+	svc, err := remoteactions.NewService(remoteactions.ServiceConfig{DB: db})
+	if err != nil {
+		t.Fatalf("svc: %v", err)
+	}
+	srv := &Server{}
+	srv.SetRemoteActions(svc)
+	return srv, func() {
+		sqldb, _ := db.DB()
+		if sqldb != nil {
+			_ = sqldb.Close()
+		}
+	}
+}

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/chrissnell/graywolf/pkg/messages"
 	"github.com/chrissnell/graywolf/pkg/modembridge"
 	"github.com/chrissnell/graywolf/pkg/packetlog"
+	"github.com/chrissnell/graywolf/pkg/remoteactions"
 	"github.com/chrissnell/graywolf/pkg/updatescheck"
 	"github.com/chrissnell/graywolf/pkg/webapi/dto"
 )
@@ -107,6 +108,12 @@ type Server struct {
 	// Nil until set; mutating handlers no-op the reload, test-fire
 	// returns 503.
 	actions ActionsService
+
+	// remoteActions is the outbound-Actions subsystem owning macro and
+	// remote-OTP credential CRUD. Wired post-construction via
+	// SetRemoteActions; nil until set, in which case the
+	// /api/remote-actions/* handlers return 503 via requireRemoteActions.
+	remoteActions *remoteactions.Service
 }
 
 // ActionsService is the narrow surface the webapi handlers consume
@@ -380,6 +387,10 @@ func (s *Server) SetPacketLog(l *packetlog.Log) { s.packetLog = l }
 // until pkg/app wiring sets it; mutating listener handlers skip the
 // reload signal when nil.
 func (s *Server) SetActionsService(svc ActionsService) { s.actions = svc }
+
+// SetRemoteActions installs the outbound-Actions service. Nil disables
+// the /api/remote-actions/* endpoints (they return 503).
+func (s *Server) SetRemoteActions(svc *remoteactions.Service) { s.remoteActions = svc }
 
 // SetIgateStatusFn installs the function used by /api/status to report
 // igate counters.

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -270,6 +270,7 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	s.registerActionInvocations(mux)
 	s.registerActionTestFire(mux)
 	s.registerRemoteActionsCreds(mux)
+	s.registerRemoteActionsMacros(mux)
 
 	mux.HandleFunc("GET /api/health", s.handleHealth)
 	mux.HandleFunc("GET /api/status", s.handleStatus)

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -269,6 +269,7 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	s.registerActionListeners(mux)
 	s.registerActionInvocations(mux)
 	s.registerActionTestFire(mux)
+	s.registerRemoteActionsCreds(mux)
 
 	mux.HandleFunc("GET /api/health", s.handleHealth)
 	mux.HandleFunc("GET /api/status", s.handleStatus)

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -271,6 +271,7 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	s.registerActionTestFire(mux)
 	s.registerRemoteActionsCreds(mux)
 	s.registerRemoteActionsMacros(mux)
+	s.registerRemoteActionsOTP(mux)
 
 	mux.HandleFunc("GET /api/health", s.handleHealth)
 	mux.HandleFunc("GET /api/status", s.handleStatus)

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -1423,6 +1423,59 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/remote-actions/macros": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List remote action macros for one target */
+        get: operations["listRemoteActionMacros"];
+        put?: never;
+        /** Create remote action macro */
+        post: operations["createRemoteActionMacro"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/remote-actions/macros/reorder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reorder remote action macros for one target */
+        post: operations["reorderRemoteActionMacros"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/remote-actions/macros/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update remote action macro */
+        put: operations["updateRemoteActionMacro"];
+        post?: never;
+        /** Delete remote action macro */
+        delete: operations["deleteRemoteActionMacro"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/smart-beacon": {
         parameters: {
             query?: never;
@@ -2629,6 +2682,17 @@ export interface components {
             last_seen?: string;
             notes?: components["schemas"]["dto.ReleaseNoteDTO"][];
             schema_version?: number;
+        };
+        "dto.RemoteActionMacro": {
+            action_name?: string;
+            args_string?: string;
+            created_at?: string;
+            id?: number;
+            label?: string;
+            position?: number;
+            remote_otp_credential_id?: number;
+            target_call?: string;
+            updated_at?: string;
         };
         "dto.RemoteOTPCredential": {
             algorithm?: string;
@@ -8512,6 +8576,141 @@ export interface operations {
                 content: {
                     "*/*": components["schemas"]["webtypes.ErrorResponse"];
                 };
+            };
+        };
+    };
+    listRemoteActionMacros: {
+        parameters: {
+            query: {
+                /** @description Target callsign (uppercased server-side) */
+                target: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.RemoteActionMacro"][];
+                };
+            };
+        };
+    };
+    createRemoteActionMacro: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.RemoteActionMacro"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    reorderRemoteActionMacros: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateRemoteActionMacro: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.RemoteActionMacro"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteRemoteActionMacro: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -1387,6 +1387,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/remote-actions/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List remote OTP credentials */
+        get: operations["listRemoteOTPCredentials"];
+        put?: never;
+        /** Create remote OTP credential */
+        post: operations["createRemoteOTPCredential"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/remote-actions/credentials/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update remote OTP credential */
+        put: operations["updateRemoteOTPCredential"];
+        post?: never;
+        /** Delete remote OTP credential */
+        delete: operations["deleteRemoteOTPCredential"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/smart-beacon": {
         parameters: {
             query?: never;
@@ -2593,6 +2629,16 @@ export interface components {
             last_seen?: string;
             notes?: components["schemas"]["dto.ReleaseNoteDTO"][];
             schema_version?: number;
+        };
+        "dto.RemoteOTPCredential": {
+            algorithm?: string;
+            created_at?: string;
+            digits?: number;
+            id?: number;
+            last_used_at?: string;
+            name?: string;
+            period?: number;
+            used_by?: string[];
         };
         "dto.SendMessageRequest": {
             /** @description Channel overrides the configured TX channel. Nil = use default. */
@@ -8342,6 +8388,129 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listRemoteOTPCredentials: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.RemoteOTPCredential"][];
+                };
+            };
+        };
+    };
+    createRemoteOTPCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.RemoteOTPCredential"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateRemoteOTPCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.RemoteOTPCredential"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteRemoteOTPCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["webtypes.ErrorResponse"];
                 };
             };
         };

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -1476,6 +1476,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/remote-actions/otp/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Generate one-shot TOTP code for a remote credential */
+        post: operations["generateRemoteOTPCode"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/smart-beacon": {
         parameters: {
             query?: never;
@@ -2693,6 +2710,10 @@ export interface components {
             remote_otp_credential_id?: number;
             target_call?: string;
             updated_at?: string;
+        };
+        "dto.RemoteOTPCode": {
+            code?: string;
+            expires_at?: string;
         };
         "dto.RemoteOTPCredential": {
             algorithm?: string;
@@ -8711,6 +8732,38 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    generateRemoteOTPCode: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Credential id */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.RemoteOTPCode"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
             };
         };
     };

--- a/web/src/components/actions/NewCredentialModal.svelte
+++ b/web/src/components/actions/NewCredentialModal.svelte
@@ -181,7 +181,7 @@
 
         <CopyableInput
           id="cred-secret"
-          label="Base32 secret"
+          label="Secret Key"
           value={revealed.secret_b32}
           monospace
         />

--- a/web/src/components/messages/MessageBubble.svelte
+++ b/web/src/components/messages/MessageBubble.svelte
@@ -29,6 +29,8 @@
   import { tick } from 'svelte';
   import { push } from 'svelte-spa-router';
   import { Badge, Button, Icon, Tooltip } from '@chrissnell/chonky-ui';
+  import ReplyBubbleAdornment from './remote_actions/ReplyBubbleAdornment.svelte';
+  import { isActionReply } from '../../lib/remote_actions/reply_match.js';
   import { callsignColors, callsignMonogram } from '../../lib/callsignColor.js';
   import { messages as store } from '../../lib/messagesStore.svelte.js';
   import { acceptTactical } from '../../api/messages.js';
@@ -65,6 +67,7 @@
   } = $props();
 
   const isOut = $derived(msg?.direction === 'out');
+  const actionReply = $derived(isActionReply(msg));
   const sender = $derived(msg?.from_call || '');
   const colors = $derived(callsignColors(sender));
   const monogram = $derived(callsignMonogram(sender));
@@ -399,6 +402,7 @@
       bind:this={bubbleEl}
       class="bubble"
       class:has-stripe={isTactical && !isOut}
+      class:action-reply={actionReply && !isOut}
       style={isTactical && !isOut ? `--stripe-color:${colors.stripe}` : undefined}
       role="group"
       aria-label={isOut ? 'Your message' : `Message from ${sender}`}
@@ -509,6 +513,11 @@
       {/if}
     {:else}
       <p class="bubble-text">{bodyText}</p>
+      {#if actionReply && !isOut}
+        <div class="action-reply-footer">
+          <ReplyBubbleAdornment text={msg?.text ?? ''} />
+        </div>
+      {/if}
     {/if}
     </div>
   </div>
@@ -536,6 +545,8 @@
     max-width: 92%;
     margin: 2px 0;
   }
+  .action-reply { opacity: 0.85; background: var(--color-surface-raised); }
+  .action-reply-footer { margin-top: 4px; }
   .bubble-wrap.out {
     align-self: flex-end;
   }

--- a/web/src/components/messages/MessageThread.svelte
+++ b/web/src/components/messages/MessageThread.svelte
@@ -25,6 +25,11 @@
   import MessageContextMenu from './MessageContextMenu.svelte';
   import MessageMetaPanel from './MessageMetaPanel.svelte';
   import ComposeBar from './ComposeBar.svelte';
+  import RemoteActionsDrawer from './remote_actions/RemoteActionsDrawer.svelte';
+  import {
+    messagesPreferencesState,
+    DEFAULT_MAX_MESSAGE_TEXT,
+  } from '../../lib/settings/messages-preferences-store.svelte.js';
   import { dayHeader, dayKey } from './time.js';
   import { messages as store } from '../../lib/messagesStore.svelte.js';
   import {
@@ -62,6 +67,16 @@
     if (m?.msg_id) return `mid:${m.msg_id}`;
     return `i:${i}`;
   }
+
+  // --- Remote-actions drawer state (DM threads only).
+  let actionsDrawerOpen = $state(false);
+  // Match ComposeBar's per-frame cap so the drawer's wire-length check
+  // tracks the same APRS budget the operator's outbound messages use.
+  const aprsBudget = $derived(
+    messagesPreferencesState.loaded
+      ? messagesPreferencesState.maxMessageText
+      : DEFAULT_MAX_MESSAGE_TEXT,
+  );
 
   // --- Local messages state (per-thread, not part of global store).
   /** @type {Array<any>} */
@@ -367,6 +382,7 @@
       {onBack}
       {onMuteToggle}
       onOpenDm={replyPrivately}
+      onActionsToggle={!isTactical ? () => (actionsDrawerOpen = !actionsDrawerOpen) : undefined}
     />
 
     <div class="scroll-wrap">
@@ -451,6 +467,13 @@
     onReplyPrivate={replyPrivately}
   />
   <MessageMetaPanel bind:open={metaOpen} msg={metaMsg} />
+  {#if !isTactical && thread?.key}
+    <RemoteActionsDrawer
+      bind:open={actionsDrawerOpen}
+      target={thread.key}
+      maxLen={aprsBudget}
+    />
+  {/if}
 {/if}
 
 <style>

--- a/web/src/components/messages/ThreadHeader.svelte
+++ b/web/src/components/messages/ThreadHeader.svelte
@@ -18,6 +18,7 @@
    *    onBack?: () => void,
    *    onMuteToggle?: (muted: boolean) => void,
    *    onOpenDm?: (callsign: string) => void,
+   *    onActionsToggle?: () => void,
    *  }}
    */
   let {
@@ -27,6 +28,7 @@
     onBack,
     onMuteToggle,
     onOpenDm,
+    onActionsToggle,
   } = $props();
 
   let inviteOpen = $state(false);
@@ -68,6 +70,24 @@
         <span class="sub">Last heard {lastHeard}</span>
       {/if}
     </div>
+    {#if !isTactical && onActionsToggle}
+      <div class="actions">
+        <Tooltip>
+          <Tooltip.Trigger>
+            <button
+              type="button"
+              class="zap-btn"
+              onclick={() => onActionsToggle?.()}
+              aria-label="Toggle remote actions drawer"
+              data-testid="thread-actions-toggle"
+            >
+              <Icon name="zap" size="md" />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Remote Actions</Tooltip.Content>
+        </Tooltip>
+      </div>
+    {/if}
     {#if isTactical}
       <div class="actions">
         <div class="monitor">
@@ -223,6 +243,28 @@
     border-color: var(--color-border);
   }
   .invite-btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+  .zap-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .zap-btn:hover {
+    background: var(--color-surface-raised);
+    color: var(--color-primary);
+    border-color: var(--color-border);
+  }
+  .zap-btn:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }

--- a/web/src/components/messages/remote_actions/CredentialPicker.svelte
+++ b/web/src/components/messages/remote_actions/CredentialPicker.svelte
@@ -1,0 +1,71 @@
+<script>
+  // CredentialPicker -- dropdown over the credentials cache + a final
+  // "None (enter OTP at fire time)" option + an inline "Manage
+  // secrets..." link that opens the credentials modal.
+  //
+  // Bound `value` is the credential id (number) or null for None. The
+  // chonky Select itself only handles string values; we coerce at the
+  // boundary using the sentinel '__none' for null.
+  import { Select } from '@chrissnell/chonky-ui';
+  import CredentialsModal from './CredentialsModal.svelte';
+  import { remoteActionsStore } from '../../../lib/remote_actions/store.svelte.js';
+
+  let { value = $bindable(null), label = 'OTP Secret' } = $props();
+
+  let modalOpen = $state(false);
+
+  const NONE = '__none';
+
+  const options = $derived([
+    ...remoteActionsStore.creds
+      .slice()
+      .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''))
+      .map((c) => ({ value: String(c.id), label: c.name })),
+    { value: NONE, label: 'None (enter OTP at fire time)' },
+  ]);
+
+  const stringValue = $derived(value == null ? NONE : String(value));
+
+  function handleChange(v) {
+    if (v === NONE || v == null) {
+      value = null;
+      return;
+    }
+    const n = Number(v);
+    value = Number.isFinite(n) ? n : null;
+  }
+</script>
+
+<div class="picker">
+  {#if label}<span class="lbl">{label}</span>{/if}
+  <Select
+    options={options}
+    value={stringValue}
+    onValueChange={handleChange}
+  />
+  <button type="button" class="manage" onclick={() => (modalOpen = true)}>Manage secrets...</button>
+</div>
+
+<CredentialsModal bind:open={modalOpen} />
+
+<style>
+  .picker { display: flex; flex-direction: column; gap: 4px; }
+  .lbl {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--color-text-dim, var(--text-muted));
+  }
+  .manage {
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    font-size: 0.8125rem;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+    align-self: flex-start;
+  }
+  .manage:hover { text-decoration: underline; }
+</style>

--- a/web/src/components/messages/remote_actions/CredentialsModal.svelte
+++ b/web/src/components/messages/remote_actions/CredentialsModal.svelte
@@ -1,0 +1,137 @@
+<script>
+  // CredentialsModal -- top-level dialog over the Messages route. Lists
+  // every RemoteOTPCredential with name, algorithm summary, last-used
+  // timestamp, used-by count, and edit / delete buttons. Delete is
+  // disabled when used_by.length > 0 with a tooltip explaining how to
+  // unbind.
+  //
+  // Mirrors the inbound CredentialsTable.svelte pattern but the data
+  // path is remoteCredsApi (separate table, separate URLs).
+  import { Button, EmptyState, Modal, Tooltip, toast } from '@chrissnell/chonky-ui';
+  import EditCredentialModal from './EditCredentialModal.svelte';
+  import { remoteCredsApi } from '../../../lib/remote_actions/api.js';
+  import { remoteActionsStore } from '../../../lib/remote_actions/store.svelte.js';
+  import { timeAgo } from '../../../lib/actions/time.js';
+
+  let { open = $bindable(false) } = $props();
+
+  let editOpen = $state(false);
+  let editTarget = $state(null);
+
+  let prevOpen = false;
+  $effect(() => {
+    if (open && !prevOpen) remoteActionsStore.loadCreds();
+    prevOpen = open;
+  });
+
+  function openNew() {
+    editTarget = null;
+    editOpen = true;
+  }
+
+  function openEdit(c) {
+    editTarget = c;
+    editOpen = true;
+  }
+
+  async function remove(c) {
+    if ((c.used_by?.length ?? 0) > 0) return;
+    const { error } = await remoteCredsApi.remove(c.id);
+    if (error) {
+      toast(`Delete failed: ${error.error ?? error.message ?? error}`, 'error');
+      return;
+    }
+    toast(`Deleted "${c.name}".`, 'success');
+    await remoteActionsStore.loadCreds();
+  }
+</script>
+
+<Modal bind:open class="remote-creds-modal">
+  <Modal.Header>
+    <h3 class="modal-title">OTP Secrets</h3>
+    <Modal.Close aria-label="Close">x</Modal.Close>
+  </Modal.Header>
+  <Modal.Body>
+    <div class="header">
+      <p class="hint">
+        Secrets are reused by every macro that fires at the same remote station.
+        Create one credential per station, named like <code>NW5W OTP</code>.
+      </p>
+      <Button variant="primary" onclick={openNew}>+ New Secret</Button>
+    </div>
+
+    {#if remoteActionsStore.creds.length === 0}
+      <EmptyState>
+        <h3>No secrets yet</h3>
+        <p>Create a credential before binding it to a macro.</p>
+        <Button variant="primary" onclick={openNew}>+ New Secret</Button>
+      </EmptyState>
+    {:else}
+      <table class="creds-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Algo</th>
+            <th>Last used</th>
+            <th>Used by</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each remoteActionsStore.creds as c (c.id)}
+            {@const inUse = (c.used_by?.length ?? 0) > 0}
+            <tr>
+              <td><strong>{c.name}</strong></td>
+              <td>TOTP / {(c.algorithm || 'sha1').toUpperCase()} / {c.digits} / {c.period}s</td>
+              <td>{c.last_used_at ? timeAgo(c.last_used_at) : '--'}</td>
+              <td>
+                {#if inUse}
+                  <Tooltip>
+                    <Tooltip.Trigger>{c.used_by.length} macro{c.used_by.length === 1 ? '' : 's'}</Tooltip.Trigger>
+                    <Tooltip.Content>{c.used_by.join(', ')}</Tooltip.Content>
+                  </Tooltip>
+                {:else}
+                  --
+                {/if}
+              </td>
+              <td class="row-actions">
+                <Button variant="ghost" size="sm" onclick={() => openEdit(c)}>Edit</Button>
+                {#if inUse}
+                  <Tooltip>
+                    <Tooltip.Trigger>
+                      <Button variant="ghost" size="sm" disabled>Delete</Button>
+                    </Tooltip.Trigger>
+                    <Tooltip.Content>Unbind from {c.used_by.length} macro(s) first.</Tooltip.Content>
+                  </Tooltip>
+                {:else}
+                  <Button variant="danger" size="sm" onclick={() => remove(c)}>Delete</Button>
+                {/if}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </Modal.Body>
+</Modal>
+
+<EditCredentialModal bind:open={editOpen} cred={editTarget} onSaved={() => remoteActionsStore.loadCreds()} />
+
+<style>
+  .modal-title { margin: 0; font-size: 14px; font-weight: 600; }
+  .header { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+  .hint { color: var(--color-text-muted); font-size: 0.875rem; max-width: 60ch; margin: 0; }
+  .creds-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .creds-table th, .creds-table td {
+    text-align: left;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .creds-table th {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-text-dim);
+  }
+  .row-actions { display: flex; gap: 6px; justify-content: flex-end; }
+</style>

--- a/web/src/components/messages/remote_actions/EditCredentialModal.svelte
+++ b/web/src/components/messages/remote_actions/EditCredentialModal.svelte
@@ -1,0 +1,114 @@
+<script>
+  // EditCredentialModal -- create or edit one RemoteOTPCredential.
+  //
+  // Field labels follow the operator-facing rename: the secret input
+  // is "Secret Key", not "Base32 secret". The handbook explains that
+  // the value is the same RFC 4648 base32 string an authenticator app
+  // would consume.
+  import { Button, Input, Modal, toast } from '@chrissnell/chonky-ui';
+  import { remoteCredsApi } from '../../../lib/remote_actions/api.js';
+  import { remoteActionsStore } from '../../../lib/remote_actions/store.svelte.js';
+
+  let { open = $bindable(false), cred = null, onSaved = () => {} } = $props();
+
+  let name = $state('');
+  let secret = $state('');
+  let saving = $state(false);
+  let err = $state('');
+
+  let prevOpen = false;
+  $effect(() => {
+    if (open && !prevOpen) {
+      name = cred?.name ?? '';
+      secret = '';
+      err = '';
+    }
+    prevOpen = open;
+  });
+
+  const isEdit = $derived(!!cred?.id);
+
+  async function save() {
+    err = '';
+    if (!name.trim()) {
+      err = 'Name required';
+      return;
+    }
+    if (!isEdit && !secret.trim()) {
+      err = 'Secret Key required';
+      return;
+    }
+    saving = true;
+    try {
+      const body = { name: name.trim() };
+      if (secret.trim()) body.secret_b32 = secret.trim();
+      const res = isEdit
+        ? await remoteCredsApi.update(cred.id, body)
+        : await remoteCredsApi.create(body);
+      if (res.error) {
+        err = res.error.error ?? res.error.message ?? 'Save failed';
+        return;
+      }
+      await remoteActionsStore.loadCreds();
+      toast(isEdit ? `Updated "${name}"` : `Created "${name}"`, 'success');
+      onSaved(res.data);
+      open = false;
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<Modal bind:open>
+  <Modal.Header>
+    <h3 class="modal-title">{isEdit ? 'Edit Credential' : 'New Credential'}</h3>
+    <Modal.Close aria-label="Close">x</Modal.Close>
+  </Modal.Header>
+  <Modal.Body>
+    <div class="form">
+      <div class="field">
+        <label for="rcred-name">Name</label>
+        <Input id="rcred-name" bind:value={name} placeholder="NW5W OTP" />
+      </div>
+      <div class="field">
+        <label for="rcred-secret">Secret Key</label>
+        <textarea
+          id="rcred-secret"
+          class="secret"
+          rows="2"
+          bind:value={secret}
+          placeholder={isEdit ? '(leave blank to keep current)' : 'paste base32 secret from authenticator'}
+        ></textarea>
+      </div>
+      {#if err}<p class="err" role="alert">{err}</p>{/if}
+    </div>
+  </Modal.Body>
+  <Modal.Footer>
+    <Button variant="ghost" onclick={() => (open = false)}>Cancel</Button>
+    <Button variant="primary" disabled={saving} onclick={save}>{isEdit ? 'Save' : 'Create'}</Button>
+  </Modal.Footer>
+</Modal>
+
+<style>
+  .modal-title { margin: 0; font-size: 14px; font-weight: 600; }
+  .form { display: flex; flex-direction: column; gap: 12px; min-width: 320px; }
+  .field { display: flex; flex-direction: column; gap: 4px; }
+  .field label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--color-text-dim, var(--text-muted));
+  }
+  .secret {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    padding: 6px 8px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    background: var(--color-surface);
+    color: var(--color-text);
+    resize: vertical;
+  }
+  .err { color: var(--color-danger); font-size: 0.875rem; margin: 0; }
+</style>

--- a/web/src/components/messages/remote_actions/FreeFormSender.svelte
+++ b/web/src/components/messages/remote_actions/FreeFormSender.svelte
@@ -19,12 +19,24 @@
 
   let { target, maxLen = 67, onFire = async () => {}, onSaveAsMacro = () => {} } = $props();
 
-  let credId = $state(remoteActionsStore.defaultCredFor(target));
+  let credId = $state(null);
   let cmd = $state('');
   let manualOtp = $state('');
   let code = $state('');
   let secs = $state(0);
   let firing = $state(false);
+
+  // Re-prime the credential picker default whenever target changes.
+  // Capturing remoteActionsStore.defaultCredFor(target) directly inside
+  // $state would freeze at mount-time (Svelte 5 state_referenced_locally
+  // warning) and never advance when the operator switches DM threads.
+  let lastTarget = null;
+  $effect.pre(() => {
+    if (target !== lastTarget) {
+      credId = remoteActionsStore.defaultCredFor(target);
+      lastTarget = target;
+    }
+  });
 
   // Split cmd into actionName + argsString at the first space.
   const parsed = $derived.by(() => {

--- a/web/src/components/messages/remote_actions/FreeFormSender.svelte
+++ b/web/src/components/messages/remote_actions/FreeFormSender.svelte
@@ -1,0 +1,146 @@
+<script>
+  // FreeFormSender -- input row at the bottom of the drawer for ad-hoc
+  // command fires.
+  //
+  // Behaviour:
+  //   - "Active OTP" picker selects the credential whose code is
+  //     auto-injected. None reveals a manual six-digit input.
+  //   - "OTP <code> . next Ns" line is driven by otp_timer.js when a
+  //     credential is selected.
+  //   - Pre-flight wire-length check disables SEND with a tooltip
+  //     when the assembled string exceeds the active APRS budget
+  //     (67 / 200 chars).
+  import { Button, Icon, Input, Tooltip } from '@chrissnell/chonky-ui';
+  import CredentialPicker from './CredentialPicker.svelte';
+  import { remoteActionsStore } from '../../../lib/remote_actions/store.svelte.js';
+  import { remoteOtpApi } from '../../../lib/remote_actions/api.js';
+  import { fetchAndScheduleNext } from '../../../lib/remote_actions/otp_timer.js';
+  import { assembleWireString } from '../../../lib/remote_actions/send.js';
+
+  let { target, maxLen = 67, onFire = async () => {}, onSaveAsMacro = () => {} } = $props();
+
+  let credId = $state(remoteActionsStore.defaultCredFor(target));
+  let cmd = $state('');
+  let manualOtp = $state('');
+  let code = $state('');
+  let secs = $state(0);
+  let firing = $state(false);
+
+  // Split cmd into actionName + argsString at the first space.
+  const parsed = $derived.by(() => {
+    const trimmed = cmd.trim();
+    const sp = trimmed.indexOf(' ');
+    if (sp < 0) return { actionName: trimmed, argsString: '' };
+    return { actionName: trimmed.slice(0, sp), argsString: trimmed.slice(sp + 1) };
+  });
+
+  const otpToUse = $derived(credId == null ? manualOtp : code);
+  const wire = $derived(assembleWireString({ otp: otpToUse, actionName: parsed.actionName, argsString: parsed.argsString }));
+  const wireLen = $derived(wire.length);
+  const overBudget = $derived(wireLen > maxLen);
+
+  const canFire = $derived(
+    !firing &&
+      parsed.actionName.length > 0 &&
+      !overBudget &&
+      (credId != null ? code.length === 6 : /^[0-9]{6}$/.test(manualOtp)),
+  );
+
+  $effect(() => {
+    if (credId == null) {
+      code = '';
+      secs = 0;
+      return;
+    }
+    const dispose = fetchAndScheduleNext(
+      async () => {
+        const { data } = await remoteOtpApi.generate(credId);
+        return data;
+      },
+      (c, s) => {
+        code = c;
+        secs = s;
+      },
+    );
+    return dispose;
+  });
+
+  async function fire() {
+    firing = true;
+    try {
+      await onFire({ otp: otpToUse, actionName: parsed.actionName, argsString: parsed.argsString });
+      remoteActionsStore.rememberCredForTarget(target, credId ?? 0);
+      cmd = '';
+      manualOtp = '';
+    } finally {
+      firing = false;
+    }
+  }
+
+  function saveAsMacro() {
+    onSaveAsMacro({
+      label: parsed.actionName,
+      action_name: parsed.actionName,
+      args_string: parsed.argsString,
+      remote_otp_credential_id: credId,
+    });
+  }
+</script>
+
+<section class="freeform">
+  <h3>Free-form</h3>
+  <CredentialPicker bind:value={credId} label="Active OTP" />
+  <div class="field">
+    <label for="ff-cmd">Command</label>
+    <Input id="ff-cmd" bind:value={cmd} placeholder="unlock door=front" />
+    <p class="hint">Enter command and optional args -- no @@ prefix needed.</p>
+  </div>
+  {#if credId == null}
+    <div class="field">
+      <label for="ff-otp">OTP (6 digits)</label>
+      <Input id="ff-otp" bind:value={manualOtp} maxlength={6} />
+    </div>
+  {:else}
+    <p class="otp" data-testid="otp-line">OTP <strong>{code || '------'}</strong> . next {secs}s</p>
+  {/if}
+
+  <button type="button" class="save-link" onclick={saveAsMacro} disabled={parsed.actionName.length === 0}>
+    Save as macro...
+  </button>
+
+  <div class="send-row">
+    <span class="len" class:over={overBudget}>{wireLen} / {maxLen}</span>
+    {#if overBudget}
+      <Tooltip>
+        <Tooltip.Trigger>
+          <Button variant="primary" disabled>SEND ACTION</Button>
+        </Tooltip.Trigger>
+        <Tooltip.Content>Line exceeds APRS budget. Shorten args or shorten action name.</Tooltip.Content>
+      </Tooltip>
+    {:else}
+      <Button variant="primary" disabled={!canFire} onclick={fire}>
+        <Icon name="zap" size="sm" /> SEND ACTION
+      </Button>
+    {/if}
+  </div>
+</section>
+
+<style>
+  .freeform { display: flex; flex-direction: column; gap: 10px; padding-top: 12px; border-top: 1px solid var(--color-border); }
+  .freeform h3 { margin: 0; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-text-muted); }
+  .field { display: flex; flex-direction: column; gap: 4px; }
+  .field label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--color-text-dim, var(--text-muted));
+  }
+  .hint { margin: 0; font-size: 11px; color: var(--color-text-muted, var(--text-muted)); }
+  .otp { font-family: var(--font-mono); font-size: 0.875rem; margin: 0; color: var(--color-text-muted); }
+  .save-link { background: transparent; border: none; color: var(--color-primary); font-size: 0.8125rem; cursor: pointer; padding: 0; align-self: flex-start; }
+  .save-link:disabled { color: var(--color-text-dim); cursor: not-allowed; }
+  .send-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+  .len { font-family: var(--font-mono); font-size: 0.75rem; color: var(--color-text-muted); }
+  .len.over { color: var(--color-danger); }
+</style>

--- a/web/src/components/messages/remote_actions/MacroEditRow.svelte
+++ b/web/src/components/messages/remote_actions/MacroEditRow.svelte
@@ -16,10 +16,26 @@
     onMoveDown = () => {},
   } = $props();
 
-  let label = $state(macro.label ?? '');
-  let actionName = $state(macro.action_name ?? '');
-  let argsString = $state(macro.args_string ?? '');
-  let credId = $state(macro.remote_otp_credential_id ?? null);
+  let label = $state('');
+  let actionName = $state('');
+  let argsString = $state('');
+  let credId = $state(null);
+
+  // Re-snapshot editable fields whenever the bound macro identity
+  // changes. Plain `$state(macro.label ?? '')` would freeze at the
+  // initial prop value (Svelte 5 state_referenced_locally warning) and
+  // never reflect server refreshes / row re-binds.
+  let lastSeenId = null;
+  $effect.pre(() => {
+    const id = macro?.id ?? null;
+    if (id !== lastSeenId) {
+      label = macro?.label ?? '';
+      actionName = macro?.action_name ?? '';
+      argsString = macro?.args_string ?? '';
+      credId = macro?.remote_otp_credential_id ?? null;
+      lastSeenId = id;
+    }
+  });
 
   function commit() {
     onChange({
@@ -34,7 +50,7 @@
   $effect(() => {
     // Propagate credential changes immediately since the picker has no
     // blur event to gate on.
-    if (credId !== (macro.remote_otp_credential_id ?? null)) {
+    if (credId !== (macro?.remote_otp_credential_id ?? null)) {
       onChange({
         ...macro,
         label,

--- a/web/src/components/messages/remote_actions/MacroEditRow.svelte
+++ b/web/src/components/messages/remote_actions/MacroEditRow.svelte
@@ -24,16 +24,18 @@
   // Re-snapshot editable fields whenever the bound macro identity
   // changes. Plain `$state(macro.label ?? '')` would freeze at the
   // initial prop value (Svelte 5 state_referenced_locally warning) and
-  // never reflect server refreshes / row re-binds.
-  let lastSeenId = null;
+  // never reflect new bindings (e.g. Save-as-macro prefill, server
+  // refresh swapping in a fresh row, parent re-keying a draft).
+  let initialized = false;
+  let lastMacroRef = null;
   $effect.pre(() => {
-    const id = macro?.id ?? null;
-    if (id !== lastSeenId) {
+    if (!initialized || macro !== lastMacroRef) {
       label = macro?.label ?? '';
       actionName = macro?.action_name ?? '';
       argsString = macro?.args_string ?? '';
       credId = macro?.remote_otp_credential_id ?? null;
-      lastSeenId = id;
+      lastMacroRef = macro;
+      initialized = true;
     }
   });
 

--- a/web/src/components/messages/remote_actions/MacroEditRow.svelte
+++ b/web/src/components/messages/remote_actions/MacroEditRow.svelte
@@ -1,0 +1,98 @@
+<script>
+  // MacroEditRow -- row in the drawer's edit mode. Operator can edit
+  // every field of one macro plus delete it.
+  //
+  // Drag re-order is intentionally not handled here: the parent
+  // drawer owns ordering state (see RemoteActionsDrawer.svelte) and
+  // exposes up/down arrow controls as the mobile fallback.
+  import { Button, Icon, Input } from '@chrissnell/chonky-ui';
+  import CredentialPicker from './CredentialPicker.svelte';
+
+  let {
+    macro,
+    onChange = () => {},
+    onDelete = () => {},
+    onMoveUp = () => {},
+    onMoveDown = () => {},
+  } = $props();
+
+  let label = $state(macro.label ?? '');
+  let actionName = $state(macro.action_name ?? '');
+  let argsString = $state(macro.args_string ?? '');
+  let credId = $state(macro.remote_otp_credential_id ?? null);
+
+  function commit() {
+    onChange({
+      ...macro,
+      label,
+      action_name: actionName,
+      args_string: argsString,
+      remote_otp_credential_id: credId,
+    });
+  }
+
+  $effect(() => {
+    // Propagate credential changes immediately since the picker has no
+    // blur event to gate on.
+    if (credId !== (macro.remote_otp_credential_id ?? null)) {
+      onChange({
+        ...macro,
+        label,
+        action_name: actionName,
+        args_string: argsString,
+        remote_otp_credential_id: credId,
+      });
+    }
+  });
+</script>
+
+<div class="row">
+  <div class="reorder">
+    <button type="button" aria-label="Move up" onclick={onMoveUp}><Icon name="chevron-up" size="sm" /></button>
+    <button type="button" aria-label="Move down" onclick={onMoveDown}><Icon name="chevron-down" size="sm" /></button>
+  </div>
+  <div class="fields">
+    <div class="field">
+      <label for={`mer-label-${macro.id ?? 'new'}`}>Label</label>
+      <Input id={`mer-label-${macro.id ?? 'new'}`} bind:value={label} onblur={commit} />
+    </div>
+    <div class="cmd-row">
+      <div class="field">
+        <label for={`mer-action-${macro.id ?? 'new'}`}>Action</label>
+        <Input id={`mer-action-${macro.id ?? 'new'}`} bind:value={actionName} onblur={commit} />
+      </div>
+      <div class="field">
+        <label for={`mer-args-${macro.id ?? 'new'}`}>Args (k=v ...)</label>
+        <Input id={`mer-args-${macro.id ?? 'new'}`} bind:value={argsString} onblur={commit} />
+      </div>
+    </div>
+    <CredentialPicker bind:value={credId} />
+  </div>
+  <Button variant="danger" size="sm" onclick={onDelete}>Delete</Button>
+</div>
+
+<style>
+  .row {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: start;
+    gap: 12px;
+    padding: 10px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    background: var(--color-surface);
+    margin-bottom: 8px;
+  }
+  .reorder { display: flex; flex-direction: column; gap: 2px; }
+  .reorder button { background: transparent; border: none; cursor: pointer; color: var(--color-text-muted); padding: 2px; }
+  .fields { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+  .field { display: flex; flex-direction: column; gap: 2px; }
+  .field label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--color-text-dim, var(--text-muted));
+  }
+  .cmd-row { display: grid; grid-template-columns: 1fr 2fr; gap: 8px; }
+</style>

--- a/web/src/components/messages/remote_actions/MacroTile.svelte
+++ b/web/src/components/messages/remote_actions/MacroTile.svelte
@@ -1,0 +1,61 @@
+<script>
+  // MacroTile -- one row in the macro list. Single tap fires; the
+  // cooldown overlay (driven by the parent's per-step boundary)
+  // disables until the next TOTP step.
+  //
+  // Props:
+  //   macro       -- RemoteActionMacro
+  //   cooldownSec -- seconds remaining; 0 = enabled
+  //   onFire      -- () => void
+  import { Icon } from '@chrissnell/chonky-ui';
+
+  let { macro, cooldownSec = 0, onFire = () => {} } = $props();
+
+  const disabled = $derived(cooldownSec > 0);
+  const argsPreview = $derived(macro.args_string ? ` ${macro.args_string}` : '');
+</script>
+
+<button
+  type="button"
+  class="tile"
+  class:disabled
+  onclick={() => !disabled && onFire()}
+  aria-label={`Fire macro: ${macro.label}`}
+  data-testid="macro-tile"
+>
+  <Icon name="zap" size="sm" />
+  <span class="label">{macro.label}</span>
+  <span class="cmd">{macro.action_name}{argsPreview}</span>
+  {#if disabled}
+    <span class="cooldown">next OTP in {cooldownSec}s</span>
+  {/if}
+</button>
+
+<style>
+  .tile {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    background: var(--color-surface-raised);
+    color: var(--color-text);
+    font: inherit;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.15s, border-color 0.15s;
+  }
+  .tile:hover:not(.disabled) { border-color: var(--color-primary); }
+  .label { font-weight: 600; }
+  .cmd { font-family: var(--font-mono); font-size: 0.8125rem; color: var(--color-text-muted); }
+  .cooldown {
+    grid-column: 1 / -1;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    margin-top: 2px;
+  }
+  .disabled { opacity: 0.5; cursor: not-allowed; }
+</style>

--- a/web/src/components/messages/remote_actions/RemoteActionsDrawer.svelte
+++ b/web/src/components/messages/remote_actions/RemoteActionsDrawer.svelte
@@ -29,6 +29,7 @@
 
   let mode = $state('fire'); // 'fire' | 'edit'
   let cooldownByMacro = $state({}); // { macroId: expiresAtMs }
+  let firingByMacro = $state({}); // { macroId: true } -- in-flight gate
   let now = $state(Date.now());
 
   // Per-second tick so the cooldown numbers refresh.
@@ -50,6 +51,7 @@
   );
 
   function cooldownFor(macroId) {
+    if (firingByMacro[macroId]) return 1; // any non-zero disables the tile
     const expiresMs = cooldownByMacro[macroId];
     if (!expiresMs) return 0;
     const left = Math.ceil((expiresMs - now) / 1000);
@@ -57,35 +59,48 @@
   }
 
   async function fireMacro(m) {
-    let otp = '';
-    let nextBoundaryMs = Date.now() + 30_000;
-    if (m.remote_otp_credential_id != null) {
-      const { data, error } = await remoteOtpApi.generate(m.remote_otp_credential_id);
-      if (error || !data) {
-        toast('OTP fetch failed', 'error');
+    // Synchronous in-flight gate -- prevents a fast double-tap from
+    // queueing a second send between click N and the server-side OTP
+    // fetch resolving. The receiver's replay ring would reject the
+    // dupe anyway, but the operator would see two outbound bubbles and
+    // a `bad_otp:replay` reply for nothing.
+    if (firingByMacro[m.id]) return;
+    firingByMacro = { ...firingByMacro, [m.id]: true };
+    try {
+      let otp = '';
+      let nextBoundaryMs = Date.now() + 30_000;
+      if (m.remote_otp_credential_id != null) {
+        const { data, error } = await remoteOtpApi.generate(m.remote_otp_credential_id);
+        if (error || !data) {
+          toast('OTP fetch failed', 'error');
+          return;
+        }
+        otp = data.code;
+        nextBoundaryMs = new Date(data.expires_at).getTime();
+      } else {
+        // Manual OTP not supported on bare macro tap; the operator must
+        // promote the macro to free-form (Save as macro path) or remove
+        // its credential binding via edit mode then enter the OTP there.
+        toast('Macro has no credential. Edit it to add one or use the free-form sender.', 'warning');
         return;
       }
-      otp = data.code;
-      nextBoundaryMs = new Date(data.expires_at).getTime();
-    } else {
-      // Manual OTP not supported on bare macro tap; the operator must
-      // promote the macro to free-form (Save as macro path) or remove
-      // its credential binding via edit mode then enter the OTP there.
-      toast('Macro has no credential. Edit it to add one or use the free-form sender.', 'warning');
-      return;
-    }
-    try {
-      await sendActionFire({
-        target,
-        otp,
-        actionName: m.action_name,
-        argsString: m.args_string,
-        sendMessage,
-      });
-      cooldownByMacro = { ...cooldownByMacro, [m.id]: nextBoundaryMs };
-      remoteActionsStore.rememberCredForTarget(target, m.remote_otp_credential_id);
-    } catch (e) {
-      toast(`Fire failed: ${e?.message ?? e}`, 'error');
+      try {
+        await sendActionFire({
+          target,
+          otp,
+          actionName: m.action_name,
+          argsString: m.args_string,
+          sendMessage,
+        });
+        cooldownByMacro = { ...cooldownByMacro, [m.id]: nextBoundaryMs };
+        remoteActionsStore.rememberCredForTarget(target, m.remote_otp_credential_id);
+      } catch (e) {
+        toast(`Fire failed: ${e?.message ?? e}`, 'error');
+      }
+    } finally {
+      const next = { ...firingByMacro };
+      delete next[m.id];
+      firingByMacro = next;
     }
   }
 
@@ -138,12 +153,17 @@
   }
 
   async function commitDraft() {
-    const { error } = await remoteMacrosApi.create(savingDraft);
-    savingDraft = null;
-    if (error) {
-      toast('Create failed', 'error');
+    if (!savingDraft?.action_name?.trim()) {
+      toast('Action name required', 'warning');
       return;
     }
+    const { error } = await remoteMacrosApi.create(savingDraft);
+    if (error) {
+      // Keep the draft so the operator can retry without re-typing.
+      toast(`Create failed: ${error.error ?? error.message ?? error}`, 'error');
+      return;
+    }
+    savingDraft = null;
     await remoteActionsStore.loadMacros(target);
   }
 </script>

--- a/web/src/components/messages/remote_actions/RemoteActionsDrawer.svelte
+++ b/web/src/components/messages/remote_actions/RemoteActionsDrawer.svelte
@@ -1,0 +1,239 @@
+<script>
+  // RemoteActionsDrawer -- slide-in panel anchored right on desktop and
+  // bottom on mobile. Owns drawer-level state (mode flip, cooldown,
+  // staged macro draft) and delegates per-row rendering to MacroTile
+  // / MacroEditRow / FreeFormSender.
+  //
+  // Cooldown source-of-truth:
+  //   - The receiver's replay ring is the actual authority. The
+  //     drawer's cooldown is a UX hint that prevents the operator
+  //     from triggering a `bad_otp:replay` reply.
+  //   - When a macro fires we record the next-step boundary (from the
+  //     OTP endpoint response) and disable that tile until then.
+  //   - For the free-form path, the SEND button shares the same
+  //     boundary; the entire FreeFormSender is the cooled-down unit.
+  import { Button, Icon, toast } from '@chrissnell/chonky-ui';
+  import MacroTile from './MacroTile.svelte';
+  import MacroEditRow from './MacroEditRow.svelte';
+  import FreeFormSender from './FreeFormSender.svelte';
+  import { remoteActionsStore } from '../../../lib/remote_actions/store.svelte.js';
+  import { remoteMacrosApi, remoteOtpApi } from '../../../lib/remote_actions/api.js';
+  import { sendActionFire } from '../../../lib/remote_actions/send.js';
+  import { sendMessage } from '../../../api/messages.js';
+
+  let {
+    open = $bindable(false),
+    target,
+    maxLen = 67,
+  } = $props();
+
+  let mode = $state('fire'); // 'fire' | 'edit'
+  let cooldownByMacro = $state({}); // { macroId: expiresAtMs }
+  let now = $state(Date.now());
+
+  // Per-second tick so the cooldown numbers refresh.
+  $effect(() => {
+    const t = setInterval(() => (now = Date.now()), 1000);
+    return () => clearInterval(t);
+  });
+
+  $effect(() => {
+    if (open && target) {
+      remoteActionsStore.refreshTarget(target);
+    }
+  });
+
+  const macros = $derived(
+    (remoteActionsStore.macrosByTarget[target] ?? [])
+      .slice()
+      .sort((a, b) => (a.position ?? 0) - (b.position ?? 0)),
+  );
+
+  function cooldownFor(macroId) {
+    const expiresMs = cooldownByMacro[macroId];
+    if (!expiresMs) return 0;
+    const left = Math.ceil((expiresMs - now) / 1000);
+    return left > 0 ? left : 0;
+  }
+
+  async function fireMacro(m) {
+    let otp = '';
+    let nextBoundaryMs = Date.now() + 30_000;
+    if (m.remote_otp_credential_id != null) {
+      const { data, error } = await remoteOtpApi.generate(m.remote_otp_credential_id);
+      if (error || !data) {
+        toast('OTP fetch failed', 'error');
+        return;
+      }
+      otp = data.code;
+      nextBoundaryMs = new Date(data.expires_at).getTime();
+    } else {
+      // Manual OTP not supported on bare macro tap; the operator must
+      // promote the macro to free-form (Save as macro path) or remove
+      // its credential binding via edit mode then enter the OTP there.
+      toast('Macro has no credential. Edit it to add one or use the free-form sender.', 'warning');
+      return;
+    }
+    try {
+      await sendActionFire({
+        target,
+        otp,
+        actionName: m.action_name,
+        argsString: m.args_string,
+        sendMessage,
+      });
+      cooldownByMacro = { ...cooldownByMacro, [m.id]: nextBoundaryMs };
+      remoteActionsStore.rememberCredForTarget(target, m.remote_otp_credential_id);
+    } catch (e) {
+      toast(`Fire failed: ${e?.message ?? e}`, 'error');
+    }
+  }
+
+  async function fireFreeForm({ otp, actionName, argsString }) {
+    try {
+      await sendActionFire({ target, otp, actionName, argsString, sendMessage });
+      toast('Action sent', 'success');
+    } catch (e) {
+      toast(`Fire failed: ${e?.message ?? e}`, 'error');
+    }
+  }
+
+  async function updateMacro(patched) {
+    const { error } = await remoteMacrosApi.update(patched.id, patched);
+    if (error) {
+      toast('Update failed', 'error');
+      return;
+    }
+    await remoteActionsStore.loadMacros(target);
+  }
+
+  async function deleteMacro(m) {
+    const { error } = await remoteMacrosApi.remove(m.id);
+    if (error) {
+      toast('Delete failed', 'error');
+      return;
+    }
+    await remoteActionsStore.loadMacros(target);
+  }
+
+  async function moveMacro(m, dir) {
+    const list = macros.slice();
+    const idx = list.findIndex((x) => x.id === m.id);
+    const swap = dir === 'up' ? idx - 1 : idx + 1;
+    if (swap < 0 || swap >= list.length) return;
+    const ids = list.map((x) => x.id);
+    [ids[idx], ids[swap]] = [ids[swap], ids[idx]];
+    const { error } = await remoteMacrosApi.reorder(target, ids);
+    if (error) {
+      toast('Reorder failed', 'error');
+      return;
+    }
+    await remoteActionsStore.loadMacros(target);
+  }
+
+  let savingDraft = $state(null);
+  function saveDraft(draft) {
+    savingDraft = { ...draft, target_call: target, position: macros.length };
+    mode = 'edit';
+  }
+
+  async function commitDraft() {
+    const { error } = await remoteMacrosApi.create(savingDraft);
+    savingDraft = null;
+    if (error) {
+      toast('Create failed', 'error');
+      return;
+    }
+    await remoteActionsStore.loadMacros(target);
+  }
+</script>
+
+{#if open}
+  <aside class="drawer" data-testid="remote-actions-drawer">
+    <header class="head">
+      <h2>{mode === 'edit' ? 'EDIT MACROS' : `MACROS . ${target}`}</h2>
+      <div class="head-actions">
+        {#if mode === 'edit'}
+          <Button variant="primary" size="sm" onclick={() => (mode = 'fire')}>Done</Button>
+        {:else}
+          <button type="button" class="gear" aria-label="Edit macros" onclick={() => (mode = 'edit')}>
+            <Icon name="settings" size="sm" />
+          </button>
+        {/if}
+        <button type="button" class="close" aria-label="Close" onclick={() => (open = false)}>
+          <Icon name="x" size="sm" />
+        </button>
+      </div>
+    </header>
+
+    {#if mode === 'fire'}
+      <ul class="tiles">
+        {#each macros as m (m.id)}
+          <li><MacroTile macro={m} cooldownSec={cooldownFor(m.id)} onFire={() => fireMacro(m)} /></li>
+        {/each}
+      </ul>
+      <FreeFormSender
+        {target}
+        {maxLen}
+        onFire={fireFreeForm}
+        onSaveAsMacro={saveDraft}
+      />
+    {:else}
+      <div class="edit-list">
+        {#each macros as m (m.id)}
+          <MacroEditRow
+            macro={m}
+            onChange={updateMacro}
+            onDelete={() => deleteMacro(m)}
+            onMoveUp={() => moveMacro(m, 'up')}
+            onMoveDown={() => moveMacro(m, 'down')}
+          />
+        {/each}
+      </div>
+      {#if savingDraft}
+        <div class="draft">
+          <h3>New macro</h3>
+          <MacroEditRow
+            macro={savingDraft}
+            onChange={(p) => (savingDraft = p)}
+            onDelete={() => (savingDraft = null)}
+          />
+          <Button variant="primary" onclick={commitDraft}>Create</Button>
+        </div>
+      {:else}
+        <Button variant="ghost" onclick={() => (savingDraft = { target_call: target, label: '', action_name: '', args_string: '', remote_otp_credential_id: null, position: macros.length })}>
+          + Add new macro
+        </Button>
+      {/if}
+    {/if}
+  </aside>
+{/if}
+
+<style>
+  .drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(420px, 100vw);
+    background: var(--color-surface);
+    border-left: 1px solid var(--color-border);
+    box-shadow: -2px 0 12px rgba(0,0,0,0.15);
+    display: flex;
+    flex-direction: column;
+    padding: 16px;
+    overflow-y: auto;
+    z-index: 50;
+  }
+  .head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 12px; }
+  .head h2 { margin: 0; font-size: 0.9375rem; letter-spacing: 0.05em; text-transform: uppercase; }
+  .head-actions { display: flex; gap: 6px; align-items: center; }
+  .gear, .close { background: transparent; border: none; cursor: pointer; color: var(--color-text-muted); padding: 4px; }
+  .tiles { list-style: none; padding: 0; margin: 0 0 12px; display: flex; flex-direction: column; gap: 6px; }
+  .edit-list { display: flex; flex-direction: column; gap: 4px; margin-bottom: 12px; }
+  .draft { padding: 12px; border: 1px dashed var(--color-border); border-radius: var(--radius); margin-bottom: 12px; }
+
+  @media (max-width: 767px) {
+    .drawer { top: auto; left: 0; right: 0; bottom: 0; width: 100vw; max-height: 80vh; border-left: none; border-top: 1px solid var(--color-border); }
+  }
+</style>

--- a/web/src/components/messages/remote_actions/ReplyBubbleAdornment.svelte
+++ b/web/src/components/messages/remote_actions/ReplyBubbleAdornment.svelte
@@ -1,0 +1,25 @@
+<script>
+  // ReplyBubbleAdornment -- small footer adornment rendered inside the
+  // MessageBubble when reply_match.isActionReply(msg) is true.
+  //
+  // Renders a zap icon, the literal text "reply", and a colored badge
+  // matching the inbound status (ok/error/bad_*/...).
+  import { Badge, Icon } from '@chrissnell/chonky-ui';
+  import { statusVariant } from '../../../lib/actions/status.js';
+  import { statusFromText } from '../../../lib/remote_actions/reply_match.js';
+
+  let { text } = $props();
+  const status = $derived(statusFromText(text));
+  const variant = $derived(statusVariant(status));
+</script>
+
+<span class="adorn">
+  <Icon name="zap" size="xs" />
+  <Badge variant={variant}>{status}</Badge>
+  <span class="lbl">reply</span>
+</span>
+
+<style>
+  .adorn { display: inline-flex; align-items: center; gap: 4px; font-size: 0.75rem; opacity: 0.85; }
+  .lbl { font-style: italic; color: var(--color-text-muted); }
+</style>

--- a/web/src/components/messages/remote_actions/ReplyBubbleAdornment.svelte
+++ b/web/src/components/messages/remote_actions/ReplyBubbleAdornment.svelte
@@ -4,13 +4,28 @@
   //
   // Renders a zap icon, the literal text "reply", and a colored badge
   // matching the inbound status (ok/error/bad_*/...).
+  //
+  // `statusFromText` returns the on-air wire form ("bad otp",
+  // "rate-limited", "no-credential" -- see reply_match.STATUS_PREFIXES)
+  // because that's what the receiver speaks. `statusVariant` switches
+  // on the Go enum form ("bad_otp", "rate_limited", "no_credential").
+  // We translate at the boundary so multi-token failure replies get
+  // their proper red/amber colour cue instead of falling through to
+  // the default badge variant.
   import { Badge, Icon } from '@chrissnell/chonky-ui';
   import { statusVariant } from '../../../lib/actions/status.js';
   import { statusFromText } from '../../../lib/remote_actions/reply_match.js';
 
+  const WIRE_TO_ENUM = {
+    'bad otp': 'bad_otp',
+    'bad arg': 'bad_arg',
+    'rate-limited': 'rate_limited',
+    'no-credential': 'no_credential',
+  };
+
   let { text } = $props();
   const status = $derived(statusFromText(text));
-  const variant = $derived(statusVariant(status));
+  const variant = $derived(statusVariant(WIRE_TO_ENUM[status] ?? status));
 </script>
 
 <span class="adorn">

--- a/web/src/lib/remote_actions/api.js
+++ b/web/src/lib/remote_actions/api.js
@@ -1,0 +1,26 @@
+// web/src/lib/remote_actions/api.js
+//
+// Hand-written wrapper around the generated openapi-fetch client. Routes
+// drop the `/api` prefix because client.ts sets baseUrl to '/api'.
+// Mirrors web/src/lib/actions/api.js so callers in the same feature
+// area look familiar.
+import { api } from '../../api/client';
+
+export const remoteCredsApi = {
+  list:   ()       => api.GET('/remote-actions/credentials'),
+  create: (body)   => api.POST('/remote-actions/credentials', { body }),
+  update: (id, b)  => api.PUT('/remote-actions/credentials/{id}', { params: { path: { id } }, body: b }),
+  remove: (id)     => api.DELETE('/remote-actions/credentials/{id}', { params: { path: { id } } }),
+};
+
+export const remoteMacrosApi = {
+  list:    (target) => api.GET('/remote-actions/macros', { params: { query: { target } } }),
+  create:  (body)   => api.POST('/remote-actions/macros', { body }),
+  update:  (id, b)  => api.PUT('/remote-actions/macros/{id}', { params: { path: { id } }, body: b }),
+  remove:  (id)     => api.DELETE('/remote-actions/macros/{id}', { params: { path: { id } } }),
+  reorder: (target_call, ids) => api.POST('/remote-actions/macros/reorder', { body: { target_call, ids } }),
+};
+
+export const remoteOtpApi = {
+  generate: (id) => api.POST('/remote-actions/otp/{id}', { params: { path: { id } } }),
+};

--- a/web/src/lib/remote_actions/otp_timer.js
+++ b/web/src/lib/remote_actions/otp_timer.js
@@ -1,0 +1,56 @@
+// web/src/lib/remote_actions/otp_timer.js
+//
+// Drives the "OTP <code> . next Ns" line in the drawer. Keeps a single
+// fetch-and-reschedule loop per credential id; the active timer dies
+// when the caller invokes the returned dispose function.
+//
+// Why not a setInterval over the wall clock: the server-supplied
+// expires_at carries the canonical step boundary, so we sleep until
+// that exact moment and refetch -- saves a round trip per second of
+// countdown and tolerates clock drift between client and server.
+
+export function secondsRemaining(expiresAtIso, now = new Date()) {
+  const expiresMs = new Date(expiresAtIso).getTime();
+  const diffMs = expiresMs - now.getTime();
+  if (diffMs <= 0) return 0;
+  return Math.ceil(diffMs / 1000);
+}
+
+// fetchAndScheduleNext drives one credential's countdown.
+// fetchOTP: () => Promise<{code: string, expires_at: string}>
+// onTick:   (code: string, secondsLeft: number) => void
+// Returns a dispose function that cancels the next scheduled refresh.
+export function fetchAndScheduleNext(fetchOTP, onTick) {
+  let cancelled = false;
+  let timer = null;
+  let tickInterval = null;
+
+  async function run() {
+    if (cancelled) return;
+    const { code, expires_at } = await fetchOTP();
+    if (cancelled) return;
+    const secs = secondsRemaining(expires_at);
+    onTick(code, secs);
+    // Per-second visual countdown.
+    let left = secs;
+    tickInterval = setInterval(() => {
+      left -= 1;
+      if (left <= 0) {
+        clearInterval(tickInterval);
+        tickInterval = null;
+        return;
+      }
+      onTick(code, left);
+    }, 1000);
+    // Refresh just past the boundary (200 ms slack).
+    timer = setTimeout(run, Math.max(200, secs * 1000 + 200));
+  }
+
+  run();
+
+  return () => {
+    cancelled = true;
+    if (timer) clearTimeout(timer);
+    if (tickInterval) clearInterval(tickInterval);
+  };
+}

--- a/web/src/lib/remote_actions/otp_timer.test.js
+++ b/web/src/lib/remote_actions/otp_timer.test.js
@@ -1,0 +1,44 @@
+// Tests for the remote-actions OTP countdown helpers.
+//   node --test src/lib/remote_actions/otp_timer.test.js
+
+import { strict as assert } from 'node:assert';
+import { secondsRemaining, fetchAndScheduleNext } from './otp_timer.js';
+
+let describe, it, mock;
+try {
+  const nodeTest = await import('node:test');
+  describe = nodeTest.describe;
+  it = nodeTest.it;
+  mock = nodeTest.mock;
+} catch {
+  describe = globalThis.describe;
+  it = globalThis.it;
+}
+
+describe('secondsRemaining', () => {
+  it('returns positive seconds when expires_at is future', () => {
+    const now = new Date('2026-05-03T17:14:15Z');
+    assert.equal(secondsRemaining('2026-05-03T17:14:30Z', now), 15);
+  });
+  it('returns 0 when expires_at is past', () => {
+    const now = new Date('2026-05-03T17:15:00Z');
+    assert.equal(secondsRemaining('2026-05-03T17:14:30Z', now), 0);
+  });
+});
+
+describe('fetchAndScheduleNext', () => {
+  it('refetches on expiry boundary and stops on dispose', async () => {
+    let calls = 0;
+    const fakeFetch = async () => {
+      calls += 1;
+      const now = Date.now();
+      return { code: '111111', expires_at: new Date(now + 1).toISOString() };
+    };
+    const onTick = mock.fn();
+    const dispose = fetchAndScheduleNext(fakeFetch, onTick);
+    await new Promise((r) => setTimeout(r, 50));
+    dispose();
+    assert.ok(calls >= 1, `expected at least one fetch, got ${calls}`);
+    assert.ok(onTick.mock.callCount() >= 1, 'expected onTick to be called');
+  });
+});

--- a/web/src/lib/remote_actions/reply_match.js
+++ b/web/src/lib/remote_actions/reply_match.js
@@ -1,0 +1,65 @@
+// web/src/lib/remote_actions/reply_match.js
+//
+// In-memory correlation between outbound `@@<otp>#cmd` fires and the
+// inbound replies they elicit. Replies arriving from the same peer
+// within REPLY_WINDOW_MS of an outbound fire are flagged so the
+// MessageBubble can render the zap-reply adornment.
+//
+// Mitigation against false positives: a candidate reply is only
+// flagged when its body starts with one of STATUS_PREFIXES -- the same
+// status enum the receiver runner emits (pkg/actions/types.go). This
+// trades a small recall miss (a free-form remark from the peer that
+// happens to start with "ok") for the safer direction.
+//
+// State is a per-tab Map keyed by (peer, action_name); each value is
+// the latest sent_at_ms. The map is bounded loosely -- keys self-expire
+// once their entries are older than REPLY_WINDOW_MS the next time
+// isActionReply runs against them, so we don't grow unboundedly.
+
+export const REPLY_WINDOW_MS = 60_000;
+
+export const STATUS_PREFIXES = [
+  'ok',
+  'error:',
+  'bad_otp',
+  'bad_arg',
+  'denied',
+  'unknown',
+  'disabled',
+  'busy',
+  'rate_limited',
+  'timeout',
+  'no_credential',
+];
+
+const fires = new Map(); // key: peer, value: { lastSentAtMs }
+
+export function recordOutboundFire(peer, actionName, sentAtMs = Date.now()) {
+  if (!peer) return;
+  fires.set(peer.toUpperCase(), { lastSentAtMs: sentAtMs, actionName });
+}
+
+export function isActionReply(msg) {
+  if (!msg || msg.direction !== 'in') return false;
+  const peer = (msg.from_call || '').toUpperCase();
+  const entry = fires.get(peer);
+  if (!entry) return false;
+  const replyMs = msg.created_at ? new Date(msg.created_at).getTime() : Date.now();
+  if (replyMs - entry.lastSentAtMs > REPLY_WINDOW_MS) {
+    fires.delete(peer);
+    return false;
+  }
+  const text = (msg.text || '').trim().toLowerCase();
+  return STATUS_PREFIXES.some((p) => text.startsWith(p));
+}
+
+// statusFromText returns the matching prefix (lower-cased) for use by
+// the badge color. Falls back to 'ok' when isActionReply returned true
+// but the prefix can't be determined (defensive).
+export function statusFromText(text) {
+  const t = (text || '').trim().toLowerCase();
+  for (const p of STATUS_PREFIXES) {
+    if (t.startsWith(p)) return p.replace(':', '');
+  }
+  return 'ok';
+}

--- a/web/src/lib/remote_actions/reply_match.js
+++ b/web/src/lib/remote_actions/reply_match.js
@@ -6,10 +6,12 @@
 // MessageBubble can render the zap-reply adornment.
 //
 // Mitigation against false positives: a candidate reply is only
-// flagged when its body starts with one of STATUS_PREFIXES -- the same
-// status enum the receiver runner emits (pkg/actions/types.go). This
-// trades a small recall miss (a free-form remark from the peer that
-// happens to start with "ok") for the safer direction.
+// flagged when its body starts with one of STATUS_PREFIXES -- the
+// on-air words emitted by pkg/actions/reply.go statusWord(). Note
+// the wire form differs from the Go enum names: "bad otp" with a
+// space, "rate-limited" with a hyphen, etc. Keep this list in sync
+// with reply.go statusWord(); a Status value whose word doesn't
+// appear here will never correlate as an action reply.
 //
 // State is a per-tab Map keyed by (peer, action_name); each value is
 // the latest sent_at_ms. The map is bounded loosely -- keys self-expire
@@ -20,22 +22,25 @@ export const REPLY_WINDOW_MS = 60_000;
 
 export const STATUS_PREFIXES = [
   'ok',
-  'error:',
-  'bad_otp',
-  'bad_arg',
+  'error',          // also matches "error: <detail>"
+  'bad otp',
+  'bad arg',
   'denied',
   'unknown',
   'disabled',
   'busy',
-  'rate_limited',
+  'rate-limited',
   'timeout',
-  'no_credential',
+  'no-credential',
 ];
 
 const fires = new Map(); // key: peer, value: { lastSentAtMs }
 
 export function recordOutboundFire(peer, actionName, sentAtMs = Date.now()) {
   if (!peer) return;
+  for (const [k, v] of fires) {
+    if (sentAtMs - v.lastSentAtMs > REPLY_WINDOW_MS) fires.delete(k);
+  }
   fires.set(peer.toUpperCase(), { lastSentAtMs: sentAtMs, actionName });
 }
 
@@ -59,7 +64,7 @@ export function isActionReply(msg) {
 export function statusFromText(text) {
   const t = (text || '').trim().toLowerCase();
   for (const p of STATUS_PREFIXES) {
-    if (t.startsWith(p)) return p.replace(':', '');
+    if (t.startsWith(p)) return p;
   }
   return 'ok';
 }

--- a/web/src/lib/remote_actions/reply_match.test.js
+++ b/web/src/lib/remote_actions/reply_match.test.js
@@ -1,0 +1,60 @@
+// Tests for the outbound/reply correlation helper.
+//   node --test src/lib/remote_actions/reply_match.test.js
+
+import { strict as assert } from 'node:assert';
+import {
+  recordOutboundFire,
+  isActionReply,
+  STATUS_PREFIXES,
+} from './reply_match.js';
+
+let describe, it;
+try {
+  const nodeTest = await import('node:test');
+  describe = nodeTest.describe;
+  it = nodeTest.it;
+} catch {
+  describe = globalThis.describe;
+  it = globalThis.it;
+}
+
+describe('isActionReply', () => {
+  it('flags inbound text starting with a status prefix from the same peer within 60s', () => {
+    const now = Date.now();
+    recordOutboundFire('KK7XYZ-9', 'unlock', now);
+    const reply = {
+      from_call: 'KK7XYZ-9',
+      direction: 'in',
+      text: 'ok unlock door=front',
+      created_at: new Date(now + 5000).toISOString(),
+    };
+    assert.ok(isActionReply(reply));
+  });
+  it('does not flag when the prefix is missing', () => {
+    const now = Date.now();
+    recordOutboundFire('KK7XYZ-9', 'unlock', now);
+    const reply = {
+      from_call: 'KK7XYZ-9',
+      direction: 'in',
+      text: 'door is open thanks',
+      created_at: new Date(now + 5000).toISOString(),
+    };
+    assert.ok(!isActionReply(reply));
+  });
+  it('does not flag when window expired', () => {
+    const now = Date.now();
+    recordOutboundFire('KK7XYZ-9', 'unlock', now - 120000);
+    const reply = {
+      from_call: 'KK7XYZ-9',
+      direction: 'in',
+      text: 'ok',
+      created_at: new Date(now).toISOString(),
+    };
+    assert.ok(!isActionReply(reply));
+  });
+  it('exposes a non-empty STATUS_PREFIXES list', () => {
+    assert.ok(STATUS_PREFIXES.includes('ok'));
+    assert.ok(STATUS_PREFIXES.includes('error:'));
+    assert.ok(STATUS_PREFIXES.includes('bad_otp'));
+  });
+});

--- a/web/src/lib/remote_actions/reply_match.test.js
+++ b/web/src/lib/remote_actions/reply_match.test.js
@@ -52,9 +52,33 @@ describe('isActionReply', () => {
     };
     assert.ok(!isActionReply(reply));
   });
-  it('exposes a non-empty STATUS_PREFIXES list', () => {
+  it('exposes a non-empty STATUS_PREFIXES list using on-air wire words', () => {
     assert.ok(STATUS_PREFIXES.includes('ok'));
-    assert.ok(STATUS_PREFIXES.includes('error:'));
-    assert.ok(STATUS_PREFIXES.includes('bad_otp'));
+    assert.ok(STATUS_PREFIXES.includes('error'));
+    assert.ok(STATUS_PREFIXES.includes('bad otp'));
+    assert.ok(STATUS_PREFIXES.includes('rate-limited'));
+    assert.ok(STATUS_PREFIXES.includes('no-credential'));
+  });
+  it('flags a "bad otp" reply (space, not underscore)', () => {
+    const now = Date.now();
+    recordOutboundFire('KK7XYZ-9', 'unlock', now);
+    const reply = {
+      from_call: 'KK7XYZ-9',
+      direction: 'in',
+      text: 'bad otp',
+      created_at: new Date(now + 1000).toISOString(),
+    };
+    assert.ok(isActionReply(reply));
+  });
+  it('flags an "error: detail" reply', () => {
+    const now = Date.now();
+    recordOutboundFire('KK7XYZ-9', 'unlock', now);
+    const reply = {
+      from_call: 'KK7XYZ-9',
+      direction: 'in',
+      text: 'error: timeout while running',
+      created_at: new Date(now + 1000).toISOString(),
+    };
+    assert.ok(isActionReply(reply));
   });
 });

--- a/web/src/lib/remote_actions/send.js
+++ b/web/src/lib/remote_actions/send.js
@@ -29,9 +29,11 @@ export async function sendActionFire({
 }) {
   const text = assembleWireString({ otp, actionName, argsString });
   const result = await sendMessage({
-    to_call: target,
+    to: target,
     text,
   });
+  // Record only after a successful await: a thrown send didn't make it
+  // to the wire, so there's no inbound reply to correlate with.
   recordOutboundFire(target, actionName, Date.now());
   return result;
 }

--- a/web/src/lib/remote_actions/send.js
+++ b/web/src/lib/remote_actions/send.js
@@ -1,0 +1,37 @@
+// web/src/lib/remote_actions/send.js
+//
+// Assembles `@@<otp>#<action> [args]` and posts it via the existing
+// /api/messages send path. We deliberately reuse the same endpoint
+// hand-typed Action lines go through so outbound Actions are
+// indistinguishable on the wire and in the audit log.
+//
+// The `sendMessage` dependency is injected (typically the helper from
+// web/src/api/messages.js) so this module stays testable without
+// hitting the real client.
+import { recordOutboundFire } from './reply_match.js';
+
+export function assembleWireString({ otp, actionName, argsString }) {
+  const head = `@@${otp ?? ''}#${actionName}`;
+  const args = (argsString ?? '').trim();
+  return args ? `${head} ${args}` : head;
+}
+
+export function lengthFor(opts) {
+  return assembleWireString(opts).length;
+}
+
+export async function sendActionFire({
+  target,
+  otp,
+  actionName,
+  argsString,
+  sendMessage,
+}) {
+  const text = assembleWireString({ otp, actionName, argsString });
+  const result = await sendMessage({
+    to_call: target,
+    text,
+  });
+  recordOutboundFire(target, actionName, Date.now());
+  return result;
+}

--- a/web/src/lib/remote_actions/send.test.js
+++ b/web/src/lib/remote_actions/send.test.js
@@ -57,7 +57,7 @@ describe('sendActionFire', () => {
     });
     assert.equal(sendMessage.mock.callCount(), 1);
     assert.deepEqual(sendMessage.mock.calls[0].arguments[0], {
-      to_call: 'KK7XYZ-9',
+      to: 'KK7XYZ-9',
       text: '@@418273#unlock',
     });
   });

--- a/web/src/lib/remote_actions/send.test.js
+++ b/web/src/lib/remote_actions/send.test.js
@@ -1,0 +1,64 @@
+// Tests for the wire-string assembler and send helper.
+//   node --test src/lib/remote_actions/send.test.js
+
+import { strict as assert } from 'node:assert';
+import { assembleWireString, lengthFor, sendActionFire } from './send.js';
+
+let describe, it, mock;
+try {
+  const nodeTest = await import('node:test');
+  describe = nodeTest.describe;
+  it = nodeTest.it;
+  mock = nodeTest.mock;
+} catch {
+  describe = globalThis.describe;
+  it = globalThis.it;
+}
+
+describe('assembleWireString', () => {
+  it('builds @@<otp>#cmd without args', () => {
+    assert.equal(
+      assembleWireString({ otp: '418273', actionName: 'status' }),
+      '@@418273#status',
+    );
+  });
+  it('builds with args', () => {
+    assert.equal(
+      assembleWireString({ otp: '418273', actionName: 'unlock', argsString: 'door=front' }),
+      '@@418273#unlock door=front',
+    );
+  });
+  it('omits otp when empty (action with otp_required=false on receiver)', () => {
+    assert.equal(
+      assembleWireString({ otp: '', actionName: 'status' }),
+      '@@#status',
+    );
+  });
+});
+
+describe('lengthFor', () => {
+  it('matches assembled length', () => {
+    assert.equal(
+      lengthFor({ otp: '418273', actionName: 'unlock', argsString: 'door=front' }),
+      '@@418273#unlock door=front'.length,
+    );
+  });
+});
+
+describe('sendActionFire', () => {
+  it('posts via the supplied sendMessage helper and records the fire', async () => {
+    const sendMessage = mock.fn(async () => ({ id: 1, text: '@@418273#unlock' }));
+    await sendActionFire({
+      target: 'KK7XYZ-9',
+      otp: '418273',
+      actionName: 'unlock',
+      argsString: '',
+      sendMessage,
+    });
+    assert.equal(sendMessage.mock.callCount(), 1);
+    assert.deepEqual(sendMessage.mock.calls[0].arguments[0], {
+      to_call: 'KK7XYZ-9',
+      text: '@@418273#unlock',
+    });
+  });
+});

--- a/web/src/lib/remote_actions/store.svelte.js
+++ b/web/src/lib/remote_actions/store.svelte.js
@@ -1,0 +1,74 @@
+// web/src/lib/remote_actions/store.svelte.js
+//
+// Singleton store for outbound-Actions feature state. Mirrors
+// lib/actions/store.svelte.js. Three slices:
+//   - macrosByTarget: per-peer macro list, lazily loaded by openDrawer().
+//   - creds:          credential list (one cache for the whole app).
+//   - lastUsedCredByTarget: peer -> cred id used most recently for free-form
+//                            fires; primes the picker default.
+import { remoteCredsApi, remoteMacrosApi } from './api.js';
+
+function describe(error, fallback) {
+  if (!error) return fallback;
+  if (typeof error === 'string') return error;
+  return error.error ?? error.message ?? fallback;
+}
+
+class RemoteActionsStore {
+  creds = $state([]);
+  macrosByTarget = $state({}); // { 'KK7XYZ-9': [macro, ...] }
+  lastUsedCredByTarget = $state({}); // { 'KK7XYZ-9': 4 }
+  loading = $state(false);
+  error = $state(null);
+
+  async loadCreds() {
+    const { data, error } = await remoteCredsApi.list();
+    if (error) {
+      this.error = describe(error, 'Failed to load credentials');
+      return;
+    }
+    this.creds = data ?? [];
+    this.error = null;
+  }
+
+  async loadMacros(target) {
+    const { data, error } = await remoteMacrosApi.list(target);
+    if (error) {
+      this.error = describe(error, 'Failed to load macros');
+      return;
+    }
+    this.macrosByTarget = { ...this.macrosByTarget, [target]: data ?? [] };
+    this.error = null;
+  }
+
+  async refreshTarget(target) {
+    this.loading = true;
+    try {
+      await Promise.all([this.loadCreds(), this.loadMacros(target)]);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  rememberCredForTarget(target, credId) {
+    if (!target || !credId) return;
+    this.lastUsedCredByTarget = {
+      ...this.lastUsedCredByTarget,
+      [target]: credId,
+    };
+  }
+
+  // Resolve the picker default for a target. Order:
+  //   1. Most recently used credential against this peer.
+  //   2. The credential whose Name is alphabetically first.
+  //   3. null (manual OTP mode).
+  defaultCredFor(target) {
+    const remembered = this.lastUsedCredByTarget[target];
+    if (remembered && this.creds.find((c) => c.id === remembered)) return remembered;
+    if (this.creds.length === 0) return null;
+    const sorted = [...this.creds].sort((a, b) => a.name.localeCompare(b.name));
+    return sorted[0]?.id ?? null;
+  }
+}
+
+export const remoteActionsStore = new RemoteActionsStore();

--- a/web/src/lib/remote_actions/store.svelte.js
+++ b/web/src/lib/remote_actions/store.svelte.js
@@ -66,7 +66,9 @@ class RemoteActionsStore {
     const remembered = this.lastUsedCredByTarget[target];
     if (remembered && this.creds.find((c) => c.id === remembered)) return remembered;
     if (this.creds.length === 0) return null;
-    const sorted = [...this.creds].sort((a, b) => a.name.localeCompare(b.name));
+    const sorted = [...this.creds].sort((a, b) =>
+      (a.name ?? '').localeCompare(b.name ?? ''),
+    );
     return sorted[0]?.id ?? null;
   }
 }

--- a/web/src/routes/Messages.svelte
+++ b/web/src/routes/Messages.svelte
@@ -25,6 +25,7 @@
   import MessageThread from '../components/messages/MessageThread.svelte';
   import TacticalSettings from '../components/messages/TacticalSettings.svelte';
   import ComposeNewModal from '../components/messages/ComposeNewModal.svelte';
+  import CredentialsModal from '../components/messages/remote_actions/CredentialsModal.svelte';
   import EmptyStates from '../components/messages/EmptyStates.svelte';
   import { messages as store } from '../lib/messagesStore.svelte.js';
   import { sendMessage } from '../api/messages.js';
@@ -401,6 +402,10 @@
   // slide transform; otherwise the grid renders both panes.
   const showList = $derived(!isMobile || !activeThreadId);
   const showThread = $derived(!isMobile || !!activeThreadId);
+
+  // Top-level entry to manage RemoteOTPCredentials (outbound Action
+  // sender). Modal is reused from drawer's "Manage secrets..." link.
+  let credsModalOpen = $state(false);
 </script>
 
 <div class="messages-shell" class:mobile={isMobile} class:has-thread={!!activeThreadId}>
@@ -411,6 +416,18 @@
 
   {#if showList}
     <div class="pane list-pane">
+      <div class="route-toolbar">
+        <button
+          type="button"
+          class="route-toolbar-item"
+          onclick={() => (credsModalOpen = true)}
+          data-testid="manage-otp-secrets"
+          aria-label="Manage OTP Secrets"
+          title="Manage OTP Secrets"
+        >
+          Manage OTP Secrets
+        </button>
+      </div>
       {#if showIgateBanner}
         <div class="igate-banner" role="status" data-testid="igate-banner">
           <span class="banner-text">{igateBannerText}</span>
@@ -456,7 +473,35 @@
   onClose={closeCompose}
 />
 
+<CredentialsModal bind:open={credsModalOpen} />
+
 <style>
+  .route-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 6px;
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-surface);
+    flex-shrink: 0;
+  }
+  .route-toolbar-item {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    padding: 4px 10px;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .route-toolbar-item:hover {
+    background: var(--color-surface-raised);
+    color: var(--color-primary);
+    border-color: var(--color-border);
+  }
   .messages-shell {
     display: grid;
     grid-template-columns: 340px minmax(0, 1fr);


### PR DESCRIPTION
## Summary

Outbound side of the `@@<otp>#<action>` Actions wire grammar. Operator opens a DM thread, taps a zap icon in the header, fires saved macros (or free-form lines) at the remote station. Counterpart to `pkg/actions/` (inbound runner).

- **Backend** (`pkg/remoteactions/`): macro + remote-OTP credential stores, base32/target-call/action-name validators, RFC 6238 TOTP generator, service composition root. Sibling of `pkg/actions/` -- shares only the wire grammar via exported `actions.ValidActionName`. Migration 16 adds `remote_otp_credentials` + `remote_action_macros` (raw SQL, FK ON DELETE SET NULL).
- **REST**: `/api/remote-actions/{credentials,macros,otp}` -- credential CRUD, macro CRUD + reorder, on-demand TOTP generate. Op IDs registered in `pkg/webapi/docs/op_ids.go`.
- **Frontend** (`web/src/components/messages/remote_actions/` + `web/src/lib/remote_actions/`): RemoteActionsDrawer, MacroTile / MacroEditRow, FreeFormSender, CredentialsModal / EditCredentialModal / CredentialPicker, ReplyBubbleAdornment. Reactive store (Svelte 5 runes), TOTP countdown, reply correlation (60s window + status-prefix allowlist), wire-string assembler. Macro fires post through the existing `POST /api/messages` send path -- indistinguishable on the wire from a hand-typed line.
- **Messages integration**: zap icon on DM threads (omitted on tactical), drawer mount, badge on inbound bubbles that match a recent fire, top-level "Manage OTP Secrets" entry.
- **Operator UX**: receiver "Base32 secret" renamed to "Secret Key" so the same label appears on both sides of the copy-paste.
- **Docs**: new `docs/wiki/remote-actions.md` + cross-links from actions / code-map / README; new `docs/handbook/remote-actions.html` operator setup guide with the receiver -> sender Secret Key copy-paste flow; sidebar link added across all 25 handbook pages.

## Test Plan

- [x] `go test ./...` PASS
- [x] `npm --prefix web test` 143/143 PASS
- [x] `npm --prefix web run api:check` PASS
- [x] `npm --prefix web run build` PASS
- [ ] Playwright e2e (project has no Playwright setup; deferred)
- [ ] Manual smoke on a live station: zap icon presence on DM vs. tactical, credential create through Messages-level entry, macro fire produces outbound `@@...#...` bubble, synthesized `ok ...` inbound from the same peer triggers the zap-reply badge, inbound without status prefix stays a normal bubble, double-fire within 30 s blocked by cooldown, free-form line over the APRS budget greys out SEND