### PR TITLE
examples: Action scripts for POSIX and Windows

### DIFF
--- a/examples/actions/README.md
+++ b/examples/actions/README.md
@@ -1,0 +1,135 @@
+# Example Action scripts
+
+Drop-in scripts you can wire to the **Actions** subsystem
+(`/#/actions` in the operator UI). Two flavors:
+
+- `posix/` — bash for Linux + macOS (Raspberry Pi too).
+- `windows/` — PowerShell, paired with a tiny `.cmd` launcher you point
+  graywolf at as the command path.
+
+## How graywolf invokes a script
+
+The runner exec's your binary directly (no shell). Every script in this
+tree reads its inputs from environment variables, never from `argv`,
+and never from `eval`. See [docs/handbook/actions.html](../../docs/handbook/actions.html)
+for the full execution contract.
+
+Variables you can use:
+
+| Env var | Meaning |
+|---|---|
+| `GW_ACTION_NAME` | Action's configured name (e.g. `weather`) |
+| `GW_SENDER_CALL` | Sender's APRS callsign (with SSID) |
+| `GW_OTP_VERIFIED` | `true` / `false` |
+| `GW_OTP_CRED_NAME` | OTP credential label, if any |
+| `GW_SOURCE` | `rf` or `is` |
+| `GW_INVOCATION_ID` | Audit row primary key |
+| `GW_ARG_<KEY>` | One per declared arg; key uppercased, non-alnum → `_` |
+
+Reply is the first line of stdout. Keep it short — graywolf snippets to
+50 runes for the on-air reply ("`ok: <snippet>`"). Exit non-zero with a
+short stderr/stdout to surface as `error: <detail>`.
+
+## Wiring a script
+
+1. Drop the script somewhere stable (e.g. `/usr/local/lib/graywolf/actions/weather.sh`).
+2. `chmod +x weather.sh` (POSIX only).
+3. Web UI → **Actions** → **New** → fill in:
+   - **Name**: `weather` (matches the `@@<otp>#weather` users will send).
+   - **Type**: command.
+   - **Command path**: full absolute path to the script (or to the
+     `.cmd` launcher on Windows).
+   - **Arg schema**: one row per `GW_ARG_*` you read. Set
+     `required` and a `regex` if the input shape matters.
+   - **OTP credential**: optional but strongly recommended for any
+     action that costs money or moves a physical thing.
+   - **Sender allowlist**: also recommended.
+   - **Timeout**: 10s default; bump for SMS/HA round-trips if your
+     network is slow.
+4. **Test** with the per-row Test dialog before letting it loose
+   on-air. Test bypasses OTP + allowlist but exercises the executor.
+
+## Per-script config (env vars to set in the graywolf service unit)
+
+Many scripts need credentials. The runner inherits graywolf's process
+env, so set them in the systemd unit (`Environment=` lines), in
+`/etc/default/graywolf`, or in the service's environment file. **Do
+not** put secrets in the script itself or pass them as Action args.
+
+| Script | Env required |
+|---|---|
+| `echo` | — |
+| `weather` | — |
+| `sms` | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM`; optional `APRSFI_API_KEY` for location follow-up |
+| `ha-lights` | `HA_URL`, `HA_TOKEN` |
+| `ha-garage` | `HA_URL`, `HA_TOKEN`, `HA_GARAGE_ENTITY` |
+| `solar` | — |
+| `iss` | — |
+| `uptime` | — |
+
+## Suggested arg schemas (paste into the Edit Action modal)
+
+`echo`:
+- `msg` — required, regex `.+`
+
+`weather`:
+- `station` — required, regex `^[A-Za-z0-9]{4}$` (ICAO airport code)
+
+`sms`:
+- `to` — required, regex `^\+[1-9][0-9]{6,14}$`
+- `msg` — required, regex `.+`
+
+`ha-lights`:
+- `entity` — required, regex `^light\.[a-z0-9_]+$`
+- `state` — required, regex `^(on|off)$`
+- `brightness` — optional, regex `^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`
+
+`ha-garage`:
+- `action` — required, regex `^(open|close|toggle)$`
+
+`solar`, `iss`, `uptime` — no args.
+
+## Example on-air sessions
+
+```
+> @@123456#echo msg=hello
+< ok: KE0XYZ said: hello
+
+> @@123456#weather station=KDEN
+< ok: KDEN 030253Z 27008KT 10SM CLR 22/M01 A3025
+
+> @@123456#solar
+< ok: SFI 142 A 8 K 2 SN 78
+
+> @@123456#ha-garage action=open
+< ok: garage open
+
+> @@123456#sms to=+15551234567 msg=on my way
+< ok: sms sent to +15551234567
+```
+
+## Security notes
+
+- Scripts run as the graywolf service user. Treat command actions
+  exactly like a `cron` entry: anything that user can do, an authorized
+  sender can ask you to do.
+- Quote every env var. `do-thing -- "$GW_ARG_ROOM"` is safe;
+  `do-thing $(echo $GW_ARG_ROOM)` and `eval` are not.
+- For irreversible or destructive actions (open garage, unlock door,
+  send money), set `OTPRequired = true` AND a sender allowlist. The
+  classifier checks the allowlist before the OTP probe, so a denied
+  sender can't enumerate which OTP digits validate.
+- `sms` and `ha-*` make outbound network calls. Audit the script
+  before installing — the same pattern can be re-pointed at any URL.
+
+## Windows specifics
+
+Each `.ps1` ships next to a same-named `.cmd` launcher. Set the
+Action's **Command path** to the `.cmd` file, not the `.ps1` —
+graywolf calls `CreateProcess` directly and Windows file associations
+don't apply. The `.cmd` just runs `powershell.exe -File <same-name>.ps1`
+with the inherited environment.
+
+PowerShell 5.1 (built into Windows 10/11) is enough. If you have
+PowerShell 7 (`pwsh.exe`), edit the `.cmd` files to call `pwsh` for
+better TLS and JSON handling.

--- a/examples/actions/posix/echo.sh
+++ b/examples/actions/posix/echo.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Action: echo
+# Grammar:  @@<otp>#echo msg=<text>
+# Args:     msg  (required) -- text to echo
+# Reply:    "<sender> said: <msg>"
+set -eu
+
+msg="${GW_ARG_MSG:-}"
+sender="${GW_SENDER_CALL:-?}"
+
+if [[ -z "$msg" ]]; then
+  echo "msg empty" >&2
+  exit 1
+fi
+
+echo "$sender said: $msg"

--- a/examples/actions/posix/ha-garage.sh
+++ b/examples/actions/posix/ha-garage.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Action: ha-garage
+# Grammar:  @@<otp>#ha-garage action=<open|close|toggle>
+# Args:     action  (required) -- open, close, or toggle
+# Reply:    "garage <action>"
+# Config:   HA_URL, HA_TOKEN, HA_GARAGE_ENTITY (e.g. cover.garage_door)
+# Deps:     curl
+#
+# DO NOT install without OTPRequired=true and a sender allowlist.
+set -eu
+
+action="${GW_ARG_ACTION:-}"
+if [[ -z "$action" ]]; then
+  echo "action required" >&2
+  exit 1
+fi
+: "${HA_URL:?HA_URL not set}"
+: "${HA_TOKEN:?HA_TOKEN not set}"
+: "${HA_GARAGE_ENTITY:?HA_GARAGE_ENTITY not set}"
+
+case "$action" in
+  open)   svc="open_cover"  ;;
+  close)  svc="close_cover" ;;
+  toggle) svc="toggle"      ;;
+  *)      echo "action must be open|close|toggle" >&2; exit 1 ;;
+esac
+
+payload=$(printf '{"entity_id":"%s"}' "$HA_GARAGE_ENTITY")
+
+curl -fsS --max-time 6 \
+  -H "Authorization: Bearer $HA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$payload" \
+  "$HA_URL/api/services/cover/$svc" -o /dev/null \
+  || { echo "ha call failed" >&2; exit 1; }
+
+echo "garage $action"

--- a/examples/actions/posix/ha-lights.sh
+++ b/examples/actions/posix/ha-lights.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Action: ha-lights
+# Grammar:  @@<otp>#ha-lights entity=light.<id> state=<on|off> [brightness=<0-255>]
+# Args:     entity     (required) -- HA light entity_id
+#           state      (required) -- on or off
+#           brightness (optional) -- 0..255, only honored with state=on
+# Reply:    "<entity> <state>"
+# Config:   HA_URL    -- e.g. http://homeassistant.local:8123
+#           HA_TOKEN  -- long-lived access token
+# Deps:     curl
+set -eu
+
+entity="${GW_ARG_ENTITY:-}"
+state="${GW_ARG_STATE:-}"
+brightness="${GW_ARG_BRIGHTNESS:-}"
+
+if [[ -z "$entity" || -z "$state" ]]; then
+  echo "entity and state required" >&2
+  exit 1
+fi
+: "${HA_URL:?HA_URL not set}"
+: "${HA_TOKEN:?HA_TOKEN not set}"
+
+case "$state" in
+  on)  svc="turn_on"  ;;
+  off) svc="turn_off" ;;
+  *)   echo "state must be on or off" >&2; exit 1 ;;
+esac
+
+if [[ "$state" == "on" && -n "$brightness" ]]; then
+  payload=$(printf '{"entity_id":"%s","brightness":%s}' "$entity" "$brightness")
+else
+  payload=$(printf '{"entity_id":"%s"}' "$entity")
+fi
+
+curl -fsS --max-time 6 \
+  -H "Authorization: Bearer $HA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$payload" \
+  "$HA_URL/api/services/light/$svc" -o /dev/null \
+  || { echo "ha call failed" >&2; exit 1; }
+
+echo "$entity $state"

--- a/examples/actions/posix/iss.sh
+++ b/examples/actions/posix/iss.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Action: iss
+# Grammar:  @@<otp>#iss
+# Args:     none
+# Reply:    "ISS <lat>,<lon> alt <km>km vel <kph>kph"
+# Source:   wheretheiss.at v1 (free, no key)
+# Deps:     curl, jq
+set -eu
+
+resp=$(curl -fsSL --max-time 6 https://api.wheretheiss.at/v1/satellites/25544) \
+  || { echo "fetch failed" >&2; exit 1; }
+
+read -r lat lon alt vel < <(printf '%s' "$resp" | jq -r '
+  "\(.latitude  | tostring | .[0:6]) " +
+  "\(.longitude | tostring | .[0:6]) " +
+  "\(.altitude  | floor) " +
+  "\(.velocity  | floor)
+"')
+
+echo "ISS ${lat},${lon} alt ${alt}km vel ${vel}kph"

--- a/examples/actions/posix/sms.sh
+++ b/examples/actions/posix/sms.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Action: sms
+# Grammar:  @@<otp>#sms to=<E164> msg=<text>
+# Args:     to   (required) -- destination phone in E.164 form (+15551234567)
+#           msg  (required) -- message body
+# Reply:    "sms sent to <to>"
+# Behavior: sends one SMS via Twilio. If APRSFI_API_KEY is set, also looks up
+#           the sender's last APRS position and sends a second SMS with a
+#           Google Maps link.
+# Config:   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM (E.164),
+#           APRSFI_API_KEY (optional)
+# Deps:     curl, jq
+set -eu
+
+to="${GW_ARG_TO:-}"
+msg="${GW_ARG_MSG:-}"
+sender="${GW_SENDER_CALL:-?}"
+
+if [[ -z "$to" || -z "$msg" ]]; then
+  echo "to and msg required" >&2
+  exit 1
+fi
+: "${TWILIO_ACCOUNT_SID:?TWILIO_ACCOUNT_SID not set}"
+: "${TWILIO_AUTH_TOKEN:?TWILIO_AUTH_TOKEN not set}"
+: "${TWILIO_FROM:?TWILIO_FROM not set}"
+
+send_sms() {
+  curl -fsS --max-time 8 \
+    -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" \
+    -X POST "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages.json" \
+    --data-urlencode "From=$TWILIO_FROM" \
+    --data-urlencode "To=$to" \
+    --data-urlencode "Body=$1" \
+    -o /dev/null
+}
+
+send_sms "From $sender (APRS): $msg" || { echo "twilio failed" >&2; exit 1; }
+
+# Best-effort location follow-up.
+if [[ -n "${APRSFI_API_KEY:-}" ]]; then
+  loc=$(curl -fsSL --max-time 6 \
+    "https://api.aprs.fi/api/get?name=${sender}&what=loc&apikey=${APRSFI_API_KEY}&format=json" \
+    2>/dev/null) || loc=""
+  if [[ -n "$loc" ]]; then
+    lat=$(printf '%s' "$loc" | jq -r '.entries[0].lat // empty' 2>/dev/null || true)
+    lng=$(printf '%s' "$loc" | jq -r '.entries[0].lng // empty' 2>/dev/null || true)
+    if [[ -n "$lat" && -n "$lng" ]]; then
+      send_sms "Location of $sender: https://maps.google.com/?q=${lat},${lng}" || true
+    fi
+  fi
+fi
+
+echo "sms sent to $to"

--- a/examples/actions/posix/solar.sh
+++ b/examples/actions/posix/solar.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Action: solar
+# Grammar:  @@<otp>#solar
+# Args:     none
+# Reply:    "SFI <n> A <n> K <n> SN <n>"
+# Source:   hamqsl.com solar XML feed (free)
+# Deps:     curl
+set -eu
+
+xml=$(curl -fsSL --max-time 8 https://www.hamqsl.com/solarxml.php) \
+  || { echo "fetch failed" >&2; exit 1; }
+
+# Extract a single XML element value. Trims whitespace.
+extract() {
+  printf '%s' "$xml" \
+    | sed -n "s|.*<$1>[[:space:]]*\([^<]*\)[[:space:]]*</$1>.*|\1|p" \
+    | head -1
+}
+
+sfi=$(extract solarflux)
+a=$(extract aindex)
+k=$(extract kindex)
+sn=$(extract sunspots)
+
+echo "SFI ${sfi:-?} A ${a:-?} K ${k:-?} SN ${sn:-?}"

--- a/examples/actions/posix/uptime.sh
+++ b/examples/actions/posix/uptime.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Action: uptime
+# Grammar:  @@<otp>#uptime
+# Args:     none
+# Reply:    "up <duration> load <1m> root <pct>"
+# Useful for remote-monitoring an unattended station.
+set -eu
+
+up=$(uptime | sed -E 's/.*up[[:space:]]+([^,]+(,[[:space:]]+[0-9]+:[0-9]+)?),[[:space:]]+[0-9]+ user.*/\1/' \
+       | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+[[ -z "$up" ]] && up="?"
+
+# 1-minute load, portable across Linux + macOS.
+load=$(uptime | sed -E 's/.*load average[s]*:[[:space:]]+([0-9.]+).*/\1/')
+[[ -z "$load" ]] && load="?"
+
+root=$(df -h / | awk 'NR==2 {print $5}')
+[[ -z "$root" ]] && root="?"
+
+echo "up $up load $load root $root"

--- a/examples/actions/posix/weather.sh
+++ b/examples/actions/posix/weather.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Action: weather
+# Grammar:  @@<otp>#weather station=<ICAO>
+# Args:     station  (required) -- 4-letter ICAO airport code
+#                                   (KDEN, EGLL, RJTT, YSSY ...)
+# Reply:    raw METAR observation, snipped to 50 chars on-air
+# Source:   aviationweather.gov (free, no key, worldwide METAR coverage)
+# Deps:     curl, jq
+set -eu
+
+station="${GW_ARG_STATION:-}"
+if [[ -z "$station" ]]; then
+  echo "station required" >&2
+  exit 1
+fi
+station=$(printf '%s' "$station" | tr '[:lower:]' '[:upper:]')
+
+url="https://aviationweather.gov/api/data/metar?ids=${station}&format=json&taf=false&hours=2"
+resp=$(curl -fsSL --max-time 8 "$url") || { echo "fetch failed" >&2; exit 1; }
+
+raw=$(printf '%s' "$resp" | jq -r 'if length==0 then "" else .[0].rawOb // "" end')
+if [[ -z "$raw" ]]; then
+  echo "$station: no recent METAR"
+  exit 0
+fi
+
+# Strip leading "METAR " / "SPECI " so the on-air 50-char snippet
+# starts with the ICAO + observation time.
+echo "${raw#METAR }" | sed 's/^SPECI //'

--- a/examples/actions/windows/echo.cmd
+++ b/examples/actions/windows/echo.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Launcher for echo.ps1 -- set this .cmd as the Action's command_path.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dpn0.ps1" %*

--- a/examples/actions/windows/echo.ps1
+++ b/examples/actions/windows/echo.ps1
@@ -1,0 +1,16 @@
+# Action: echo
+# Grammar:  @@<otp>#echo msg=<text>
+# Args:     msg  (required) -- text to echo
+# Reply:    "<sender> said: <msg>"
+
+$ErrorActionPreference = 'Stop'
+
+$msg = $env:GW_ARG_MSG
+$sender = if ($env:GW_SENDER_CALL) { $env:GW_SENDER_CALL } else { '?' }
+
+if (-not $msg) {
+  [Console]::Error.WriteLine('msg empty')
+  exit 1
+}
+
+"$sender said: $msg"

--- a/examples/actions/windows/ha-garage.cmd
+++ b/examples/actions/windows/ha-garage.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Launcher for ha-garage.ps1 -- set this .cmd as the Action's command_path.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dpn0.ps1" %*

--- a/examples/actions/windows/ha-garage.ps1
+++ b/examples/actions/windows/ha-garage.ps1
@@ -1,0 +1,43 @@
+# Action: ha-garage
+# Grammar:  @@<otp>#ha-garage action=<open|close|toggle>
+# Args:     action  (required) -- open, close, or toggle
+# Reply:    "garage <action>"
+# Config:   HA_URL, HA_TOKEN, HA_GARAGE_ENTITY (e.g. cover.garage_door)
+#
+# DO NOT install without OTPRequired=true and a sender allowlist.
+
+$ErrorActionPreference = 'Stop'
+
+$action = $env:GW_ARG_ACTION
+if (-not $action) {
+  [Console]::Error.WriteLine('action required')
+  exit 1
+}
+foreach ($v in 'HA_URL','HA_TOKEN','HA_GARAGE_ENTITY') {
+  if (-not (Get-Item "env:$v" -ErrorAction SilentlyContinue)) {
+    [Console]::Error.WriteLine("$v not set")
+    exit 1
+  }
+}
+
+switch ($action) {
+  'open'   { $svc = 'open_cover'  }
+  'close'  { $svc = 'close_cover' }
+  'toggle' { $svc = 'toggle'      }
+  default {
+    [Console]::Error.WriteLine('action must be open|close|toggle')
+    exit 1
+  }
+}
+
+try {
+  Invoke-RestMethod -Method Post -TimeoutSec 6 `
+    -Headers @{ Authorization = "Bearer $($env:HA_TOKEN)"; 'Content-Type' = 'application/json' } `
+    -Uri "$($env:HA_URL)/api/services/cover/$svc" `
+    -Body (@{ entity_id = $env:HA_GARAGE_ENTITY } | ConvertTo-Json -Compress) | Out-Null
+} catch {
+  [Console]::Error.WriteLine('ha call failed')
+  exit 1
+}
+
+"garage $action"

--- a/examples/actions/windows/ha-lights.cmd
+++ b/examples/actions/windows/ha-lights.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Launcher for ha-lights.ps1 -- set this .cmd as the Action's command_path.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dpn0.ps1" %*

--- a/examples/actions/windows/ha-lights.ps1
+++ b/examples/actions/windows/ha-lights.ps1
@@ -1,0 +1,50 @@
+# Action: ha-lights
+# Grammar:  @@<otp>#ha-lights entity=light.<id> state=<on|off> [brightness=<0-255>]
+# Args:     entity     (required) -- HA light entity_id
+#           state      (required) -- on or off
+#           brightness (optional) -- 0..255, only on
+# Reply:    "<entity> <state>"
+# Config:   HA_URL, HA_TOKEN
+
+$ErrorActionPreference = 'Stop'
+
+$entity = $env:GW_ARG_ENTITY
+$state = $env:GW_ARG_STATE
+$brightness = $env:GW_ARG_BRIGHTNESS
+
+if (-not $entity -or -not $state) {
+  [Console]::Error.WriteLine('entity and state required')
+  exit 1
+}
+foreach ($v in 'HA_URL','HA_TOKEN') {
+  if (-not (Get-Item "env:$v" -ErrorAction SilentlyContinue)) {
+    [Console]::Error.WriteLine("$v not set")
+    exit 1
+  }
+}
+
+switch ($state) {
+  'on'  { $svc = 'turn_on' }
+  'off' { $svc = 'turn_off' }
+  default {
+    [Console]::Error.WriteLine('state must be on or off')
+    exit 1
+  }
+}
+
+$body = @{ entity_id = $entity }
+if ($state -eq 'on' -and $brightness) {
+  $body.brightness = [int]$brightness
+}
+
+try {
+  Invoke-RestMethod -Method Post -TimeoutSec 6 `
+    -Headers @{ Authorization = "Bearer $($env:HA_TOKEN)"; 'Content-Type' = 'application/json' } `
+    -Uri "$($env:HA_URL)/api/services/light/$svc" `
+    -Body ($body | ConvertTo-Json -Compress) | Out-Null
+} catch {
+  [Console]::Error.WriteLine('ha call failed')
+  exit 1
+}
+
+"$entity $state"

--- a/examples/actions/windows/iss.cmd
+++ b/examples/actions/windows/iss.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Launcher for iss.ps1 -- set this .cmd as the Action's command_path.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dpn0.ps1" %*

--- a/examples/actions/windows/iss.ps1
+++ b/examples/actions/windows/iss.ps1
@@ -1,0 +1,21 @@
+# Action: iss
+# Grammar:  @@<otp>#iss
+# Args:     none
+# Reply:    "ISS <lat>,<lon> alt <km>km vel <kph>kph"
+# Source:   wheretheiss.at v1 (free, no key)
+
+$ErrorActionPreference = 'Stop'
+
+try {
+  $r = Invoke-RestMethod -TimeoutSec 6 https://api.wheretheiss.at/v1/satellites/25544
+} catch {
+  [Console]::Error.WriteLine('fetch failed')
+  exit 1
+}
+
+$lat = ([string]$r.latitude).Substring(0, [Math]::Min(6, ([string]$r.latitude).Length))
+$lon = ([string]$r.longitude).Substring(0, [Math]::Min(6, ([string]$r.longitude).Length))
+$alt = [int][Math]::Floor([double]$r.altitude)
+$vel = [int][Math]::Floor([double]$r.velocity)
+
+"ISS $lat,$lon alt ${alt}km vel ${vel}kph"

--- a/examples/actions/windows/sms.cmd
+++ b/examples/actions/windows/sms.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Launcher for sms.ps1 -- set this .cmd as the Action's command_path.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dpn0.ps1" %*

--- a/examples/actions/windows/sms.ps1
+++ b/examples/actions/windows/sms.ps1
@@ -1,0 +1,58 @@
+# Action: sms
+# Grammar:  @@<otp>#sms to=<E164> msg=<text>
+# Args:     to   (required) -- E.164 phone number (+15551234567)
+#           msg  (required) -- message body
+# Reply:    "sms sent to <to>"
+# Behavior: SMS via Twilio; if APRSFI_API_KEY is set, also sends a second
+#           SMS with a Google Maps link to the sender's last APRS position.
+# Config:   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM,
+#           APRSFI_API_KEY (optional)
+
+$ErrorActionPreference = 'Stop'
+
+$to = $env:GW_ARG_TO
+$msg = $env:GW_ARG_MSG
+$sender = if ($env:GW_SENDER_CALL) { $env:GW_SENDER_CALL } else { '?' }
+
+if (-not $to -or -not $msg) {
+  [Console]::Error.WriteLine('to and msg required')
+  exit 1
+}
+foreach ($v in 'TWILIO_ACCOUNT_SID','TWILIO_AUTH_TOKEN','TWILIO_FROM') {
+  if (-not (Get-Item "env:$v" -ErrorAction SilentlyContinue)) {
+    [Console]::Error.WriteLine("$v not set")
+    exit 1
+  }
+}
+
+$sid = $env:TWILIO_ACCOUNT_SID
+$tok = $env:TWILIO_AUTH_TOKEN
+$auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${sid}:${tok}"))
+$headers = @{ Authorization = "Basic $auth" }
+$uri = "https://api.twilio.com/2010-04-01/Accounts/$sid/Messages.json"
+
+function Send-Sms($body) {
+  $form = @{ From = $env:TWILIO_FROM; To = $to; Body = $body }
+  Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $form -TimeoutSec 8 | Out-Null
+}
+
+try {
+  Send-Sms "From $sender (APRS): $msg"
+} catch {
+  [Console]::Error.WriteLine('twilio failed')
+  exit 1
+}
+
+# Best-effort location follow-up.
+if ($env:APRSFI_API_KEY) {
+  try {
+    $loc = Invoke-RestMethod -TimeoutSec 6 `
+      "https://api.aprs.fi/api/get?name=$sender&what=loc&apikey=$($env:APRSFI_API_KEY)&format=json"
+    $e = $loc.entries | Select-Object -First 1
+    if ($e -and $e.lat -and $e.lng) {
+      Send-Sms "Location of $sender: https://maps.google.com/?q=$($e.lat),$($e.lng)"
+    }
+  } catch { }
+}
+
+"sms sent to $to"

--- a/examples/actions/windows/solar.cmd
+++ b/examples/actions/windows/solar.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Launcher for solar.ps1 -- set this .cmd as the Action's command_path.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dpn0.ps1" %*

--- a/examples/actions/windows/solar.ps1
+++ b/examples/actions/windows/solar.ps1
@@ -1,0 +1,30 @@
+# Action: solar
+# Grammar:  @@<otp>#solar
+# Args:     none
+# Reply:    "SFI <n> A <n> K <n> SN <n>"
+# Source:   hamqsl.com solar XML feed (free)
+
+$ErrorActionPreference = 'Stop'
+
+try {
+  [xml]$x = Invoke-WebRequest -TimeoutSec 8 -UseBasicParsing https://www.hamqsl.com/solarxml.php `
+    | Select-Object -ExpandProperty Content
+} catch {
+  [Console]::Error.WriteLine('fetch failed')
+  exit 1
+}
+
+$d = $x.solar.solardata
+
+function Trim1($v) {
+  if ($null -eq $v) { return '?' }
+  $s = ([string]$v).Trim()
+  if ($s) { $s } else { '?' }
+}
+
+$sfi = Trim1 $d.solarflux
+$a   = Trim1 $d.aindex
+$k   = Trim1 $d.kindex
+$sn  = Trim1 $d.sunspots
+
+"SFI $sfi A $a K $k SN $sn"

--- a/examples/actions/windows/uptime.cmd
+++ b/examples/actions/windows/uptime.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Launcher for uptime.ps1 -- set this .cmd as the Action's command_path.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dpn0.ps1" %*

--- a/examples/actions/windows/uptime.ps1
+++ b/examples/actions/windows/uptime.ps1
@@ -1,0 +1,30 @@
+# Action: uptime
+# Grammar:  @@<otp>#uptime
+# Args:     none
+# Reply:    "up <Xd Yh> load <pct cpu> root <pct used>"
+
+$ErrorActionPreference = 'Stop'
+
+$os = Get-CimInstance Win32_OperatingSystem
+$boot = $os.LastBootUpTime
+$span = (Get-Date) - $boot
+$up = "$($span.Days)d$($span.Hours)h"
+
+# Approximate "load" via CPU queue length / utilization.
+try {
+  $cpu = (Get-CimInstance Win32_Processor | Measure-Object -Property LoadPercentage -Average).Average
+  $load = "${cpu}%"
+} catch {
+  $load = '?'
+}
+
+try {
+  $c = Get-PSDrive C
+  $total = [double]($c.Used + $c.Free)
+  $pct = if ($total -gt 0) { [int](100 * $c.Used / $total) } else { 0 }
+  $root = "${pct}%"
+} catch {
+  $root = '?'
+}
+
+"up $up load $load root $root"

--- a/examples/actions/windows/weather.cmd
+++ b/examples/actions/windows/weather.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Launcher for weather.ps1 -- set this .cmd as the Action's command_path.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dpn0.ps1" %*

--- a/examples/actions/windows/weather.ps1
+++ b/examples/actions/windows/weather.ps1
@@ -1,0 +1,32 @@
+# Action: weather
+# Grammar:  @@<otp>#weather station=<ICAO>
+# Args:     station  (required) -- 4-letter ICAO airport code
+# Reply:    raw METAR observation, snipped to 50 chars on-air
+# Source:   aviationweather.gov (free, no key, worldwide)
+
+$ErrorActionPreference = 'Stop'
+
+$station = $env:GW_ARG_STATION
+if (-not $station) {
+  [Console]::Error.WriteLine('station required')
+  exit 1
+}
+$station = $station.ToUpper()
+
+try {
+  $resp = Invoke-RestMethod -TimeoutSec 8 `
+    "https://aviationweather.gov/api/data/metar?ids=$station&format=json&taf=false&hours=2"
+} catch {
+  [Console]::Error.WriteLine('fetch failed')
+  exit 1
+}
+
+if (-not $resp -or $resp.Count -eq 0 -or -not $resp[0].rawOb) {
+  "$station no recent METAR"
+  exit 0
+}
+
+# Strip leading "METAR " / "SPECI " so the on-air 50-char snippet
+# starts with the ICAO + observation time.
+$raw = $resp[0].rawOb -replace '^(METAR|SPECI)\s+', ''
+$raw


### PR DESCRIPTION
## Summary

- Eight example Action scripts in `examples/actions/`, split into `posix/` (bash) and `windows/` (PowerShell + matching `.cmd` launcher operators set as `command_path`).
- Scripts: `echo`, `weather` (worldwide METAR via aviationweather.gov), `sms` (Twilio + aprs.fi position follow-up), `ha-lights`, `ha-garage`, `solar` (HamQSL band conditions), `iss` (wheretheiss.at), `uptime` (station health).
- README covers the executor contract (env vars, argv, 50-rune reply snip, 4 KiB output cap), per-script env-var requirements, suggested arg-schema regexes for the Edit Action modal, and Windows `.cmd`-as-`command_path` setup.

## Test plan

- [x] `echo`, `weather KDEN`, `solar`, `iss`, `uptime` smoke-tested locally; one-line replies fit (or sensibly snip into) the 67-char APRS budget.
- [ ] `sms` exercised against a Twilio sandbox account.
- [ ] `ha-lights` and `ha-garage` exercised against a real Home Assistant instance with a long-lived token.
- [ ] Windows `.cmd` -> `.ps1` chain run through the Test dialog on a Windows host.
- [ ] README install steps walked end-to-end on a fresh station (drop script, chmod, register in UI, OTP + allowlist on destructive actions).