### PR TITLE
actions: arg_mode toggle with freeform payload support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,51 @@ jobs:
       - name: go test -race
         run: go test -race ./...
 
+  example-scripts:
+    name: Example Scripts Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install shellcheck
+        run: sudo apt-get update -y && sudo apt-get install -y shellcheck
+
+      - name: shellcheck POSIX example scripts
+        run: shellcheck examples/actions/posix/*.sh
+
+      - name: Forbid eval / sh -c in example scripts
+        run: |
+          set -euo pipefail
+          if grep -rnE '(\beval\b|\bsh -c\b)' examples/actions/posix/; then
+            echo "::error::examples must not use eval or sh -c" >&2
+            exit 1
+          fi
+
+      - name: Forbid unquoted GW_* expansions
+        run: |
+          set -euo pipefail
+          # Match $GW_* not preceded by a quote char. Quoted forms
+          # like "$GW_*", '$GW_*', "${GW_*}" all pass.
+          if grep -rnE '(^|[^"'"'"'])\$GW_[A-Z_]+' examples/actions/posix/; then
+            echo "::error::examples must quote GW_* variable expansions" >&2
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python deps
+        run: pip install -r examples/actions/python/requirements.txt ruff
+
+      - name: ruff check Python examples
+        run: ruff check examples/actions/python/
+
+      - name: pytest Python examples
+        run: pytest examples/actions/python/
+
   rust-ci:
     name: Rust Check + Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,16 +95,24 @@ jobs:
       - name: Forbid eval / sh -c in example scripts
         run: |
           set -euo pipefail
-          if grep -rnE '(\beval\b|\bsh -c\b)' examples/actions/posix/; then
+          # Skip pure comment lines so safety prose like "no eval"
+          # in script headers doesn't trip the gate.
+          hits=$(grep -rnE '(\beval\b|\bsh -c\b)' examples/actions/posix/ \
+                 | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' || true)
+          if [ -n "$hits" ]; then
             echo "::error::examples must not use eval or sh -c" >&2
+            echo "$hits" >&2
             exit 1
           fi
 
       - name: Forbid unquoted GW_* expansions
         run: |
           set -euo pipefail
-          # Match $GW_* not preceded by a quote char. Quoted forms
-          # like "$GW_*", '$GW_*', "${GW_*}" all pass.
+          # Best-effort gate: matches $GW_* not preceded by a quote
+          # char. Quoted forms like "$GW_*", '$GW_*' pass. Known
+          # blind spots: bare ${GW_*} (brace form) and $GW_* glued
+          # after a quoted prefix (e.g. "x"$GW_Y). Treat as a first
+          # line of defense, not a substitute for shellcheck + review.
           if grep -rnE '(^|[^"'"'"'])\$GW_[A-Z_]+' examples/actions/posix/; then
             echo "::error::examples must quote GW_* variable expansions" >&2
             exit 1

--- a/docs/handbook/actions-handler-safety-powershell.html
+++ b/docs/handbook/actions-handler-safety-powershell.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Actions: PowerShell Handler Safety &mdash; Graywolf Handbook</title>
+  <link rel="stylesheet" href="handbook.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="index.html" class="site-logo">
+      <img src="img/graywolf-logo.svg" alt="" />
+      <span>graywolf <span class="handbook-label">handbook</span></span>
+    </a>
+    <div class="header-actions">
+      <button class="theme-toggle" aria-label="Toggle theme">[ dark ]</button>
+    </div>
+  </div>
+</header>
+
+<div class="layout">
+  <aside class="sidebar">
+    <nav>
+      <div class="sidebar-section">Getting Started</div>
+      <a href="index.html">Introduction</a>
+      <a href="installation.html">Installation</a>
+      <a href="callsign.html">Station Callsign</a>
+      <div class="sidebar-section">Radio</div>
+      <a href="audio.html">Audio Devices</a>
+      <a href="channels.html">Radio Channels</a>
+      <a href="ptt.html">Push-to-Talk</a>
+      <div class="sidebar-section">APRS</div>
+      <a href="beacons.html">Beacons</a>
+      <a href="digipeater.html">Digipeater</a>
+      <a href="igate.html">iGate</a>
+      <a href="messaging.html">Messaging</a>
+      <a href="actions.html">Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
+      <a href="livemap.html">Live Map</a>
+      <div class="sidebar-section">Packet</div>
+      <a href="ax25-terminal.html">AX.25 Terminal</a>
+      <div class="sidebar-section">Interfaces</div>
+      <a href="kiss.html">KISS TNC</a>
+      <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
+      <a href="agwpe.html">AGWPE</a>
+      <a href="gps.html">GPS</a>
+      <div class="sidebar-section">Operations</div>
+      <a href="history-database.html">Position Log</a>
+      <a href="logs.html">Logs</a>
+      <a href="monitoring.html">Monitoring</a>
+      <a href="simulation.html">Simulation</a>
+      <a href="maps.html">Maps</a>
+      <a href="preferences.html">Preferences</a>
+      <a href="architecture.html">Architecture</a>
+      <div class="sidebar-section">Reference</div>
+      <a href="configurations.html">Known-Working Configs</a>
+      <a href="api.html">REST API Reference</a>
+    </nav>
+  </aside>
+
+  <main class="content">
+    <h1>Safe PowerShell Action handlers</h1>
+
+<p>This page walks through a complete worked example of a PowerShell
+handler &mdash; the freeform SMS Action wired for a Windows host &mdash;
+and explains the safety patterns line by line. The script is also
+shipped at <code>examples/actions/windows/sms-freeform.ps1</code>.</p>
+
+<p>The general modes-and-contract overview lives at
+<a href="actions-handler-safety.html">Actions: handler safety</a>;
+read it first if you haven't.</p>
+
+<h2 id="freeform-ps">SMS as a freeform PowerShell Action</h2>
+
+<p>The Action sender writes:</p>
+
+<pre><code>@@482910#sms +15555551212 hello there</code></pre>
+
+<p>graywolf invokes:</p>
+
+<pre><code>powershell.exe -NoProfile -File C:\graywolf\sms-freeform.ps1 sms KE0XYZ true "+15555551212 hello there"</code></pre>
+
+<p>Here is the complete script (also at
+<code>examples/actions/windows/sms-freeform.ps1</code>):</p>
+
+<pre><code class="language-powershell"># sms-freeform.ps1 &mdash; Send an SMS via Twilio. Freeform Action variant.
+
+# Strict mode catches typos, uninitialized variables, and out-of-bounds
+# indexing. Stop on any cmdlet error so failures don't get swallowed.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Positional args from the runner. Only $payload is used here.
+$action      = $args[0]
+$sender      = $args[1]
+$otpVerified = $args[2]
+$payload     = $args[3]
+
+if (-not $payload) {
+    [Console]::Error.WriteLine("payload missing")
+    exit 64
+}
+
+# Validate format AND split into number + message in one regex match.
+# Named groups: 'num' = E.164 number, 'msg' = message body.
+$rx = '^(?&lt;num&gt;\+[1-9][0-9]{6,14})\s+(?&lt;msg&gt;.+)$'
+$match = [regex]::Match($payload, $rx)
+if (-not $match.Success) {
+    [Console]::Error.WriteLine("expected '+&lt;E164&gt; &lt;message&gt;'")
+    exit 64
+}
+$number  = $match.Groups['num'].Value
+$message = $match.Groups['msg'].Value
+
+# Defense in depth: graywolf already strips control characters, but
+# re-check so this script stays safe if the operator widens the regex.
+# \p{Cc} is the Unicode "Other, Control" category.
+if ($message -match '\p{Cc}') {
+    [Console]::Error.WriteLine("message contains control characters")
+    exit 65
+}
+if ($message.Length -lt 1 -or $message.Length -gt 160) {
+    [Console]::Error.WriteLine("message length out of range (1..160)")
+    exit 65
+}
+
+# Required Twilio credentials. Fail fast with a clear message if unset.
+foreach ($v in 'TWILIO_ACCOUNT_SID','TWILIO_AUTH_TOKEN','TWILIO_FROM') {
+    if (-not (Get-Item "env:$v" -ErrorAction SilentlyContinue)) {
+        [Console]::Error.WriteLine("$v not set")
+        exit 1
+    }
+}
+
+$sid  = $env:TWILIO_ACCOUNT_SID
+$tok  = $env:TWILIO_AUTH_TOKEN
+$auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${sid}:${tok}"))
+$headers = @{ Authorization = "Basic $auth" }
+$uri = "https://api.twilio.com/2010-04-01/Accounts/$sid/Messages.json"
+
+# Hashtable -Body causes Invoke-RestMethod to URL-encode each value
+# correctly. Never build the request body via string concatenation.
+$form = @{
+    From = $env:TWILIO_FROM
+    To   = $number
+    Body = $message
+}
+
+try {
+    $resp = Invoke-RestMethod -Method Post -Uri $uri -Headers $headers `
+        -Body $form -TimeoutSec 8
+    if ($resp.sid) {
+        "sent $($resp.sid)"
+        exit 0
+    }
+} catch {
+    [Console]::Error.WriteLine("twilio rejected: $($_.Exception.Message)")
+    exit 1
+}
+
+[Console]::Error.WriteLine("twilio rejected: no sid in response")
+exit 1
+</code></pre>
+
+<h3>Explanation</h3>
+
+<pre><code class="language-powershell">Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'</code></pre>
+
+<p>The PowerShell equivalent of <code>set -euo pipefail</code>.
+<code>Set-StrictMode -Version Latest</code> turns reading an undefined
+variable, calling a non-existent property, and out-of-range index
+access into hard errors &mdash; so a typo like <code>$payloud</code>
+fails loudly instead of being silently <code>$null</code>.
+<code>$ErrorActionPreference = 'Stop'</code> upgrades non-terminating
+cmdlet errors to terminating ones, so the first failure halts the
+script. Both belong at the top of every PowerShell handler.</p>
+
+<pre><code class="language-powershell">$match = [regex]::Match($payload, '^(?&lt;num&gt;\+[1-9][0-9]{6,14})\s+(?&lt;msg&gt;.+)$')</code></pre>
+
+<p>One .NET regex match validates the format <em>and</em> splits the
+payload in a single step. The pattern reads:</p>
+
+<ul>
+  <li><code>^</code> &mdash; anchor at start.</li>
+  <li><code>(?&lt;num&gt;\+[1-9][0-9]{6,14})</code> &mdash; named group
+      <code>num</code>: an E.164 number. A literal <code>+</code>, a
+      leading digit 1..9 (E.164 forbids <code>0</code>), then 6 to 14
+      more digits.</li>
+  <li><code>\s+</code> &mdash; one or more whitespace separators
+      between the number and the message.</li>
+  <li><code>(?&lt;msg&gt;.+)</code> &mdash; named group <code>msg</code>:
+      the message body, at least one character.</li>
+  <li><code>$</code> &mdash; anchor at end.</li>
+</ul>
+
+<p>If the match fails, <code>$match.Success</code> is
+<code>$false</code> and the script exits before any value is bound.
+Like the bash variant, this is pure in-process string matching: no
+<code>Invoke-Expression</code>, no subshell, no command substitution.
+Bytes in <code>$payload</code> are bytes the regex tries (and fails)
+to match &mdash; they cannot become PowerShell.</p>
+
+<pre><code class="language-powershell">$number  = $match.Groups['num'].Value
+$message = $match.Groups['msg'].Value</code></pre>
+
+<p>After the previous successful <code>[regex]::Match</code> against
+the <code>^(?&lt;num&gt;\+[1-9][0-9]{6,14})\s+(?&lt;msg&gt;.+)$</code>
+pattern, the <code>Match</code> object's <code>Groups</code>
+collection holds the captures. Indexing by name
+(<code>['num']</code>, <code>['msg']</code>) is more durable than
+indexing by position because adding a non-capturing group later
+won't shift the indices. Reading the values is purely in-process.</p>
+
+<pre><code class="language-powershell">if ($message -match '\p{Cc}') { ... }</code></pre>
+
+<p><code>\p{Cc}</code> is the Unicode "Other, Control" category &mdash;
+the .NET regex equivalent of POSIX <code>[:cntrl:]</code>. graywolf's
+sanitizer already strips control characters for freeform Actions,
+but checking again here keeps the script self-contained.</p>
+
+<pre><code class="language-powershell">$form = @{ From = $env:TWILIO_FROM; To = $number; Body = $message }
+Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $form -TimeoutSec 8</code></pre>
+
+<p>When <code>-Body</code> is a hashtable on a
+<code>POST</code>/<code>PUT</code>, <code>Invoke-RestMethod</code>
+serializes it as <code>application/x-www-form-urlencoded</code> and
+URL-encodes each value for us. Critically, this means we never
+construct the request body by string-concatenation &mdash; an
+<code>&amp;</code> in <code>$message</code> can't smuggle extra form
+fields, and a <code>"</code> can't break out of a quoted value. This
+is the PowerShell counterpart of curl's
+<code>--data-urlencode</code>.</p>
+
+<h3>Anti-patterns to avoid in PowerShell handlers</h3>
+
+<table>
+  <thead><tr><th>Anti-pattern</th><th>Attack it enables</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>Invoke-Expression $payload</code> (or <code>iex</code>)</td>
+      <td>Re-parses the payload as PowerShell &mdash; full code injection.</td>
+    </tr>
+    <tr>
+      <td><code>cmd.exe /c "send.exe $payload"</code></td>
+      <td>Same as <code>eval</code>, but with cmd's own quoting traps.</td>
+    </tr>
+    <tr>
+      <td><code>Start-Process send.exe -ArgumentList $payload</code> (string)</td>
+      <td>String form of <code>-ArgumentList</code> re-splits on whitespace and re-parses quotes; pass an array instead.</td>
+    </tr>
+    <tr>
+      <td><code>Invoke-RestMethod -Body "From=$from&amp;To=$to"</code></td>
+      <td>String concatenation: <code>&amp;</code> in the value smuggles extra form fields.</td>
+    </tr>
+    <tr>
+      <td>Omitting <code>Set-StrictMode</code></td>
+      <td>Typoed variable names silently expand to <code>$null</code>, bypassing validation.</td>
+    </tr>
+    <tr>
+      <td><code>Invoke-RestMethod $url</code> with <code>$url</code> from the payload</td>
+      <td>SSRF &mdash; the payload becomes a URL the handler fetches.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Run it through PSScriptAnalyzer</h3>
+
+<p>Before deploying any PowerShell Action handler, run:</p>
+
+<pre><code>Invoke-ScriptAnalyzer -Path .\your-handler.ps1</code></pre>
+
+<p>PSScriptAnalyzer flags the most common PowerShell footguns &mdash;
+unapproved verbs, unused variables, plain-text passwords,
+<code>Invoke-Expression</code> on user input. Fix what it flags;
+don't disable rules.</p>
+
+    <nav class="page-nav">
+      <a href="actions-handler-safety-shell.html">
+        <span class="label">Previous</span>
+        Shell handlers
+      </a>
+      <a href="actions-handler-safety-webhooks.html" class="next">
+        <span class="label">Next</span>
+        Webhook handlers
+      </a>
+    </nav>
+  </main>
+</div>
+
+<footer class="site-footer">
+  graywolf &middot; modern APRS station
+</footer>
+
+<script src="handbook.js"></script>
+</body>
+</html>

--- a/docs/handbook/actions-handler-safety-shell.html
+++ b/docs/handbook/actions-handler-safety-shell.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Actions: Shell Handler Safety &mdash; Graywolf Handbook</title>
+  <link rel="stylesheet" href="handbook.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="index.html" class="site-logo">
+      <img src="img/graywolf-logo.svg" alt="" />
+      <span>graywolf <span class="handbook-label">handbook</span></span>
+    </a>
+    <div class="header-actions">
+      <button class="theme-toggle" aria-label="Toggle theme">[ dark ]</button>
+    </div>
+  </div>
+</header>
+
+<div class="layout">
+  <aside class="sidebar">
+    <nav>
+      <div class="sidebar-section">Getting Started</div>
+      <a href="index.html">Introduction</a>
+      <a href="installation.html">Installation</a>
+      <a href="callsign.html">Station Callsign</a>
+      <div class="sidebar-section">Radio</div>
+      <a href="audio.html">Audio Devices</a>
+      <a href="channels.html">Radio Channels</a>
+      <a href="ptt.html">Push-to-Talk</a>
+      <div class="sidebar-section">APRS</div>
+      <a href="beacons.html">Beacons</a>
+      <a href="digipeater.html">Digipeater</a>
+      <a href="igate.html">iGate</a>
+      <a href="messaging.html">Messaging</a>
+      <a href="actions.html">Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
+      <a href="livemap.html">Live Map</a>
+      <div class="sidebar-section">Packet</div>
+      <a href="ax25-terminal.html">AX.25 Terminal</a>
+      <div class="sidebar-section">Interfaces</div>
+      <a href="kiss.html">KISS TNC</a>
+      <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
+      <a href="agwpe.html">AGWPE</a>
+      <a href="gps.html">GPS</a>
+      <div class="sidebar-section">Operations</div>
+      <a href="history-database.html">Position Log</a>
+      <a href="logs.html">Logs</a>
+      <a href="monitoring.html">Monitoring</a>
+      <a href="simulation.html">Simulation</a>
+      <a href="maps.html">Maps</a>
+      <a href="preferences.html">Preferences</a>
+      <a href="architecture.html">Architecture</a>
+      <div class="sidebar-section">Reference</div>
+      <a href="configurations.html">Known-Working Configs</a>
+      <a href="api.html">REST API Reference</a>
+    </nav>
+  </aside>
+
+  <main class="content">
+    <h1>Safe shell-script Action handlers</h1>
+
+<p>This page walks through two complete worked examples of bash
+handlers &mdash; one freeform, one kv &mdash; and explains the safety
+patterns line by line. Both scripts are also shipped in
+<code>examples/actions/posix/</code>.</p>
+
+<p>The general modes-and-contract overview lives at
+<a href="actions-handler-safety.html">Actions: handler safety</a>;
+read it first if you haven't.</p>
+
+<h2 id="freeform">Worked example 1: SMS as a freeform shell Action</h2>
+
+<p>The Action sender writes:</p>
+
+<pre><code>@@482910#sms +15555551212 hello there</code></pre>
+
+<p>graywolf invokes:</p>
+
+<pre><code>/usr/local/bin/sms-freeform.sh sms KE0XYZ true "+15555551212 hello there"</code></pre>
+
+<p>Here is the complete script (also at
+<code>examples/actions/posix/sms-freeform.sh</code>):</p>
+
+<pre><code class="language-bash">#!/bin/bash
+# sms-freeform.sh &mdash; Send an SMS via Twilio. Freeform Action variant.
+
+# Abort on any error, unset variable, or failed pipeline stage.
+set -euo pipefail
+
+# Positional args from the runner. Only PAYLOAD is used here.
+ACTION="$1"
+SENDER="$2"
+OTP_VERIFIED="$3"
+PAYLOAD="$4"
+
+# Validate format AND split into number + message in one regex match.
+# Group 1 = E.164 number, group 2 = message body.
+if [[ ! "$PAYLOAD" =~ ^(\+[1-9][0-9]{6,14})[[:space:]]+(.+)$ ]]; then
+    echo "expected '+&lt;E164&gt; &lt;message&gt;'" &gt;&amp;2
+    exit 64
+fi
+NUMBER="${BASH_REMATCH[1]}"
+MESSAGE="${BASH_REMATCH[2]}"
+
+# Defense in depth: graywolf already strips control characters, but
+# re-check so this script stays safe if the operator widens the regex.
+if [[ "$MESSAGE" =~ [[:cntrl:]] ]]; then
+    echo "message contains control characters" &gt;&amp;2
+    exit 65
+fi
+if (( ${#MESSAGE} &lt; 1 || ${#MESSAGE} &gt; 160 )); then
+    echo "message length out of range (1..160)" &gt;&amp;2
+    exit 65
+fi
+
+# Required Twilio credentials. Fail fast with a clear message if unset.
+: "${TWILIO_ACCOUNT_SID:?TWILIO_ACCOUNT_SID not set}"
+: "${TWILIO_AUTH_TOKEN:?TWILIO_AUTH_TOKEN not set}"
+: "${TWILIO_FROM:?TWILIO_FROM not set}"
+
+# curl invoked argv-style; --data-urlencode lets curl URL-encode each
+# value so we never concatenate user data into the request body.
+response=$(curl -sS --max-time 8 -X POST \
+    --data-urlencode "From=${TWILIO_FROM}" \
+    --data-urlencode "To=${NUMBER}" \
+    --data-urlencode "Body=${MESSAGE}" \
+    -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
+    -- "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json")
+
+# Success heuristic: Twilio returns JSON with a "sid" field on success.
+# Echo it so the on-air reply ("ok: SM&lt;sid&gt;...") confirms delivery.
+if printf '%s' "$response" | grep -q '"sid"'; then
+    sid=$(printf '%s' "$response" | grep -o '"sid":"SM[A-Za-z0-9]*"' | head -n1 | sed 's/.*"\(SM[^"]*\)"/\1/')
+    echo "sent ${sid:-?}"
+    exit 0
+fi
+
+echo "twilio rejected: $(printf '%s' "$response" | head -c 80)" &gt;&amp;2
+exit 1
+</code></pre>
+
+<h3>Explanation</h3>
+
+<pre><code class="language-bash">set -euo pipefail</code></pre>
+
+<p>Three flags in one line. <code>-e</code> aborts on any non-zero
+exit. <code>-u</code> treats unset variables as errors (so a typo in
+<code>$GW_ARG_NUMER</code> doesn't silently expand to empty string).
+<code>-o pipefail</code> makes a pipeline fail if any stage fails, not
+just the last one. Always at the top of every shell handler.</p>
+
+<pre><code class="language-bash">if [[ ! "$PAYLOAD" =~ ^(\+[1-9][0-9]{6,14})[[:space:]]+(.+)$ ]]; then</code></pre>
+
+<p>One POSIX extended regex match validates the format
+<em>and</em> splits the payload in a single step. Bash's
+<code>[[ =~ ]]</code> operator runs the match and populates the
+<code>BASH_REMATCH</code> array with the capture groups on success.
+The pattern reads:</p>
+
+<ul>
+  <li><code>^</code> &mdash; anchor at start.</li>
+  <li><code>(\+[1-9][0-9]{6,14})</code> &mdash; group 1: an E.164
+      number. A literal <code>+</code>, then a leading digit 1..9
+      (E.164 forbids <code>0</code>), then 6 to 14 more digits.</li>
+  <li><code>[[:space:]]+</code> &mdash; one or more whitespace
+      separators between the number and the message.</li>
+  <li><code>(.+)</code> &mdash; group 2: the message body, at least
+      one character.</li>
+  <li><code>$</code> &mdash; anchor at end.</li>
+</ul>
+
+<p>If the match fails, the branch fires and we exit before any value
+is bound &mdash; there is no partial state, no separate "missing
+separator" branch to forget. We <em>revalidate</em> in the script
+even though the Action's own arg_schema regex should already have
+rejected malformed numbers, because this script's safety contract
+should not depend on the operator setting a strict regex.</p>
+
+<p>The match is a pure in-process string operation: no
+<code>eval</code>, no command substitution, no subshell. An attacker
+sending <code>; rm -rf ~ #</code> as the payload cannot trigger any
+shell command &mdash; those characters are just bytes the regex tries
+(and fails) to match.</p>
+
+<pre><code class="language-bash">NUMBER="${BASH_REMATCH[1]}"
+MESSAGE="${BASH_REMATCH[2]}"</code></pre>
+
+<p>After the previous <code>=~</code> match against the
+<code>^(\+[1-9][0-9]{6,14})[[:space:]]+(.+)$</code> pattern,
+bash populates the <code>BASH_REMATCH</code> array from that match's
+capture groups. <code>BASH_REMATCH[0]</code> holds the whole match;
+<code>BASH_REMATCH[1]</code> holds group 1 (the E.164 number) and
+<code>BASH_REMATCH[2]</code> holds group 2 (the message body), in
+the order the parentheses appear in the regex. Reading them into
+named variables happens entirely inside the bash process &mdash; no
+fork, no exec.</p>
+
+<pre><code class="language-bash">[[ "$MESSAGE" =~ [[:cntrl:]] ]]</code></pre>
+
+<p><code>[:cntrl:]</code> is the POSIX character class for ASCII
+control characters (0x00&ndash;0x1F plus 0x7F). graywolf's sanitizer
+already strips these unconditionally for freeform Actions, but
+checking again here keeps the script self-contained.</p>
+
+<pre><code class="language-bash">: "${VAR:?msg}"</code></pre>
+
+<p>The colon is the no-op builtin. The expansion
+<code>${VAR:?msg}</code> exits with <code>msg</code> if
+<code>VAR</code> is unset or empty. Combined, this is a one-liner
+"abort with a clear error if the operator forgot to set this env
+var".</p>
+
+<pre><code class="language-bash">--data-urlencode "From=${TWILIO_FROM}"</code></pre>
+
+<p><code>curl</code> performs the URL-encoding for us. Critically,
+this means we never construct the request body by string-concatenation
+&mdash; which would risk smuggling <code>&amp;Foo=bar</code> into the
+form if the message contained an ampersand.</p>
+
+<pre><code class="language-bash">-- "https://...Messages.json"</code></pre>
+
+<p>The double-dash is a convention curl supports to terminate option
+parsing. Habit: always put it before any positional argument that could
+conceivably begin with a <code>-</code>.</p>
+
+<h3>Anti-patterns to avoid</h3>
+
+<p>Each of these would compromise the script's safety:</p>
+
+<table>
+  <thead><tr><th>Anti-pattern</th><th>Attack it enables</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>curl ... -d to=$TEXT</code> (unquoted)</td>
+      <td>Word-splitting smuggles extra fields or flags.</td>
+    </tr>
+    <tr>
+      <td><code>eval "twilio send $TEXT"</code></td>
+      <td>Re-parses the payload as shell &mdash; full command injection.</td>
+    </tr>
+    <tr>
+      <td><code>sh -c "twilio send $TEXT"</code></td>
+      <td>Same as eval. Anything in the payload becomes shell.</td>
+    </tr>
+    <tr>
+      <td>String-concat into <code>--data</code></td>
+      <td><code>&amp;</code> in the payload smuggles extra form fields.</td>
+    </tr>
+    <tr>
+      <td><code>twilio send-sms "$NUMBER" "$MESSAGE"</code> with no <code>--</code></td>
+      <td>Payload starting with <code>-</code> becomes a flag.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Run it through shellcheck</h3>
+
+<p>Before deploying any Action handler, run:</p>
+
+<pre><code>shellcheck /path/to/your-handler.sh</code></pre>
+
+<p>shellcheck catches every common quoting and word-splitting mistake.
+If your script is failing checks, fix the script &mdash; don't add
+<code>#shellcheck disable</code> directives.</p>
+
+<h2 id="kv-shell">Worked example 2: SMS as a kv-mode shell Action</h2>
+
+<p>Same outcome, different wire format:</p>
+
+<pre><code>@@482910#sms to=+15555551212 msg="hello there"</code></pre>
+
+<p>graywolf invokes:</p>
+
+<pre><code>/usr/local/bin/sms.sh sms KE0XYZ true "to=+15555551212" "msg=hello there"</code></pre>
+
+<p>And the script (also at
+<code>examples/actions/posix/sms.sh</code>):</p>
+
+<pre><code class="language-bash">#!/bin/bash
+set -euo pipefail
+
+# kv mode: graywolf sets GW_ARG_TO and GW_ARG_MSG.
+
+NUMBER="${GW_ARG_TO:?missing to=}"
+MESSAGE="${GW_ARG_MSG:?missing msg=}"
+
+if [[ ! "$NUMBER" =~ ^\+[1-9][0-9]{6,14}$ ]]; then
+    echo "invalid E.164: $NUMBER" &gt;&amp;2
+    exit 65
+fi
+if [[ "$MESSAGE" =~ [[:cntrl:]] ]]; then
+    echo "message contains control characters" &gt;&amp;2
+    exit 65
+fi
+
+curl -sS --max-time 8 -X POST \
+    --data-urlencode "From=${TWILIO_FROM}" \
+    --data-urlencode "To=${NUMBER}" \
+    --data-urlencode "Body=${MESSAGE}" \
+    -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
+    -- "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json"
+</code></pre>
+
+<p>The script body is shorter because graywolf has already split the
+payload for us &mdash; <code>GW_ARG_TO</code> and <code>GW_ARG_MSG</code>
+arrive as separate variables, each individually validated by the
+Action's <code>arg_schema</code> regex. The same revalidation pattern
+still applies (defense in depth), but the splitting work moves up to
+graywolf's parser.</p>
+
+<p>For when to pick kv vs freeform, see
+<a href="actions-handler-safety.html#kv-vs-freeform">kv vs freeform
+&mdash; when to pick which</a> on the overview page.</p>
+
+    <nav class="page-nav">
+      <a href="actions-handler-safety.html">
+        <span class="label">Previous</span>
+        Actions: handler safety
+      </a>
+      <a href="actions-handler-safety-powershell.html" class="next">
+        <span class="label">Next</span>
+        PowerShell handlers
+      </a>
+    </nav>
+  </main>
+</div>
+
+<footer class="site-footer">
+  graywolf &middot; modern APRS station
+</footer>
+
+<script src="handbook.js"></script>
+</body>
+</html>

--- a/docs/handbook/actions-handler-safety-webhooks.html
+++ b/docs/handbook/actions-handler-safety-webhooks.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Actions: Webhook Handler Safety &mdash; Graywolf Handbook</title>
+  <link rel="stylesheet" href="handbook.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="index.html" class="site-logo">
+      <img src="img/graywolf-logo.svg" alt="" />
+      <span>graywolf <span class="handbook-label">handbook</span></span>
+    </a>
+    <div class="header-actions">
+      <button class="theme-toggle" aria-label="Toggle theme">[ dark ]</button>
+    </div>
+  </div>
+</header>
+
+<div class="layout">
+  <aside class="sidebar">
+    <nav>
+      <div class="sidebar-section">Getting Started</div>
+      <a href="index.html">Introduction</a>
+      <a href="installation.html">Installation</a>
+      <a href="callsign.html">Station Callsign</a>
+      <div class="sidebar-section">Radio</div>
+      <a href="audio.html">Audio Devices</a>
+      <a href="channels.html">Radio Channels</a>
+      <a href="ptt.html">Push-to-Talk</a>
+      <div class="sidebar-section">APRS</div>
+      <a href="beacons.html">Beacons</a>
+      <a href="digipeater.html">Digipeater</a>
+      <a href="igate.html">iGate</a>
+      <a href="messaging.html">Messaging</a>
+      <a href="actions.html">Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
+      <a href="livemap.html">Live Map</a>
+      <div class="sidebar-section">Packet</div>
+      <a href="ax25-terminal.html">AX.25 Terminal</a>
+      <div class="sidebar-section">Interfaces</div>
+      <a href="kiss.html">KISS TNC</a>
+      <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
+      <a href="agwpe.html">AGWPE</a>
+      <a href="gps.html">GPS</a>
+      <div class="sidebar-section">Operations</div>
+      <a href="history-database.html">Position Log</a>
+      <a href="logs.html">Logs</a>
+      <a href="monitoring.html">Monitoring</a>
+      <a href="simulation.html">Simulation</a>
+      <a href="maps.html">Maps</a>
+      <a href="preferences.html">Preferences</a>
+      <a href="architecture.html">Architecture</a>
+      <div class="sidebar-section">Reference</div>
+      <a href="configurations.html">Known-Working Configs</a>
+      <a href="api.html">REST API Reference</a>
+    </nav>
+  </aside>
+
+  <main class="content">
+    <h1>Safe webhook Action handlers</h1>
+
+<p>This page walks through a complete worked example of a webhook
+receiver &mdash; a Python Flask app &mdash; and explains the safety
+patterns line by line. The receiver is also shipped at
+<code>examples/actions/python/webhook_receiver_flask.py</code>.
+The page also covers custom webhook body templates and the filter
+syntax you should use when templating user data.</p>
+
+<p>The general modes-and-contract overview lives at
+<a href="actions-handler-safety.html">Actions: handler safety</a>;
+read it first if you haven't.</p>
+
+<h2 id="webhook">SMS as a webhook Action</h2>
+
+<p>graywolf POSTs the form-encoded body to your URL. The Action is
+configured as:</p>
+
+<ul>
+  <li><strong>Type:</strong> webhook</li>
+  <li><strong>Method:</strong> POST</li>
+  <li><strong>URL:</strong> <code>https://your-host/aprs-webhook</code></li>
+  <li><strong>Headers:</strong>
+      <code>X-Graywolf-Auth: 0123456789abcdef0123456789abcdef</code></li>
+  <li><strong>Body template:</strong> empty (use the default form encoding)</li>
+</ul>
+
+<p>The receiver (this is
+<code>examples/actions/python/webhook_receiver_flask.py</code>):</p>
+
+<pre><code class="language-python">from flask import Flask, abort, render_template_string, request
+import hmac, os, re, sqlite3
+
+SHARED_SECRET = os.environ["GW_WEBHOOK_SECRET"]
+MAX_BODY_BYTES = 8 * 1024
+MAX_ARG_LEN = 200
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+app = Flask(__name__)
+
+def verify_secret(provided):
+    if not provided:
+        return False
+    return hmac.compare_digest(provided.encode(), SHARED_SECRET.encode())
+
+@app.before_request
+def cap_body_size():
+    if (request.content_length or 0) &gt; MAX_BODY_BYTES:
+        abort(413)
+
+@app.post("/aprs-webhook")
+def aprs_webhook():
+    if not verify_secret(request.headers.get("X-Graywolf-Auth")):
+        abort(401)
+    payload = request.form.get("arg", "")
+    if len(payload) &gt; MAX_ARG_LEN or CONTROL_CHARS.search(payload):
+        abort(400)
+    sender = request.form.get("sender_callsign", "")
+    with sqlite3.connect(os.environ["GW_RECEIVER_DB"]) as db:
+        db.execute(
+            "INSERT INTO deliveries (sender, payload) VALUES (?, ?)",
+            (sender, payload),
+        )
+    return render_template_string(
+        "&lt;p&gt;received from &lt;strong&gt;{{ sender }}&lt;/strong&gt;: {{ payload }}&lt;/p&gt;",
+        sender=sender, payload=payload,
+    )
+</code></pre>
+
+<h3>Explanation</h3>
+
+<p><strong>Authenticate the inbound POST.</strong> Your webhook URL
+is in graywolf's database, and graywolf is the only thing that knows
+the shared secret you set in <code>X-Graywolf-Auth</code>. Anything
+else hitting your endpoint should get a 401 immediately.
+<code>hmac.compare_digest</code> compares in constant time so an
+attacker can't measure timing to brute-force the secret one byte at a
+time.</p>
+
+<p><strong>Cap the body size <em>before</em> parsing it.</strong>
+graywolf already limits payload bytes, but a bug or downgrade attack
+on graywolf's side shouldn't be able to OOM your receiver. The
+<code>before_request</code> hook bails on
+<code>Content-Length</code> too high.</p>
+
+<p><strong>Use form-encoded input, not JSON.</strong> graywolf's
+default body is <code>application/x-www-form-urlencoded</code>, which
+the framework parses for you with no eval involved. JSON parsing is
+also fine, but only because Python's <code>json.loads</code> doesn't
+eval &mdash; never <code>eval(request.body)</code>.</p>
+
+<p><strong>Revalidate.</strong> Same length-and-control-char floor
+as the shell example. Even though graywolf already validated, your
+receiver shouldn't depend on graywolf staying bug-free forever.</p>
+
+<p><strong>Parameterized SQL.</strong> The two <code>?</code>
+placeholders are bound by the SQLite driver. The string
+<code>"INSERT INTO deliveries..."</code> is constant &mdash; there is no
+f-string, no <code>%</code>-format, no concatenation involving
+<code>payload</code>. SQL injection cannot happen here, regardless of
+what bytes <code>payload</code> contains.</p>
+
+<p><strong>Auto-escaped templating.</strong> Jinja escapes
+<code>&lt;</code>, <code>&gt;</code>, <code>&amp;</code>, and quotes
+by default in <code>{{ payload }}</code>. If <code>payload</code> were
+<code>&lt;script&gt;alert(1)&lt;/script&gt;</code>, the rendered HTML
+would contain <code>&amp;lt;script&amp;gt;</code>, not a real
+<code>script</code> tag. Never use <code>{{ payload|safe }}</code> or
+<code>Markup(payload)</code>.</p>
+
+<h3>Anti-patterns to avoid in webhook receivers</h3>
+
+<table>
+  <thead><tr><th>Anti-pattern</th><th>Attack it enables</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>f"INSERT ... ('{payload}')"</code></td>
+      <td>SQL injection.</td>
+    </tr>
+    <tr>
+      <td><code>render_template_string("{{ msg|safe }}", ...)</code></td>
+      <td>Stored XSS.</td>
+    </tr>
+    <tr>
+      <td><code>os.system(f"send {payload}")</code></td>
+      <td>Shell injection on the receiver host.</td>
+    </tr>
+    <tr>
+      <td><code>requests.get(payload)</code></td>
+      <td>SSRF &mdash; payload becomes a URL the server fetches.</td>
+    </tr>
+    <tr>
+      <td>No auth on the endpoint</td>
+      <td>Anyone on the internet can POST as if they were graywolf.</td>
+    </tr>
+    <tr>
+      <td>Logging payload without escaping CR/LF</td>
+      <td>Log forging &mdash; fake log entries, terminal escape attacks.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="custom-template">Custom webhook body templates</h2>
+
+<p>Most operators should leave the body template blank and use
+graywolf's default form encoding &mdash; the framework handles escaping
+correctly and there's nothing to get wrong. If you need a custom
+template (e.g., a downstream API expects JSON), use the filter
+syntax:</p>
+
+<pre><code>{
+  "to": "{{arg.to|json}}",
+  "msg": "{{arg.msg|json}}"
+}</code></pre>
+
+<p>The <code>|json</code> filter performs JSON-string escaping so the
+value can sit safely between the surrounding quotes. Never write:</p>
+
+<pre><code>{
+  "msg": "{{arg.msg}}"   &larr; UNSAFE -- a quote or backslash in the
+                           value will break the JSON.
+}</code></pre>
+
+<p>Available filters:</p>
+
+<table>
+  <thead><tr><th>Filter</th><th>Use when templating into</th></tr></thead>
+  <tbody>
+    <tr><td><code>|json</code></td><td>JSON string contents</td></tr>
+    <tr><td><code>|url</code></td><td>URL paths or query strings</td></tr>
+    <tr><td><code>|html</code></td><td>HTML attribute values or text content</td></tr>
+  </tbody>
+</table>
+
+    <nav class="page-nav">
+      <a href="actions-handler-safety-powershell.html">
+        <span class="label">Previous</span>
+        PowerShell handlers
+      </a>
+      <a href="livemap.html" class="next">
+        <span class="label">Next</span>
+        Live Map
+      </a>
+    </nav>
+  </main>
+</div>
+
+<footer class="site-footer">
+  graywolf &middot; modern APRS station
+</footer>
+
+<script src="handbook.js"></script>
+</body>
+</html>

--- a/docs/handbook/actions-handler-safety.html
+++ b/docs/handbook/actions-handler-safety.html
@@ -1,0 +1,599 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Actions: Handler Safety &mdash; Graywolf Handbook</title>
+  <link rel="stylesheet" href="handbook.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="index.html" class="site-logo">
+      <img src="img/graywolf-logo.svg" alt="" />
+      <span>graywolf <span class="handbook-label">handbook</span></span>
+    </a>
+    <div class="header-actions">
+      <button class="theme-toggle" aria-label="Toggle theme">[ dark ]</button>
+    </div>
+  </div>
+</header>
+
+<div class="layout">
+  <aside class="sidebar">
+    <nav>
+      <div class="sidebar-section">Getting Started</div>
+      <a href="index.html">Introduction</a>
+      <a href="installation.html">Installation</a>
+      <a href="callsign.html">Station Callsign</a>
+      <div class="sidebar-section">Radio</div>
+      <a href="audio.html">Audio Devices</a>
+      <a href="channels.html">Radio Channels</a>
+      <a href="ptt.html">Push-to-Talk</a>
+      <div class="sidebar-section">APRS</div>
+      <a href="beacons.html">Beacons</a>
+      <a href="digipeater.html">Digipeater</a>
+      <a href="igate.html">iGate</a>
+      <a href="messaging.html">Messaging</a>
+      <a href="actions.html">Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="livemap.html">Live Map</a>
+      <div class="sidebar-section">Packet</div>
+      <a href="ax25-terminal.html">AX.25 Terminal</a>
+      <div class="sidebar-section">Interfaces</div>
+      <a href="kiss.html">KISS TNC</a>
+      <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
+      <a href="agwpe.html">AGWPE</a>
+      <a href="gps.html">GPS</a>
+      <div class="sidebar-section">Operations</div>
+      <a href="history-database.html">Position Log</a>
+      <a href="logs.html">Logs</a>
+      <a href="monitoring.html">Monitoring</a>
+      <a href="simulation.html">Simulation</a>
+      <a href="maps.html">Maps</a>
+      <a href="preferences.html">Preferences</a>
+      <a href="architecture.html">Architecture</a>
+      <div class="sidebar-section">Reference</div>
+      <a href="configurations.html">Known-Working Configs</a>
+      <a href="api.html">REST API Reference</a>
+    </nav>
+  </aside>
+
+  <main class="content">
+    <h1>Writing safe Action handlers</h1>
+
+<p>An Action handler is a handler &mdash; a shell script, a webhook
+receiver &mdash; that you control. graywolf gives it a payload from a
+remote APRS sender. Your handler decides what to do with that
+payload. Anything an attacker can persuade your handler to do, they
+can do over the air.</p>
+
+<p>This page walks through two complete worked examples &mdash; one
+shell-script Action, one webhook Action &mdash; and explains the safety
+patterns line by line. Every example here is also shipped in
+<code>examples/actions/</code> in the source tree, fully commented,
+shellcheck-clean, ruff-clean, and exercised by CI.</p>
+
+<h2 id="modes">Two argument modes</h2>
+
+<p>Each Action has a mode that controls how the wire-format arguments
+reach your handler:</p>
+
+<table>
+  <thead><tr><th>Mode</th><th>Wire format</th><th>Use when</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>kv</code> (default)</td>
+      <td><code>@@&lt;otp&gt;#name k1=v1 k2=v2</code></td>
+      <td>You have multiple, named, individually-validated arguments.</td>
+    </tr>
+    <tr>
+      <td><code>freeform</code></td>
+      <td><code>@@&lt;otp&gt;#name &lt;raw text&gt;</code></td>
+      <td>Everything after the verb is one payload (e.g. an SMS).</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Pick freeform when you want a sender to type something natural like
+<code>@@482910#sms +15555551212 hello there</code> instead of
+<code>@@482910#sms to=+15555551212 msg=&quot;hello there&quot;</code>.
+The cost: the operator (you) takes on more responsibility for
+parsing and revalidating the payload. The rest of this page is about
+discharging that responsibility correctly.</p>
+
+<h2 id="contract">What graywolf passes to your handler</h2>
+
+<h3>Command Actions (shell script)</h3>
+
+<p>The runner exec's your binary directly &mdash; no shell, no PATH lookup
+funkiness, no <code>system()</code>. argv layout depends on mode:</p>
+
+<table>
+  <thead><tr><th></th><th><code>kv</code></th><th><code>freeform</code></th></tr></thead>
+  <tbody>
+    <tr><td>$1</td><td>action name</td><td>action name</td></tr>
+    <tr><td>$2</td><td>sender callsign</td><td>sender callsign</td></tr>
+    <tr><td>$3</td><td><code>true</code> | <code>false</code> (OTP verified)</td><td>same</td></tr>
+    <tr><td>$4..$N</td><td><code>k=v</code> tokens, schema order</td><td>the entire raw payload, one token</td></tr>
+  </tbody>
+</table>
+
+<p>Environment variables are also set:</p>
+
+<ul>
+  <li><code>GW_ACTION_NAME</code>, <code>GW_SENDER_CALL</code>,
+      <code>GW_OTP_VERIFIED</code>, <code>GW_OTP_CRED_NAME</code>,
+      <code>GW_SOURCE</code>, <code>GW_INVOCATION_ID</code> &mdash; always.</li>
+  <li>kv: <code>GW_ARG_&lt;KEY&gt;=&lt;value&gt;</code> per declared arg.</li>
+  <li>freeform: <code>GW_ARG=&lt;raw payload&gt;</code> (single var, no key suffix).</li>
+</ul>
+
+<h3>Webhook Actions</h3>
+
+<p>graywolf POSTs URL-encoded form data by default (or your custom
+template body if you set one). Default form fields:</p>
+
+<ul>
+  <li><code>action</code>, <code>sender_callsign</code>,
+      <code>otp_verified</code>, <code>otp_cred</code>, <code>source</code></li>
+  <li>kv: one field per declared arg (key = your schema key).</li>
+  <li>freeform: one field named <code>arg</code> with the raw payload.</li>
+</ul>
+
+<p>Custom body templates support these tokens:</p>
+
+<ul>
+  <li><code>{{action}}</code>, <code>{{sender-callsign}}</code>,
+      <code>{{otp-verified}}</code>, <code>{{otp-cred}}</code>,
+      <code>{{source}}</code></li>
+  <li>kv: <code>{{arg.&lt;key&gt;}}</code></li>
+  <li>freeform: <code>{{arg}}</code> (bare)</li>
+  <li>Filters: <code>{{arg|json}}</code>, <code>{{arg|url}}</code>,
+      <code>{{arg|html}}</code> &mdash; same for any token. Use these.</li>
+</ul>
+
+<h2 id="freeform">Worked example 1: SMS as a freeform shell Action</h2>
+
+<p>The Action sender writes:</p>
+
+<pre><code>@@482910#sms +15555551212 hello there</code></pre>
+
+<p>graywolf invokes:</p>
+
+<pre><code>/usr/local/bin/sms-freeform.sh sms KE0XYZ true "+15555551212 hello there"</code></pre>
+
+<p>Here is the complete script (also at
+<code>examples/actions/posix/sms-freeform.sh</code>, shellcheck-clean,
+exercised by CI):</p>
+
+<pre><code class="language-bash">#!/bin/bash
+# sms-freeform.sh &mdash; Send an SMS via Twilio. Freeform Action variant.
+
+set -euo pipefail
+
+ACTION="$1"
+SENDER="$2"
+OTP_VERIFIED="$3"
+PAYLOAD="$4"
+
+NUMBER="${PAYLOAD%% *}"
+MESSAGE="${PAYLOAD#* }"
+
+if [[ "$NUMBER" == "$PAYLOAD" ]]; then
+    echo "expected '+&lt;E164&gt; &lt;message&gt;'" &gt;&amp;2
+    exit 64
+fi
+if [[ ! "$NUMBER" =~ ^\+[1-9][0-9]{6,14}$ ]]; then
+    echo "invalid E.164: $NUMBER" &gt;&amp;2
+    exit 65
+fi
+if [[ "$MESSAGE" =~ [[:cntrl:]] ]]; then
+    echo "message contains control characters" &gt;&amp;2
+    exit 65
+fi
+if (( ${#MESSAGE} &lt; 1 || ${#MESSAGE} &gt; 160 )); then
+    echo "message length out of range (1..160)" &gt;&amp;2
+    exit 65
+fi
+
+: "${TWILIO_ACCOUNT_SID:?TWILIO_ACCOUNT_SID not set}"
+: "${TWILIO_AUTH_TOKEN:?TWILIO_AUTH_TOKEN not set}"
+: "${TWILIO_FROM:?TWILIO_FROM not set}"
+
+response=$(curl -sS --max-time 8 -X POST \
+    --data-urlencode "From=${TWILIO_FROM}" \
+    --data-urlencode "To=${NUMBER}" \
+    --data-urlencode "Body=${MESSAGE}" \
+    -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
+    -- "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json")
+
+if printf '%s' "$response" | grep -q '"sid"'; then
+    sid=$(printf '%s' "$response" | grep -o '"sid":"SM[A-Za-z0-9]*"' | head -n1 | sed 's/.*"\(SM[^"]*\)"/\1/')
+    echo "sent ${sid:-?}"
+    exit 0
+fi
+
+echo "twilio rejected: $(printf '%s' "$response" | head -c 80)" &gt;&amp;2
+exit 1
+</code></pre>
+
+<h3>Walkthrough</h3>
+
+<p><strong><code>set -euo pipefail</code></strong>. Three flags in one
+line. <code>-e</code> aborts on any non-zero exit. <code>-u</code>
+treats unset variables as errors (so a typo in
+<code>$GW_ARG_NUMER</code> doesn't silently expand to empty string).
+<code>-o pipefail</code> makes a pipeline fail if any stage fails, not
+just the last one. Always at the top of every shell handler.</p>
+
+<p><strong><code>NUMBER="${PAYLOAD%% *}"</code></strong>. This is bash
+parameter expansion, not a regex. <code>${VAR%% PATTERN}</code> removes
+the longest suffix of <code>$VAR</code> that matches
+<code>PATTERN</code>. Here the pattern is <code>* </code> &mdash; anything
+followed by a space &mdash; which removes everything from the first space to
+the end. What's left is everything <em>before</em> the first space,
+which is the phone number.</p>
+
+<p><strong><code>MESSAGE="${PAYLOAD#* }"</code></strong>. The mirror.
+<code>${VAR#PATTERN}</code> removes the shortest prefix matching
+<code>PATTERN</code>. <code>* </code> matches "anything plus a space"
+non-greedily, so the shortest match is "the first word plus its
+trailing space". What's left is everything after the first space.</p>
+
+<p>Concretely, with <code>PAYLOAD="+15555551212 hello world"</code>:</p>
+
+<pre><code>"${PAYLOAD%% *}"  -&gt;  "+15555551212"
+"${PAYLOAD#* }"   -&gt;  "hello world"
+</code></pre>
+
+<p>This is pure shell string manipulation. There is no
+<code>eval</code>, no command substitution, no subshell. An attacker
+sending <code>; rm -rf ~ #</code> as the payload cannot trigger
+any shell command &mdash; those characters are just bytes in the strings
+<code>NUMBER</code> and <code>MESSAGE</code>.</p>
+
+<p><strong><code>if [[ ! "$NUMBER" =~ ^\+[1-9][0-9]{6,14}$ ]]</code></strong>.
+Bash's <code>[[ =~ ]]</code> operator runs a POSIX extended regex
+match. The pattern says: a literal <code>+</code>, one digit 1..9, then
+6 to 14 more digits. We <em>revalidate</em> in the script even though
+the Action's own arg_schema regex should have already rejected
+malformed numbers. The reason: this script's safety contract should
+not depend on the operator setting a strict regex.</p>
+
+<p><strong><code>[[ "$MESSAGE" =~ [[:cntrl:]] ]]</code></strong>.
+<code>[:cntrl:]</code> is the POSIX character class for ASCII control
+characters (0x00&ndash;0x1F plus 0x7F). graywolf's sanitizer already strips
+these unconditionally for freeform Actions, but checking again here
+keeps the script self-contained.</p>
+
+<p><strong><code>: "${VAR:?msg}"</code></strong>. The colon is the
+no-op builtin. The expansion <code>${VAR:?msg}</code> exits with
+<code>msg</code> if <code>VAR</code> is unset or empty. Combined, this
+is a one-liner "abort with a clear error if the operator forgot to set
+this env var".</p>
+
+<p><strong><code>--data-urlencode "From=${TWILIO_FROM}"</code></strong>.
+<code>curl</code> performs the URL-encoding for us. Critically, this
+means we never construct the request body by string-concatenation &mdash;
+which would risk smuggling <code>&amp;Foo=bar</code> into the form if
+the message contained an ampersand.</p>
+
+<p><strong><code>-- "https://...Messages.json"</code></strong>. The
+double-dash is a convention curl supports to terminate option parsing.
+Habit: always put it before any positional argument that could
+conceivably begin with a <code>-</code>.</p>
+
+<h3>Anti-patterns to avoid</h3>
+
+<p>Each of these would compromise the script's safety:</p>
+
+<table>
+  <thead><tr><th>Anti-pattern</th><th>Attack it enables</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>curl ... -d to=$TEXT</code> (unquoted)</td>
+      <td>Word-splitting smuggles extra fields or flags.</td>
+    </tr>
+    <tr>
+      <td><code>eval "twilio send $TEXT"</code></td>
+      <td>Re-parses the payload as shell &mdash; full command injection.</td>
+    </tr>
+    <tr>
+      <td><code>sh -c "twilio send $TEXT"</code></td>
+      <td>Same as eval. Anything in the payload becomes shell.</td>
+    </tr>
+    <tr>
+      <td>String-concat into <code>--data</code></td>
+      <td><code>&amp;</code> in the payload smuggles extra form fields.</td>
+    </tr>
+    <tr>
+      <td><code>twilio send-sms "$NUMBER" "$MESSAGE"</code> with no <code>--</code></td>
+      <td>Payload starting with <code>-</code> becomes a flag.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Run it through shellcheck</h3>
+
+<p>Before deploying any Action handler, run:</p>
+
+<pre><code>shellcheck /path/to/your-handler.sh</code></pre>
+
+<p>shellcheck catches every common quoting and word-splitting mistake.
+The graywolf example scripts pass shellcheck cleanly; if your script
+is failing checks, fix the script &mdash; don't add <code>#shellcheck
+disable</code> directives.</p>
+
+<h2 id="kv-shell">Worked example 2: SMS as a kv-mode shell Action</h2>
+
+<p>Same outcome, different wire format:</p>
+
+<pre><code>@@482910#sms to=+15555551212 msg="hello there"</code></pre>
+
+<p>graywolf invokes:</p>
+
+<pre><code>/usr/local/bin/sms.sh sms KE0XYZ true "to=+15555551212" "msg=hello there"</code></pre>
+
+<p>And the script (existing
+<code>examples/actions/posix/sms.sh</code>, abridged for the
+walkthrough):</p>
+
+<pre><code class="language-bash">#!/bin/bash
+set -euo pipefail
+
+# kv mode: graywolf sets GW_ARG_TO and GW_ARG_MSG.
+
+NUMBER="${GW_ARG_TO:?missing to=}"
+MESSAGE="${GW_ARG_MSG:?missing msg=}"
+
+if [[ ! "$NUMBER" =~ ^\+[1-9][0-9]{6,14}$ ]]; then
+    echo "invalid E.164: $NUMBER" &gt;&amp;2
+    exit 65
+fi
+if [[ "$MESSAGE" =~ [[:cntrl:]] ]]; then
+    echo "message contains control characters" &gt;&amp;2
+    exit 65
+fi
+
+curl -sS --max-time 8 -X POST \
+    --data-urlencode "From=${TWILIO_FROM}" \
+    --data-urlencode "To=${NUMBER}" \
+    --data-urlencode "Body=${MESSAGE}" \
+    -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
+    -- "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json"
+</code></pre>
+
+<p>The script body is shorter because graywolf has already split the
+payload for us &mdash; <code>GW_ARG_TO</code> and <code>GW_ARG_MSG</code>
+arrive as separate variables, each individually validated by the
+Action's <code>arg_schema</code> regex. The same revalidation pattern
+still applies (defense in depth), but the splitting work moves up to
+graywolf's parser.</p>
+
+<p><strong>kv vs freeform &mdash; when to pick which?</strong></p>
+
+<ul>
+  <li>If your Action has 2+ structured fields each with their own
+      regex (an entity ID and a state, a phone number and a message),
+      <strong>kv is friendlier</strong>. Each field gets its own
+      validator. Mistakes from senders are reported per-field
+      ("bad arg: state").</li>
+  <li>If the natural form of the input is one chunk of text (an SMS
+      body, a notification body, a message-to-be-spoken),
+      <strong>freeform reads better</strong> on-air. The cost is that
+      you do the splitting.</li>
+  <li>If the value is going to be passed through your handler to a
+      downstream API that already accepts it as one string,
+      <strong>freeform avoids needless ceremony</strong>.</li>
+</ul>
+
+<h2 id="webhook">Worked example 3: SMS as a webhook Action</h2>
+
+<p>graywolf POSTs the form-encoded body to your URL. The Action is
+configured as:</p>
+
+<ul>
+  <li><strong>Type:</strong> webhook</li>
+  <li><strong>Method:</strong> POST</li>
+  <li><strong>URL:</strong> <code>https://your-host/aprs-webhook</code></li>
+  <li><strong>Headers:</strong>
+      <code>X-Graywolf-Auth: 0123456789abcdef0123456789abcdef</code></li>
+  <li><strong>Body template:</strong> empty (use the default form encoding)</li>
+</ul>
+
+<p>The receiver (this is
+<code>examples/actions/python/webhook_receiver_flask.py</code>):</p>
+
+<pre><code class="language-python">from flask import Flask, abort, render_template_string, request
+import hmac, os, re, sqlite3
+
+SHARED_SECRET = os.environ["GW_WEBHOOK_SECRET"]
+MAX_BODY_BYTES = 8 * 1024
+MAX_ARG_LEN = 200
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+app = Flask(__name__)
+
+def verify_secret(provided):
+    if not provided:
+        return False
+    return hmac.compare_digest(provided.encode(), SHARED_SECRET.encode())
+
+@app.before_request
+def cap_body_size():
+    if (request.content_length or 0) &gt; MAX_BODY_BYTES:
+        abort(413)
+
+@app.post("/aprs-webhook")
+def aprs_webhook():
+    if not verify_secret(request.headers.get("X-Graywolf-Auth")):
+        abort(401)
+    payload = request.form.get("arg", "")
+    if len(payload) &gt; MAX_ARG_LEN or CONTROL_CHARS.search(payload):
+        abort(400)
+    sender = request.form.get("sender_callsign", "")
+    with sqlite3.connect(os.environ["GW_RECEIVER_DB"]) as db:
+        db.execute(
+            "INSERT INTO deliveries (sender, payload) VALUES (?, ?)",
+            (sender, payload),
+        )
+    return render_template_string(
+        "&lt;p&gt;received from &lt;strong&gt;{{ sender }}&lt;/strong&gt;: {{ payload }}&lt;/p&gt;",
+        sender=sender, payload=payload,
+    )
+</code></pre>
+
+<h3>Walkthrough</h3>
+
+<p><strong>Authenticate the inbound POST.</strong> Your webhook URL
+is in graywolf's database, and graywolf is the only thing that knows
+the shared secret you set in <code>X-Graywolf-Auth</code>. Anything
+else hitting your endpoint should get a 401 immediately.
+<code>hmac.compare_digest</code> compares in constant time so an
+attacker can't measure timing to brute-force the secret one byte at a
+time.</p>
+
+<p><strong>Cap the body size <em>before</em> parsing it.</strong>
+graywolf already limits payload bytes, but a bug or downgrade attack
+on graywolf's side shouldn't be able to OOM your receiver. The
+<code>before_request</code> hook bails on
+<code>Content-Length</code> too high.</p>
+
+<p><strong>Use form-encoded input, not JSON.</strong> graywolf's
+default body is <code>application/x-www-form-urlencoded</code>, which
+the framework parses for you with no eval involved. JSON parsing is
+also fine, but only because Python's <code>json.loads</code> doesn't
+eval &mdash; never <code>eval(request.body)</code>.</p>
+
+<p><strong>Revalidate.</strong> Same length-and-control-char floor
+as the shell example. Even though graywolf already validated, your
+receiver shouldn't depend on graywolf staying bug-free forever.</p>
+
+<p><strong>Parameterized SQL.</strong> The two <code>?</code>
+placeholders are bound by the SQLite driver. The string
+<code>"INSERT INTO deliveries..."</code> is constant &mdash; there is no
+f-string, no <code>%</code>-format, no concatenation involving
+<code>payload</code>. SQL injection cannot happen here, regardless of
+what bytes <code>payload</code> contains.</p>
+
+<p><strong>Auto-escaped templating.</strong> Jinja escapes
+<code>&lt;</code>, <code>&gt;</code>, <code>&amp;</code>, and quotes
+by default in <code>{{ payload }}</code>. If <code>payload</code> were
+<code>&lt;script&gt;alert(1)&lt;/script&gt;</code>, the rendered HTML
+would contain <code>&amp;lt;script&amp;gt;</code>, not a real
+<code>script</code> tag. Never use <code>{{ payload|safe }}</code> or
+<code>Markup(payload)</code>.</p>
+
+<h3>Anti-patterns to avoid in webhook receivers</h3>
+
+<table>
+  <thead><tr><th>Anti-pattern</th><th>Attack it enables</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>f"INSERT ... ('{payload}')"</code></td>
+      <td>SQL injection.</td>
+    </tr>
+    <tr>
+      <td><code>render_template_string("{{ msg|safe }}", ...)</code></td>
+      <td>Stored XSS.</td>
+    </tr>
+    <tr>
+      <td><code>os.system(f"send {payload}")</code></td>
+      <td>Shell injection on the receiver host.</td>
+    </tr>
+    <tr>
+      <td><code>requests.get(payload)</code></td>
+      <td>SSRF &mdash; payload becomes a URL the server fetches.</td>
+    </tr>
+    <tr>
+      <td>No auth on the endpoint</td>
+      <td>Anyone on the internet can POST as if they were graywolf.</td>
+    </tr>
+    <tr>
+      <td>Logging payload without escaping CR/LF</td>
+      <td>Log forging &mdash; fake log entries, terminal escape attacks.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="custom-template">Custom webhook body templates</h2>
+
+<p>Most operators should leave the body template blank and use
+graywolf's default form encoding &mdash; the framework handles escaping
+correctly and there's nothing to get wrong. If you need a custom
+template (e.g., a downstream API expects JSON), use the filter
+syntax:</p>
+
+<pre><code>{
+  "to": "{{arg.to|json}}",
+  "msg": "{{arg.msg|json}}"
+}</code></pre>
+
+<p>The <code>|json</code> filter performs JSON-string escaping so the
+value can sit safely between the surrounding quotes. Never write:</p>
+
+<pre><code>{
+  "msg": "{{arg.msg}}"   &larr; UNSAFE -- a quote or backslash in the
+                           value will break the JSON.
+}</code></pre>
+
+<p>Available filters:</p>
+
+<table>
+  <thead><tr><th>Filter</th><th>Use when templating into</th></tr></thead>
+  <tbody>
+    <tr><td><code>|json</code></td><td>JSON string contents</td></tr>
+    <tr><td><code>|url</code></td><td>URL paths or query strings</td></tr>
+    <tr><td><code>|html</code></td><td>HTML attribute values or text content</td></tr>
+  </tbody>
+</table>
+
+<h2 id="checklist">Final safety checklist</h2>
+
+<p>Before deploying any Action handler:</p>
+
+<ol>
+  <li>Run <code>shellcheck</code> (shell) or <code>ruff</code>
+      (Python). Fix everything it flags. Don't disable rules.</li>
+  <li>Quote every variable expansion. Search for
+      <code>$GW_</code> not preceded by <code>"</code>.</li>
+  <li>Confirm there is no <code>eval</code>, no
+      <code>sh -c</code> with user data, no
+      <code>Invoke-Expression</code>.</li>
+  <li>Confirm any external command takes user data via
+      <code>--</code>-terminated argv, not concatenated strings.</li>
+  <li>Confirm any database write uses parameterized placeholders.</li>
+  <li>Confirm any HTML render uses framework auto-escape.</li>
+  <li>For webhooks: confirm the receiver authenticates
+      (HMAC / shared secret), caps body size, and is reachable only
+      via TLS.</li>
+  <li>Test the handler with payloads designed to break it: leading
+      <code>-</code>, embedded <code>'</code> and <code>"</code>,
+      <code>&amp;</code> and <code>=</code>, max-length values.
+      Use the <strong>Test</strong> dialog in the operator UI for
+      this &mdash; it runs the handler bypassing OTP and the sender
+      allowlist.</li>
+</ol>
+
+    <nav class="page-nav">
+      <a href="actions.html">
+        <span class="label">Previous</span>
+        Actions
+      </a>
+      <a href="livemap.html" class="next">
+        <span class="label">Next</span>
+        Live Map
+      </a>
+    </nav>
+  </main>
+</div>
+
+<footer class="site-footer">
+  graywolf &middot; modern APRS station
+</footer>
+
+<script src="handbook.js"></script>
+</body>
+</html>

--- a/docs/handbook/actions-handler-safety.html
+++ b/docs/handbook/actions-handler-safety.html
@@ -38,6 +38,9 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
@@ -63,17 +66,34 @@
   <main class="content">
     <h1>Writing safe Action handlers</h1>
 
-<p>An Action handler is a handler &mdash; a shell script, a webhook
-receiver &mdash; that you control. graywolf gives it a payload from a
-remote APRS sender. Your handler decides what to do with that
-payload. Anything an attacker can persuade your handler to do, they
-can do over the air.</p>
+<p>An Action handler is a handler &mdash; a shell script, a PowerShell
+script, a webhook receiver &mdash; that you control. graywolf gives
+it a payload from a remote APRS sender. Your handler decides what to
+do with that payload. Anything an attacker can persuade your handler
+to do, they can do over the air.</p>
 
-<p>This page walks through two complete worked examples &mdash; one
-shell-script Action, one webhook Action &mdash; and explains the safety
-patterns line by line. Every example here is also shipped in
-<code>examples/actions/</code> in the source tree, fully commented,
-shellcheck-clean, ruff-clean, and exercised by CI.</p>
+<p>This page is the overview: the two argument modes, the contract
+graywolf passes to your handler, and the final safety checklist that
+applies to every handler.</p>
+
+<p>Three sub-pages drill into worked examples
+for each handler kind, with line-by-line explanations and
+anti-patterns to avoid:</p>
+
+<ul>
+  <li><a href="actions-handler-safety-shell.html"><strong>Shell
+      handlers</strong></a> &mdash; bash freeform and kv worked examples,
+      shellcheck guidance.</li>
+  <li><a href="actions-handler-safety-powershell.html"><strong>PowerShell
+      handlers</strong></a> &mdash; the freeform SMS Action wired for a
+      Windows host, PSScriptAnalyzer guidance.</li>
+  <li><a href="actions-handler-safety-webhooks.html"><strong>Webhook
+      handlers</strong></a> &mdash; a Python Flask receiver, custom body
+      templates and the filter syntax for templated user data.</li>
+</ul>
+
+<p>Every example is also shipped in <code>examples/actions/</code> in
+the source tree.</p>
 
 <h2 id="modes">Two argument modes</h2>
 
@@ -100,23 +120,49 @@ reach your handler:</p>
 <code>@@482910#sms +15555551212 hello there</code> instead of
 <code>@@482910#sms to=+15555551212 msg=&quot;hello there&quot;</code>.
 The cost: the operator (you) takes on more responsibility for
-parsing and revalidating the payload. The rest of this page is about
+parsing and revalidating the payload. The sub-pages are about
 discharging that responsibility correctly.</p>
+
+<h3 id="kv-vs-freeform">kv vs freeform &mdash; when to pick which</h3>
+
+<ul>
+  <li>If your Action has 2+ structured fields each with their own
+      regex (an entity ID and a state, a phone number and a message),
+      <strong>kv is friendlier</strong>. Each field gets its own
+      validator. Mistakes from senders are reported per-field
+      ("bad arg: state").</li>
+  <li>If the natural form of the input is one chunk of text (an SMS
+      body, a notification body, a message-to-be-spoken),
+      <strong>freeform reads better</strong> on-air. The cost is that
+      you do the splitting.</li>
+  <li>If the value is going to be passed through your handler to a
+      downstream API that already accepts it as one string,
+      <strong>freeform avoids needless ceremony</strong>.</li>
+  <li><strong>Freeform is much easier on the sender</strong>,
+      especially from a limited user interface like an HT keypad.
+      <code>@@482103#sms +15555551212 hello there</code> is realistic
+      to thumb in on a radio's number-pad multi-tap;
+      <code>@@482103#sms to=+15555551212 msg=&quot;hello there&quot;</code>
+      &mdash; with the <code>=</code>, the quotes, and the second key
+      &mdash; is not. If your senders are likely to be on portables,
+      prefer freeform whenever the input is naturally one chunk.</li>
+</ul>
 
 <h2 id="contract">What graywolf passes to your handler</h2>
 
-<h3>Command Actions (shell script)</h3>
+<h3>Command Actions (shell or PowerShell)</h3>
 
-<p>The runner exec's your binary directly &mdash; no shell, no PATH lookup
-funkiness, no <code>system()</code>. argv layout depends on mode:</p>
+<p>The runner exec's your binary directly &mdash; no shell, no PATH
+lookup funkiness, no <code>system()</code>. argv layout depends on
+mode:</p>
 
 <table>
   <thead><tr><th></th><th><code>kv</code></th><th><code>freeform</code></th></tr></thead>
   <tbody>
-    <tr><td>$1</td><td>action name</td><td>action name</td></tr>
-    <tr><td>$2</td><td>sender callsign</td><td>sender callsign</td></tr>
-    <tr><td>$3</td><td><code>true</code> | <code>false</code> (OTP verified)</td><td>same</td></tr>
-    <tr><td>$4..$N</td><td><code>k=v</code> tokens, schema order</td><td>the entire raw payload, one token</td></tr>
+    <tr><td>$1 / $args[0]</td><td>action name</td><td>action name</td></tr>
+    <tr><td>$2 / $args[1]</td><td>sender callsign</td><td>sender callsign</td></tr>
+    <tr><td>$3 / $args[2]</td><td><code>true</code> | <code>false</code> (OTP verified)</td><td>same</td></tr>
+    <tr><td>$4..$N / $args[3..N]</td><td><code>k=v</code> tokens, schema order</td><td>the entire raw payload, one token</td></tr>
   </tbody>
 </table>
 
@@ -151,419 +197,29 @@ template body if you set one). Default form fields:</p>
   <li>kv: <code>{{arg.&lt;key&gt;}}</code></li>
   <li>freeform: <code>{{arg}}</code> (bare)</li>
   <li>Filters: <code>{{arg|json}}</code>, <code>{{arg|url}}</code>,
-      <code>{{arg|html}}</code> &mdash; same for any token. Use these.</li>
+      <code>{{arg|html}}</code> &mdash; same for any token. Use these.
+      See the
+      <a href="actions-handler-safety-webhooks.html#custom-template">webhook
+      handlers page</a> for worked examples.</li>
 </ul>
-
-<h2 id="freeform">Worked example 1: SMS as a freeform shell Action</h2>
-
-<p>The Action sender writes:</p>
-
-<pre><code>@@482910#sms +15555551212 hello there</code></pre>
-
-<p>graywolf invokes:</p>
-
-<pre><code>/usr/local/bin/sms-freeform.sh sms KE0XYZ true "+15555551212 hello there"</code></pre>
-
-<p>Here is the complete script (also at
-<code>examples/actions/posix/sms-freeform.sh</code>, shellcheck-clean,
-exercised by CI):</p>
-
-<pre><code class="language-bash">#!/bin/bash
-# sms-freeform.sh &mdash; Send an SMS via Twilio. Freeform Action variant.
-
-set -euo pipefail
-
-ACTION="$1"
-SENDER="$2"
-OTP_VERIFIED="$3"
-PAYLOAD="$4"
-
-NUMBER="${PAYLOAD%% *}"
-MESSAGE="${PAYLOAD#* }"
-
-if [[ "$NUMBER" == "$PAYLOAD" ]]; then
-    echo "expected '+&lt;E164&gt; &lt;message&gt;'" &gt;&amp;2
-    exit 64
-fi
-if [[ ! "$NUMBER" =~ ^\+[1-9][0-9]{6,14}$ ]]; then
-    echo "invalid E.164: $NUMBER" &gt;&amp;2
-    exit 65
-fi
-if [[ "$MESSAGE" =~ [[:cntrl:]] ]]; then
-    echo "message contains control characters" &gt;&amp;2
-    exit 65
-fi
-if (( ${#MESSAGE} &lt; 1 || ${#MESSAGE} &gt; 160 )); then
-    echo "message length out of range (1..160)" &gt;&amp;2
-    exit 65
-fi
-
-: "${TWILIO_ACCOUNT_SID:?TWILIO_ACCOUNT_SID not set}"
-: "${TWILIO_AUTH_TOKEN:?TWILIO_AUTH_TOKEN not set}"
-: "${TWILIO_FROM:?TWILIO_FROM not set}"
-
-response=$(curl -sS --max-time 8 -X POST \
-    --data-urlencode "From=${TWILIO_FROM}" \
-    --data-urlencode "To=${NUMBER}" \
-    --data-urlencode "Body=${MESSAGE}" \
-    -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
-    -- "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json")
-
-if printf '%s' "$response" | grep -q '"sid"'; then
-    sid=$(printf '%s' "$response" | grep -o '"sid":"SM[A-Za-z0-9]*"' | head -n1 | sed 's/.*"\(SM[^"]*\)"/\1/')
-    echo "sent ${sid:-?}"
-    exit 0
-fi
-
-echo "twilio rejected: $(printf '%s' "$response" | head -c 80)" &gt;&amp;2
-exit 1
-</code></pre>
-
-<h3>Walkthrough</h3>
-
-<p><strong><code>set -euo pipefail</code></strong>. Three flags in one
-line. <code>-e</code> aborts on any non-zero exit. <code>-u</code>
-treats unset variables as errors (so a typo in
-<code>$GW_ARG_NUMER</code> doesn't silently expand to empty string).
-<code>-o pipefail</code> makes a pipeline fail if any stage fails, not
-just the last one. Always at the top of every shell handler.</p>
-
-<p><strong><code>NUMBER="${PAYLOAD%% *}"</code></strong>. This is bash
-parameter expansion, not a regex. <code>${VAR%% PATTERN}</code> removes
-the longest suffix of <code>$VAR</code> that matches
-<code>PATTERN</code>. Here the pattern is <code>* </code> &mdash; anything
-followed by a space &mdash; which removes everything from the first space to
-the end. What's left is everything <em>before</em> the first space,
-which is the phone number.</p>
-
-<p><strong><code>MESSAGE="${PAYLOAD#* }"</code></strong>. The mirror.
-<code>${VAR#PATTERN}</code> removes the shortest prefix matching
-<code>PATTERN</code>. <code>* </code> matches "anything plus a space"
-non-greedily, so the shortest match is "the first word plus its
-trailing space". What's left is everything after the first space.</p>
-
-<p>Concretely, with <code>PAYLOAD="+15555551212 hello world"</code>:</p>
-
-<pre><code>"${PAYLOAD%% *}"  -&gt;  "+15555551212"
-"${PAYLOAD#* }"   -&gt;  "hello world"
-</code></pre>
-
-<p>This is pure shell string manipulation. There is no
-<code>eval</code>, no command substitution, no subshell. An attacker
-sending <code>; rm -rf ~ #</code> as the payload cannot trigger
-any shell command &mdash; those characters are just bytes in the strings
-<code>NUMBER</code> and <code>MESSAGE</code>.</p>
-
-<p><strong><code>if [[ ! "$NUMBER" =~ ^\+[1-9][0-9]{6,14}$ ]]</code></strong>.
-Bash's <code>[[ =~ ]]</code> operator runs a POSIX extended regex
-match. The pattern says: a literal <code>+</code>, one digit 1..9, then
-6 to 14 more digits. We <em>revalidate</em> in the script even though
-the Action's own arg_schema regex should have already rejected
-malformed numbers. The reason: this script's safety contract should
-not depend on the operator setting a strict regex.</p>
-
-<p><strong><code>[[ "$MESSAGE" =~ [[:cntrl:]] ]]</code></strong>.
-<code>[:cntrl:]</code> is the POSIX character class for ASCII control
-characters (0x00&ndash;0x1F plus 0x7F). graywolf's sanitizer already strips
-these unconditionally for freeform Actions, but checking again here
-keeps the script self-contained.</p>
-
-<p><strong><code>: "${VAR:?msg}"</code></strong>. The colon is the
-no-op builtin. The expansion <code>${VAR:?msg}</code> exits with
-<code>msg</code> if <code>VAR</code> is unset or empty. Combined, this
-is a one-liner "abort with a clear error if the operator forgot to set
-this env var".</p>
-
-<p><strong><code>--data-urlencode "From=${TWILIO_FROM}"</code></strong>.
-<code>curl</code> performs the URL-encoding for us. Critically, this
-means we never construct the request body by string-concatenation &mdash;
-which would risk smuggling <code>&amp;Foo=bar</code> into the form if
-the message contained an ampersand.</p>
-
-<p><strong><code>-- "https://...Messages.json"</code></strong>. The
-double-dash is a convention curl supports to terminate option parsing.
-Habit: always put it before any positional argument that could
-conceivably begin with a <code>-</code>.</p>
-
-<h3>Anti-patterns to avoid</h3>
-
-<p>Each of these would compromise the script's safety:</p>
-
-<table>
-  <thead><tr><th>Anti-pattern</th><th>Attack it enables</th></tr></thead>
-  <tbody>
-    <tr>
-      <td><code>curl ... -d to=$TEXT</code> (unquoted)</td>
-      <td>Word-splitting smuggles extra fields or flags.</td>
-    </tr>
-    <tr>
-      <td><code>eval "twilio send $TEXT"</code></td>
-      <td>Re-parses the payload as shell &mdash; full command injection.</td>
-    </tr>
-    <tr>
-      <td><code>sh -c "twilio send $TEXT"</code></td>
-      <td>Same as eval. Anything in the payload becomes shell.</td>
-    </tr>
-    <tr>
-      <td>String-concat into <code>--data</code></td>
-      <td><code>&amp;</code> in the payload smuggles extra form fields.</td>
-    </tr>
-    <tr>
-      <td><code>twilio send-sms "$NUMBER" "$MESSAGE"</code> with no <code>--</code></td>
-      <td>Payload starting with <code>-</code> becomes a flag.</td>
-    </tr>
-  </tbody>
-</table>
-
-<h3>Run it through shellcheck</h3>
-
-<p>Before deploying any Action handler, run:</p>
-
-<pre><code>shellcheck /path/to/your-handler.sh</code></pre>
-
-<p>shellcheck catches every common quoting and word-splitting mistake.
-The graywolf example scripts pass shellcheck cleanly; if your script
-is failing checks, fix the script &mdash; don't add <code>#shellcheck
-disable</code> directives.</p>
-
-<h2 id="kv-shell">Worked example 2: SMS as a kv-mode shell Action</h2>
-
-<p>Same outcome, different wire format:</p>
-
-<pre><code>@@482910#sms to=+15555551212 msg="hello there"</code></pre>
-
-<p>graywolf invokes:</p>
-
-<pre><code>/usr/local/bin/sms.sh sms KE0XYZ true "to=+15555551212" "msg=hello there"</code></pre>
-
-<p>And the script (existing
-<code>examples/actions/posix/sms.sh</code>, abridged for the
-walkthrough):</p>
-
-<pre><code class="language-bash">#!/bin/bash
-set -euo pipefail
-
-# kv mode: graywolf sets GW_ARG_TO and GW_ARG_MSG.
-
-NUMBER="${GW_ARG_TO:?missing to=}"
-MESSAGE="${GW_ARG_MSG:?missing msg=}"
-
-if [[ ! "$NUMBER" =~ ^\+[1-9][0-9]{6,14}$ ]]; then
-    echo "invalid E.164: $NUMBER" &gt;&amp;2
-    exit 65
-fi
-if [[ "$MESSAGE" =~ [[:cntrl:]] ]]; then
-    echo "message contains control characters" &gt;&amp;2
-    exit 65
-fi
-
-curl -sS --max-time 8 -X POST \
-    --data-urlencode "From=${TWILIO_FROM}" \
-    --data-urlencode "To=${NUMBER}" \
-    --data-urlencode "Body=${MESSAGE}" \
-    -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
-    -- "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json"
-</code></pre>
-
-<p>The script body is shorter because graywolf has already split the
-payload for us &mdash; <code>GW_ARG_TO</code> and <code>GW_ARG_MSG</code>
-arrive as separate variables, each individually validated by the
-Action's <code>arg_schema</code> regex. The same revalidation pattern
-still applies (defense in depth), but the splitting work moves up to
-graywolf's parser.</p>
-
-<p><strong>kv vs freeform &mdash; when to pick which?</strong></p>
-
-<ul>
-  <li>If your Action has 2+ structured fields each with their own
-      regex (an entity ID and a state, a phone number and a message),
-      <strong>kv is friendlier</strong>. Each field gets its own
-      validator. Mistakes from senders are reported per-field
-      ("bad arg: state").</li>
-  <li>If the natural form of the input is one chunk of text (an SMS
-      body, a notification body, a message-to-be-spoken),
-      <strong>freeform reads better</strong> on-air. The cost is that
-      you do the splitting.</li>
-  <li>If the value is going to be passed through your handler to a
-      downstream API that already accepts it as one string,
-      <strong>freeform avoids needless ceremony</strong>.</li>
-</ul>
-
-<h2 id="webhook">Worked example 3: SMS as a webhook Action</h2>
-
-<p>graywolf POSTs the form-encoded body to your URL. The Action is
-configured as:</p>
-
-<ul>
-  <li><strong>Type:</strong> webhook</li>
-  <li><strong>Method:</strong> POST</li>
-  <li><strong>URL:</strong> <code>https://your-host/aprs-webhook</code></li>
-  <li><strong>Headers:</strong>
-      <code>X-Graywolf-Auth: 0123456789abcdef0123456789abcdef</code></li>
-  <li><strong>Body template:</strong> empty (use the default form encoding)</li>
-</ul>
-
-<p>The receiver (this is
-<code>examples/actions/python/webhook_receiver_flask.py</code>):</p>
-
-<pre><code class="language-python">from flask import Flask, abort, render_template_string, request
-import hmac, os, re, sqlite3
-
-SHARED_SECRET = os.environ["GW_WEBHOOK_SECRET"]
-MAX_BODY_BYTES = 8 * 1024
-MAX_ARG_LEN = 200
-CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
-
-app = Flask(__name__)
-
-def verify_secret(provided):
-    if not provided:
-        return False
-    return hmac.compare_digest(provided.encode(), SHARED_SECRET.encode())
-
-@app.before_request
-def cap_body_size():
-    if (request.content_length or 0) &gt; MAX_BODY_BYTES:
-        abort(413)
-
-@app.post("/aprs-webhook")
-def aprs_webhook():
-    if not verify_secret(request.headers.get("X-Graywolf-Auth")):
-        abort(401)
-    payload = request.form.get("arg", "")
-    if len(payload) &gt; MAX_ARG_LEN or CONTROL_CHARS.search(payload):
-        abort(400)
-    sender = request.form.get("sender_callsign", "")
-    with sqlite3.connect(os.environ["GW_RECEIVER_DB"]) as db:
-        db.execute(
-            "INSERT INTO deliveries (sender, payload) VALUES (?, ?)",
-            (sender, payload),
-        )
-    return render_template_string(
-        "&lt;p&gt;received from &lt;strong&gt;{{ sender }}&lt;/strong&gt;: {{ payload }}&lt;/p&gt;",
-        sender=sender, payload=payload,
-    )
-</code></pre>
-
-<h3>Walkthrough</h3>
-
-<p><strong>Authenticate the inbound POST.</strong> Your webhook URL
-is in graywolf's database, and graywolf is the only thing that knows
-the shared secret you set in <code>X-Graywolf-Auth</code>. Anything
-else hitting your endpoint should get a 401 immediately.
-<code>hmac.compare_digest</code> compares in constant time so an
-attacker can't measure timing to brute-force the secret one byte at a
-time.</p>
-
-<p><strong>Cap the body size <em>before</em> parsing it.</strong>
-graywolf already limits payload bytes, but a bug or downgrade attack
-on graywolf's side shouldn't be able to OOM your receiver. The
-<code>before_request</code> hook bails on
-<code>Content-Length</code> too high.</p>
-
-<p><strong>Use form-encoded input, not JSON.</strong> graywolf's
-default body is <code>application/x-www-form-urlencoded</code>, which
-the framework parses for you with no eval involved. JSON parsing is
-also fine, but only because Python's <code>json.loads</code> doesn't
-eval &mdash; never <code>eval(request.body)</code>.</p>
-
-<p><strong>Revalidate.</strong> Same length-and-control-char floor
-as the shell example. Even though graywolf already validated, your
-receiver shouldn't depend on graywolf staying bug-free forever.</p>
-
-<p><strong>Parameterized SQL.</strong> The two <code>?</code>
-placeholders are bound by the SQLite driver. The string
-<code>"INSERT INTO deliveries..."</code> is constant &mdash; there is no
-f-string, no <code>%</code>-format, no concatenation involving
-<code>payload</code>. SQL injection cannot happen here, regardless of
-what bytes <code>payload</code> contains.</p>
-
-<p><strong>Auto-escaped templating.</strong> Jinja escapes
-<code>&lt;</code>, <code>&gt;</code>, <code>&amp;</code>, and quotes
-by default in <code>{{ payload }}</code>. If <code>payload</code> were
-<code>&lt;script&gt;alert(1)&lt;/script&gt;</code>, the rendered HTML
-would contain <code>&amp;lt;script&amp;gt;</code>, not a real
-<code>script</code> tag. Never use <code>{{ payload|safe }}</code> or
-<code>Markup(payload)</code>.</p>
-
-<h3>Anti-patterns to avoid in webhook receivers</h3>
-
-<table>
-  <thead><tr><th>Anti-pattern</th><th>Attack it enables</th></tr></thead>
-  <tbody>
-    <tr>
-      <td><code>f"INSERT ... ('{payload}')"</code></td>
-      <td>SQL injection.</td>
-    </tr>
-    <tr>
-      <td><code>render_template_string("{{ msg|safe }}", ...)</code></td>
-      <td>Stored XSS.</td>
-    </tr>
-    <tr>
-      <td><code>os.system(f"send {payload}")</code></td>
-      <td>Shell injection on the receiver host.</td>
-    </tr>
-    <tr>
-      <td><code>requests.get(payload)</code></td>
-      <td>SSRF &mdash; payload becomes a URL the server fetches.</td>
-    </tr>
-    <tr>
-      <td>No auth on the endpoint</td>
-      <td>Anyone on the internet can POST as if they were graywolf.</td>
-    </tr>
-    <tr>
-      <td>Logging payload without escaping CR/LF</td>
-      <td>Log forging &mdash; fake log entries, terminal escape attacks.</td>
-    </tr>
-  </tbody>
-</table>
-
-<h2 id="custom-template">Custom webhook body templates</h2>
-
-<p>Most operators should leave the body template blank and use
-graywolf's default form encoding &mdash; the framework handles escaping
-correctly and there's nothing to get wrong. If you need a custom
-template (e.g., a downstream API expects JSON), use the filter
-syntax:</p>
-
-<pre><code>{
-  "to": "{{arg.to|json}}",
-  "msg": "{{arg.msg|json}}"
-}</code></pre>
-
-<p>The <code>|json</code> filter performs JSON-string escaping so the
-value can sit safely between the surrounding quotes. Never write:</p>
-
-<pre><code>{
-  "msg": "{{arg.msg}}"   &larr; UNSAFE -- a quote or backslash in the
-                           value will break the JSON.
-}</code></pre>
-
-<p>Available filters:</p>
-
-<table>
-  <thead><tr><th>Filter</th><th>Use when templating into</th></tr></thead>
-  <tbody>
-    <tr><td><code>|json</code></td><td>JSON string contents</td></tr>
-    <tr><td><code>|url</code></td><td>URL paths or query strings</td></tr>
-    <tr><td><code>|html</code></td><td>HTML attribute values or text content</td></tr>
-  </tbody>
-</table>
 
 <h2 id="checklist">Final safety checklist</h2>
 
 <p>Before deploying any Action handler:</p>
 
 <ol>
-  <li>Run <code>shellcheck</code> (shell) or <code>ruff</code>
-      (Python). Fix everything it flags. Don't disable rules.</li>
+  <li>Run <code>shellcheck</code> (shell), <code>Invoke-ScriptAnalyzer</code>
+      (PowerShell), or <code>ruff</code> (Python). Fix everything it
+      flags. Don't disable rules.</li>
   <li>Quote every variable expansion. Search for
       <code>$GW_</code> not preceded by <code>"</code>.</li>
   <li>Confirm there is no <code>eval</code>, no
       <code>sh -c</code> with user data, no
       <code>Invoke-Expression</code>.</li>
   <li>Confirm any external command takes user data via
-      <code>--</code>-terminated argv, not concatenated strings.</li>
+      <code>--</code>-terminated argv (or array
+      <code>-ArgumentList</code> in PowerShell), not concatenated
+      strings.</li>
   <li>Confirm any database write uses parameterized placeholders.</li>
   <li>Confirm any HTML render uses framework auto-escape.</li>
   <li>For webhooks: confirm the receiver authenticates
@@ -582,9 +238,9 @@ value can sit safely between the surrounding quotes. Never write:</p>
         <span class="label">Previous</span>
         Actions
       </a>
-      <a href="livemap.html" class="next">
+      <a href="actions-handler-safety-shell.html" class="next">
         <span class="label">Next</span>
-        Live Map
+        Shell handlers
       </a>
     </nav>
   </main>

--- a/docs/handbook/actions.html
+++ b/docs/handbook/actions.html
@@ -87,6 +87,15 @@
       <div class="caption">The Actions page: the top table holds your Actions, the middle table holds OTP credentials, and the bottom panel tails every invocation in real time.</div>
     </div>
 
+    <div class="callout warn">
+      <div class="callout-body">
+        <strong>Before writing a handler:</strong> read
+        <a href="actions-handler-safety.html">Writing safe Action handlers</a>.
+        Action handlers run with the privileges of the graywolf service
+        user; safe defaults are not automatic.
+      </div>
+    </div>
+
     <h2>Message grammar</h2>
 
     <p>
@@ -158,6 +167,47 @@
       The <strong>Actions</strong> page shows the exact wire syntax under
       every Action&rsquo;s name as a copy-paste-ready hint, so you can
       verify the grammar without referring back to this page.
+    </p>
+
+    <h3>Argument mode: <code>kv</code> vs <code>freeform</code></h3>
+
+    <p>
+      Each Action has an <strong>argument mode</strong> that decides how
+      the part of the wire body after the verb is parsed:
+    </p>
+
+    <ul>
+      <li>
+        <code>kv</code> (default) &mdash; the rest of the body is split
+        into space-separated <code>key=value</code> tokens, each
+        validated against the Action&rsquo;s argument schema. Use this
+        when an Action has multiple structured fields.
+      </li>
+      <li>
+        <code>freeform</code> &mdash; everything after the action name is
+        one untokenized payload, validated against a single-row schema.
+        Use this when the natural form of the input is one chunk of
+        text (an SMS body, a notification body, a message-to-be-spoken).
+      </li>
+    </ul>
+
+    <div class="box">
+      <div class="box-body">
+        <pre><code># kv mode (default):
+@@482103#sms to=+15555551212 msg="hello there"
+
+# freeform mode:
+@@482103#sms +15555551212 hello there</code></pre>
+      </div>
+    </div>
+
+    <p>
+      Freeform shifts more responsibility to the handler &mdash; the
+      operator parses and revalidates the payload inside the script or
+      receiver. The
+      <a href="actions-handler-safety.html">handler safety guide</a>
+      walks through both modes with worked examples and is required
+      reading before deploying a freeform Action.
     </p>
 
     <h2>Defining an Action</h2>
@@ -235,12 +285,23 @@
         replies <code>rate_limited</code>.
       </li>
       <li>
+        <strong>Argument mode.</strong> A radio between <code>kv</code>
+        (default) and <code>freeform</code>. In freeform mode the
+        multi-row schema editor collapses to a single-row editor for
+        the lone payload field, since the whole post-verb body becomes
+        one value. Switching to freeform requires reading the
+        <a href="actions-handler-safety.html">handler safety guide</a>
+        first &mdash; the operator (you) becomes responsible for
+        splitting and revalidating the payload inside the handler.
+      </li>
+      <li>
         <strong>Argument schema.</strong> A list of
         <code>{key, regex, required}</code> rows. Every key/value token
         on the wire must match a row in the schema, and the value must
         match the row&rsquo;s regex. Required keys missing from the
         wire reply <code>bad_arg: &lt;key&gt;</code>. Empty schema
-        means no args accepted.
+        means no args accepted. In freeform mode the editor shows a
+        single row whose key is fixed to <code>arg</code>.
       </li>
     </ul>
 

--- a/docs/handbook/actions.html
+++ b/docs/handbook/actions.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/agwpe.html
+++ b/docs/handbook/agwpe.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/architecture.html
+++ b/docs/handbook/architecture.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/audio.html
+++ b/docs/handbook/audio.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/ax25-terminal.html
+++ b/docs/handbook/ax25-terminal.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/beacons.html
+++ b/docs/handbook/beacons.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/callsign.html
+++ b/docs/handbook/callsign.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/channels.html
+++ b/docs/handbook/channels.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/configurations.html
+++ b/docs/handbook/configurations.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/digipeater.html
+++ b/docs/handbook/digipeater.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/gps.html
+++ b/docs/handbook/gps.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/history-database.html
+++ b/docs/handbook/history-database.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/igate.html
+++ b/docs/handbook/igate.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/index.html
+++ b/docs/handbook/index.html
@@ -38,6 +38,7 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: handler safety</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/index.html
+++ b/docs/handbook/index.html
@@ -39,6 +39,9 @@
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
       <a href="actions-handler-safety.html">Actions: handler safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/installation.html
+++ b/docs/handbook/installation.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/kiss.html
+++ b/docs/handbook/kiss.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/livemap.html
+++ b/docs/handbook/livemap.html
@@ -39,6 +39,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/logs.html
+++ b/docs/handbook/logs.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/maps.html
+++ b/docs/handbook/maps.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/messaging.html
+++ b/docs/handbook/messaging.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/monitoring.html
+++ b/docs/handbook/monitoring.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/preferences.html
+++ b/docs/handbook/preferences.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/ptt.html
+++ b/docs/handbook/ptt.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/remote-kiss-tnc.html
+++ b/docs/handbook/remote-kiss-tnc.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/handbook/simulation.html
+++ b/docs/handbook/simulation.html
@@ -38,6 +38,10 @@
       <a href="messaging.html">Messaging</a>
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>

--- a/docs/wiki/actions.md
+++ b/docs/wiki/actions.md
@@ -26,6 +26,32 @@ hooks in [`../../pkg/app/`](../../pkg/app/).
 Source: [`../../pkg/actions/parser.go`](../../pkg/actions/parser.go),
 [`../../pkg/actions/sanitize.go`](../../pkg/actions/sanitize.go).
 
+### Argument mode
+
+Each Action has an `arg_mode` column with values `kv` (default) or
+`freeform`:
+
+| Mode | Wire grammar | After-the-verb shape |
+|---|---|---|
+| `kv` | `@@<otp>#<action> [k=v ...]` | tokenized, validated per-key against `arg_schema` |
+| `freeform` | `@@<otp>#<action> <text>` | one untokenized payload, validated against a single-row schema |
+
+The classifier branches in `Classify` (`pkg/actions/classifier.go`):
+`kv` calls `Sanitize`, `freeform` calls `SanitizeFreeform`. The
+freeform path applies a server-side ceiling of 200 bytes and an
+unconditional control-character floor (0x00..0x1F, 0x7F) regardless
+of operator regex.
+
+The cmd executor (`buildArgv`/`buildEnv` in `cmd_executor.go`)
+detects freeform via the synthetic `FreeformArgKey == "arg"` and
+emits a bare positional argv plus `GW_ARG=<value>`. Webhook
+templates expose the value as the bare `{{arg}}` token; the new
+filter syntax (`|json` / `|url` / `|html`) covers escaping for
+operator-set body templates.
+
+Operator-facing documentation lives in
+[`../handbook/actions-handler-safety.html`](../handbook/actions-handler-safety.html).
+
 ## Trigger surface
 
 An inbound message is a candidate when its addressee matches **any**

--- a/examples/actions/posix/echo.sh
+++ b/examples/actions/posix/echo.sh
@@ -3,7 +3,7 @@
 # Grammar:  @@<otp>#echo msg=<text>
 # Args:     msg  (required) -- text to echo
 # Reply:    "<sender> said: <msg>"
-set -eu
+set -euo pipefail
 
 msg="${GW_ARG_MSG:-}"
 sender="${GW_SENDER_CALL:-?}"

--- a/examples/actions/posix/ha-garage.sh
+++ b/examples/actions/posix/ha-garage.sh
@@ -7,7 +7,7 @@
 # Deps:     curl
 #
 # DO NOT install without OTPRequired=true and a sender allowlist.
-set -eu
+set -euo pipefail
 
 action="${GW_ARG_ACTION:-}"
 if [[ -z "$action" ]]; then

--- a/examples/actions/posix/ha-lights.sh
+++ b/examples/actions/posix/ha-lights.sh
@@ -8,7 +8,7 @@
 # Config:   HA_URL    -- e.g. http://homeassistant.local:8123
 #           HA_TOKEN  -- long-lived access token
 # Deps:     curl
-set -eu
+set -euo pipefail
 
 entity="${GW_ARG_ENTITY:-}"
 state="${GW_ARG_STATE:-}"

--- a/examples/actions/posix/iss.sh
+++ b/examples/actions/posix/iss.sh
@@ -5,7 +5,7 @@
 # Reply:    "ISS <lat>,<lon> alt <km>km vel <kph>kph"
 # Source:   wheretheiss.at v1 (free, no key)
 # Deps:     curl, jq
-set -eu
+set -euo pipefail
 
 resp=$(curl -fsSL --max-time 6 https://api.wheretheiss.at/v1/satellites/25544) \
   || { echo "fetch failed" >&2; exit 1; }

--- a/examples/actions/posix/notify-freeform.sh
+++ b/examples/actions/posix/notify-freeform.sh
@@ -15,13 +15,20 @@
 
 set -euo pipefail
 
-# Positional args captured by name for clarity; only SENDER and MESSAGE are used.
+# Positional args captured by name for clarity.
 # shellcheck disable=SC2034
 ACTION="$1"
 SENDER="$2"
-# shellcheck disable=SC2034
 OTP_VERIFIED="$3"
 MESSAGE="$4"
+
+# Defense in depth: refuse if the runtime did not verify an OTP.
+# Push notifications are sent to a single operator so this is less
+# critical than SMS, but the pattern keeps the example honest.
+if [[ "$OTP_VERIFIED" != "true" ]]; then
+    echo "otp required" >&2
+    exit 65
+fi
 
 # Revalidate. Even though the Action regex should already catch this,
 # this script's safety contract should not depend on operator

--- a/examples/actions/posix/notify-freeform.sh
+++ b/examples/actions/posix/notify-freeform.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# notify-freeform.sh -- Send a Pushover notification. Freeform Action.
+#
+# Wire it as an Action with arg_mode=freeform. Senders write:
+#
+#     @@<otp>#notify mowing the lawn brb
+#
+# Required env:
+#   PUSHOVER_TOKEN   (application token from pushover.net)
+#   PUSHOVER_USER    (user key)
+#
+# This is a second worked example to demonstrate that freeform isn't
+# just for "phone-number space message" patterns -- you can take any
+# blob of text and pass it directly to a downstream API.
+
+set -euo pipefail
+
+# Positional args captured by name for clarity; only SENDER and MESSAGE are used.
+# shellcheck disable=SC2034
+ACTION="$1"
+SENDER="$2"
+# shellcheck disable=SC2034
+OTP_VERIFIED="$3"
+MESSAGE="$4"
+
+# Revalidate. Even though the Action regex should already catch this,
+# this script's safety contract should not depend on operator
+# configuration.
+if [[ "$MESSAGE" =~ [[:cntrl:]] ]]; then
+    echo "message contains control characters" >&2
+    exit 65
+fi
+if (( ${#MESSAGE} < 1 || ${#MESSAGE} > 200 )); then
+    echo "message length out of range (1..200)" >&2
+    exit 65
+fi
+
+: "${PUSHOVER_TOKEN:?PUSHOVER_TOKEN not set}"
+: "${PUSHOVER_USER:?PUSHOVER_USER not set}"
+
+# Build the title from the sender's callsign so the operator can see
+# who triggered the notification at a glance.
+TITLE="aprs from ${SENDER}"
+
+# Note the use of --data-urlencode for every operator-provided value.
+# This is the same pattern as sms-freeform.sh -- never concatenate
+# user-supplied bytes into a URL or a shell command.
+response=$(curl -sS --max-time 8 -X POST \
+    --data-urlencode "token=${PUSHOVER_TOKEN}" \
+    --data-urlencode "user=${PUSHOVER_USER}" \
+    --data-urlencode "title=${TITLE}" \
+    --data-urlencode "message=${MESSAGE}" \
+    -- "https://api.pushover.net/1/messages.json")
+
+if printf '%s' "$response" | grep -q '"status":1'; then
+    echo "pushed"
+    exit 0
+fi
+
+echo "pushover rejected: $(printf '%s' "$response" | head -c 80)" >&2
+exit 1

--- a/examples/actions/posix/sms-freeform.sh
+++ b/examples/actions/posix/sms-freeform.sh
@@ -29,14 +29,24 @@
 
 set -euo pipefail
 
-# Positional args captured by name for clarity; only PAYLOAD is used here.
+# Positional args captured by name for clarity.
 # shellcheck disable=SC2034
 ACTION="$1"
 # shellcheck disable=SC2034
 SENDER="$2"
-# shellcheck disable=SC2034
 OTP_VERIFIED="$3"
 PAYLOAD="$4"
+
+# --- 0. Refuse without a verified OTP --------------------------------
+#
+# SMS sends are exactly the surface that should require the per-Action
+# OTP toggle to be set. The runtime should not have invoked us if OTP
+# was missing -- this is defense in depth so the script's contract
+# does not depend on operator configuration.
+if [[ "$OTP_VERIFIED" != "true" ]]; then
+    echo "otp required" >&2
+    exit 65
+fi
 
 # --- 1. Validate + split in one regex ---------------------------------
 #
@@ -107,10 +117,12 @@ response=$(curl -sS --max-time 8 -X POST \
     -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
     -- "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json")
 
-# Cheap success heuristic: Twilio returns a JSON document with a "sid"
-# field on success. We don't pull in jq because not every operator has
-# it; grep is enough for a one-line reply.
-if printf '%s' "$response" | grep -q '"sid"'; then
+# Twilio Message SIDs are documented to start with "SM". Match the
+# full prefix instead of just any "sid" key, so error bodies that
+# mention subaccount_sid / application_sid don't false-positive as
+# success. We don't pull in jq because not every operator has it;
+# grep is enough for a one-line reply.
+if printf '%s' "$response" | grep -q '"sid":"SM'; then
     sid=$(printf '%s' "$response" | grep -o '"sid":"SM[A-Za-z0-9]*"' | head -n1 | sed 's/.*"\(SM[^"]*\)"/\1/')
     echo "sent ${sid:-?}"
     exit 0

--- a/examples/actions/posix/sms-freeform.sh
+++ b/examples/actions/posix/sms-freeform.sh
@@ -38,53 +38,36 @@ SENDER="$2"
 OTP_VERIFIED="$3"
 PAYLOAD="$4"
 
-# --- 1. Split number from message body --------------------------------
+# --- 1. Validate + split in one regex ---------------------------------
 #
-# We expect:  +<E.164 digits><single space><message>
+# Bash regex (POSIX ERE flavor under [[ =~ ]]) with capture groups.
+# Pattern:
+#   ^                        anchor at start
+#   (\+[1-9][0-9]{6,14})     group 1: E.164 number
+#                              \+        literal '+'
+#                              [1-9]     leading digit (E.164 forbids 0)
+#                              [0-9]{6,14} 6-14 more digits (8-16 total)
+#   [[:space:]]+             one or more whitespace separators
+#   (.+)                     group 2: message body (non-empty)
+#   $                        anchor at end
 #
-# Bash parameter expansion ${VAR%% PAT} removes the LONGEST suffix
-# matching PAT, so "${PAYLOAD%% *}" yields everything up to the FIRST
-# space (the number). "${PAYLOAD#* }" removes the SHORTEST prefix
-# matching "anything followed by a space", yielding everything after
-# the first space (the message).
+# A single match enforces both the format AND the split atomically.
+# BASH_REMATCH[1] is the number, [2] is the message. A malformed
+# input simply fails the match -- no partial state, no separate
+# "missing separator" branch.
 #
-# Example:
-#   PAYLOAD="+15555551212 hello there"
-#   "${PAYLOAD%% *}" -> "+15555551212"
-#   "${PAYLOAD#* }"  -> "hello there"
-#
-# This is purely string surgery in the shell -- no eval, no subshell,
-# no command substitution. An attacker cannot inject shell commands
-# through this expansion.
+# The match is purely an in-process string operation: no eval, no
+# subshell, no command substitution. An attacker cannot inject shell
+# commands through it.
 
-NUMBER="${PAYLOAD%% *}"
-MESSAGE="${PAYLOAD#* }"
-
-# Edge case: no space in payload means we never split. Reject explicitly.
-if [[ "$NUMBER" == "$PAYLOAD" ]]; then
+if [[ ! "$PAYLOAD" =~ ^(\+[1-9][0-9]{6,14})[[:space:]]+(.+)$ ]]; then
     echo "expected '+<E164> <message>'" >&2
     exit 64
 fi
+NUMBER="${BASH_REMATCH[1]}"
+MESSAGE="${BASH_REMATCH[2]}"
 
-# --- 2. Revalidate the number -----------------------------------------
-#
-# Bash regex (POSIX ERE flavor under [[ =~ ]]). The pattern requires:
-#   ^\+        a literal '+'
-#   [1-9]      a single digit 1..9 (E.164 doesn't allow leading 0)
-#   [0-9]{6,14} 6 to 14 more digits
-#   $          end of string
-# Total length: 8..16 characters.
-#
-# We do this even though the Action's arg_schema regex should already
-# reject malformed numbers -- defense in depth. The script's contract
-# does not depend on the operator picking a strict regex.
-
-if [[ ! "$NUMBER" =~ ^\+[1-9][0-9]{6,14}$ ]]; then
-    echo "invalid E.164: $NUMBER" >&2
-    exit 65
-fi
-
-# --- 3. Revalidate the message ----------------------------------------
+# --- 2. Revalidate the message ----------------------------------------
 #
 # [[:cntrl:]] is the POSIX character class for ASCII control characters
 # (0x00..0x1F plus 0x7F). The graywolf sanitizer already strips these,
@@ -100,12 +83,12 @@ if (( ${#MESSAGE} < 1 || ${#MESSAGE} > 160 )); then
     exit 65
 fi
 
-# --- 4. Verify required env (helpful failure mode) --------------------
+# --- 3. Verify required env (helpful failure mode) --------------------
 : "${TWILIO_ACCOUNT_SID:?TWILIO_ACCOUNT_SID not set}"
 : "${TWILIO_AUTH_TOKEN:?TWILIO_AUTH_TOKEN not set}"
 : "${TWILIO_FROM:?TWILIO_FROM not set}"
 
-# --- 5. Send -----------------------------------------------------------
+# --- 4. Send -----------------------------------------------------------
 #
 # curl is invoked argv-style, every variable quoted, and we use
 # --data-urlencode so curl performs URL-encoding of values (no shell

--- a/examples/actions/posix/sms-freeform.sh
+++ b/examples/actions/posix/sms-freeform.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# sms-freeform.sh -- Send an SMS via Twilio. Freeform Action variant.
+#
+# Wire it as an Action with arg_mode=freeform. Senders write:
+#
+#     @@<otp>#sms +15555551212 hello there
+#
+# The runner invokes this script as:
+#
+#     sms-freeform.sh sms KE0XYZ true "+15555551212 hello there"
+#                     ^   ^      ^   ^
+#                     |   |      |   GW_ARG (positional $4): the entire
+#                     |   |      |   freeform payload, no "text=" prefix
+#                     |   |      OTP_VERIFIED: "true" or "false"
+#                     |   GW_SENDER_CALL: APRS callsign that triggered us
+#                     GW_ACTION_NAME: always "sms" here
+#
+# Required environment (set in the systemd unit, NOT in this script):
+#   TWILIO_ACCOUNT_SID
+#   TWILIO_AUTH_TOKEN
+#   TWILIO_FROM            (your Twilio number, e.g. +14155551111)
+#
+# Defense layers (left-to-right, fail-fast):
+#   1. set -euo pipefail              -- abort on any error or unset var
+#   2. quote every expansion          -- no word-splitting / globbing
+#   3. revalidate inputs              -- Action regex is one layer; this is two
+#   4. no eval, no sh -c              -- argv-style exec only
+#   5. -- terminator before user data -- no flag injection into curl
+
+set -euo pipefail
+
+# Positional args captured by name for clarity; only PAYLOAD is used here.
+# shellcheck disable=SC2034
+ACTION="$1"
+# shellcheck disable=SC2034
+SENDER="$2"
+# shellcheck disable=SC2034
+OTP_VERIFIED="$3"
+PAYLOAD="$4"
+
+# --- 1. Split number from message body --------------------------------
+#
+# We expect:  +<E.164 digits><single space><message>
+#
+# Bash parameter expansion ${VAR%% PAT} removes the LONGEST suffix
+# matching PAT, so "${PAYLOAD%% *}" yields everything up to the FIRST
+# space (the number). "${PAYLOAD#* }" removes the SHORTEST prefix
+# matching "anything followed by a space", yielding everything after
+# the first space (the message).
+#
+# Example:
+#   PAYLOAD="+15555551212 hello there"
+#   "${PAYLOAD%% *}" -> "+15555551212"
+#   "${PAYLOAD#* }"  -> "hello there"
+#
+# This is purely string surgery in the shell -- no eval, no subshell,
+# no command substitution. An attacker cannot inject shell commands
+# through this expansion.
+
+NUMBER="${PAYLOAD%% *}"
+MESSAGE="${PAYLOAD#* }"
+
+# Edge case: no space in payload means we never split. Reject explicitly.
+if [[ "$NUMBER" == "$PAYLOAD" ]]; then
+    echo "expected '+<E164> <message>'" >&2
+    exit 64
+fi
+
+# --- 2. Revalidate the number -----------------------------------------
+#
+# Bash regex (POSIX ERE flavor under [[ =~ ]]). The pattern requires:
+#   ^\+        a literal '+'
+#   [1-9]      a single digit 1..9 (E.164 doesn't allow leading 0)
+#   [0-9]{6,14} 6 to 14 more digits
+#   $          end of string
+# Total length: 8..16 characters.
+#
+# We do this even though the Action's arg_schema regex should already
+# reject malformed numbers -- defense in depth. The script's contract
+# does not depend on the operator picking a strict regex.
+
+if [[ ! "$NUMBER" =~ ^\+[1-9][0-9]{6,14}$ ]]; then
+    echo "invalid E.164: $NUMBER" >&2
+    exit 65
+fi
+
+# --- 3. Revalidate the message ----------------------------------------
+#
+# [[:cntrl:]] is the POSIX character class for ASCII control characters
+# (0x00..0x1F plus 0x7F). The graywolf sanitizer already strips these,
+# but checking again here means the script remains safe even if the
+# operator widens the Action regex.
+
+if [[ "$MESSAGE" =~ [[:cntrl:]] ]]; then
+    echo "message contains control characters" >&2
+    exit 65
+fi
+if (( ${#MESSAGE} < 1 || ${#MESSAGE} > 160 )); then
+    echo "message length out of range (1..160)" >&2
+    exit 65
+fi
+
+# --- 4. Verify required env (helpful failure mode) --------------------
+: "${TWILIO_ACCOUNT_SID:?TWILIO_ACCOUNT_SID not set}"
+: "${TWILIO_AUTH_TOKEN:?TWILIO_AUTH_TOKEN not set}"
+: "${TWILIO_FROM:?TWILIO_FROM not set}"
+
+# --- 5. Send -----------------------------------------------------------
+#
+# curl is invoked argv-style, every variable quoted, and we use
+# --data-urlencode so curl performs URL-encoding of values (no shell
+# concatenation of escaped strings). The "--" separator before the URL
+# is conventional for curl; here the URL doesn't start with -, but we
+# still keep the habit.
+#
+# We send the response to stdout (truncated to one line by graywolf),
+# so a successful send echoes the Twilio message SID into the on-air
+# reply ("ok: SM<sid>...").
+
+response=$(curl -sS --max-time 8 -X POST \
+    --data-urlencode "From=${TWILIO_FROM}" \
+    --data-urlencode "To=${NUMBER}" \
+    --data-urlencode "Body=${MESSAGE}" \
+    -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
+    -- "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json")
+
+# Cheap success heuristic: Twilio returns a JSON document with a "sid"
+# field on success. We don't pull in jq because not every operator has
+# it; grep is enough for a one-line reply.
+if printf '%s' "$response" | grep -q '"sid"'; then
+    sid=$(printf '%s' "$response" | grep -o '"sid":"SM[A-Za-z0-9]*"' | head -n1 | sed 's/.*"\(SM[^"]*\)"/\1/')
+    echo "sent ${sid:-?}"
+    exit 0
+fi
+
+echo "twilio rejected: $(printf '%s' "$response" | head -c 80)" >&2
+exit 1

--- a/examples/actions/posix/sms.sh
+++ b/examples/actions/posix/sms.sh
@@ -10,7 +10,7 @@
 # Config:   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM (E.164),
 #           APRSFI_API_KEY (optional)
 # Deps:     curl, jq
-set -eu
+set -euo pipefail
 
 to="${GW_ARG_TO:-}"
 msg="${GW_ARG_MSG:-}"

--- a/examples/actions/posix/solar.sh
+++ b/examples/actions/posix/solar.sh
@@ -5,7 +5,7 @@
 # Reply:    "SFI <n> A <n> K <n> SN <n>"
 # Source:   hamqsl.com solar XML feed (free)
 # Deps:     curl
-set -eu
+set -euo pipefail
 
 xml=$(curl -fsSL --max-time 8 https://www.hamqsl.com/solarxml.php) \
   || { echo "fetch failed" >&2; exit 1; }

--- a/examples/actions/posix/uptime.sh
+++ b/examples/actions/posix/uptime.sh
@@ -4,7 +4,7 @@
 # Args:     none
 # Reply:    "up <duration> load <1m> root <pct>"
 # Useful for remote-monitoring an unattended station.
-set -eu
+set -euo pipefail
 
 up=$(uptime | sed -E 's/.*up[[:space:]]+([^,]+(,[[:space:]]+[0-9]+:[0-9]+)?),[[:space:]]+[0-9]+ user.*/\1/' \
        | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')

--- a/examples/actions/posix/weather.sh
+++ b/examples/actions/posix/weather.sh
@@ -25,6 +25,10 @@ if [[ -z "$raw" ]]; then
 fi
 
 # Strip leading "METAR " / "SPECI " so the on-air 50-char snippet
-# starts with the ICAO + observation time.
-trimmed="${raw#METAR }"
-echo "${trimmed#SPECI }"
+# starts with the ICAO + observation time. Bash regex captures the
+# tail in BASH_REMATCH[2]; if neither prefix matches, echo raw as-is.
+if [[ "$raw" =~ ^(METAR|SPECI)\ (.+)$ ]]; then
+  echo "${BASH_REMATCH[2]}"
+else
+  echo "$raw"
+fi

--- a/examples/actions/posix/weather.sh
+++ b/examples/actions/posix/weather.sh
@@ -6,7 +6,7 @@
 # Reply:    raw METAR observation, snipped to 50 chars on-air
 # Source:   aviationweather.gov (free, no key, worldwide METAR coverage)
 # Deps:     curl, jq
-set -eu
+set -euo pipefail
 
 station="${GW_ARG_STATION:-}"
 if [[ -z "$station" ]]; then
@@ -26,4 +26,5 @@ fi
 
 # Strip leading "METAR " / "SPECI " so the on-air 50-char snippet
 # starts with the ICAO + observation time.
-echo "${raw#METAR }" | sed 's/^SPECI //'
+trimmed="${raw#METAR }"
+echo "${trimmed#SPECI }"

--- a/examples/actions/python/.gitignore
+++ b/examples/actions/python/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/

--- a/examples/actions/python/README.md
+++ b/examples/actions/python/README.md
@@ -1,0 +1,67 @@
+# Python webhook receivers for graywolf Actions
+
+Two minimal examples that accept an Action's webhook POST, verify a
+shared secret, and persist the delivery to SQLite. Pick whichever
+matches your existing Python stack:
+
+| File | Framework | Use when |
+|---|---|---|
+| `webhook_receiver_flask.py` | Flask 3 | You already run Flask, or you want auto-escaped HTML rendering. |
+| `webhook_receiver_aiohttp.py` | aiohttp | You're already async and want non-blocking handlers. |
+
+## Wiring
+
+1. Pick a shared secret. Treat it like a password -- generate with
+   `openssl rand -hex 32`.
+2. Install requirements:
+   ```
+   pip install -r requirements.txt
+   ```
+3. Run the receiver behind a TLS-terminating reverse proxy (nginx,
+   caddy, traefik). The example binds to `127.0.0.1:5000`; do not
+   expose port 5000 to the internet directly.
+4. In graywolf, create a webhook Action:
+   - **Type**: webhook
+   - **Method**: POST
+   - **URL**: `https://your-host/aprs-webhook` (the public URL fronted
+     by your reverse proxy)
+   - **Headers**: `X-Graywolf-Auth: <your-shared-secret>`
+   - **Body template**: leave blank to use the default form encoding.
+     This is the safest choice -- graywolf URL-encodes every value.
+5. Set the receiver's environment variables in your service unit:
+   - `GW_WEBHOOK_SECRET=<your-shared-secret>`
+   - `GW_RECEIVER_DB=/var/lib/graywolf-receiver/log.db`
+
+## Testing
+
+```
+pytest examples/actions/python/
+```
+
+## Why this is safe
+
+Both examples implement the defense layers documented in
+`docs/handbook/actions-handler-safety.html`:
+
+1. **HMAC-comparison auth** (no timing oracle).
+2. **Body-size cap** before parsing (defense in depth against bugs in
+   graywolf's own caps).
+3. **Form-encoded parse** (graywolf's default), avoiding `eval` or
+   raw JSON-with-user-bytes-in-the-template.
+4. **Per-field revalidation** (length + control-char floor),
+   independent of what the operator-set Action regex allows.
+5. **Parameterized SQL** -- `?` placeholders, never f-strings.
+6. **Auto-escaped templating** -- Jinja's default; never `|safe` on
+   user input. The aiohttp version returns `text/plain` to avoid
+   the question entirely.
+
+## What we deliberately don't do
+
+- **No `eval` or `exec`** on the payload, ever.
+- **No subprocess shelling out** in the examples. If you need to call
+  an external command, use `subprocess.run([...], shell=False)` with a
+  list argv and a `--` terminator before any user value.
+- **No HTML rendering of unescaped user input.** The Flask example
+  uses Jinja autoescape; the aiohttp example returns plain text.
+- **No raw JSON body parsing** when graywolf's default form encoding
+  is available -- form parsing has a smaller surface than ad-hoc JSON.

--- a/examples/actions/python/requirements.txt
+++ b/examples/actions/python/requirements.txt
@@ -1,0 +1,3 @@
+flask>=3.0,<4
+aiohttp>=3.9,<4
+pytest>=8,<9

--- a/examples/actions/python/test_webhook_receiver.py
+++ b/examples/actions/python/test_webhook_receiver.py
@@ -1,0 +1,84 @@
+"""Tests for webhook_receiver_flask.
+
+Run: pytest examples/actions/python/
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("GW_WEBHOOK_SECRET", "test-secret")
+    monkeypatch.setenv("GW_RECEIVER_DB", str(db_path))
+    # Re-import to pick up the env vars.
+    import importlib
+
+    import webhook_receiver_flask
+    importlib.reload(webhook_receiver_flask)
+    webhook_receiver_flask.init_db()
+    webhook_receiver_flask.app.config["TESTING"] = True
+    yield webhook_receiver_flask.app
+
+
+def test_rejects_missing_auth(app):
+    client = app.test_client()
+    resp = client.post("/aprs-webhook", data={"action": "x", "sender_callsign": "K", "source": "rf", "arg": "hi"})
+    assert resp.status_code == 401
+
+
+def test_rejects_wrong_auth(app):
+    client = app.test_client()
+    resp = client.post(
+        "/aprs-webhook",
+        headers={"X-Graywolf-Auth": "wrong"},
+        data={"action": "x", "sender_callsign": "K", "source": "rf", "arg": "hi"},
+    )
+    assert resp.status_code == 401
+
+
+def test_accepts_valid_request(app):
+    client = app.test_client()
+    resp = client.post(
+        "/aprs-webhook",
+        headers={"X-Graywolf-Auth": "test-secret"},
+        data={"action": "notify", "sender_callsign": "KE0XYZ", "source": "rf", "arg": "hello world"},
+    )
+    assert resp.status_code == 200
+    assert b"KE0XYZ" in resp.data
+
+
+def test_rejects_control_chars(app):
+    client = app.test_client()
+    resp = client.post(
+        "/aprs-webhook",
+        headers={"X-Graywolf-Auth": "test-secret"},
+        data={"action": "notify", "sender_callsign": "KE0XYZ", "source": "rf", "arg": "hi\x00there"},
+    )
+    assert resp.status_code == 400
+
+
+def test_rejects_oversize_value(app):
+    client = app.test_client()
+    resp = client.post(
+        "/aprs-webhook",
+        headers={"X-Graywolf-Auth": "test-secret"},
+        data={"action": "notify", "sender_callsign": "KE0XYZ", "source": "rf", "arg": "a" * 201},
+    )
+    assert resp.status_code == 400
+
+
+def test_xss_payload_is_escaped(app):
+    client = app.test_client()
+    resp = client.post(
+        "/aprs-webhook",
+        headers={"X-Graywolf-Auth": "test-secret"},
+        data={"action": "notify", "sender_callsign": "KE0XYZ", "source": "rf", "arg": "<script>alert(1)</script>"},
+    )
+    assert resp.status_code == 200
+    # Jinja autoescape converts < and >; the literal <script> tag must
+    # not appear in the rendered body.
+    assert b"<script>" not in resp.data
+    assert b"&lt;script&gt;" in resp.data

--- a/examples/actions/python/webhook_receiver_aiohttp.py
+++ b/examples/actions/python/webhook_receiver_aiohttp.py
@@ -44,7 +44,7 @@ async def handle(request: web.Request) -> web.Response:
     action = str(form.get("action", ""))
     sender = str(form.get("sender_callsign", ""))
     source = str(form.get("source", ""))
-    payload = str(form.get("arg") or form.get("text") or "")
+    payload = str(form.get("arg") or "")
 
     for v in (action, sender, source, payload):
         revalidate(v)

--- a/examples/actions/python/webhook_receiver_aiohttp.py
+++ b/examples/actions/python/webhook_receiver_aiohttp.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""aiohttp webhook receiver -- same contract as the Flask example, with
+async handlers and stdlib-style sqlite usage. Provided so operators
+who already run aiohttp don't need to add Flask just for graywolf.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+import re
+import sqlite3
+from typing import Final
+
+from aiohttp import web
+
+SHARED_SECRET: Final = os.environ.get("GW_WEBHOOK_SECRET", "")
+MAX_BODY_BYTES: Final = 8 * 1024
+MAX_ARG_LEN: Final = 200
+DB_PATH: Final = os.environ.get("GW_RECEIVER_DB", "/var/lib/graywolf-receiver/log.db")
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def verify_secret(provided: str | None) -> bool:
+    if not SHARED_SECRET or provided is None:
+        return False
+    return hmac.compare_digest(provided.encode(), SHARED_SECRET.encode())
+
+
+def revalidate(value: str) -> None:
+    if len(value) > MAX_ARG_LEN:
+        raise web.HTTPBadRequest(reason="value too long")
+    if CONTROL_CHARS.search(value):
+        raise web.HTTPBadRequest(reason="control chars in value")
+
+
+async def handle(request: web.Request) -> web.Response:
+    if not verify_secret(request.headers.get("X-Graywolf-Auth")):
+        raise web.HTTPUnauthorized()
+    if (request.content_length or 0) > MAX_BODY_BYTES:
+        raise web.HTTPRequestEntityTooLarge(MAX_BODY_BYTES, request.content_length or 0)
+
+    form = await request.post()
+    action = str(form.get("action", ""))
+    sender = str(form.get("sender_callsign", ""))
+    source = str(form.get("source", ""))
+    payload = str(form.get("arg") or form.get("text") or "")
+
+    for v in (action, sender, source, payload):
+        revalidate(v)
+
+    # Synchronous sqlite is fine for low-rate APRS traffic; switch to
+    # aiosqlite if you expect bursts.
+    with sqlite3.connect(DB_PATH) as db:
+        db.execute(
+            """INSERT INTO deliveries
+               (action, sender, otp_verified, source, payload)
+               VALUES (?, ?, ?, ?, ?)""",
+            (action, sender, int(form.get("otp_verified") == "true"), source, payload),
+        )
+
+    # No HTML rendered; respond with text/plain so XSS surface is zero.
+    return web.Response(text=f"received from {sender}", content_type="text/plain")
+
+
+def init_db() -> None:
+    with sqlite3.connect(DB_PATH) as db:
+        db.execute(
+            """CREATE TABLE IF NOT EXISTS deliveries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                received_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                action TEXT NOT NULL,
+                sender TEXT NOT NULL,
+                otp_verified INTEGER NOT NULL,
+                source TEXT NOT NULL,
+                payload TEXT NOT NULL
+            )"""
+        )
+
+
+def main() -> None:
+    init_db()
+    app = web.Application(client_max_size=MAX_BODY_BYTES)
+    app.router.add_post("/aprs-webhook", handle)
+    web.run_app(app, host="127.0.0.1", port=5000)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/actions/python/webhook_receiver_flask.py
+++ b/examples/actions/python/webhook_receiver_flask.py
@@ -41,6 +41,9 @@ CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
 # ---- App --------------------------------------------------------------
 
 app = Flask(__name__)
+# Cap request bodies at the Werkzeug layer too, so chunked transfer
+# encoding (no Content-Length header) still gets bounded.
+app.config["MAX_CONTENT_LENGTH"] = MAX_BODY_BYTES
 
 
 def init_db() -> None:
@@ -84,8 +87,11 @@ def revalidate(value: str) -> None:
 def cap_body_size() -> None:
     """Reject oversize bodies before parsing them.
 
-    Werkzeug's ``MAX_CONTENT_LENGTH`` setting also enforces this, but
-    setting it AND failing fast in middleware double-locks the door.
+    Werkzeug's ``MAX_CONTENT_LENGTH`` (set above) is the load-bearing
+    cap; this middleware runs first and rejects requests that
+    advertise an oversize Content-Length without ever reading the
+    body, which is friendlier on the network for obviously-huge
+    requests.
     """
     cl = request.content_length
     if cl is not None and cl > MAX_BODY_BYTES:
@@ -104,7 +110,7 @@ def aprs_webhook():
     sender = form.get("sender_callsign", "")
     otp_verified = form.get("otp_verified", "false") == "true"
     source = form.get("source", "")
-    payload = form.get("arg", form.get("text", ""))  # 'arg' for freeform; 'text' historical
+    payload = form.get("arg", "")  # graywolf's freeform key
 
     # ---- Revalidate -------------------------------------------------
     for v in (action, sender, source, payload):

--- a/examples/actions/python/webhook_receiver_flask.py
+++ b/examples/actions/python/webhook_receiver_flask.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Flask webhook receiver for graywolf Actions.
+
+Wire this up as a 'webhook' Action with method POST. Set the URL to
+http://your-host:5000/aprs-webhook and add a header
+``X-Graywolf-Auth: <SHARED_SECRET>`` so this receiver can verify the
+caller is your graywolf instance and not a random internet host that
+guessed your URL.
+
+Defense layers, in order, mirror the script-side example:
+  1. Constant-time secret comparison (no early-out timing oracle).
+  2. Body-size cap before parsing (defense against future graywolf bugs).
+  3. Form-encoded parse (graywolf's default), NOT JSON eval.
+  4. Per-field revalidation (length, character class).
+  5. Parameterized SQL -- never string-concat user input.
+  6. Auto-escaped templating -- Jinja escapes by default; we keep the
+     default and never use ``Markup`` or ``|safe`` on user input.
+  7. argv-style subprocess if shelling out (we don't here, but the
+     pattern is shown in the comments).
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+import re
+import sqlite3
+from typing import Final
+
+from flask import Flask, abort, render_template_string, request
+
+# ---- Configuration ----------------------------------------------------
+
+SHARED_SECRET: Final = os.environ.get("GW_WEBHOOK_SECRET", "")
+MAX_BODY_BYTES: Final = 8 * 1024  # graywolf bodies are tiny; cap aggressively
+MAX_ARG_LEN: Final = 200          # mirrors actions.FreeformValueCeiling
+DB_PATH: Final = os.environ.get("GW_RECEIVER_DB", "/var/lib/graywolf-receiver/log.db")
+
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+# ---- App --------------------------------------------------------------
+
+app = Flask(__name__)
+
+
+def init_db() -> None:
+    """Create the audit table if missing. Schema is small on purpose."""
+    with sqlite3.connect(DB_PATH) as db:
+        db.execute(
+            """CREATE TABLE IF NOT EXISTS deliveries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                received_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                action TEXT NOT NULL,
+                sender TEXT NOT NULL,
+                otp_verified INTEGER NOT NULL,
+                source TEXT NOT NULL,
+                payload TEXT NOT NULL
+            )"""
+        )
+
+
+def verify_secret(provided: str | None) -> bool:
+    """Constant-time comparison.
+
+    A naive ``provided == SHARED_SECRET`` leaks length and prefix
+    information through string-equality timing. ``hmac.compare_digest``
+    runs in time proportional to the longer string regardless of where
+    the first mismatch occurs.
+    """
+    if not SHARED_SECRET or provided is None:
+        return False
+    return hmac.compare_digest(provided.encode(), SHARED_SECRET.encode())
+
+
+def revalidate(value: str) -> None:
+    """Reject control chars and oversize values. Raises 400 on violation."""
+    if len(value) > MAX_ARG_LEN:
+        abort(400, "value exceeds max length")
+    if CONTROL_CHARS.search(value):
+        abort(400, "value contains control characters")
+
+
+@app.before_request
+def cap_body_size() -> None:
+    """Reject oversize bodies before parsing them.
+
+    Werkzeug's ``MAX_CONTENT_LENGTH`` setting also enforces this, but
+    setting it AND failing fast in middleware double-locks the door.
+    """
+    cl = request.content_length
+    if cl is not None and cl > MAX_BODY_BYTES:
+        abort(413, "request body too large")
+
+
+@app.post("/aprs-webhook")
+def aprs_webhook():
+    # ---- Authenticate -----------------------------------------------
+    if not verify_secret(request.headers.get("X-Graywolf-Auth")):
+        abort(401)
+
+    # ---- Parse (form-encoded; that's graywolf's default body shape) -
+    form = request.form
+    action = form.get("action", "")
+    sender = form.get("sender_callsign", "")
+    otp_verified = form.get("otp_verified", "false") == "true"
+    source = form.get("source", "")
+    payload = form.get("arg", form.get("text", ""))  # 'arg' for freeform; 'text' historical
+
+    # ---- Revalidate -------------------------------------------------
+    for v in (action, sender, source, payload):
+        revalidate(v)
+
+    # ---- Persist ----------------------------------------------------
+    #
+    # Parameterized query. The ``?`` placeholders are bound by the
+    # driver -- there is no string concatenation of user input into the
+    # SQL, so SQL injection is impossible regardless of payload bytes.
+    with sqlite3.connect(DB_PATH) as db:
+        db.execute(
+            """INSERT INTO deliveries
+               (action, sender, otp_verified, source, payload)
+               VALUES (?, ?, ?, ?, ?)""",
+            (action, sender, int(otp_verified), source, payload),
+        )
+
+    # ---- Render the reply -------------------------------------------
+    #
+    # Jinja autoescapes by default. ``payload`` contains user-controlled
+    # bytes -- if we used ``Markup(payload)`` or piped through ``|safe``,
+    # an attacker could inject HTML into our response. We don't.
+    return render_template_string(
+        "<p>received from <strong>{{ sender }}</strong>: {{ payload }}</p>",
+        sender=sender,
+        payload=payload,
+    )
+
+
+if __name__ == "__main__":
+    init_db()
+    # Bind to localhost; put a TLS-terminating reverse proxy in front.
+    app.run(host="127.0.0.1", port=5000)

--- a/examples/actions/windows/echo.ps1
+++ b/examples/actions/windows/echo.ps1
@@ -3,6 +3,7 @@
 # Args:     msg  (required) -- text to echo
 # Reply:    "<sender> said: <msg>"
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $msg = $env:GW_ARG_MSG

--- a/examples/actions/windows/ha-garage.ps1
+++ b/examples/actions/windows/ha-garage.ps1
@@ -6,6 +6,7 @@
 #
 # DO NOT install without OTPRequired=true and a sender allowlist.
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $action = $env:GW_ARG_ACTION

--- a/examples/actions/windows/ha-lights.ps1
+++ b/examples/actions/windows/ha-lights.ps1
@@ -6,6 +6,7 @@
 # Reply:    "<entity> <state>"
 # Config:   HA_URL, HA_TOKEN
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $entity = $env:GW_ARG_ENTITY

--- a/examples/actions/windows/iss.ps1
+++ b/examples/actions/windows/iss.ps1
@@ -4,6 +4,7 @@
 # Reply:    "ISS <lat>,<lon> alt <km>km vel <kph>kph"
 # Source:   wheretheiss.at v1 (free, no key)
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 try {

--- a/examples/actions/windows/sms-freeform.ps1
+++ b/examples/actions/windows/sms-freeform.ps1
@@ -1,0 +1,128 @@
+# sms-freeform.ps1 -- Send an SMS via Twilio. Freeform Action variant.
+#
+# Wire it as an Action with arg_mode=freeform. Senders write:
+#
+#     @@<otp>#sms +15555551212 hello there
+#
+# graywolf invokes this script as:
+#
+#     powershell.exe -NoProfile -File sms-freeform.ps1 sms KE0XYZ true "+15555551212 hello there"
+#                                                       ^   ^      ^   ^
+#                                                       |   |      |   $payload (positional $args[3]):
+#                                                       |   |      |   the entire freeform payload
+#                                                       |   |      OTP_VERIFIED: "true" or "false"
+#                                                       |   GW_SENDER_CALL: APRS callsign
+#                                                       GW_ACTION_NAME: always "sms" here
+#
+# Required environment (set in the system context, NOT in this script):
+#   TWILIO_ACCOUNT_SID
+#   TWILIO_AUTH_TOKEN
+#   TWILIO_FROM            (your Twilio number, e.g. +14155551111)
+#
+# Defense layers (top-to-bottom, fail-fast):
+#   1. Set-StrictMode + $ErrorActionPreference='Stop' -- typos and
+#      cmdlet errors are hard failures, not silent $null.
+#   2. Single regex match validates AND splits the payload.
+#   3. Revalidate the message body (control chars, length).
+#   4. No Invoke-Expression, no cmd.exe /c -- argv-style cmdlet calls.
+#   5. Hashtable -Body so Invoke-RestMethod URL-encodes for us.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Positional args from the runner. Only $payload is used here.
+$action      = $args[0]
+$sender      = $args[1]
+$otpVerified = $args[2]
+$payload     = $args[3]
+
+if (-not $payload) {
+    [Console]::Error.WriteLine("payload missing")
+    exit 64
+}
+
+# --- 1. Validate + split in one regex ---------------------------------
+#
+# .NET regex with named capture groups. Pattern:
+#   ^                               anchor at start
+#   (?<num>\+[1-9][0-9]{6,14})      named group 'num': E.164 number
+#                                     \+        literal '+'
+#                                     [1-9]     leading digit (E.164 forbids 0)
+#                                     [0-9]{6,14} 6-14 more digits
+#   \s+                             one or more whitespace separators
+#   (?<msg>.+)                      named group 'msg': message body
+#   $                               anchor at end
+#
+# A single match enforces both the format AND the split atomically.
+# If the match fails, $match.Success is $false -- no partial state.
+#
+# This is purely an in-process string operation: no Invoke-Expression,
+# no subshell, no command substitution. An attacker cannot inject
+# PowerShell through it.
+
+$rx = '^(?<num>\+[1-9][0-9]{6,14})\s+(?<msg>.+)$'
+$match = [regex]::Match($payload, $rx)
+if (-not $match.Success) {
+    [Console]::Error.WriteLine("expected '+<E164> <message>'")
+    exit 64
+}
+$number  = $match.Groups['num'].Value
+$message = $match.Groups['msg'].Value
+
+# --- 2. Revalidate the message ----------------------------------------
+#
+# \p{Cc} is the Unicode "Other, Control" category (the .NET regex
+# counterpart of POSIX [:cntrl:]). graywolf's sanitizer already strips
+# these, but checking again here means the script remains safe even
+# if the operator widens the Action regex.
+
+if ($message -match '\p{Cc}') {
+    [Console]::Error.WriteLine("message contains control characters")
+    exit 65
+}
+if ($message.Length -lt 1 -or $message.Length -gt 160) {
+    [Console]::Error.WriteLine("message length out of range (1..160)")
+    exit 65
+}
+
+# --- 3. Verify required env (helpful failure mode) --------------------
+foreach ($v in 'TWILIO_ACCOUNT_SID','TWILIO_AUTH_TOKEN','TWILIO_FROM') {
+    if (-not (Get-Item "env:$v" -ErrorAction SilentlyContinue)) {
+        [Console]::Error.WriteLine("$v not set")
+        exit 1
+    }
+}
+
+$sid  = $env:TWILIO_ACCOUNT_SID
+$tok  = $env:TWILIO_AUTH_TOKEN
+$auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${sid}:${tok}"))
+$headers = @{ Authorization = "Basic $auth" }
+$uri = "https://api.twilio.com/2010-04-01/Accounts/$sid/Messages.json"
+
+# --- 4. Send -----------------------------------------------------------
+#
+# Hashtable -Body causes Invoke-RestMethod to serialize as
+# application/x-www-form-urlencoded and URL-encode each value. We
+# never concatenate user data into a request body string, so a '&'
+# or '=' in the message cannot smuggle extra form fields.
+
+$form = @{
+    From = $env:TWILIO_FROM
+    To   = $number
+    Body = $message
+}
+
+try {
+    $resp = Invoke-RestMethod -Method Post -Uri $uri -Headers $headers `
+        -Body $form -TimeoutSec 8
+    if ($resp.sid) {
+        "sent $($resp.sid)"
+        exit 0
+    }
+} catch {
+    [Console]::Error.WriteLine("twilio rejected: $($_.Exception.Message)")
+    exit 1
+}
+
+[Console]::Error.WriteLine("twilio rejected: no sid in response")
+exit 1

--- a/examples/actions/windows/sms.ps1
+++ b/examples/actions/windows/sms.ps1
@@ -8,6 +8,7 @@
 # Config:   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM,
 #           APRSFI_API_KEY (optional)
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $to = $env:GW_ARG_TO

--- a/examples/actions/windows/solar.ps1
+++ b/examples/actions/windows/solar.ps1
@@ -4,6 +4,7 @@
 # Reply:    "SFI <n> A <n> K <n> SN <n>"
 # Source:   hamqsl.com solar XML feed (free)
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 try {

--- a/examples/actions/windows/uptime.ps1
+++ b/examples/actions/windows/uptime.ps1
@@ -3,6 +3,7 @@
 # Args:     none
 # Reply:    "up <Xd Yh> load <pct cpu> root <pct used>"
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $os = Get-CimInstance Win32_OperatingSystem

--- a/examples/actions/windows/weather.ps1
+++ b/examples/actions/windows/weather.ps1
@@ -4,6 +4,7 @@
 # Reply:    raw METAR observation, snipped to 50 chars on-air
 # Source:   aviationweather.gov (free, no key, worldwide)
 
+Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $station = $env:GW_ARG_STATION

--- a/examples/skills/writing-graywolf-action-handlers/SKILL.md
+++ b/examples/skills/writing-graywolf-action-handlers/SKILL.md
@@ -1,0 +1,651 @@
+---
+name: writing-graywolf-action-handlers
+description: Use when authoring a Graywolf Actions handler — POSIX/bash, PowerShell, or webhook receiver — that fires on inbound APRS messages of the form `@@<otp>#<action>`. Triggers when an operator says "write me an Action script", "scaffold an Action handler", "I need an SMS/garage/notify Action", or asks how to wire a script to a remote sender safely. Covers OTP/allowlist sizing, kv-vs-freeform mode, argument validation, and the safety invariants that keep an over-the-air payload from compromising the host.
+---
+
+# Writing Graywolf Action handlers
+
+## Overview
+
+A Graywolf **Action handler** runs locally — or on a webhook receiver
+you control — when a remote APRS sender transmits
+`@@<otp>#<name> ...`. The payload arrives over the air and must be
+treated as **untrusted input from a public radio frequency**. A handler
+that mishandles it can shell-inject the host, smuggle SMS to arbitrary
+numbers, unlock the wrong door, or DOS a downstream API.
+
+This skill walks an operator through the **interview** that shapes a
+correct handler and then **emits** an idiomatic, lint-clean script that
+follows every invariant the Graywolf project documents. Three flavors:
+
+- **POSIX shell** (`bash` for Linux + macOS) — see [`reference-posix.md`](reference-posix.md)
+- **PowerShell** (Windows 10/11, PS 5.1 or `pwsh` 7) — see [`reference-powershell.md`](reference-powershell.md)
+- **Webhook** (HTTP receiver, examples in Python Flask/aiohttp) — see [`reference-webhook.md`](reference-webhook.md)
+
+OTP and sender-allowlist sizing applies to all three: see
+[`reference-otp-allowlist.md`](reference-otp-allowlist.md).
+
+## Threat model — always Internet-hostile
+
+**Every Action handler is exposed to arbitrary attacker-controlled input
+from the public Internet and the APRS-IS / RF networks.** This is true
+*regardless of what the operator believes the exposure is*:
+
+- APRS-IS is a public, federated, unauthenticated message bus. Any
+  station with an Internet connection can transmit to any addressee.
+- RF traffic is monitored at scale by aprs.fi, aprs2.net mirrors, SDR
+  hobbyists, and anyone within range of a digipeater. Sender callsigns
+  can be forged on RF; SSID stripping further widens the impersonation
+  surface.
+- The OTP and sender allowlist are *probabilistic* defenses — strong
+  defenses, but the script's safety must not depend on them holding.
+  Write the script as if every byte of input is attacker-chosen.
+
+The skill must **proactively explain this** to the operator if they
+say things like "this is just for me" or "only my friends will use
+it". Their model of the exposure is wrong; correct it before
+generating code.
+
+### Trust arguments are out of scope
+
+"Only my friends," "only licensed hams," "I'm the only one with the
+OTP," "my callsign is on the FCC database so I'm verified" — none of
+these are authentication boundaries. The FCC license database is
+public, callsigns are forged routinely on APRS-IS, OTP is a
+30-second / six-digit window with a knowable secret, and a sender
+allowlist is a callsign string match (no per-user identity). When
+the operator's argument for relaxing a defense is the *identity* of
+the senders, the skill must refuse and re-explain the threat model.
+When the argument is the *cost* of the defense (latency, complexity,
+operator effort), it can be weighed. Identity-based arguments never
+weigh.
+
+### The threat is not just side effects — read-only Actions can leak
+
+An Action that "only reads" can still exfiltrate state. `journalctl
+-u <pattern>` discloses logs from services the sender should not
+see; `cat /etc/<file>` discloses arbitrary file contents the service
+account can read; `kubectl logs -l <selector>` discloses pod logs;
+`Get-EventLog -LogName Security` discloses authentication history.
+Apply the same blast-radius reasoning to read-only Actions: *what
+can the underlying user account read?* That is the worst-case
+disclosure surface, regardless of what the operator believes the
+Action exposes.
+
+### Blast radius — what does this handler actually let me do?
+
+Most handlers integrate with an external service (Twilio, AWS, Home
+Assistant, a smart-home cloud, a VoIP provider, a downstream webhook).
+The handler holds the credentials for that service. **A handler bug
+or a regex gap does not just expose the one Action — it exposes
+everything the credential can do.**
+
+Walk the operator through this explicitly during the interview. The
+question is *not* "what does this Action do?" — it is "if a remote
+attacker successfully drove this handler with arbitrary input, what
+could they reach?" Concrete examples:
+
+| Integration | Naive scoping | What goes wrong |
+|---|---|---|
+| **AWS SNS** with default IAM user / admin access key | Send any SMS | Attacker can pivot to S3, SES, Lambda, IAM, billing — full account takeover via the same key. |
+| **Twilio** with main account auth token | Send one SMS | Attacker can send unlimited SMS / MMS / voice, run up the bill, originate calls from your number. |
+| **Home Assistant** with a long-lived access token | Toggle one entity | Attacker can call any service: unlock doors, disable alarms, read every sensor. |
+| **Generic SaaS API key** | One endpoint | Attacker can usually reach every endpoint that key authenticates. |
+| **SSH / pkexec / sudo from the handler** | Run one command | Attacker reaches the underlying user's full shell privilege. |
+
+The countermeasures are always the same:
+
+1. **Scope the credential as narrowly as the service allows.**
+   - AWS: a dedicated IAM user or role with a *single* `sns:Publish`
+     statement, scoped via `Resource:` to one topic ARN, plus a
+     `Condition:` on the destination phone number prefix where
+     possible. Never the AWS root key, never an admin policy, never
+     `Resource: "*"`.
+   - Twilio: a sub-account auth token, not the master account.
+   - Home Assistant: a long-lived access token tied to a *least-privilege
+     user* with limited entity access, not the operator's admin user.
+   - SSH: a dedicated key with a `command="..."` restriction in
+     `authorized_keys`, or `forced-command` via the agent.
+2. **Validate every byte of user input that touches the request.**
+   E.164 number? Anchor the regex. State `on|off`? Anchor it. Entity
+   name? Anchor it.
+3. **Cap the rate.** Set `RateLimitSec` on the Action so a runaway
+   sender cannot drain the credential's quota.
+4. **Log the credential scope** in the script's header comment so a
+   future reader can audit it without reading the IAM console.
+
+The skill must explain the blast-radius concept in language the
+operator can act on, then ask the operator: *"Show me — or describe —
+the credential this script will use. What is its scope?"* If the
+operator does not know the answer, generate the script anyway but
+include a prominent `# AUDIT THIS:` block at the top listing the
+scoping work that must happen before the Action goes live.
+
+## When to use
+
+- Operator asks for a handler script for a specific Action (SMS, home
+  automation, notification, lookup, status, etc.).
+- Operator has a draft script and wants it reviewed against the
+  handler-safety contract.
+- A new Action will perform anything irreversible, anything that
+  touches money, anything that triggers a physical actuator, or
+  anything that talks to an external API.
+- Operator asks "kv or freeform?", "do I need OTP?", "is this safe?".
+
+**Skip this skill** for non-Action work (general bash, generic
+PowerShell, unrelated webhook receivers). The patterns here are
+specific to the Graywolf Actions execution contract.
+
+## Interview — ask these questions in order
+
+Don't generate code until every question is answered. Ask the operator
+one block at a time; combine answers into the script.
+
+### 1. What does the Action do?
+
+One sentence. Examples:
+
+- *Sends an SMS via Twilio.*
+- *Toggles a Home Assistant light.*
+- *Returns current solar weather.*
+- *Posts a status note into a webhook receiver that logs to SQLite.*
+
+Capture the verb and the side effect. The verb decides the Action's
+`name`. The side effect decides everything below.
+
+### 2. What is the side-effect class?
+
+| Class | Examples | Implications |
+|---|---|---|
+| **Read-only** | weather lookup, ISS pass, uptime | OTP optional, allowlist optional, no extra hardening |
+| **Notification** | SMS, push, log entry | OTP recommended, **allowlist required if cost-per-fire** (Twilio etc.) |
+| **State change, reversible** | turn light on/off, post note | OTP required, allowlist recommended |
+| **State change, irreversible / physical** | open garage, unlock door, ignition, money movement | **OTP required, allowlist required**, narrow regex on every arg |
+
+If the operator is uncertain, default up one tier. Ask: "If a stranger
+sent this Action with valid OTP, what is the worst they could do?"
+
+### 3. Who can trigger it?
+
+- *Just me.* → Sender allowlist with the operator's callsign(s) only.
+- *A small group (family, club).* → Allowlist with each callsign.
+  Mention SSID handling: graywolf strips SSID for the comparison
+  (base-call match), so `KE0XYZ-9` and `KE0XYZ` both match `KE0XYZ`.
+- *Anyone on the band.* → No allowlist. Only acceptable for read-only
+  Actions or Actions whose side effect is harmless if abused.
+
+The classifier checks the allowlist **before** the OTP probe, so a
+denied sender cannot enumerate which OTP digits validate. Operators do
+not need to design around this — just recommend the allowlist when the
+side-effect class warrants it.
+
+### 4. OTP credential — yes or no, and is the script defending in depth?
+
+- **Yes** for any side-effect class except read-only.
+- **Yes** if the Action consumes a paid API.
+- **No** is acceptable for pure-information Actions whose worst-case
+  abuse is a small amount of RF chatter.
+
+If yes, the operator must mint an OTP credential in
+`/#/actions` → Credentials before saving the Action. The skill should
+remind them: *"Create the OTP credential first; the Action's OTP
+credential dropdown will be empty until you do."*
+
+The station is single-user; do not invent issuer / account fields. The
+issuer is always Graywolf and the account is always the station
+callsign (see `feedback_single_user_station`).
+
+**Defense in depth: the script must also check `GW_OTP_VERIFIED`.**
+The Action editor's `OTPRequired` toggle is the *first* defense; an
+operator can flip it off in the UI without re-deploying the script.
+Every generated handler that performs a side effect must therefore
+re-assert OTP at the script level:
+
+```bash
+# bash
+[[ "${GW_OTP_VERIFIED:-false}" == "true" ]] || { echo "otp not verified" >&2; exit 77; }
+```
+
+```powershell
+# PowerShell
+if ($env:GW_OTP_VERIFIED -ne 'true') {
+    [Console]::Error.WriteLine("otp not verified")
+    exit 77
+}
+```
+
+```python
+# Webhook receiver (Flask)
+if request.form.get("otp_verified", "false") != "true":
+    abort(401)
+```
+
+Skip this only for genuinely read-only Actions where unauthenticated
+RF chatter is acceptable. Do not skip for anything that costs money,
+moves a physical thing, or persists data downstream.
+
+### 5. Wire format — kv or freeform?
+
+| Question | If yes | If no |
+|---|---|---|
+| Are there 2+ structurally different inputs (entity + state, number + body)? | **kv** | go on |
+| Will the natural sender phrasing be one chunk of text (an SMS, a notification body)? | **freeform** | **kv** |
+| Will the value be passed straight through to a downstream API as one string? | **freeform** | **kv** |
+
+Default to **kv** when in doubt. Freeform is friendlier on-air for
+text-y payloads but pushes the splitting + revalidation onto the
+handler script, which the operator must then write correctly.
+
+### 6. Arguments — names, regexes, required?
+
+For **kv** mode, list every argument with:
+
+- `key` — short, lowercased, `[a-z][a-z0-9_]*`
+- `required` — yes/no
+- `regex` — anchor with `^` and `$`. Make it as narrow as the input
+  shape allows. Examples in [`reference-otp-allowlist.md`](reference-otp-allowlist.md).
+
+For **freeform** mode, the schema has a single synthetic row keyed
+`arg`. The script does the splitting in one regex match (see the
+platform-specific reference). The schema's regex still applies as a
+first-pass filter; do not skip it.
+
+### 7. Platform + invocation surface?
+
+- *Linux / macOS* → POSIX shell. Use `reference-posix.md`.
+- *Windows* → PowerShell. Use `reference-powershell.md`. Remember:
+  graywolf calls `CreateProcess` directly, not the Windows shell, so
+  the **Command path** in the UI must point at the `.cmd` launcher,
+  which then calls `powershell.exe -NoProfile -File <name>.ps1`.
+- *Different host or already-running service* → Webhook. Use
+  `reference-webhook.md`.
+
+If the operator's downstream is a SaaS endpoint (HTTP API), prefer a
+**webhook Action** over a shell handler that just invokes `curl`.
+Graywolf's templating + filter syntax (`|json` / `|url` / `|html`) does
+the escaping correctly, removes the script-process round trip, and
+keeps secrets in graywolf's config rather than in a shell environment.
+
+### 8. Secrets, configuration, and credential scope
+
+Enumerate every credential the script will need (API keys, tokens,
+URLs, entity IDs). All of these go in the **graywolf service's
+environment**, never in the script body, never as Action arguments,
+never committed to the example handlers shipped with the project.
+
+- Linux: `Environment=` lines in the systemd unit, or
+  `/etc/default/graywolf`.
+- macOS launchd: `EnvironmentVariables` dict in the plist.
+- Windows: System Environment Variables panel; restart the graywolf
+  service for changes to take effect.
+
+The handler reads them via the language's normal env mechanism
+(`$VAR` / `$env:VAR` / `os.environ[]`).
+
+**For every credential, ask:** *"What can this credential do that
+the Action does not need?"* Walk the operator through the
+[blast-radius table](#blast-radius--what-does-this-handler-actually-let-me-do)
+above. Specifically:
+
+- AWS: confirm there is a dedicated IAM user or role *just for this
+  Action*, with a policy that names the exact API operation
+  (`sns:Publish`, `ses:SendEmail`, etc.) and a `Resource:` ARN that
+  pins it to a single topic / queue / bucket. If the operator is
+  about to use their root account key or an admin user, **stop and
+  fix the IAM scope first** — generate a sample policy snippet for
+  them.
+
+  Example policy for SMS-via-SNS (note that direct phone-number
+  publish requires `Resource: "*"` because there is no per-phone
+  ARN; the `Condition` block is what scopes it):
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": "sns:Publish",
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "sns:PhoneNumber": "+1*"
+        }
+      }
+    }]
+  }
+  ```
+
+  Example policy for SES email send (real ARN, no wildcard):
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": "ses:SendEmail",
+      "Resource": "arn:aws:ses:us-east-1:123456789012:identity/alerts@example.com"
+    }]
+  }
+  ```
+- Twilio / Plivo / Vonage: confirm sub-account credentials, not the
+  master account. Confirm the From number is fixed in env, not
+  drawn from sender input.
+- Home Assistant: confirm the long-lived token belongs to a
+  least-privilege HA user with no admin role. If `entity` is a
+  `GW_ARG_*`, narrow the regex to the specific domain
+  (e.g. `^light\.[a-z0-9_]+$`, never `^.+$`).
+- Anything that gives shell or SQL: this is almost always wrong —
+  push the operator toward a dedicated service account or a webhook
+  that brokers the call instead.
+
+If the operator cannot describe the scope, the generated script
+must carry a top-of-file `# AUDIT THIS:` comment block listing the
+credential and the scoping work that must happen before deployment.
+
+#### Webhook receiver shared secrets — entropy floor
+
+For webhook Actions, the `X-Graywolf-Auth` shared secret (or any
+HMAC key) **must be at least 32 bytes (256 bits) of entropy**.
+Translate operator phrasing immediately:
+
+| Operator says | Bytes of entropy | Verdict |
+|---|---|---|
+| `openssl rand -hex 16` | 16 (128 bits) | **REJECT** — too short, ask for 32 |
+| `openssl rand -hex 32` | 32 (256 bits) | OK |
+| `openssl rand -base64 32` | 32 (256 bits) | OK |
+| "a 32-character hex string" | 16 | **REJECT** (32 hex chars = 16 bytes) |
+| "a 64-character hex string" | 32 | OK |
+| "a memorable passphrase I'll remember" | unknown / low | **REJECT** — generate it |
+
+Hex doubles the character count, so "32 hex characters" is only 16
+bytes. The skill must catch this language during the interview and
+push the operator to `openssl rand -hex 32` (or equivalent) before
+generating any code that depends on it.
+
+## Universal safety invariants
+
+These apply to **every** handler regardless of platform or wire mode.
+They are non-negotiable. The platform reference files restate them in
+the local idiom.
+
+1. **Treat every byte of input as attacker-controlled.** APRS-IS is
+   a public unauthenticated bus; RF callsigns can be forged. OTP and
+   allowlist are real defenses but the script's correctness must not
+   depend on them. The operator's belief that "only friends will use
+   this" is irrelevant — write the script as if every byte came from
+   a hostile stranger on the open Internet.
+2. **Revalidate every argument inside the script.** Graywolf's
+   sanitizer applies the Action's `arg_schema` regex, but the script's
+   safety must not depend on the operator setting that regex strictly.
+3. **Never re-introduce a shell.** The runner exec's your binary
+   directly; do not undo that. This forbids **every** form that hands
+   user data to an interpreter:
+   - `eval`, `source`, `.` with user data
+   - `sh -c`, `bash -c`, `zsh -c`, `dash -c`, `ksh -c`
+   - `cmd /c`, `cmd.exe /c`, `pwsh -c`, `pwsh -Command`,
+     `powershell -Command`, `Invoke-Expression`, `iex`
+   - `Start-Process cmd.exe -ArgumentList @('/c', $userdata)` — the
+     array form does not save you when the *target binary itself
+     parses arguments as a shell* (cmd, sh, bash, sqlcmd, etc.).
+     Call the real target binary directly.
+   - `xargs sh`, `find -exec sh -c '...' {}`, `ssh host "$cmd"`,
+     `Invoke-Command -ScriptBlock { ... $userdata ... }` — same
+     class: nested shell on the far side of an argv-clean call.
+4. **Pass user data as argv, not as a substring of a command line.**
+   Use `--` terminators on commands that accept them. PowerShell:
+   array `-ArgumentList`, never the string form. Python: `subprocess`
+   with a list, `shell=False`.
+
+   **Argv-clean is not the same as input-safe.** A binary can accept
+   its arguments via argv and still interpret them as patterns,
+   globs, paths, or sub-shell instructions:
+
+   | Argv-clean call | Hidden footgun |
+   |---|---|
+   | `journalctl -u "$pattern"` | `-u` accepts globs / instance syntax (`*`, `foo@.service`) — discloses other services' journals. |
+   | `Stop-Process -Name "$name"` | `-Name` accepts `*`, `?`, `[abc]`, `,` — `*` kills every process. |
+   | `Stop-Service -Name "$name"` | Schema regex says shape, not identity — `WinDefend`, `vss`, `EventLog` are valid shapes. |
+   | `& "C:\scripts\$name.ps1"` | Path traversal via `..\..\evil`. |
+   | `cat "/var/log/$file"` | Same — discloses arbitrary files. |
+   | `kubectl logs -l "$selector"` | Selectors and namespaces accept wildcards. |
+   | `find / -name "$pattern" -delete` | Patterns + a destructive verb. |
+
+   For each downstream binary, ask: *what wildcard / pattern / path
+   syntax does this flag accept?* Validate the value to forbid
+   metacharacters the binary would honor, **and** keep an in-script
+   allowlist of the specific identities (services, units, files,
+   selectors) that the Action is allowed to touch. The schema regex
+   constrains *shape*; the in-script allowlist constrains *identity*.
+   Both. Not either.
+5. **Build HTTP request bodies via the library's encoder, not string
+   concatenation.** `curl --data-urlencode`,
+   `Invoke-RestMethod -Body @{...}`, `requests.post(..., data={...})`.
+6. **Parameterized queries on every database write.** Never f-string,
+   never `%`-format, never concatenate.
+7. **Auto-escape on every templated render.** Jinja default,
+   PowerShell's `[System.Web.HttpUtility]::HtmlEncode`, etc. Never
+   `Markup(...)`, never `|safe`, never `{{ ...|safe }}`.
+8. **Reply on the first line of stdout, ≤50 runes** (graywolf snippets
+   it for the on-air `ok: <snippet>` reply). Diagnostics go to stderr.
+9. **Exit non-zero on failure** with a short stderr line. Graywolf
+   echoes the snippet as `error: <detail>` on-air.
+10. **Run the linter for the language.** `shellcheck` for bash,
+    `Invoke-ScriptAnalyzer` for PowerShell, `ruff` for Python. Fix
+    every diagnostic; never disable rules.
+11. **Test through the Test dialog** in `/#/actions` before letting
+    the Action loose on-air. The dialog bypasses OTP + allowlist but
+    exercises the executor and sanitizer.
+12. **Webhooks only**: authenticate (HMAC or shared secret in a
+    custom header), cap body size **before** parsing, terminate TLS
+    in front of the receiver. See [`reference-webhook.md`](reference-webhook.md).
+13. **Cmdlet / flag values are still attacker-controlled.** PowerShell
+    cmdlets do not re-shell, but many accept wildcards (`-Name *`),
+    comma-separated lists (`-Name a,b`), or paths that resolve outside
+    their intended root. The same applies to POSIX flag values
+    (`journalctl -u <pattern>`, `find -name <glob>`, `tar -C
+    <path>`). Validate the *value*, not just the *call shape*.
+14. **No "run-this-by-name" dispatcher Actions.** A handler that
+    accepts a verb / script-name / service-name / file-name and
+    routes to a corresponding command is a remote shell with extra
+    steps. Each verb gets its own Action with its own parameterized
+    handler. If you must dispatch (e.g. a small enum of verbs),
+    use a switch-case on a tightly-anchored regex with **no
+    fallthrough default that runs anything** — the `*)` branch must
+    reject and exit non-zero. Never `eval`, `exec`, or
+    `& "$path/$name"` a value derived from the wire.
+
+## What graywolf passes to the handler
+
+This is the execution contract. Memorize it; the platform references
+restate it in their language.
+
+### Command Actions (shell or PowerShell)
+
+The runner exec's the binary directly — no shell, no `PATH` lookup,
+no `system()`. argv layout:
+
+| Index | `kv` mode | `freeform` mode |
+|---|---|---|
+| `$1` / `$args[0]` | action name | action name |
+| `$2` / `$args[1]` | sender callsign | sender callsign |
+| `$3` / `$args[2]` | `true` / `false` (OTP verified) | same |
+| `$4..$N` / `$args[3..N]` | `k=v` tokens in schema order | the entire raw payload, one token |
+
+Environment variables, set on every invocation:
+
+- Always: `GW_ACTION_NAME`, `GW_SENDER_CALL`, `GW_OTP_VERIFIED`,
+  `GW_OTP_CRED_NAME`, `GW_SOURCE` (`rf` or `is`), `GW_INVOCATION_ID`.
+- kv: one `GW_ARG_<KEY>=<value>` per declared arg. Key is uppercased,
+  non-alphanumeric becomes `_`.
+- freeform: one variable named `GW_ARG=<raw payload>` (no key suffix).
+
+**Prefer the env vars over argv** in scripts. They survive ordering
+changes in the schema and they are easier to read.
+
+### Webhook Actions
+
+Graywolf POSTs `application/x-www-form-urlencoded` by default with
+fields:
+
+- Always: `action`, `sender_callsign`, `otp_verified`, `otp_cred`,
+  `source`.
+- kv: one field per declared arg (key = your schema key).
+- freeform: one field named `arg` with the raw payload.
+
+A custom body template can be configured per-Action with token
+substitution and filters:
+
+- `{{action}}`, `{{sender-callsign}}`, `{{otp-verified}}`,
+  `{{otp-cred}}`, `{{source}}`
+- kv: `{{arg.<key>}}`
+- freeform: `{{arg}}`
+- Filters (mandatory when interpolating into a structured
+  destination): `{{arg|json}}` for JSON string contents,
+  `{{arg|url}}` for URL paths or query strings, `{{arg|html}}` for
+  HTML attribute / text content.
+
+## Generation — how the skill emits the script
+
+After the interview, follow this order. **Do not skip the lint step
+and do not show the script to the operator until lint passes clean.**
+
+1. **Pick the reference file** matching the platform answer.
+2. **Read the template skeleton** in that reference; do not improvise
+   from memory.
+3. **Substitute** the action name, args, regexes, env-var names, and
+   downstream call.
+4. **Self-validate** the generated script against the
+   universal-invariants checklist above. If anything is missing, fix
+   it before the next step.
+5. **Write the script to a file in the working directory** — do not
+   only display it inline. The lint step in step 6 needs a file on
+   disk.
+6. **Lint the file (mandatory).** This is non-negotiable. Run the
+   appropriate command and read its output:
+   - POSIX shell: `shellcheck -s bash -S style <file.sh>`. Diagnostics
+     are bugs. Fix the script — never add `# shellcheck disable`
+     directives. If the operator does not have shellcheck installed,
+     suggest `brew install shellcheck` / `apt install shellcheck` /
+     `pacman -S shellcheck` and refuse to declare the script ready
+     until it has been linted on their machine.
+   - PowerShell: `Invoke-ScriptAnalyzer -Path <file.ps1> -Severity
+     Information,Warning,Error`. Same rule — fix the script, do not
+     suppress rules. If the operator does not have PSScriptAnalyzer,
+     `Install-Module PSScriptAnalyzer -Scope CurrentUser`.
+   - Webhook (Python): `ruff check <file.py>` and `ruff format
+     --check <file.py>`. For Bandit users (recommended for webhook
+     receivers), also run `bandit <file.py>` and triage every
+     finding.
+7. **Run a sanity test pass** for the safety invariants the linter
+   does not catch:
+   - `grep -nE '\beval\b|\b(sh|bash|zsh|dash|ksh)[[:space:]]+-c\b|Invoke-Expression|\biex\b|cmd(\.exe)?[[:space:]]+/c|pwsh[[:space:]]+(-c|-Command)|powershell[[:space:]]+-Command' <file>`
+     must return no hits. This catches every shell-with-`-c` form,
+     not just `sh -c`.
+   - `grep -nE '\bxargs[[:space:]]+sh\b|find[[:space:]].*-exec[[:space:]]+sh' <file>` — nested-shell
+     escalations of an argv-clean call.
+   - `grep -n 'GW_ARG' <file>` — every reference must be quoted
+     (POSIX) or pass through `Set-StrictMode` (PS).
+   - PowerShell only: `grep -nE 'Stop-Process[[:space:]]+-Name|Stop-Service[[:space:]]+-Name|& *"[^"]*\$' <file>` —
+     surface cmdlet-wildcard and `& "$path/$name"` patterns for
+     manual review of the in-script allowlist.
+   - For webhooks: confirm the receiver verifies a shared secret /
+     HMAC and caps body size before parsing.
+   - For any handler that builds a path from user input: confirm
+     `realpath` / `[IO.Path]::GetFullPath` containment check is
+     present.
+   If any check fails, fix the script and re-run the linter.
+8. **Emit the postamble in the chat reply, not as a file.** The
+   script goes to disk; the postamble is operator-facing instructions
+   that follow the script in the chat thread. It must include:
+   - Suggested install path (`/usr/local/lib/graywolf/actions/<name>.sh`
+     or equivalent).
+   - The `chmod +x` (POSIX) or `.cmd` launcher (Windows) command.
+   - The exact lint command that just passed (so the operator can
+     re-run it on their host) **and** the install command if the
+     linter is missing on the host.
+   - The env-var wiring snippet for systemd / launchd / Windows
+     services, with the credential names from the interview.
+   - For webhook handlers: the systemd unit's `User=`,
+     `ProtectSystem=strict`, `PrivateTmp=yes`, and
+     `ReadWritePaths=` lines, plus a sample Caddy / nginx vhost
+     terminating TLS in front of `127.0.0.1:5000`.
+   - Action-editor field values from the interview (Name, Type,
+     Command path / URL, Arg schema rows, OTP credential, Sender
+     allowlist, Timeout, RateLimitSec, QueueDepth).
+   - A reminder to use the per-row **Test** dialog in `/#/actions`
+     before letting the Action loose on-air, and to recheck linting
+     on any future edit.
+
+**Linter unavailable on the host?** If the operator's machine does
+not have shellcheck / PSScriptAnalyzer / ruff / bandit installed,
+the skill **does not declare the script ready**. Instead, emit the
+install command for their platform (`brew install shellcheck`,
+`Install-Module PSScriptAnalyzer -Scope CurrentUser`,
+`pip install ruff bandit`) and tell the operator: "*Install the
+linter, run it on the file, fix any findings, and only then deploy.
+The skill cannot certify a handler that has not been linted on the
+target host.*" Visual review by the model is not a substitute.
+
+Keep the generated script's comment density **high**. Operators are
+not always strong scripters; the comments are the operator-facing
+documentation for what each line is doing and why. Mirror the comment
+style of `examples/actions/posix/sms-freeform.sh` and
+`examples/actions/windows/sms-freeform.ps1`.
+
+## Anti-patterns the skill must reject
+
+If the operator asks for any of these, **push back** with the safer
+alternative. Do not generate the unsafe form.
+
+| Operator request | Counter |
+|---|---|
+| "Just `eval` the args, it's easier." | Re-parses payload as shell — full RCE. Use named args + regex. |
+| "Build the URL with `+ $GW_ARG_FOO` so I can use it as a query string." | Use `--data-urlencode` (curl) / hashtable `-Body` (PS) / `params={}` (requests). String-concat smuggles `&` and `=`. |
+| "Skip OTP, the allowlist is enough." | Allowlist proves the *callsign*, not the operator pressing the key. OTP proves possession of the credential. Use both for irreversible actions. |
+| "Inline the API key in the script." | The script lands in git eventually. Use the graywolf service env. |
+| "Skip the auth header on the webhook, the URL is unguessable." | URL leaks via TLS SNI, DNS, server logs, and shoulder surfing. Add HMAC or shared secret. |
+| "Disable shellcheck SC2086." | The diagnostic is the bug. Quote the variable. |
+| "Use `{{arg.msg}}` directly in the JSON body template." | A `"` in `msg` breaks the JSON. Use `{{arg.msg|json}}`. |
+| "Use my AWS root key / admin user — IAM is a hassle." | One regex gap = full account takeover. Mint a dedicated IAM user with a single-statement policy scoped to one ARN. |
+| "Use my Home Assistant admin token, it already works." | One bad regex unlocks every entity HA can reach. Mint a least-privilege HA user and a token bound to it. |
+| "I'll skip linting just this once, the script is short." | Short scripts have the same footguns as long ones — quoting, control chars, missing `--`. Lint always; never declare done before lint passes. |
+| "Just `bash -c "$GW_ARG"` then." / "Just `pwsh -Command $payload`." | Same as `eval` / `Invoke-Expression`. The runner exec's your binary directly so the shell is not in the loop; piping the payload back through *any* shell-with-`-c` undoes that. Refuse all forms: `sh -c`, `bash -c`, `zsh -c`, `dash -c`, `cmd /c`, `pwsh -c`, `powershell -Command`. |
+| "Make me a `@@<otp>#run <command>` Action so I can run any command." | This is a remote shell on a public bus. **Refuse the design.** Each verb gets its own Action: `@@<otp>#restart-nginx`, `@@<otp>#rotate-logs`. If you need flexibility, use Tailscale + SSH, not a graywolf Action. |
+| "Let me dispatch by name with a switch-case." | Acceptable shape *only* with: anchored verb regex `^(verb1\|verb2)$`; each branch calls a fixed argv (no variable-as-command); the default `*)` branch rejects with `exit 65` and a stderr line; no `eval` / `& $name` / `journalctl -u $name` in any branch. |
+| "Pass the user's input to `journalctl -u`/`systemctl`/`ssh`/`find -exec`/`xargs sh`/`Stop-Process -Name`/`kubectl logs -l`." | Argv-safe binaries are not all input-safe. These accept patterns, glob expansions, or pass user data to nested shells. Validate the value to forbid metacharacters the binary honors *and* keep an in-script allowlist of identities the Action may touch. |
+| "`Stop-Process -Name $name` — cmdlets are safe from injection." | Cmdlets accept wildcards (`*`, `?`, `[abc]`) and comma-separated lists. `-Name *` kills every process the service can signal. Resolve to a PID first (`(Get-Process -Name $name).Id`, confirm exactly one match) or forbid `*?[],` in the regex *and* keep an in-script allowlist. |
+| "`& "C:\scripts\$name.ps1"` — let me run any of my scripts by name." | Path traversal (`..\..\evil`) plus arbitrary-script-execution by design. Refuse the dispatcher; convert each script to its own Action. If a dispatcher is unavoidable, canonicalize with `[IO.Path]::GetFullPath`, confirm the result `StartsWith` the base directory, and keep an explicit allowlist of script names. |
+| "The schema regex on `name` is enough — I don't need an in-script allowlist." | Schema regex is *shape*; it does not constrain *identity*. A regex that accepts `[a-z]+` does not say which `[a-z]+` the Action may target. Keep both: anchored regex on the wire, exact-match allowlist inside the script. |
+| "`{{arg.msg}}` is fine in my JSON template — the regex never lets quotes through." | Body templates and arg-schema regexes live on different lifecycles. The regex protects today's shape; the template will outlive it. A future regex-widening to allow apostrophes silently breaks the template's safety. **The filter is the load-bearing defense; the regex is a friendliness check.** Always use `\|json` / `\|url` / `\|html`. |
+| "I trust my hams / it's just my friends / only I have OTP." | Identity is not authentication. Refuse the relaxation and re-explain the threat model. See "Trust arguments are out of scope" above. |
+
+## Final checklist (run before showing the script)
+
+- [ ] First line of stdout is the on-air reply, ≤50 runes.
+- [ ] Every error path writes a short stderr line and exits non-zero.
+- [ ] Every external command receives user data via argv, not concatenation.
+- [ ] Every regex is anchored with `^` and `$`.
+- [ ] Every env-var reference is quoted (shell) or strict-mode-checked (PS).
+- [ ] No `eval`, `Invoke-Expression`, `iex`, `sh -c`, `bash -c`, `zsh -c`, `dash -c`, `cmd /c`, `pwsh -c`, `pwsh -Command`, `powershell -Command`. (Run the extended pre-emit grep from step 7.)
+- [ ] No nested-shell escalations: `xargs sh`, `find -exec sh -c`, `ssh host "$cmd"`.
+- [ ] No `Start-Process` / `subprocess` whose target binary is itself a shell (`cmd.exe`, `bash`, `sqlcmd`).
+- [ ] Every downstream binary's flag values reviewed for wildcard / pattern / glob acceptance (cmdlet `-Name *`, `journalctl -u <pat>`, `find -name <glob>`).
+- [ ] In-script identity allowlist present for any verb-style Action (services, processes, files, hosts).
+- [ ] Path-from-input handlers canonicalize and verify containment (`realpath` / `[IO.Path]::GetFullPath` + `StartsWith` check).
+- [ ] **Linter actually run on the file and clean.** Not "linter command included" — linter *executed* and the output was empty / clean.
+- [ ] Webhook only: HMAC/secret check + body-size cap before parse + OTP-verified recheck + `|json`/`|url`/`|html` filter on every templated user value.
+- [ ] OTP credential, allowlist, and arg schema match the interview answers.
+- [ ] Credential scope walked through with the operator; if scoping is incomplete, an `# AUDIT THIS:` block names what to do before deployment.
+- [ ] If the operator argued for a relaxation based on *who* the senders are (rather than *cost*), the relaxation was refused.
+- [ ] Comments explain *why* for every non-obvious line.
+
+## Cross-references
+
+- Wiki page (architecture, hot path, failure modes):
+  [`docs/wiki/actions.md`](../../docs/wiki/actions.md)
+- Operator handbook (long-form prose, anti-pattern tables):
+  [`docs/handbook/actions-handler-safety.html`](../../docs/handbook/actions-handler-safety.html),
+  with sub-pages for shell, PowerShell, and webhooks.
+- Shipped example handlers (every one of these is shellcheck /
+  PSScriptAnalyzer / ruff clean and exercised by CI):
+  [`examples/actions/`](../../examples/actions/).

--- a/examples/skills/writing-graywolf-action-handlers/reference-otp-allowlist.md
+++ b/examples/skills/writing-graywolf-action-handlers/reference-otp-allowlist.md
@@ -1,0 +1,179 @@
+# Reference: OTP credentials, sender allowlist, arg schemas
+
+How to size the three Action-level controls that gate a handler
+*before* its code runs. Read [`SKILL.md`](SKILL.md) first for the
+threat model.
+
+## OTP credential
+
+The OTP credential is a TOTP secret (RFC 6238) shared between the
+operator and the trusted senders. The sender bakes it into their
+APRS client; graywolf verifies the six-digit code on every fire.
+
+### When OTP is mandatory
+
+- **Any irreversible action** (open a garage, unlock a door, send
+  money, send SMS, send email).
+- **Any action that consumes a paid credential** (Twilio, AWS, any
+  metered API).
+- **Any action that talks to an actuator on the physical world.**
+
+### When OTP is optional
+
+- Pure read-only lookups (weather, ISS pass, uptime, solar weather).
+  These are fine to leave unauthenticated; the worst-case abuse is
+  small RF chatter and graywolf's per-Action rate limit caps it.
+
+### Single-user station — what the UI does *not* show
+
+Graywolf is a single-user station (see
+`feedback_single_user_station`). The credentials editor deliberately
+hides issuer / account fields:
+
+- **Issuer** is always `Graywolf`.
+- **Account** is always the station callsign.
+
+Do not fabricate UI fields that the operator must populate. The skill
+must not generate documentation that says "set issuer to ...".
+
+### TOTP digit handling
+
+The `@@`-prefix grammar treats the digits as **optional**; the
+per-Action `OTPRequired` toggle gates enforcement (see
+`project_actions_grammar`). Concretely:
+
+| `OTPRequired` | Wire format accepted | Wire format rejected |
+|---|---|---|
+| `false` | `@@#name args` (no digits) and `@@123456#name args` | nothing |
+| `true` | `@@123456#name args` | `@@#name args` (returns `bad_otp: missing`) |
+
+When `OTPRequired = true`, the runner accepts a one-step skew on
+either side (±30 s by default) and refuses replays of the same code
+within a 3-step + 30 s ring.
+
+### Minting a credential
+
+- `/#/actions` → **Credentials** → **New**.
+- The secret is shown **once**. The operator must capture it now —
+  graywolf will never display it again.
+- The secret is `secret_b32` (Base32, RFC 4648). Most TOTP apps
+  (1Password, Bitwarden, Aegis, Google Authenticator) accept either
+  the QR code or the Base32 secret directly.
+
+### Pointing an Action at the credential
+
+- In the Action editor, select the credential from the dropdown.
+- Toggle `OTPRequired = true`.
+- Save.
+
+Reminder for the skill: the Action's OTP credential dropdown is
+empty until at least one credential exists. If the operator wants
+OTP and has no credential, **mint the credential first**.
+
+## Sender allowlist
+
+A comma-separated list of callsigns that are permitted to fire this
+Action. Empty = anyone may fire. Non-empty = only listed senders
+pass; everyone else gets `denied`.
+
+### Matching rules
+
+- **Base-call match.** SSID is stripped before comparison. `KE0XYZ-9`
+  and `KE0XYZ` both match an allowlist entry of `KE0XYZ`.
+- **Case-insensitive.** APRS callsigns are conventionally upper-case
+  but the matcher does not enforce it.
+- **Wildcards are not supported.** Each callsign is exact (post-SSID).
+
+### When an allowlist is mandatory
+
+- Anything with a paid credential downstream (Twilio, AWS, etc.) —
+  even with OTP, an allowlist limits the blast radius if the OTP
+  secret leaks.
+- Anything physical / irreversible.
+- Anything where the operator can enumerate the trusted senders
+  (themselves, their spouse, their club's officers).
+
+### When an allowlist is optional
+
+- Read-only public-good Actions (weather lookup, ISS pass) — leave
+  empty so anyone in the field can use the service.
+- Demo / test Actions on a closed band.
+
+### Ordering — why this matters
+
+The classifier checks the allowlist **before** the OTP probe (see
+`pkg/actions/classifier.go`). A denied sender cannot enumerate which
+OTP digits validate by trial-and-error — they get `denied` and the
+classifier short-circuits before touching the OTP ring.
+
+The operator does not need to design around this; it is just the
+property the skill should mention if asked.
+
+## Argument schemas
+
+Each `kv` argument has a row in the Action editor with three columns:
+
+| Column | Meaning | Default |
+|---|---|---|
+| `key` | argument name on the wire | required, `[a-z][a-z0-9_]*` |
+| `required` | reject if missing | `false` |
+| `regex` | sanitizer-side validation | empty (anything passes) |
+
+For `freeform` Actions, the schema has a single synthetic row keyed
+`arg` and the same regex column applies as a first-pass filter.
+
+### Anchoring
+
+**Always anchor with `^` and `$`.** A regex like `\+[1-9][0-9]+`
+matches *anywhere* in the string, so `garbage+15551234567` would
+slip through. Use `^\+[1-9][0-9]{6,14}$`.
+
+The Action editor's regex validator runs `new RegExp(...)` on blur;
+it does not enforce anchoring. The skill must.
+
+### Common shapes
+
+| Field | Recommended regex |
+|---|---|
+| E.164 phone | `^\+[1-9][0-9]{6,14}$` |
+| ICAO airport | `^[A-Z0-9]{4}$` |
+| Boolean state | `^(on\|off)$` |
+| Garage state | `^(open\|close\|toggle)$` |
+| HA light entity | `^light\.[a-z0-9_]+$` |
+| HA switch entity | `^switch\.[a-z0-9_]+$` |
+| Brightness 0-255 | `^([0-9]\|[1-9][0-9]\|1[0-9]{2}\|2[0-4][0-9]\|25[0-5])$` |
+| Slug | `^[a-z0-9-]{1,32}$` |
+| Hex digest 64 | `^[a-f0-9]{64}$` |
+| Tactical alias | `^[A-Z0-9]{1,9}$` |
+
+### What the regex *cannot* protect against
+
+The schema regex runs in graywolf's process and is the *first* line
+of defense. The handler script must still revalidate (see the
+platform reference files). Reasons:
+
+- The operator might widen the regex later for a different reason
+  and the script keeps running.
+- The schema does not protect against semantic abuse (a numeric arg
+  in range but addressing the wrong entity).
+- For freeform Actions, graywolf strips control characters
+  unconditionally but does not enforce the regex by default — the
+  script still revalidates.
+
+## Rate limiting + queue depth
+
+Two more knobs in the Action editor:
+
+- **`RateLimitSec`** — minimum seconds between fires of the same
+  Action. Honest: `lastFire` rolls back on `busy` rejects so the
+  window is not poisoned by queued requests.
+- **`QueueDepth`** — per-Action worker queue. Once full, further
+  fires return `busy` immediately rather than piling up.
+- **`TimeoutSec`** — executor enforces this; the script's network
+  timeouts should be lower so the executor's timeout is the *outer*
+  bound.
+
+Set conservative values for any Action that consumes a paid
+credential. A `RateLimitSec` of 30 + `QueueDepth` of 1 caps a runaway
+sender to two fires per minute — usually plenty for an SMS or HA
+toggle, and a hard ceiling on credential abuse.

--- a/examples/skills/writing-graywolf-action-handlers/reference-posix.md
+++ b/examples/skills/writing-graywolf-action-handlers/reference-posix.md
@@ -1,0 +1,477 @@
+# Reference: POSIX shell (bash) handlers
+
+Authoring guide for `bash` handlers that run on Linux + macOS. Every
+shipped handler in `examples/actions/posix/` is shellcheck-clean and
+exercised by CI; mirror their style.
+
+> **Read [`SKILL.md`](SKILL.md) first.** This file assumes the
+> interview is already complete. The threat model, the credential
+> blast-radius discussion, and the universal invariants are stated
+> there and are not repeated here.
+
+## What graywolf invokes
+
+The runner exec's the binary directly via `execve(2)` — no shell, no
+`PATH` re-search, no `system()`. argv is exactly:
+
+```
+/abs/path/to/handler.sh <action> <sender> <true|false> [<arg> ...]
+```
+
+Environment carries:
+
+- Always: `GW_ACTION_NAME`, `GW_SENDER_CALL`, `GW_OTP_VERIFIED`,
+  `GW_OTP_CRED_NAME`, `GW_SOURCE` (`rf` or `is`), `GW_INVOCATION_ID`.
+- kv: `GW_ARG_<KEY>=<value>` per declared arg, key uppercased,
+  non-alphanumeric `→` `_`.
+- freeform: `GW_ARG=<raw payload>`, single variable, no key suffix.
+
+**Use the env vars, not argv.** They survive arg-schema reordering
+and are easier to audit.
+
+## Mandatory prelude
+
+Every handler starts with these lines, in this order:
+
+```bash
+#!/usr/bin/env bash
+# <Action name> -- <one-sentence purpose>
+# Wire format: @@<otp>#<name> <kv|freeform shape>
+# Args: <list>
+# Reply: <first-line success snippet>
+# Config: <env vars and required scope>
+# Deps: <external commands invoked>
+set -euo pipefail
+```
+
+- `#!/usr/bin/env bash` not `#!/bin/sh` — these patterns rely on
+  bash's `[[ =~ ]]` and `BASH_REMATCH`.
+- The header comment is operator-facing documentation. Include the
+  credential scope (e.g. `IAM: dedicated user, single sns:Publish
+  statement on arn:aws:sns:us-east-1:123456789012:graywolf-alerts`).
+- `set -euo pipefail`:
+  - `-e` aborts on any non-zero exit.
+  - `-u` treats unset variables as errors — typos in `$GW_ARG_*` fail
+    loudly instead of silently expanding to empty.
+  - `-o pipefail` makes a pipeline fail if any stage fails, not just
+    the last.
+
+## Reading inputs
+
+### kv mode
+
+```bash
+to="${GW_ARG_TO:?missing to=}"
+msg="${GW_ARG_MSG:?missing msg=}"
+sender="${GW_SENDER_CALL:-?}"
+```
+
+`${VAR:?msg}` aborts with a clear stderr line if `VAR` is unset or
+empty. Use it on every required arg. `${VAR:-default}` is the
+fallback for optional args.
+
+Quote every reference. Always. `"$to"` not `$to`. shellcheck flags
+this; do not disable.
+
+### freeform mode
+
+```bash
+ACTION="$1"
+SENDER="$2"
+OTP_VERIFIED="$3"
+PAYLOAD="${GW_ARG:-${4:-}}"
+
+if [[ -z "$PAYLOAD" ]]; then
+    echo "payload missing" >&2
+    exit 64
+fi
+
+# One regex match validates AND splits in one step.
+# BASH_REMATCH[1..N] hold the capture groups on success.
+if [[ ! "$PAYLOAD" =~ ^(\+[1-9][0-9]{6,14})[[:space:]]+(.+)$ ]]; then
+    echo "expected '+<E164> <message>'" >&2
+    exit 64
+fi
+NUMBER="${BASH_REMATCH[1]}"
+MESSAGE="${BASH_REMATCH[2]}"
+```
+
+Why `[[ =~ ]]`:
+
+- It is a pure in-process operation. No fork, no exec, no command
+  substitution. Bytes in `$PAYLOAD` cannot become shell.
+- It validates *and* splits in a single step. There is no partial
+  state between "did the format check pass" and "did we extract the
+  fields".
+- `BASH_REMATCH` indices follow the parenthesis order in the regex,
+  exactly like other regex engines.
+
+## Revalidate inside the handler
+
+Graywolf's sanitizer applies the Action's `arg_schema` regex and
+strips control characters in freeform mode, but the handler's safety
+must not depend on that. Re-check:
+
+```bash
+# Reject control characters (POSIX [:cntrl:] is 0x00-0x1F + 0x7F).
+if [[ "$MESSAGE" =~ [[:cntrl:]] ]]; then
+    echo "message contains control characters" >&2
+    exit 65
+fi
+
+# Length range. Tighten to the downstream API's actual limit.
+if (( ${#MESSAGE} < 1 || ${#MESSAGE} > 160 )); then
+    echo "message length out of range (1..160)" >&2
+    exit 65
+fi
+```
+
+For numeric args, validate range with `[[ =~ ^[0-9]+$ ]]` *and* a
+numeric comparison — the regex prevents word-splitting attacks, the
+range check prevents semantic abuse.
+
+## Verifying required env
+
+```bash
+: "${TWILIO_ACCOUNT_SID:?TWILIO_ACCOUNT_SID not set}"
+: "${TWILIO_AUTH_TOKEN:?TWILIO_AUTH_TOKEN not set}"
+: "${TWILIO_FROM:?TWILIO_FROM not set}"
+```
+
+`:` is the no-op builtin. Combined with `${VAR:?msg}` this is a
+one-line "abort with clear error if the operator forgot to set this".
+Run these checks immediately after argument parsing — fail fast
+before the script touches the network.
+
+## Calling external commands
+
+### Always argv, never strings
+
+`curl` (or any binary) accepts user data via flag-pinned arguments,
+not as part of a command string:
+
+```bash
+# GOOD — each value is its own argv entry, curl URL-encodes for us.
+curl -fsS --max-time 8 -X POST \
+    --data-urlencode "From=${TWILIO_FROM}" \
+    --data-urlencode "To=${NUMBER}" \
+    --data-urlencode "Body=${MESSAGE}" \
+    -u "${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}" \
+    -- "https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json"
+
+# BAD — string concatenation. '&' in $MESSAGE smuggles extra fields.
+curl ... -d "Body=${MESSAGE}&Hidden=evil"   # never do this
+
+# BAD — eval. Full RCE.
+eval "twilio send $NUMBER \"$MESSAGE\""     # never do this
+```
+
+`--data-urlencode` makes curl encode each value into the
+`application/x-www-form-urlencoded` body. The `--` before the URL is
+habit: it terminates option parsing so a value that starts with `-`
+cannot be misinterpreted.
+
+### `--` on every command that accepts it
+
+Always pass `--` before any positional argument that could start with
+a `-`. This is one character of typing that prevents an entire class
+of attack.
+
+```bash
+# Without -- a payload starting with '-' becomes a flag.
+do-thing -- "$NUMBER" "$MESSAGE"
+```
+
+### `jq` for JSON, not regex
+
+When parsing API responses, prefer `jq` over `grep`/`sed`. `jq`
+handles escapes correctly and never executes anything:
+
+```bash
+sid=$(printf '%s' "$response" | jq -r '.sid // empty')
+```
+
+If `jq` is not available, the very narrow `grep -o` pattern is
+acceptable but should be a last resort.
+
+## Reply contract
+
+Graywolf snippets the **first line of stdout** for the on-air reply
+(50-rune cap). Diagnostics go to stderr. Exit non-zero on failure
+with a short stderr line (also snippeted).
+
+```bash
+echo "sent ${sid}"          # success: first line of stdout
+exit 0
+# ----
+echo "twilio rejected: ..." >&2   # failure: stderr
+exit 1
+```
+
+Standard exit codes (loosely follow `sysexits.h`):
+
+| Exit | Meaning |
+|---|---|
+| 0 | success |
+| 1 | generic failure |
+| 64 | usage / payload format error |
+| 65 | data error (revalidation rejected) |
+| 69 | service unavailable |
+| 75 | temporary failure (retry hint) |
+| 77 | permission denied (OTP-verified defense-in-depth check failed) |
+
+## Anti-pattern table
+
+| Anti-pattern | Fix |
+|---|---|
+| `eval "$cmd"` | Validate args, then call the binary directly. |
+| `sh -c "$cmd"` / `bash -c "$cmd"` / `zsh -c "$cmd"` / `dash -c "$cmd"` | Same as eval. The shell binary doesn't matter — *any* `-c` form re-parses the payload as shell. |
+| `xargs sh -c '...' _ "$arg"` / `find ... -exec sh -c '...' _ "$arg" \;` | Nested shell on the far side of an argv-clean call. Refactor to call the target binary directly: `find ... -exec target -- {} +`. |
+| `ssh host "do-thing $arg"` | The remote shell parses the string. Use `ssh host -- do-thing -- "$arg"` only if the remote `do-thing` is itself argv-safe; otherwise restructure. |
+| `journalctl -u "$service"` with passthrough `$service` | `-u` accepts globs and unit-instance syntax. Allowlist exact unit names: `case "$service" in nginx\|postgresql) ;; *) exit 65 ;; esac`. |
+| `cat "/var/log/$file"` | Path traversal + arbitrary file read. Allowlist filenames; canonicalize with `realpath` and confirm prefix. |
+| Unquoted `$GW_ARG_FOO` | Quote always. shellcheck SC2086 catches this. |
+| `curl ... -d "Body=${MESSAGE}&extra=evil"` | `--data-urlencode "Body=${MESSAGE}"`. |
+| `cmd $NUMBER $MESSAGE` (no `--`) | `cmd -- "$NUMBER" "$MESSAGE"`. |
+| Inline API key | Read from env (`${API_KEY:?...}`). |
+| `# shellcheck disable=...` | Fix the underlying issue. The diagnostic is the bug. |
+| Reading from stdin | The runner does not pipe stdin. Read env / argv only. |
+| `do-thing "$@"` passthrough | Argv passthrough still re-routes attacker control to the target. Validate every value first. |
+
+## Patterns the skill explicitly blesses
+
+### Switch-case verb dispatcher (when one Action covers multiple verbs)
+
+When the operator wants `@@<otp>#run <verb>` to map to a small,
+fixed set of commands, a switch-case is the safe shape — but only
+with these guardrails. Skip any one and the dispatcher becomes a
+remote shell:
+
+```bash
+verb="${GW_ARG_VERB:?missing verb=}"
+
+# 1. Anchor the regex on the wire AND inside the script.
+if [[ ! "$verb" =~ ^(restart-nginx|rotate-logs|backup)$ ]]; then
+    echo "unknown verb: $verb" >&2
+    exit 65
+fi
+
+# 2. Each branch calls a fixed argv. No variable holds a command.
+# 3. The default branch (*) MUST reject -- never fall through to a
+#    generic exec.
+case "$verb" in
+    restart-nginx)
+        systemctl restart -- nginx
+        ;;
+    rotate-logs)
+        /usr/local/bin/rotate-logs.sh -- "$(date +%F)"
+        ;;
+    backup)
+        /usr/local/bin/backup.sh
+        ;;
+    *)
+        # Defense in depth. If the regex above ever widens, this still rejects.
+        echo "unknown verb (defense in depth): $verb" >&2
+        exit 65
+        ;;
+esac
+```
+
+**Hard rules:**
+
+- The wire regex is anchored AND duplicated in-script.
+- No branch contains `eval`, `sh -c`, `bash -c`, `& $name`, or any
+  variable that holds a command string.
+- The `*)` default rejects with non-zero exit and a stderr line.
+  Never fall through to a generic `exec "$@"` or
+  `systemctl restart "$verb"`.
+
+### Path-containment helper
+
+When the script must build a filesystem path from user input, use
+`realpath` to canonicalize and verify containment:
+
+```bash
+base=/usr/local/lib/graywolf/files
+name="${GW_ARG_NAME:?missing name=}"
+
+# Reject path metacharacters early.
+if [[ ! "$name" =~ ^[a-z0-9_.-]+$ ]]; then
+    echo "invalid name" >&2
+    exit 65
+fi
+
+# Canonicalize and confirm the result stays under $base.
+candidate=$(realpath -m -- "$base/$name")
+case "$candidate" in
+    "$base"/*) ;;
+    *) echo "path escape" >&2; exit 65 ;;
+esac
+
+cat -- "$candidate"
+```
+
+The leading `^[a-z0-9_.-]+$` blocks `..`-style paths even before the
+canonicalization runs; the `realpath` + `case` check is the
+load-bearing defense — file names like `foo..bar` pass the regex but
+correctly resolve under `$base`.
+
+## Linter — mandatory
+
+```bash
+shellcheck -s bash -S style /path/to/handler.sh
+```
+
+Diagnostics are bugs. Fix them. Never disable. The skill must run
+this command on the generated file and confirm clean output before
+declaring the script ready.
+
+Common diagnostics worth knowing:
+
+- **SC2086** Double quote to prevent globbing and word splitting.
+- **SC2046** Quote this to prevent word splitting.
+- **SC2155** Declare and assign separately to avoid masking return values.
+- **SC2059** Don't use variables in the printf format string.
+- **SC1090** Source includes a variable; consider quoting.
+
+## Skeleton — copy and adapt
+
+### kv-mode skeleton
+
+```bash
+#!/usr/bin/env bash
+# <NAME> -- <one-sentence purpose>
+# Wire: @@<otp>#<name> key1=<shape> key2=<shape>
+# Args: key1 (required, ^...$), key2 (optional, ^...$)
+# Reply: success: "ok <result-id> for <sender>"; failure: "<error snippet>"
+# Config:
+#   MY_API_KEY      required. Scope: <e.g. "tied to a single project, no admin role">
+# Deps:   curl, jq
+set -euo pipefail
+
+# 0. OTP defense in depth. The Action editor's OTPRequired toggle is
+#    the first defense; this check is the second. Skip ONLY for
+#    genuinely read-only Actions.
+[[ "${GW_OTP_VERIFIED:-false}" == "true" ]] || { echo "otp not verified" >&2; exit 77; }
+
+SENDER="${GW_SENDER_CALL:-?}"
+
+# 1. Read args via env (preferred over $4..).
+key1="${GW_ARG_KEY1:?missing key1=}"
+key2="${GW_ARG_KEY2:-default}"
+
+# 2. Revalidate (defense in depth).
+if [[ ! "$key1" =~ ^...$ ]]; then
+    echo "invalid key1: $key1" >&2
+    exit 65
+fi
+
+# 3. Verify env.
+: "${MY_API_KEY:?MY_API_KEY not set}"
+
+# 4. Call downstream with argv-style args.
+response=$(curl -fsS --max-time 8 -X POST \
+    --data-urlencode "field1=${key1}" \
+    --data-urlencode "field2=${key2}" \
+    -H "Authorization: Bearer ${MY_API_KEY}" \
+    -- "https://api.example.com/v1/do-thing")
+
+# 5. Parse response, emit first-line reply (≤50 runes).
+result=$(printf '%s' "$response" | jq -r '.id // empty')
+if [[ -n "$result" ]]; then
+    echo "ok ${result:0:8} for ${SENDER}"
+    exit 0
+fi
+
+echo "downstream rejected: $(printf '%s' "$response" | head -c 80)" >&2
+exit 1
+```
+
+### freeform-mode skeleton
+
+```bash
+#!/usr/bin/env bash
+# <NAME> -- <one-sentence purpose>
+# Wire: @@<otp>#<name> <freeform shape, e.g. "+<E164> <message>">
+# Reply: success: "sent <id> to <sender>"; failure: "<error snippet>"
+# Config:
+#   SECRET          required. Scope: <e.g. "single sns:Publish statement, ARN-pinned">
+# Deps:   curl
+set -euo pipefail
+
+# OTP defense in depth.
+[[ "${GW_OTP_VERIFIED:-false}" == "true" ]] || { echo "otp not verified" >&2; exit 77; }
+
+ACTION="$1"
+SENDER="$2"
+OTP_VERIFIED="$3"
+PAYLOAD="${GW_ARG:-${4:-}}"
+
+if [[ -z "$PAYLOAD" ]]; then
+    echo "payload missing" >&2
+    exit 64
+fi
+
+# Single regex match validates AND splits.
+if [[ ! "$PAYLOAD" =~ ^(<group1>)[[:space:]]+(<group2>)$ ]]; then
+    echo "expected '<format>'" >&2
+    exit 64
+fi
+field1="${BASH_REMATCH[1]}"
+field2="${BASH_REMATCH[2]}"
+
+# Revalidate (control chars, length).
+if [[ "$field2" =~ [[:cntrl:]] ]]; then
+    echo "field2 contains control characters" >&2
+    exit 65
+fi
+if (( ${#field2} < 1 || ${#field2} > <max> )); then
+    echo "field2 length out of range" >&2
+    exit 65
+fi
+
+# Verify env.
+: "${SECRET:?SECRET not set}"
+
+# Call downstream argv-style.
+response=$(curl -fsS --max-time 8 -X POST \
+    --data-urlencode "f1=${field1}" \
+    --data-urlencode "f2=${field2}" \
+    -H "Authorization: Bearer ${SECRET}" \
+    -- "https://api.example.com/v1/do") || {
+    echo "downstream rejected" >&2
+    exit 69
+}
+
+# First line of stdout is the on-air reply (≤50 runes).
+id=$(printf '%s' "$response" | jq -r '.id // empty')
+echo "sent ${id:-ok} to ${SENDER}"
+```
+
+## Operator postamble template
+
+Always print this after the script:
+
+```
+Install path:    /usr/local/lib/graywolf/actions/<name>.sh
+Make executable: chmod +x /usr/local/lib/graywolf/actions/<name>.sh
+
+Lint (mandatory): shellcheck -s bash -S style /usr/local/lib/graywolf/actions/<name>.sh
+
+Env vars (add to /etc/systemd/system/graywolf.service.d/override.conf
+or /etc/default/graywolf):
+  Environment=MY_API_KEY=...
+  Environment=...
+Then: systemctl daemon-reload && systemctl restart graywolf
+
+Wire it up: /#/actions → New
+  Name: <name>
+  Type: command
+  Command path: /usr/local/lib/graywolf/actions/<name>.sh
+  Arg schema: <one row per declared arg>
+  OTP credential: <chosen credential | none>
+  Sender allowlist: <callsigns | empty>
+  Timeout: <seconds>
+
+Test: per-row Test dialog before letting it loose on-air.
+```

--- a/examples/skills/writing-graywolf-action-handlers/reference-powershell.md
+++ b/examples/skills/writing-graywolf-action-handlers/reference-powershell.md
@@ -1,0 +1,433 @@
+# Reference: PowerShell handlers (Windows)
+
+Authoring guide for PowerShell `.ps1` handlers on Windows 10 / 11.
+PS 5.1 (built-in) is sufficient; PS 7 (`pwsh`) is preferred for
+better TLS and JSON. Every shipped Windows handler in
+`examples/actions/windows/` is PSScriptAnalyzer-clean.
+
+> **Read [`SKILL.md`](SKILL.md) first.** The threat model, credential
+> blast-radius discussion, and universal invariants live there. This
+> file is the language idioms.
+
+## What graywolf invokes
+
+Graywolf calls `CreateProcess` directly — Windows file associations
+do not apply. The Action's **Command path** in the operator UI must
+point at a small `.cmd` launcher, which then invokes
+`powershell.exe -NoProfile -File <name>.ps1` with the inherited
+environment.
+
+argv (`$args[0..]`) layout:
+
+| Index | `kv` mode | `freeform` mode |
+|---|---|---|
+| `$args[0]` | action name | action name |
+| `$args[1]` | sender callsign | sender callsign |
+| `$args[2]` | `true` / `false` (OTP verified) | same |
+| `$args[3..N]` | `k=v` tokens, schema order | the entire raw payload, one token |
+
+Environment is identical to POSIX: `GW_ACTION_NAME`,
+`GW_SENDER_CALL`, `GW_OTP_VERIFIED`, `GW_OTP_CRED_NAME`, `GW_SOURCE`,
+`GW_INVOCATION_ID`, `GW_ARG_<KEY>` (kv) or `GW_ARG` (freeform).
+**Prefer the env vars over `$args`** — they survive arg-schema
+ordering changes.
+
+## Mandatory prelude
+
+```powershell
+# <NAME>.ps1 -- <one-sentence purpose>
+# Wire: @@<otp>#<name> <kv|freeform shape>
+# Reply: <first-line success snippet>
+# Config: <env vars + credential scope>
+# Deps:   <cmdlets / external tools>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+```
+
+- The `# AUDIT THIS:` block, when present, sits above the
+  `Set-StrictMode` line.
+- `Set-StrictMode -Version Latest` turns reading an undefined variable,
+  calling a non-existent property, and out-of-range index access into
+  hard errors. A typo like `$payloud` fails loudly instead of
+  silently being `$null`.
+- `$ErrorActionPreference = 'Stop'` upgrades non-terminating cmdlet
+  errors to terminating ones — the first failure halts the script.
+- Both are non-negotiable. PSScriptAnalyzer will not catch their
+  absence; the skill must verify them by reading the file.
+
+## The `.cmd` launcher
+
+For every `<name>.ps1` ship a sibling `<name>.cmd`:
+
+```bat
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0<name>.ps1" %*
+```
+
+Notes:
+
+- `%~dp0` resolves to the directory the `.cmd` lives in, so the
+  launcher works no matter where graywolf calls it from.
+- `-NoProfile` skips loading the user's PowerShell profile — fewer
+  surprises and a tiny startup speedup.
+- `-ExecutionPolicy Bypass` is scoped to this single invocation; it
+  does not change the system policy.
+- `%*` passes all argv through unmodified.
+- The Action's **Command path** in the operator UI points at the
+  `.cmd`, not the `.ps1`.
+
+If the operator runs PowerShell 7, change `powershell.exe` to
+`pwsh.exe` (and confirm it is on `PATH` for the graywolf service
+account).
+
+## Reading inputs
+
+### kv mode
+
+```powershell
+$to     = $env:GW_ARG_TO
+$msg    = $env:GW_ARG_MSG
+$sender = $env:GW_SENDER_CALL
+
+if (-not $to)  { [Console]::Error.WriteLine("missing to=");  exit 64 }
+if (-not $msg) { [Console]::Error.WriteLine("missing msg="); exit 64 }
+```
+
+`Set-StrictMode` makes a typo like `$env:GW_ARG_MSGS` fail
+immediately rather than silently yielding `$null`. Always check
+required args explicitly even so — the strict-mode failure mode is
+"throw at first read," which makes the operator's diagnostic less
+clear than the explicit check above.
+
+### freeform mode
+
+```powershell
+$action      = $args[0]
+$sender      = $args[1]
+$otpVerified = $args[2]
+$payload     = if ($env:GW_ARG) { $env:GW_ARG } else { $args[3] }
+
+if (-not $payload) {
+    [Console]::Error.WriteLine("payload missing")
+    exit 64
+}
+
+# .NET regex with named groups validates AND splits in one match.
+$rx = '^(?<num>\+[1-9][0-9]{6,14})\s+(?<msg>.+)$'
+$match = [regex]::Match($payload, $rx)
+if (-not $match.Success) {
+    [Console]::Error.WriteLine("expected '+<E164> <message>'")
+    exit 64
+}
+$number  = $match.Groups['num'].Value
+$message = $match.Groups['msg'].Value
+```
+
+Why named groups: indexing by name is durable. Adding a non-capturing
+group later does not shift positional indices. Match objects are
+in-process; no `Invoke-Expression`, no subshell.
+
+## Revalidate inside the handler
+
+```powershell
+# \p{Cc} is Unicode "Other, Control" -- the .NET counterpart of POSIX [:cntrl:].
+if ($message -match '\p{Cc}') {
+    [Console]::Error.WriteLine("message contains control characters")
+    exit 65
+}
+if ($message.Length -lt 1 -or $message.Length -gt 160) {
+    [Console]::Error.WriteLine("message length out of range (1..160)")
+    exit 65
+}
+```
+
+For numeric args, validate with `[int]::TryParse` plus a range
+check — not just a regex, because `1e5` looks numeric to a regex but
+is not an integer.
+
+## Verifying required env
+
+```powershell
+foreach ($v in 'TWILIO_ACCOUNT_SID','TWILIO_AUTH_TOKEN','TWILIO_FROM') {
+    if (-not (Get-Item "env:$v" -ErrorAction SilentlyContinue)) {
+        [Console]::Error.WriteLine("$v not set")
+        exit 1
+    }
+}
+```
+
+Use `Get-Item env:$v` not `$env:$v` — the latter cannot interpolate
+the variable name. Run this loop immediately after the input checks
+so the script fails fast before touching the network.
+
+## Calling external services
+
+### Use cmdlet hashtable bodies, not strings
+
+```powershell
+$form = @{
+    From = $env:TWILIO_FROM
+    To   = $number
+    Body = $message
+}
+
+try {
+    $resp = Invoke-RestMethod -Method Post -Uri $uri -Headers $headers `
+        -Body $form -TimeoutSec 8
+} catch {
+    [Console]::Error.WriteLine("downstream rejected: $($_.Exception.Message)")
+    exit 1
+}
+```
+
+When `-Body` is a hashtable on a `POST`/`PUT`, `Invoke-RestMethod`
+serializes it as `application/x-www-form-urlencoded` and URL-encodes
+each value. We never construct the request body via string
+concatenation. An `&` in `$message` cannot smuggle extra form fields.
+
+For JSON bodies, use `ConvertTo-Json` on a hashtable and pass the
+result through `-Body` with `-ContentType 'application/json'`. Never
+hand-build JSON with string formatting.
+
+### `Start-Process` and external binaries
+
+If you must shell out to an external command:
+
+```powershell
+# GOOD -- array form. Each element is its own argv entry.
+Start-Process -FilePath 'C:\Tools\send.exe' `
+    -ArgumentList @('--to', $number, '--body', $message) `
+    -Wait -NoNewWindow
+
+# BAD -- string form. PowerShell re-splits on whitespace and
+# re-parses quotes. A space in $message becomes a new flag.
+Start-Process -FilePath 'send.exe' -ArgumentList "--to $number --body $message"
+```
+
+`-ArgumentList` accepts an array. Always use the array form when any
+element comes from user input.
+
+### Auth headers
+
+```powershell
+$auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${sid}:${tok}"))
+$headers = @{ Authorization = "Basic $auth" }
+```
+
+For HMAC-style auth, compute the digest with
+`[System.Security.Cryptography.HMACSHA256]` against the request body
+*after* the body is serialized to a fixed byte sequence; do not HMAC
+the hashtable.
+
+## Reply contract
+
+```powershell
+"sent $($resp.sid)"     # success: stdout, first line is the on-air reply
+exit 0
+# ----
+[Console]::Error.WriteLine("downstream rejected: $msg")
+exit 1
+```
+
+Same exit-code conventions as POSIX (`64` usage, `65` data,
+`69` service unavailable, `75` retry hint).
+
+## Anti-pattern table
+
+| Anti-pattern | Fix |
+|---|---|
+| `Invoke-Expression $payload` (or `iex`) | Validate, then call cmdlets directly. |
+| `cmd.exe /c "send.exe $payload"` | `Start-Process -ArgumentList @(...)` with an array. |
+| `Start-Process -ArgumentList "..."` (string) | Always use the array form. |
+| `Invoke-RestMethod -Body "From=$f&To=$t"` (string) | Hashtable `-Body @{}`. |
+| Omit `Set-StrictMode` | Typoed variables silently expand to `$null`. Always set strict mode. |
+| `Invoke-RestMethod $url` with `$url` from payload | SSRF. The URL must be a constant or built from validated tokens. |
+| `Write-Host` for diagnostics | `[Console]::Error.WriteLine(...)` — `Write-Host` does not go to stderr. |
+| Storing the API key in the script | Read from `$env:VAR`. |
+| `Invoke-RestMethod -Body $msg -ContentType 'application/json'` (string) | `ConvertTo-Json @{ msg = $msg }`. |
+| `Start-Process cmd.exe -ArgumentList @('/c', $payload)` | The array form does **not** save you when the target binary is itself a shell. cmd.exe parses its own arguments — `&`, `&&`, `\|`, `>` all chain. Don't put `cmd.exe`/`bash`/`pwsh -Command` in `-FilePath`; call the real target binary directly. |
+| `Stop-Process -Name $userInput` (cmdlet wildcards) | Cmdlets accept `*`, `?`, `[abc]`, `,`. `Stop-Process -Name *` kills every process the service can signal. Resolve to a PID first: `(Get-Process -Name $name).Id` and confirm exactly one match, *or* forbid `*?[],` in the regex **and** keep an in-script allowlist of process names. |
+| `Stop-Service -Name $userInput` without an in-script allowlist | The schema regex says *shape* (charset, length); it does not say *which services*. `WinDefend`, `vss`, `EventLog` are all valid shapes and disastrous targets. Anchored regex + `if ($name -notin $allowed) { exit 65 }`. |
+| `& "C:\scripts\$userInput.ps1"` | Path traversal (`..\..\evil`) plus arbitrary-script-trigger by design. Refuse the dispatcher; convert each script to its own Action. If a dispatcher is unavoidable: `[IO.Path]::GetFullPath((Join-Path 'C:\scripts' "$name.ps1"))` and confirm the result `StartsWith('C:\scripts\', [StringComparison]::OrdinalIgnoreCase)` *and* allowlist the names. |
+| `Invoke-Command -ComputerName $h -ScriptBlock { ... $args[0] ... }` with payload | `ScriptBlock` is PowerShell source on the remote — same class as `Invoke-Expression`. Pass parameters via `-ArgumentList` and use named parameters inside the block, never string-interpolate user data into the block source. |
+| `pwsh -Command $payload` / `powershell -Command $payload` | Same as `Invoke-Expression`. Both accept a string of PowerShell source. |
+| `Set-Content -Path "C:\out\$file"` with payload as `$file` | Path traversal on writes, too. Canonicalize and StartsWith-check the same way as for execution. |
+
+## Linter — mandatory
+
+```powershell
+Install-Module PSScriptAnalyzer -Scope CurrentUser   # one-time setup
+Invoke-ScriptAnalyzer -Path .\handler.ps1 -Severity Information,Warning,Error
+```
+
+Diagnostics are bugs. Fix them. Never use `[Diagnostics.CodeAnalysis.SuppressMessageAttribute]`
+to silence a finding. The skill must run this command on the
+generated file and confirm clean output before declaring the script
+ready.
+
+Common diagnostics worth knowing:
+
+- **PSAvoidUsingInvokeExpression** — never use `Invoke-Expression` /
+  `iex`.
+- **PSUseDeclaredVarsMoreThanAssignments** — flags dead variables;
+  often a sign of a typo.
+- **PSAvoidUsingPlainTextForPassword** — credentials must come from
+  env or `Get-Credential`.
+- **PSAvoidUsingWMICmdlet** — `Get-CimInstance` instead of `Get-WmiObject`.
+
+## Skeleton — copy and adapt
+
+### kv-mode skeleton
+
+```powershell
+# <NAME>.ps1 -- <one-sentence purpose>
+# Wire: @@<otp>#<name> key1=<shape> key2=<shape>
+# Reply: success: "ok <id> for <sender>"; failure: "<error snippet>"
+# Config:
+#   MY_API_KEY      required. Scope: <e.g. "non-admin user, project-scoped">
+# Deps:   Invoke-RestMethod
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# OTP defense in depth. Skip ONLY for genuinely read-only Actions.
+if ($env:GW_OTP_VERIFIED -ne 'true') {
+    [Console]::Error.WriteLine("otp not verified")
+    exit 77
+}
+
+$sender = $env:GW_SENDER_CALL
+$key1 = $env:GW_ARG_KEY1
+$key2 = $env:GW_ARG_KEY2
+if (-not $key1) { [Console]::Error.WriteLine("missing key1="); exit 64 }
+
+if ($key1 -notmatch '^...$') {
+    [Console]::Error.WriteLine("invalid key1: $key1")
+    exit 65
+}
+
+if (-not (Get-Item env:MY_API_KEY -ErrorAction SilentlyContinue)) {
+    [Console]::Error.WriteLine("MY_API_KEY not set")
+    exit 1
+}
+
+$body = @{
+    field1 = $key1
+    field2 = $key2
+}
+$headers = @{ Authorization = "Bearer $($env:MY_API_KEY)" }
+
+try {
+    $resp = Invoke-RestMethod -Method Post `
+        -Uri 'https://api.example.com/v1/do-thing' `
+        -Headers $headers -Body $body -TimeoutSec 8
+    if ($resp.id) {
+        $shortId = ($resp.id.ToString()).Substring(0, [Math]::Min(8, $resp.id.ToString().Length))
+        "ok $shortId for $sender"
+        exit 0
+    }
+} catch {
+    [Console]::Error.WriteLine("downstream rejected: $($_.Exception.Message)")
+    exit 1
+}
+
+[Console]::Error.WriteLine("downstream rejected: no id in response")
+exit 1
+```
+
+### freeform-mode skeleton
+
+```powershell
+# <NAME>.ps1 -- <one-sentence purpose>
+# Wire: @@<otp>#<name> <freeform shape>
+# Reply: success: "sent <id> to <sender>"; failure: "<error snippet>"
+# Config:
+#   SECRET          required. Scope: <e.g. "least-privilege, no admin role">
+# Deps:   Invoke-RestMethod
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# OTP defense in depth.
+if ($env:GW_OTP_VERIFIED -ne 'true') {
+    [Console]::Error.WriteLine("otp not verified")
+    exit 77
+}
+
+$action      = $args[0]
+$sender      = $args[1]
+$otpVerified = $args[2]
+$payload     = if ($env:GW_ARG) { $env:GW_ARG } else { $args[3] }
+
+if (-not $payload) {
+    [Console]::Error.WriteLine("payload missing")
+    exit 64
+}
+
+$rx = '^(?<g1><pattern1>)\s+(?<g2><pattern2>)$'
+$match = [regex]::Match($payload, $rx)
+if (-not $match.Success) {
+    [Console]::Error.WriteLine("expected '<format>'")
+    exit 64
+}
+$f1 = $match.Groups['g1'].Value
+$f2 = $match.Groups['g2'].Value
+
+if ($f2 -match '\p{Cc}') {
+    [Console]::Error.WriteLine("f2 contains control characters")
+    exit 65
+}
+if ($f2.Length -lt 1 -or $f2.Length -gt <max>) {
+    [Console]::Error.WriteLine("f2 length out of range")
+    exit 65
+}
+
+if (-not (Get-Item env:SECRET -ErrorAction SilentlyContinue)) {
+    [Console]::Error.WriteLine("SECRET not set")
+    exit 1
+}
+
+$body = @{ f1 = $f1; f2 = $f2 }
+$headers = @{ Authorization = "Bearer $($env:SECRET)" }
+
+try {
+    Invoke-RestMethod -Method Post -Uri 'https://api.example.com/v1/do' `
+        -Headers $headers -Body $body -TimeoutSec 8 | Out-Null
+    "ok"
+    exit 0
+} catch {
+    [Console]::Error.WriteLine("downstream rejected: $($_.Exception.Message)")
+    exit 1
+}
+```
+
+## Operator postamble template
+
+```
+Install path:  C:\graywolf\actions\<name>.ps1
+Launcher:      C:\graywolf\actions\<name>.cmd  (paired -- contents below)
+
+  @echo off
+  powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0<name>.ps1" %*
+
+Lint (mandatory):
+  Install-Module PSScriptAnalyzer -Scope CurrentUser   # one-time
+  Invoke-ScriptAnalyzer -Path C:\graywolf\actions\<name>.ps1 -Severity Information,Warning,Error
+
+Env vars (System Properties -> Environment Variables, or set per-service
+via sc.exe / NSSM, then restart graywolf):
+  MY_API_KEY=...
+  ...
+
+Wire it up: /#/actions -> New
+  Name: <name>
+  Type: command
+  Command path: C:\graywolf\actions\<name>.cmd       <-- the .cmd, not the .ps1
+  Arg schema: <one row per declared arg>
+  OTP credential: <chosen credential | none>
+  Sender allowlist: <callsigns | empty>
+  Timeout: <seconds>
+
+Test: per-row Test dialog before letting it loose on-air.
+```

--- a/examples/skills/writing-graywolf-action-handlers/reference-webhook.md
+++ b/examples/skills/writing-graywolf-action-handlers/reference-webhook.md
@@ -1,0 +1,488 @@
+# Reference: Webhook handlers
+
+Authoring guide for HTTP receivers that graywolf POSTs to as a
+**webhook** Action. Examples in Python (Flask / aiohttp); the
+patterns are language-independent. Every shipped Python receiver in
+`examples/actions/python/` is ruff-clean and exercised by pytest.
+
+> **Read [`SKILL.md`](SKILL.md) first.** Threat model, credential
+> blast-radius, and universal invariants live there.
+
+## When to choose webhook over a script
+
+A webhook is the right answer when:
+
+- The downstream is already an HTTP API (do not write `curl` in bash;
+  use the webhook directly).
+- The handler lives on a different host than graywolf.
+- Several Actions share a single audit / logging surface.
+- You want graywolf's templating filters (`|json` / `|url` / `|html`)
+  to do the escaping rather than scripting it yourself.
+
+A webhook is the wrong answer when the side effect is a local-host
+operation (toggling a USB-attached relay, reading the host's load
+average) — write a shell or PowerShell handler instead and skip the
+network round trip.
+
+## What graywolf POSTs
+
+By default, graywolf POSTs `application/x-www-form-urlencoded` with
+these fields:
+
+- Always: `action`, `sender_callsign`, `otp_verified` (`"true"` /
+  `"false"`), `otp_cred`, `source` (`"rf"` / `"is"`).
+- kv: one field per declared arg (key = your schema key).
+- freeform: a single field named `arg` with the raw payload.
+
+Headers carry whatever the operator configured on the Action's
+**Headers** editor — typically `X-Graywolf-Auth: <shared secret>` or
+an HMAC.
+
+### Custom body templates
+
+Each Action can override the body with a templated string. Tokens:
+
+- `{{action}}`, `{{sender-callsign}}`, `{{otp-verified}}`,
+  `{{otp-cred}}`, `{{source}}`
+- kv: `{{arg.<key>}}`
+- freeform: `{{arg}}`
+- Filters (use these for any non-default destination):
+  - `{{x|json}}` — JSON string contents (escapes `"`, `\`, control chars)
+  - `{{x|url}}` — URL paths or query strings (percent-encodes)
+  - `{{x|html}}` — HTML attribute values or text content (entity-encodes)
+
+```
+{
+  "to":  "{{arg.to|json}}",
+  "msg": "{{arg.msg|json}}"
+}
+```
+
+Never write `"{{arg.msg}}"` (no filter) into a JSON template — a `"`
+or `\` in the value will break the JSON. The filter is mandatory when
+templating into a structured destination.
+
+**Why filters are mandatory even when the arg-schema regex looks
+tight.** The schema regex and the body template live on different
+lifecycles. The regex protects today's arg shape; the template will
+outlive any individual regex. Operators routinely widen a regex
+months later — to allow apostrophes in SMS bodies, dashes in slugs,
+quotes in subject lines — without revisiting body templates that
+quietly assumed the old regex held. `{{arg.msg|json}}` is safe
+regardless of what the regex permits; `{{arg.msg}}` is safe only as
+long as nobody ever broadens the regex to allow `"` or `\`. **The
+filter is the load-bearing defense; the regex is a friendliness
+check.** Never invert that.
+
+The same lifecycle reasoning applies to `|url` (path / query string
+templates) and `|html` (HTML attribute / text content). Use the
+filter for the destination context, not for the input character
+class.
+
+## Required defenses (every receiver)
+
+Six defenses must be present **in this order**:
+
+1. **Body-size cap before parsing.** Cap at the framework layer
+   *and* in middleware so chunked transfer encoding still gets
+   bounded.
+2. **Authentication on every request.** Constant-time comparison of
+   a shared secret in a custom header, or HMAC of the body. Reject
+   401 immediately if missing or wrong. **Secret must be ≥32 bytes
+   / 256 bits of entropy** (`openssl rand -hex 32` or
+   `openssl rand -base64 32`).
+3. **TLS in front.** Run the receiver on `127.0.0.1` and put a
+   TLS-terminating reverse proxy (Caddy / nginx / Traefik) in front.
+   Never expose the receiver on `0.0.0.0` over plaintext HTTP.
+4. **OTP defense in depth.** Even though graywolf is supposed to
+   only POST when `OTPRequired=true` matched, the receiver should
+   still check `request.form.get("otp_verified") == "true"` and
+   `abort(401)` otherwise. Cheap, catches the case where the
+   operator flips OTPRequired off in the UI without telling the
+   receiver.
+5. **Per-field revalidation.** Length cap, control-char rejection,
+   schema-specific regex for every field that came from the wire.
+6. **Parameterized everything downstream.** SQL placeholders,
+   auto-escaping templates, argv-style subprocess. The same
+   universal invariants from `SKILL.md` apply on this side too.
+
+Skipping any one of these is a CVE waiting to happen. The skill must
+verify all six appear in the generated code before declaring it
+ready.
+
+## Authentication patterns
+
+### Shared secret in a header
+
+Simplest. Use when the channel is already encrypted (TLS) and the
+receiver does not need to verify message integrity beyond
+authentication.
+
+```python
+import hmac, os
+from flask import abort, request
+
+SHARED_SECRET = os.environ["GW_WEBHOOK_SECRET"]
+
+def verify_secret(provided: str | None) -> bool:
+    if not provided:
+        return False
+    return hmac.compare_digest(provided.encode(), SHARED_SECRET.encode())
+
+@app.before_request
+def auth_gate():
+    if not verify_secret(request.headers.get("X-Graywolf-Auth")):
+        abort(401)
+```
+
+`hmac.compare_digest` runs in time proportional to the longer string
+regardless of where the first mismatch occurs. A naive `==`
+comparison leaks length and prefix information through timing.
+
+The Action's Headers editor carries `X-Graywolf-Auth: <secret>`.
+
+**Generate the secret with `openssl rand -hex 32` (32 bytes / 256
+bits) — never less.** Hex doubles the character count, so "32 hex
+characters" = 16 bytes = 128 bits, which is below the floor. If the
+operator says "I'll use a 32-character hex string," correct them
+before generating any code: it must be **64 hex characters**, which
+is what `openssl rand -hex 32` produces. `openssl rand -base64 32`
+is also acceptable (43 base64 characters, same 32 bytes).
+
+Store the secret in the graywolf service environment as
+`GW_WEBHOOK_SECRET` and in the receiver's environment under the
+same name.
+
+### HMAC over the body
+
+Stronger — verifies that the body has not been tampered with in
+flight. Use when the channel is not end-to-end TLS (older relays,
+shared infrastructure) or when you want non-repudiation.
+
+```python
+import hmac, hashlib, os
+from flask import abort, request
+
+KEY = os.environ["GW_WEBHOOK_HMAC_KEY"].encode()
+
+def verify_hmac():
+    sig_hex = request.headers.get("X-Graywolf-Sig", "")
+    body = request.get_data()  # raw bytes, before parse
+    expected = hmac.new(KEY, body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(sig_hex, expected):
+        abort(401)
+```
+
+The Action's body template includes the corresponding HMAC; if
+graywolf does not yet emit one, fall back to the shared-secret
+pattern.
+
+## Body-size cap
+
+```python
+MAX_BODY_BYTES = 8 * 1024  # graywolf bodies are tiny
+
+app.config["MAX_CONTENT_LENGTH"] = MAX_BODY_BYTES   # framework cap
+
+@app.before_request
+def cap_body_size():
+    cl = request.content_length
+    if cl is not None and cl > MAX_BODY_BYTES:
+        abort(413)
+```
+
+Both layers matter. `MAX_CONTENT_LENGTH` is the load-bearing cap
+(handles chunked transfer encoding without a `Content-Length`
+header). The middleware bails on obviously oversized requests
+without reading the body, which is friendlier on the network.
+
+aiohttp equivalent:
+
+```python
+app = web.Application(client_max_size=8 * 1024)
+```
+
+## Per-field revalidation
+
+```python
+import re
+
+MAX_ARG_LEN = 200
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+def revalidate(value: str) -> None:
+    if len(value) > MAX_ARG_LEN:
+        abort(400, "value exceeds max length")
+    if CONTROL_CHARS.search(value):
+        abort(400, "value contains control characters")
+```
+
+Apply on every field that originated from the wire. Even though
+graywolf already validates, the receiver must not depend on graywolf
+staying bug-free forever.
+
+## Persisting the payload
+
+```python
+import sqlite3, os
+
+with sqlite3.connect(os.environ["GW_RECEIVER_DB"]) as db:
+    db.execute(
+        """INSERT INTO deliveries (action, sender, payload)
+           VALUES (?, ?, ?)""",
+        (action, sender, payload),
+    )
+```
+
+Always parameterized. Never f-string. Never `%`-format. Never
+concatenate. The driver binds `?` at the protocol level so SQL
+injection is impossible regardless of payload bytes.
+
+For PostgreSQL with `psycopg`, use `%s` placeholders the same way:
+
+```python
+cur.execute("INSERT INTO deliveries (...) VALUES (%s, %s, %s)", (a, s, p))
+```
+
+## Rendering responses
+
+```python
+return render_template_string(
+    "<p>received from <strong>{{ sender }}</strong>: {{ payload }}</p>",
+    sender=sender, payload=payload,
+)
+```
+
+Jinja autoescapes by default. `{{ payload }}` of
+`<script>alert(1)</script>` renders as
+`&lt;script&gt;alert(1)&lt;/script&gt;`, not a real script tag.
+
+Forbidden patterns:
+
+- `Markup(payload)` / `{{ payload | safe }}` / `{% autoescape off %}`
+- `render_template_string(payload, ...)` — using the payload as a
+  *template* re-introduces server-side template injection.
+- Hand-built HTML via f-string.
+
+If the response should be JSON, return `jsonify(...)` (Flask) /
+`web.json_response(...)` (aiohttp); both encode safely.
+
+## Shelling out from a webhook
+
+If the receiver must call an external binary, use `subprocess` with
+a list and `shell=False`:
+
+```python
+import subprocess
+
+# GOOD -- list form, shell=False, timeout, capture.
+result = subprocess.run(
+    ["/usr/local/bin/send", "--to", number, "--body", message],
+    shell=False,
+    timeout=8,
+    capture_output=True,
+    check=False,
+)
+
+# BAD -- shell=True turns the string into a shell command.
+subprocess.run(f"send --to {number} --body {message}", shell=True)
+```
+
+Validate inputs before they reach `subprocess`, including length
+and a regex that excludes shell metacharacters even though
+`shell=False` makes them inert.
+
+## SSRF — never let the payload pick a URL
+
+```python
+# DO NOT
+requests.get(payload)            # SSRF -- payload becomes a URL.
+requests.get(f"https://api/{payload}")
+```
+
+If the Action allows the sender to specify any URL component, the
+receiver can be turned into an HTTP scanner against the local network
+(metadata service, internal admin panels, etc.).
+
+If you need a configurable URL, accept only an *enum* from the
+sender (a short list of slugs) and map it to a constant URL inside
+the receiver:
+
+```python
+TARGETS = {
+    "weather": "https://api.weather.gov/...",
+    "tides":   "https://api.tidesandcurrents.noaa.gov/...",
+}
+target = TARGETS.get(payload)
+if not target:
+    abort(400, "unknown target")
+```
+
+## Process isolation + filesystem hygiene
+
+- Run the receiver as a **dedicated user** (`graywolf-webhook` or
+  similar). Never as root, never as a user with sudo.
+- Restrict filesystem access via `systemd` `ProtectSystem=strict`,
+  `PrivateTmp=yes`, `ReadWritePaths=` for only the receiver's data
+  dir.
+- Write files with explicit modes (`0o600` for secrets, `0o644` for
+  logs); never rely on `umask`.
+- Rotate the auth secret periodically; coordinate with graywolf's
+  Action editor.
+
+## Linter — mandatory
+
+```bash
+ruff check examples/actions/python/handler.py
+ruff format --check examples/actions/python/handler.py
+bandit examples/actions/python/handler.py
+```
+
+`ruff` covers style + a large class of static-analysis rules.
+`bandit` adds security-oriented checks (uses of `subprocess` with
+`shell=True`, `yaml.load` without `SafeLoader`, hard-coded passwords,
+etc.). Triage every finding; do not suppress with comments.
+
+The skill must run all three on the generated file (or, at minimum,
+`ruff` and `bandit`) and confirm clean output before declaring the
+receiver ready.
+
+## Anti-pattern table
+
+| Anti-pattern | Attack |
+|---|---|
+| No auth on the endpoint | Anyone who guesses the URL can POST as if they were graywolf. |
+| `==` for secret comparison | Timing oracle on length / prefix. |
+| `f"INSERT ... ('{payload}')"` | SQL injection. |
+| `{{ payload \| safe }}` / `Markup(payload)` | Stored XSS. |
+| `os.system(f"send {payload}")` | Shell injection on the receiver host. |
+| `subprocess.run(..., shell=True)` with payload | Same as `os.system`. |
+| `requests.get(payload)` | SSRF — payload becomes a URL the server fetches (cloud metadata, internal admin, router). |
+| `requests.get(f"https://api.example/{slug}")` with `slug` = payload | Slot-style SSRF — still attacker-controlled URL component. Map `slug` to a constant URL via an enum. |
+| `urlopen(payload)` / `httpx.get(payload)` | All HTTP clients have the same SSRF surface. The shape applies regardless of library. |
+| Following redirects to attacker-chosen URLs | Even with a constant initial URL, `allow_redirects=True` (default in `requests`) lets the response steer the client elsewhere. Use `allow_redirects=False` for any handler the sender can influence. |
+| Slicing the response *after* full read (`r.content[:200]`) | A hostile target streams gigabytes before the slice runs. Use `stream=True` + `r.iter_content(decode_unicode=False)` with a byte budget, or `r.raw.read(N)`. |
+| `eval(request.get_data())` | RCE. (Yes, people do this. No, never.) |
+| Logging `payload` raw | Log forging via embedded `\r\n`, terminal escapes. |
+| No body-size cap | OOM via 4 GB POST. |
+| `{{arg.msg}}` in JSON body template (no `\|json`) | A `"` breaks the JSON, smuggles fields. |
+| Returning the payload in a redirect URL | Open-redirect / SSRF gadget. |
+
+## Skeleton — Flask
+
+```python
+#!/usr/bin/env python3
+"""<NAME> webhook receiver.
+
+Wired as a Graywolf 'webhook' Action with method POST,
+URL https://your-host/aprs-webhook, and a header
+X-Graywolf-Auth: <shared secret>. Default form-encoded body.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+import re
+import sqlite3
+from typing import Final
+
+from flask import Flask, abort, render_template_string, request
+
+SHARED_SECRET: Final = os.environ["GW_WEBHOOK_SECRET"]
+DB_PATH: Final = os.environ["GW_RECEIVER_DB"]
+MAX_BODY_BYTES: Final = 8 * 1024
+MAX_ARG_LEN: Final = 200
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = MAX_BODY_BYTES
+
+
+def verify_secret(provided: str | None) -> bool:
+    if not provided:
+        return False
+    return hmac.compare_digest(provided.encode(), SHARED_SECRET.encode())
+
+
+def revalidate(value: str) -> None:
+    if len(value) > MAX_ARG_LEN:
+        abort(400, "value exceeds max length")
+    if CONTROL_CHARS.search(value):
+        abort(400, "value contains control characters")
+
+
+@app.before_request
+def cap_body_size() -> None:
+    cl = request.content_length
+    if cl is not None and cl > MAX_BODY_BYTES:
+        abort(413)
+
+
+@app.post("/aprs-webhook")
+def aprs_webhook():
+    if not verify_secret(request.headers.get("X-Graywolf-Auth")):
+        abort(401)
+
+    form = request.form
+
+    # OTP defense in depth: even though the Action is configured with
+    # OTPRequired=true, recheck on the receiver side. Cheap insurance.
+    if form.get("otp_verified", "false") != "true":
+        abort(401)
+
+    action = form.get("action", "")
+    sender = form.get("sender_callsign", "")
+    payload = form.get("arg", "")
+
+    for v in (action, sender, payload):
+        revalidate(v)
+
+    with sqlite3.connect(DB_PATH) as db:
+        db.execute(
+            "INSERT INTO deliveries (action, sender, payload) VALUES (?, ?, ?)",
+            (action, sender, payload),
+        )
+
+    return render_template_string(
+        "<p>received from <strong>{{ sender }}</strong>: {{ payload }}</p>",
+        sender=sender,
+        payload=payload,
+    )
+
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=5000)
+```
+
+## Operator postamble template
+
+```
+Install path:    /opt/graywolf-webhook/<name>.py
+Run as user:     graywolf-webhook (dedicated, no sudo)
+Reverse proxy:   Caddy / nginx terminating TLS in front of 127.0.0.1:5000
+
+Lint (mandatory):
+  ruff check /opt/graywolf-webhook/<name>.py
+  ruff format --check /opt/graywolf-webhook/<name>.py
+  bandit /opt/graywolf-webhook/<name>.py
+
+Env vars (systemd unit / launchd plist for the receiver, not graywolf):
+  GW_WEBHOOK_SECRET=<openssl rand -hex 32>
+  GW_RECEIVER_DB=/var/lib/graywolf-webhook/log.db
+  ...
+
+Wire it up: /#/actions -> New
+  Name: <name>
+  Type: webhook
+  Method: POST
+  URL: https://your-host/aprs-webhook
+  Headers: X-Graywolf-Auth: <same secret as GW_WEBHOOK_SECRET>
+  Body template: <empty for default form-encoded, or use {{arg|json}} filters>
+  Arg schema: <one row per declared arg>
+  OTP credential: <chosen credential | none>
+  Sender allowlist: <callsigns | empty>
+  Timeout: <seconds>
+
+Test: per-row Test dialog before letting it loose on-air.
+```

--- a/pkg/actions/classifier.go
+++ b/pkg/actions/classifier.go
@@ -93,13 +93,18 @@ func (c *Classifier) Classify(ctx context.Context, pkt *aprs.DecodedAPRSPacket) 
 	sender := strings.ToUpper(strings.TrimSpace(innerSource))
 	channel := uint32(pkt.Channel)
 
-	parsed, err := Parse(innerMsg.Text)
-	if err != nil {
+	parsed, parseErr := Parse(innerMsg.Text)
+	if parseErr != nil && parsed == nil {
+		// Truly malformed (no @@, no #, bad action name). Reply unknown.
 		c.cfg.Runner.Reply(ctx, Invocation{
 			SenderCall: sender, Source: source,
 		}, channel, Result{Status: StatusUnknown})
 		return true
 	}
+	// A non-nil parsed with a non-nil parseErr means kv tokenization
+	// failed but the action name is valid. Defer the decision: a
+	// freeform Action will recover via RawArgTail; a kv Action will
+	// surface this as StatusBadArg below.
 
 	a, err := c.cfg.ActionStore.GetActionByName(ctx, parsed.Action)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -174,7 +179,9 @@ func (c *Classifier) Classify(ctx context.Context, pkt *aprs.DecodedAPRSPacket) 
 		inv.OTPCredentialID = cred.ID
 	}
 
-	// Sanitize args against the action's schema.
+	// Sanitize args against the action's schema. Branches on
+	// ArgMode: kv (default) tokenizes raw key=value pairs, freeform
+	// validates the single RawArgTail payload.
 	schema, schemaErr := decodeArgSchema(a.ArgSchema)
 	if schemaErr != nil {
 		c.cfg.Runner.Reply(ctx, inv, channel, Result{
@@ -183,7 +190,21 @@ func (c *Classifier) Classify(ctx context.Context, pkt *aprs.DecodedAPRSPacket) 
 		})
 		return true
 	}
-	clean, sErr := Sanitize(schema, parsed.Args)
+	var clean []KeyValue
+	var sErr error
+	switch ArgMode(a.ArgMode) {
+	case ArgModeFreeform:
+		// Freeform ignores kv parseErr — it reads RawArgTail directly.
+		clean, sErr = SanitizeFreeform(schema, parsed.RawArgTail, FreeformValueCeiling)
+	default:
+		// kv mode (and any unknown value, forward-compat). A kv
+		// tokenization failure surfaces as StatusBadArg here.
+		if parseErr != nil {
+			c.cfg.Runner.Reply(ctx, inv, channel, Result{Status: StatusBadArg, StatusDetail: "parse"})
+			return true
+		}
+		clean, sErr = Sanitize(schema, parsed.Args)
+	}
 	if sErr != nil {
 		var bae *BadArgError
 		detail := "bad arg"

--- a/pkg/actions/classifier_test.go
+++ b/pkg/actions/classifier_test.go
@@ -470,6 +470,66 @@ func TestClassifyNilVerifierRepliesError(t *testing.T) {
 	}
 }
 
+func TestClassifyFreeformDispatchesRawTail(t *testing.T) {
+	a := &configstore.Action{
+		ID: 7, Name: "sms", Type: "command", Enabled: true, OTPRequired: false,
+		ArgMode:   "freeform",
+		ArgSchema: `[{"key":"arg","regex":"^\\+[1-9][0-9]{6,14} .+$","max_len":120,"required":true}]`,
+	}
+	sub := &stubSubmitter{}
+	c := newClassifierForTest(t, sub, &stubActionStore{byName: map[string]*configstore.Action{"sms": a}}, &stubCredStore{}, nil, nil)
+	pkt := makeMessagePkt(aprs.DirectionRF, "KE0XYZ", "N0CALL", "@@#sms +15555551212 hello world", 0)
+	if !c.Classify(context.Background(), pkt) {
+		t.Fatal("freeform action must be consumed")
+	}
+	if len(sub.submits) != 1 {
+		t.Fatalf("expected 1 submit, got submits=%d replies=%+v", len(sub.submits), sub.replies)
+	}
+	got := sub.submits[0].inv.Args
+	if len(got) != 1 || got[0].Key != FreeformArgKey || got[0].Value != "+15555551212 hello world" {
+		t.Fatalf("freeform args wrong: %+v", got)
+	}
+}
+
+func TestClassifyFreeformBadArgRepliesBadArg(t *testing.T) {
+	a := &configstore.Action{
+		ID: 7, Name: "sms", Type: "command", Enabled: true, OTPRequired: false,
+		ArgMode:   "freeform",
+		ArgSchema: `[{"key":"arg","regex":"^[A-Z]+$","max_len":50,"required":true}]`,
+	}
+	sub := &stubSubmitter{}
+	c := newClassifierForTest(t, sub, &stubActionStore{byName: map[string]*configstore.Action{"sms": a}}, &stubCredStore{}, nil, nil)
+	pkt := makeMessagePkt(aprs.DirectionRF, "KE0XYZ", "N0CALL", "@@#sms lowercase payload", 0)
+	if !c.Classify(context.Background(), pkt) {
+		t.Fatal("freeform bad-arg must be consumed")
+	}
+	if len(sub.submits) != 0 {
+		t.Fatalf("expected no submit, got %+v", sub.submits)
+	}
+	if len(sub.replies) != 1 || sub.replies[0].res.Status != StatusBadArg {
+		t.Fatalf("expected StatusBadArg, got %+v", sub.replies)
+	}
+}
+
+func TestClassifyKVActionWithFreeformPayloadRepliesBadArg(t *testing.T) {
+	// kv-mode Action receiving a non-key=value payload must surface
+	// StatusBadArg, not StatusUnknown — the action exists, the args
+	// are wrong.
+	a := &configstore.Action{
+		ID: 1, Name: "ping", Type: "command", Enabled: true, OTPRequired: false,
+		ArgSchema: `[{"key":"room","regex":"^[a-z]+$"}]`,
+	}
+	sub := &stubSubmitter{}
+	c := newClassifierForTest(t, sub, &stubActionStore{byName: map[string]*configstore.Action{"ping": a}}, &stubCredStore{}, nil, nil)
+	pkt := makeMessagePkt(aprs.DirectionRF, "OTHER", "N0CALL", "@@#ping bareword", 0)
+	if !c.Classify(context.Background(), pkt) {
+		t.Fatal("kv parse-fail with valid action name must be consumed")
+	}
+	if len(sub.replies) != 1 || sub.replies[0].res.Status != StatusBadArg {
+		t.Fatalf("expected StatusBadArg, got %+v", sub.replies)
+	}
+}
+
 func TestSenderAllowed(t *testing.T) {
 	cases := []struct {
 		csv, sender string

--- a/pkg/actions/cmd_executor.go
+++ b/pkg/actions/cmd_executor.go
@@ -83,10 +83,22 @@ func buildArgv(inv Invocation) []string {
 		inv.SenderCall,
 		boolStr(inv.OTPVerified),
 	}
+	if isFreeformInvocation(inv) {
+		out = append(out, inv.Args[0].Value)
+		return out
+	}
 	for _, kv := range inv.Args {
 		out = append(out, kv.Key+"="+kv.Value)
 	}
 	return out
+}
+
+// isFreeformInvocation returns true when Args is the single-entry shape
+// produced by SanitizeFreeform. We detect by Key rather than threading
+// ArgMode down to the executor — the synthetic key is reserved
+// (validateAction rejects "arg" as a kv-mode key).
+func isFreeformInvocation(inv Invocation) bool {
+	return len(inv.Args) == 1 && inv.Args[0].Key == FreeformArgKey
 }
 
 func buildEnv(req ExecRequest) []string {
@@ -99,6 +111,10 @@ func buildEnv(req ExecRequest) []string {
 		"GW_SOURCE=" + string(inv.Source),
 		fmt.Sprintf("GW_INVOCATION_ID=%d", inv.ID),
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	}
+	if isFreeformInvocation(inv) {
+		env = append(env, "GW_ARG="+inv.Args[0].Value)
+		return env
 	}
 	for _, kv := range inv.Args {
 		env = append(env, "GW_ARG_"+envSafe(kv.Key)+"="+kv.Value)

--- a/pkg/actions/cmd_executor_test.go
+++ b/pkg/actions/cmd_executor_test.go
@@ -76,6 +76,89 @@ func TestCmdExecutorOutputCap(t *testing.T) {
 	}
 }
 
+func TestBuildArgvFreeformShape(t *testing.T) {
+	inv := Invocation{
+		ActionName:  "sms",
+		SenderCall:  "KE0XYZ",
+		OTPVerified: true,
+		Args:        []KeyValue{{Key: FreeformArgKey, Value: "+15555551212 hello world"}},
+	}
+	got := buildArgv(inv)
+	want := []string{"sms", "KE0XYZ", "true", "+15555551212 hello world"}
+	if len(got) != len(want) {
+		t.Fatalf("argv = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("argv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildArgvKVShapeUnchanged(t *testing.T) {
+	inv := Invocation{
+		ActionName:  "echo",
+		SenderCall:  "KE0XYZ",
+		OTPVerified: false,
+		Args:        []KeyValue{{Key: "msg", Value: "hi"}, {Key: "to", Value: "+1"}},
+	}
+	got := buildArgv(inv)
+	want := []string{"echo", "KE0XYZ", "false", "msg=hi", "to=+1"}
+	if len(got) != len(want) {
+		t.Fatalf("argv = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("argv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildEnvFreeform(t *testing.T) {
+	req := ExecRequest{
+		Invocation: Invocation{
+			ActionName:  "sms",
+			SenderCall:  "KE0XYZ",
+			OTPVerified: true,
+			Args:        []KeyValue{{Key: FreeformArgKey, Value: "+15555551212 hello"}},
+		},
+	}
+	env := buildEnv(req)
+	var sawArg bool
+	for _, kv := range env {
+		if kv == "GW_ARG=+15555551212 hello" {
+			sawArg = true
+		}
+		if strings.HasPrefix(kv, "GW_ARG_ARG=") {
+			t.Fatalf("freeform must not double-name as GW_ARG_ARG: %q", kv)
+		}
+	}
+	if !sawArg {
+		t.Fatalf("expected GW_ARG=... in env, got %v", env)
+	}
+}
+
+func TestBuildEnvKVUnchanged(t *testing.T) {
+	req := ExecRequest{
+		Invocation: Invocation{
+			ActionName: "echo",
+			Args:       []KeyValue{{Key: "msg", Value: "hi"}, {Key: "to", Value: "+1"}},
+		},
+	}
+	env := buildEnv(req)
+	want := map[string]bool{"GW_ARG_MSG=hi": false, "GW_ARG_TO=+1": false}
+	for _, kv := range env {
+		if _, ok := want[kv]; ok {
+			want[kv] = true
+		}
+	}
+	for k, v := range want {
+		if !v {
+			t.Fatalf("missing %q in env: %v", k, env)
+		}
+	}
+}
+
 func TestCmdExecutorNonZero(t *testing.T) {
 	exe := NewCommandExecutor()
 	a := &configstore.Action{Name: "F", Type: "command", CommandPath: absTestData(t, "fail.sh"), TimeoutSec: 5}

--- a/pkg/actions/parser.go
+++ b/pkg/actions/parser.go
@@ -53,9 +53,23 @@ func Parse(body string) (*ParsedInvocation, error) {
 	}
 	args, err := parseArgs(argTail)
 	if err != nil {
-		return nil, err
+		// kv tokenization failed but the action name is valid. Return a
+		// partial ParsedInvocation so freeform consumers (which read
+		// RawArgTail directly) can still dispatch — the classifier
+		// branches on Action.ArgMode to decide whether the kv error is
+		// fatal. Args is nil to signal "tokenization failed".
+		return &ParsedInvocation{
+			OTPDigits:  otp,
+			Action:     action,
+			RawArgTail: argTail,
+		}, err
 	}
-	return &ParsedInvocation{OTPDigits: otp, Action: action, Args: args}, nil
+	return &ParsedInvocation{
+		OTPDigits:  otp,
+		Action:     action,
+		Args:       args,
+		RawArgTail: argTail,
+	}, nil
 }
 
 // ValidActionName reports whether s is a legal action name. Mirrors the

--- a/pkg/actions/parser_test.go
+++ b/pkg/actions/parser_test.go
@@ -18,6 +18,7 @@ func TestParseOTPPresent(t *testing.T) {
 			{Key: "room", Value: "garage"},
 			{Key: "state", Value: "on"},
 		},
+		RawArgTail: "room=garage state=on",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("\n got: %+v\nwant: %+v", got, want)
@@ -119,6 +120,49 @@ func TestParseEmptyArgValueAllowed(t *testing.T) {
 	}
 	if len(got.Args) != 1 || got.Args[0].Key != "k" || got.Args[0].Value != "" {
 		t.Fatalf("expected single empty-value arg, got %+v", got.Args)
+	}
+}
+
+func TestParseCapturesRawArgTail(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantTail string
+	}{
+		{"no args", "@@123456#act", ""},
+		{"single kv", "@@123456#act k=v", "k=v"},
+		{"freeform-shaped", "@@123456#sms +15555551212 hello world", "+15555551212 hello world"},
+		{"trailing whitespace preserved", "@@123456#act   x  ", "  x  "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := Parse(tc.body)
+			if got == nil {
+				t.Fatalf("Parse returned nil result for %q", tc.body)
+			}
+			if got.RawArgTail != tc.wantTail {
+				t.Fatalf("RawArgTail = %q, want %q", got.RawArgTail, tc.wantTail)
+			}
+		})
+	}
+}
+
+func TestParseFreeformShapedReturnsPartial(t *testing.T) {
+	// kv tokenization fails (`+15555551212` has no `=`) but the action
+	// name is valid. Parser must return a partial ParsedInvocation with
+	// RawArgTail populated so the freeform classifier path can recover.
+	got, err := Parse("@@#sms +15555551212 hello world")
+	if err == nil {
+		t.Fatal("expected kv-tokenization error")
+	}
+	if got == nil {
+		t.Fatal("expected partial result, got nil")
+	}
+	if got.Action != "sms" {
+		t.Fatalf("Action = %q, want %q", got.Action, "sms")
+	}
+	if got.RawArgTail != "+15555551212 hello world" {
+		t.Fatalf("RawArgTail = %q, want freeform tail", got.RawArgTail)
 	}
 }
 

--- a/pkg/actions/runner.go
+++ b/pkg/actions/runner.go
@@ -275,8 +275,16 @@ func marshalArgs(kvs []KeyValue) string {
 	m := make(map[string]string, len(kvs))
 	for _, kv := range kvs {
 		v := kv.Value
-		if len(v) > 64 {
-			v = v[:64]
+		// kv values cap at 64; freeform values cap at the schema
+		// ceiling so the audit row preserves what the operator
+		// actually sent (kv args max out at 32 in practice; freeform
+		// payloads can run to 200).
+		limit := 64
+		if kv.Key == FreeformArgKey {
+			limit = FreeformValueCeiling
+		}
+		if len(v) > limit {
+			v = v[:limit]
 		}
 		m[kv.Key] = v
 	}

--- a/pkg/actions/runner_test.go
+++ b/pkg/actions/runner_test.go
@@ -2,6 +2,8 @@ package actions
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -242,4 +244,32 @@ func waitFor(t *testing.T, cond func() bool) {
 		time.Sleep(2 * time.Millisecond)
 	}
 	t.Fatal("timeout waiting for condition")
+}
+
+func TestMarshalArgsKVTruncatesAt64(t *testing.T) {
+	long := strings.Repeat("a", 100)
+	got := marshalArgs([]KeyValue{{Key: "k", Value: long}})
+	// Decode and verify the kv value was clipped to 64 bytes.
+	var m map[string]string
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatal(err)
+	}
+	if len(m["k"]) != 64 {
+		t.Fatalf("kv truncation: len=%d want 64", len(m["k"]))
+	}
+}
+
+func TestMarshalArgsFreeformKeepsFullCeiling(t *testing.T) {
+	// Freeform Actions can ship up to FreeformValueCeiling (200) bytes
+	// — clipping at 64 in the audit log would hide most of the
+	// operator's payload.
+	long := strings.Repeat("a", FreeformValueCeiling)
+	got := marshalArgs([]KeyValue{{Key: FreeformArgKey, Value: long}})
+	var m map[string]string
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatal(err)
+	}
+	if len(m[FreeformArgKey]) != FreeformValueCeiling {
+		t.Fatalf("freeform truncation: len=%d want %d", len(m[FreeformArgKey]), FreeformValueCeiling)
+	}
 }

--- a/pkg/actions/sanitize.go
+++ b/pkg/actions/sanitize.go
@@ -11,6 +11,13 @@ import (
 const (
 	defaultArgRegex  = `^[A-Za-z0-9,_-]{1,32}$`
 	defaultArgMaxLen = 32
+
+	// FreeformValueCeiling is the absolute server-side cap on a single
+	// freeform payload, regardless of operator MaxLen. Matches the APRS
+	// message body limit comfortably and prevents an over-permissive
+	// schema from accepting payloads larger than the message subsystem
+	// can stage.
+	FreeformValueCeiling = 200
 )
 
 // ArgSpec is one entry in an Action's arg_schema, decoded from JSON.

--- a/pkg/actions/sanitize_freeform.go
+++ b/pkg/actions/sanitize_freeform.go
@@ -1,0 +1,87 @@
+package actions
+
+import (
+	"errors"
+	"fmt"
+)
+
+// SanitizeFreeform validates a single untokenized payload against an
+// Action's freeform arg schema. The schema must contain exactly one
+// ArgSpec; the synthetic FreeformArgKey is imposed on the result so
+// downstream executors can rely on a stable key.
+//
+// Defense layers, in order:
+//
+//  1. Schema shape — exactly one ArgSpec.
+//  2. Required check — empty value rejected when Required.
+//  3. Length — operator MaxLen, hard-capped by ceiling.
+//  4. Control-char floor — bytes outside printable ASCII + extended
+//     UTF-8 are rejected unconditionally. Specifically: any byte in
+//     0x00..0x1F or 0x7F. Catches tabs, NUL, CR/LF, escape codes and
+//     other terminal/log-injection vectors regardless of operator
+//     regex permissiveness.
+//  5. Regex — operator pattern, defaulted to `.*` if empty so a blank
+//     pattern doesn't fall through to the kv default that requires the
+//     value to look like an identifier.
+//
+// Order matters: the control-char floor runs BEFORE regex so a
+// permissive `.*` cannot widen the floor.
+func SanitizeFreeform(schema []ArgSpec, raw string, ceiling int) ([]KeyValue, error) {
+	if len(schema) != 1 {
+		return nil, errors.New("freeform schema must have exactly one ArgSpec")
+	}
+	spec := schema[0]
+
+	if raw == "" {
+		if spec.Required {
+			return nil, &BadArgError{Key: FreeformArgKey, Reason: "missing"}
+		}
+		return nil, nil
+	}
+
+	maxLen := spec.MaxLen
+	if maxLen <= 0 || maxLen > ceiling {
+		maxLen = ceiling
+	}
+	if len(raw) > maxLen {
+		return nil, &BadArgError{Key: FreeformArgKey, Reason: "too long"}
+	}
+
+	if i, ok := firstControlByte(raw); ok {
+		return nil, &BadArgError{Key: FreeformArgKey, Reason: fmt.Sprintf("control char at byte %d", i)}
+	}
+
+	pat := spec.Regex
+	if pat == "" {
+		// Freeform's default is permissive — the operator opted into a
+		// single payload, the kv-style identifier regex would reject
+		// almost any realistic message body. Control-char floor above
+		// already filters the dangerous bytes.
+		pat = `.*`
+	}
+	re, err := compileRegex(pat)
+	if err != nil {
+		return nil, &BadArgError{Key: FreeformArgKey, Reason: "schema regex invalid"}
+	}
+	if !re.MatchString(raw) {
+		return nil, &BadArgError{Key: FreeformArgKey, Reason: "regex"}
+	}
+
+	return []KeyValue{{Key: FreeformArgKey, Value: raw}}, nil
+}
+
+// firstControlByte returns the byte offset of the first ASCII control
+// character (0x00..0x1F or 0x7F) in s. Multi-byte UTF-8 sequences are
+// allowed through — those start at >= 0x80 and never collide with the
+// rejection range. Tabs are rejected even though they are technically
+// "whitespace": APRS bodies have no legitimate use for tab and tabs
+// in shell-script argv smuggle word boundaries.
+func firstControlByte(s string) (int, bool) {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c == 0x7F {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/pkg/actions/sanitize_freeform_test.go
+++ b/pkg/actions/sanitize_freeform_test.go
@@ -1,0 +1,107 @@
+package actions
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeFreeformAcceptsValidPayload(t *testing.T) {
+	schema := []ArgSpec{{Key: FreeformArgKey, Regex: `^[\x20-\x7E]+$`, MaxLen: 100}}
+	clean, err := SanitizeFreeform(schema, "+15555551212 hello world", FreeformValueCeiling)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []KeyValue{{Key: FreeformArgKey, Value: "+15555551212 hello world"}}
+	if !reflect.DeepEqual(clean, want) {
+		t.Fatalf("got %+v, want %+v", clean, want)
+	}
+}
+
+func TestSanitizeFreeformRejectsControlChars(t *testing.T) {
+	// Tab, NUL, CR, LF, ESC must all be rejected even with `.*` regex —
+	// defense in depth against log injection and terminal-escape attacks
+	// via APRS messages.
+	schema := []ArgSpec{{Key: FreeformArgKey, Regex: `.*`, MaxLen: 200}}
+	for _, bad := range []string{"hello\tworld", "ab\x00cd", "line1\rline2", "line1\nline2", "esc\x1b[31mred"} {
+		t.Run(bad, func(t *testing.T) {
+			_, err := SanitizeFreeform(schema, bad, FreeformValueCeiling)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "control") {
+				t.Fatalf("err = %v, want to mention control", err)
+			}
+		})
+	}
+}
+
+func TestSanitizeFreeformAppliesCeiling(t *testing.T) {
+	// MaxLen left at 0; ceiling enforces.
+	schema := []ArgSpec{{Key: FreeformArgKey, Regex: `.*`, MaxLen: 0}}
+	value := strings.Repeat("a", FreeformValueCeiling+1)
+	_, err := SanitizeFreeform(schema, value, FreeformValueCeiling)
+	if err == nil {
+		t.Fatal("expected too-long error")
+	}
+	if !strings.Contains(err.Error(), "too long") {
+		t.Fatalf("err = %v, want too long", err)
+	}
+}
+
+func TestSanitizeFreeformRespectsOperatorMaxLen(t *testing.T) {
+	schema := []ArgSpec{{Key: FreeformArgKey, Regex: `.*`, MaxLen: 32}}
+	if _, err := SanitizeFreeform(schema, strings.Repeat("a", 33), FreeformValueCeiling); err == nil {
+		t.Fatal("expected too-long error")
+	}
+}
+
+func TestSanitizeFreeformOperatorMaxLenCappedByCeiling(t *testing.T) {
+	// Operator MaxLen wider than ceiling cannot widen past it.
+	schema := []ArgSpec{{Key: FreeformArgKey, Regex: `.*`, MaxLen: FreeformValueCeiling + 50}}
+	if _, err := SanitizeFreeform(schema, strings.Repeat("a", FreeformValueCeiling+10), FreeformValueCeiling); err == nil {
+		t.Fatal("expected ceiling to cap operator MaxLen")
+	}
+}
+
+func TestSanitizeFreeformRejectsBadRegex(t *testing.T) {
+	schema := []ArgSpec{{Key: FreeformArgKey, Regex: `^[A-Z]+$`, MaxLen: 100}}
+	_, err := SanitizeFreeform(schema, "lowercase", FreeformValueCeiling)
+	if err == nil {
+		t.Fatal("expected regex error")
+	}
+	var bae *BadArgError
+	if !errors.As(err, &bae) || bae.Reason != "regex" {
+		t.Fatalf("expected BadArgError reason=regex, got %v", err)
+	}
+}
+
+func TestSanitizeFreeformRequiresExactlyOneSpec(t *testing.T) {
+	if _, err := SanitizeFreeform(nil, "x", FreeformValueCeiling); err == nil {
+		t.Fatal("expected error for nil schema")
+	}
+	twoSpecs := []ArgSpec{{Key: "a"}, {Key: "b"}}
+	if _, err := SanitizeFreeform(twoSpecs, "x", FreeformValueCeiling); err == nil {
+		t.Fatal("expected error for two specs")
+	}
+}
+
+func TestSanitizeFreeformEmptyValueWhenRequired(t *testing.T) {
+	schema := []ArgSpec{{Key: FreeformArgKey, Regex: `.+`, MaxLen: 100, Required: true}}
+	_, err := SanitizeFreeform(schema, "", FreeformValueCeiling)
+	if err == nil {
+		t.Fatal("expected missing-arg error")
+	}
+}
+
+func TestSanitizeFreeformEmptyValueWhenOptional(t *testing.T) {
+	schema := []ArgSpec{{Key: FreeformArgKey, Regex: `.*`, MaxLen: 100}}
+	clean, err := SanitizeFreeform(schema, "", FreeformValueCeiling)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if clean != nil {
+		t.Fatalf("expected nil result for empty optional, got %+v", clean)
+	}
+}

--- a/pkg/actions/template_filters.go
+++ b/pkg/actions/template_filters.go
@@ -1,0 +1,113 @@
+package actions
+
+import (
+	"bytes"
+	"encoding/json"
+	"html"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// tokenRE matches {{name}} and {{name|filter}} where name is one of:
+//
+//	arg              (freeform synthetic value)
+//	arg.<key>        (kv-mode value by key; key matches [A-Za-z0-9._-])
+//	action, sender-callsign, otp-verified, otp-cred, source
+//
+// and filter is one of: json, url, html (optional).
+//
+// Matching {{ }} eagerly is fine — substituted text is never re-scanned
+// (single-pass ReplaceAllStringFunc), so a value containing literal
+// "{{x}}" cannot trigger a second substitution.
+var tokenRE = regexp.MustCompile(`\{\{([a-zA-Z][a-zA-Z0-9._-]*)(?:\|(json|url|html))?\}\}`)
+
+// expandTokenFiltered substitutes tokens in `in` using a single regex
+// scan. baseEncoder applies to bare tokens (no filter); filtered tokens
+// override it. Used by webhook URL templates (urlEncoder default) and
+// body templates (identityEncoder default).
+func expandTokenFiltered(in string, inv Invocation, baseEncoder tokenEncoder) string {
+	return tokenRE.ReplaceAllStringFunc(in, func(match string) string {
+		m := tokenRE.FindStringSubmatch(match)
+		if len(m) == 0 {
+			return match
+		}
+		name := m[1]
+		filter := m[2]
+		raw, ok := lookupTokenValue(name, inv)
+		if !ok {
+			return match
+		}
+		if filter != "" {
+			return applyFilter(raw, filter)
+		}
+		return baseEncoder(raw)
+	})
+}
+
+func lookupTokenValue(name string, inv Invocation) (string, bool) {
+	switch name {
+	case "action":
+		return inv.ActionName, true
+	case "sender-callsign":
+		return inv.SenderCall, true
+	case "otp-verified":
+		return boolStr(inv.OTPVerified), true
+	case "otp-cred":
+		return inv.OTPCredName, true
+	case "source":
+		return string(inv.Source), true
+	case "arg":
+		// Freeform synthetic value. Only present when ArgMode=freeform.
+		for _, kv := range inv.Args {
+			if kv.Key == FreeformArgKey {
+				return kv.Value, true
+			}
+		}
+		return "", false
+	}
+	const argDot = "arg."
+	if strings.HasPrefix(name, argDot) {
+		key := name[len(argDot):]
+		for _, kv := range inv.Args {
+			if kv.Key == key {
+				return kv.Value, true
+			}
+		}
+	}
+	return "", false
+}
+
+// applyFilter encodes `raw` for the requested context. The encodings are
+// chosen so an operator can place the token inside a literal: a JSON
+// string literal, a URL query, or an HTML body.
+func applyFilter(raw, filter string) string {
+	switch filter {
+	case "json":
+		// Encode as a JSON string then strip the surrounding quotes so
+		// the operator can place {{arg|json}} inside their own quotes
+		// (e.g., `"msg":"{{arg|json}}"`).
+		//
+		// SetEscapeHTML(false) keeps `<`, `>`, `&` literal — the
+		// surrounding context is JSON, not HTML. Operators rendering
+		// the JSON into a browser should use {{arg|html}} on the
+		// rendering side instead.
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(raw); err != nil {
+			return ""
+		}
+		// Encoder appends a trailing newline; strip it plus the quotes.
+		out := bytes.TrimRight(buf.Bytes(), "\n")
+		if len(out) >= 2 {
+			return string(out[1 : len(out)-1])
+		}
+		return ""
+	case "url":
+		return url.QueryEscape(raw)
+	case "html":
+		return html.EscapeString(raw)
+	}
+	return raw
+}

--- a/pkg/actions/template_filters_test.go
+++ b/pkg/actions/template_filters_test.go
@@ -1,0 +1,79 @@
+package actions
+
+import "testing"
+
+func TestExpandTokenFreeformBareArg(t *testing.T) {
+	inv := Invocation{
+		ActionName: "sms",
+		SenderCall: "KE0XYZ",
+		Args:       []KeyValue{{Key: FreeformArgKey, Value: "hello world"}},
+	}
+	got := expandToken("payload={{arg}}", inv, identityEncoder)
+	if got != "payload=hello world" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExpandTokenJSONFilter(t *testing.T) {
+	inv := Invocation{
+		Args: []KeyValue{{Key: FreeformArgKey, Value: `she said "hi"` + "\nline2"}},
+	}
+	got := expandToken(`{"msg":"{{arg|json}}"}`, inv, identityEncoder)
+	want := `{"msg":"she said \"hi\"\nline2"}`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestExpandTokenURLFilter(t *testing.T) {
+	inv := Invocation{
+		Args: []KeyValue{{Key: FreeformArgKey, Value: "a b&c=d"}},
+	}
+	got := expandToken("https://x.test/?q={{arg|url}}", inv, identityEncoder)
+	want := "https://x.test/?q=a+b%26c%3Dd"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestExpandTokenHTMLFilter(t *testing.T) {
+	inv := Invocation{
+		Args: []KeyValue{{Key: FreeformArgKey, Value: `<script>alert(1)</script>`}},
+	}
+	got := expandToken("<p>{{arg|html}}</p>", inv, identityEncoder)
+	want := "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestExpandTokenKVFilters(t *testing.T) {
+	inv := Invocation{
+		Args: []KeyValue{{Key: "to", Value: `a"b`}, {Key: "msg", Value: "x&y"}},
+	}
+	got := expandToken(`{"to":"{{arg.to|json}}","msg":"{{arg.msg|json}}"}`, inv, identityEncoder)
+	want := `{"to":"a\"b","msg":"x&y"}`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestExpandTokenUnknownTokenLeftUntouched(t *testing.T) {
+	inv := Invocation{}
+	got := expandToken("hi {{nobody}}", inv, identityEncoder)
+	if got != "hi {{nobody}}" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExpandTokenSubstitutionNotRescanned(t *testing.T) {
+	// A value that itself looks like a token must not trigger a second
+	// substitution.
+	inv := Invocation{
+		Args: []KeyValue{{Key: FreeformArgKey, Value: "{{action}}"}},
+	}
+	got := expandToken("{{arg}}", inv, identityEncoder)
+	if got != "{{action}}" {
+		t.Fatalf("substituted text was re-scanned: %q", got)
+	}
+}

--- a/pkg/actions/types.go
+++ b/pkg/actions/types.go
@@ -28,16 +28,40 @@ const (
 	SourceIS Source = "is"
 )
 
+// ArgMode controls how argv after the action verb is interpreted.
+//
+//	kv:       "@@<otp>#name k1=v1 k2=v2"  (current behavior, default)
+//	freeform: "@@<otp>#name <one untokenized payload>"
+type ArgMode string
+
+const (
+	ArgModeKV       ArgMode = "kv"
+	ArgModeFreeform ArgMode = "freeform"
+)
+
+// FreeformArgKey is the synthetic key used for the single freeform
+// value. Stable so executors, audit log, and webhook templates can
+// refer to it as `arg` (env var GW_ARG, token {{arg}}). Not operator-
+// settable.
+const FreeformArgKey = "arg"
+
 // ParsedInvocation is the output of parser.Parse. Args preserve key
 // order as parsed off the wire so executors can present a stable argv.
 //
 // Args contains raw, untrusted key=value tokens straight off the wire.
 // Callers MUST run them through the runner's sanitizer (Phase C) before
 // passing them to an Executor.
+//
+// RawArgTail is the raw bytes after the action name and the first
+// space, with no trimming or tokenization. Freeform consumers read it
+// directly; kv consumers ignore it. May be populated even when Args is
+// nil (kv tokenization failed but the action name parsed cleanly), so
+// the classifier can still dispatch a freeform Action.
 type ParsedInvocation struct {
-	OTPDigits string // empty if message had no OTP digits
-	Action    string
-	Args      []KeyValue
+	OTPDigits  string // empty if message had no OTP digits
+	Action     string
+	Args       []KeyValue
+	RawArgTail string
 }
 
 type KeyValue struct {

--- a/pkg/actions/webhook_executor.go
+++ b/pkg/actions/webhook_executor.go
@@ -132,22 +132,16 @@ type tokenEncoder func(s string) string
 func urlEncoder(s string) string      { return url.QueryEscape(s) }
 func identityEncoder(s string) string { return s }
 
-// expandToken substitutes {{name}} tokens in `in` using a single-pass
-// replacer. Single-pass is load-bearing: a naive loop of strings.ReplaceAll
-// re-feeds output as input, so a per-key arg regex permitting `{` / `}`
-// would let one arg's value reference another's token. NewReplacer scans
-// once, left-to-right, never reconsidering substituted text — and gives
-// deterministic output regardless of map iteration order.
+// expandToken substitutes operator-template tokens. Two-stage:
+//
+//  1. tokenRE matches {{name}} and {{name|filter}}.
+//  2. lookupTokenValue resolves the name; applyFilter handles the
+//     filter (or the legacy URL-vs-identity baseEncoder if absent).
+//
+// The single regex pass guarantees substituted output is never
+// re-scanned: a value containing literal "{{x}}" does not trigger a
+// second substitution. This was load-bearing in the previous
+// strings.NewReplacer implementation and remains so.
 func expandToken(in string, inv Invocation, enc tokenEncoder) string {
-	pairs := []string{
-		"{{action}}", enc(inv.ActionName),
-		"{{sender-callsign}}", enc(inv.SenderCall),
-		"{{otp-verified}}", enc(boolStr(inv.OTPVerified)),
-		"{{otp-cred}}", enc(inv.OTPCredName),
-		"{{source}}", enc(string(inv.Source)),
-	}
-	for _, kv := range inv.Args {
-		pairs = append(pairs, "{{arg."+kv.Key+"}}", enc(kv.Value))
-	}
-	return strings.NewReplacer(pairs...).Replace(in)
+	return expandTokenFiltered(in, inv, enc)
 }

--- a/pkg/configstore/migrate.go
+++ b/pkg/configstore/migrate.go
@@ -168,6 +168,7 @@ var schemaMigrations = []migration{
 	{version: 14, name: "ax25_terminal_tables", phase: postAutoMigrate, run: migrateAX25TerminalTables},
 	{version: 15, name: "actions_tables", phase: postAutoMigrate, run: migrateActionsTables},
 	{version: 16, name: "remote_actions_tables", phase: postAutoMigrate, run: migrateRemoteActionsTables},
+	{version: 17, name: "actions_arg_mode", phase: postAutoMigrate, run: migrateActionsArgMode},
 }
 
 // runMigrations applies every pending migration in the given phase,

--- a/pkg/configstore/migrate_actions_argmode.go
+++ b/pkg/configstore/migrate_actions_argmode.go
@@ -1,0 +1,29 @@
+package configstore
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// migrateActionsArgMode adds the arg_mode column to the actions table.
+// Default 'kv' preserves existing-row behavior. The column is NOT NULL
+// so application code can always read it without a sentinel check.
+//
+// Idempotent: if the column already exists (e.g. AutoMigrate added it
+// from the model in a later-binary first run, or the test harness
+// rolled user_version back to re-fire migrations), the ALTER is
+// skipped. Rerun safety matches the channel_mode migration pattern.
+func migrateActionsArgMode(tx *gorm.DB) error {
+	hasCol, err := columnExists(tx, "actions", "arg_mode")
+	if err != nil {
+		return fmt.Errorf("probe actions.arg_mode: %w", err)
+	}
+	if hasCol {
+		return nil
+	}
+	if err := tx.Exec(`ALTER TABLE actions ADD COLUMN arg_mode TEXT NOT NULL DEFAULT 'kv'`).Error; err != nil {
+		return fmt.Errorf("add actions.arg_mode: %w", err)
+	}
+	return nil
+}

--- a/pkg/configstore/migrate_actions_argmode_test.go
+++ b/pkg/configstore/migrate_actions_argmode_test.go
@@ -1,0 +1,49 @@
+package configstore
+
+import (
+	"testing"
+)
+
+// TestMigration17AddsArgModeColumn verifies that migration 17 adds
+// arg_mode to the actions table with NOT NULL DEFAULT 'kv', so existing
+// rows materialize the default at read time without an explicit UPDATE.
+func TestMigration17AddsArgModeColumn(t *testing.T) {
+	s := newTestStore(t)
+
+	// Insert a row with NO arg_mode value via raw SQL — proving the
+	// column is materialized with the documented default for legacy
+	// rows that predate the migration field on the model.
+	if err := s.DB().Exec(`INSERT INTO actions
+		(name, type, command_path, timeout_sec, otp_required,
+		 sender_allowlist, arg_schema, rate_limit_sec, queue_depth,
+		 enabled, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,datetime('now'),datetime('now'))`,
+		"legacy", "command", "/bin/true", 10, 0, "", "[]", 5, 8, 1).Error; err != nil {
+		t.Fatalf("insert legacy: %v", err)
+	}
+
+	var mode string
+	if err := s.DB().Raw(`SELECT arg_mode FROM actions WHERE name = 'legacy'`).Scan(&mode).Error; err != nil {
+		t.Fatalf("scan arg_mode: %v", err)
+	}
+	if mode != "kv" {
+		t.Fatalf("arg_mode = %q, want %q", mode, "kv")
+	}
+
+	// Round-trip a freeform row through the model layer.
+	a := &Action{
+		Name: "fm", Type: "command", CommandPath: "/bin/true",
+		TimeoutSec: 5, ArgSchema: `[]`, RateLimitSec: 0, QueueDepth: 1,
+		Enabled: true, ArgMode: "freeform",
+	}
+	if err := s.DB().Create(a).Error; err != nil {
+		t.Fatalf("create freeform action: %v", err)
+	}
+	var got Action
+	if err := s.DB().Where("name = ?", "fm").First(&got).Error; err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if got.ArgMode != "freeform" {
+		t.Fatalf("ArgMode round-trip = %q, want %q", got.ArgMode, "freeform")
+	}
+}

--- a/pkg/configstore/migrate_actions_argmode_test.go
+++ b/pkg/configstore/migrate_actions_argmode_test.go
@@ -1,6 +1,7 @@
 package configstore
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -45,5 +46,63 @@ func TestMigration17AddsArgModeColumn(t *testing.T) {
 	}
 	if got.ArgMode != "freeform" {
 		t.Fatalf("ArgMode round-trip = %q, want %q", got.ArgMode, "freeform")
+	}
+}
+
+// TestMigration16_ReAddsArgModeColumn exercises migrateActionsArgMode
+// directly against the legacy-database scenario it exists for: drops
+// arg_mode on a populated database, invokes the migration body, and
+// asserts the column was re-added with the 'kv' default. Then runs
+// the migration a second time to verify the columnExists guard makes
+// it a no-op.
+//
+// Going through the migration body directly (rather than rolling
+// PRAGMA user_version back) is the only way to test the columnExists
+// branch — re-Open would let AutoMigrate add the column from the Go
+// struct first, masking the regression we want to catch.
+func TestMigration16_ReAddsArgModeColumn(t *testing.T) {
+	t.Parallel()
+	dsn := filepath.Join(t.TempDir(), "actions_arg_mode.db")
+	store, err := Open(dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.DB().Exec(`INSERT INTO actions
+		(name, type, command_path, timeout_sec, otp_required,
+		 sender_allowlist, arg_schema, rate_limit_sec, queue_depth,
+		 enabled, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,datetime('now'),datetime('now'))`,
+		"legacy", "command", "/bin/true", 10, 0, "", "[]", 5, 8, 1).Error; err != nil {
+		t.Fatalf("insert legacy: %v", err)
+	}
+	if err := store.DB().Exec(`ALTER TABLE actions DROP COLUMN arg_mode`).Error; err != nil {
+		t.Fatalf("drop arg_mode: %v", err)
+	}
+
+	hasCol, err := columnExists(store.DB(), "actions", "arg_mode")
+	if err != nil {
+		t.Fatalf("probe pre-migration: %v", err)
+	}
+	if hasCol {
+		t.Fatal("pre-migration: arg_mode unexpectedly present")
+	}
+
+	if err := migrateActionsArgMode(store.DB()); err != nil {
+		t.Fatalf("first invocation: %v", err)
+	}
+
+	var mode string
+	if err := store.DB().Raw(`SELECT arg_mode FROM actions WHERE name='legacy'`).Scan(&mode).Error; err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if mode != "kv" {
+		t.Fatalf("arg_mode = %q, want %q", mode, "kv")
+	}
+
+	// Idempotence: second invocation must short-circuit on columnExists.
+	if err := migrateActionsArgMode(store.DB()); err != nil {
+		t.Fatalf("second invocation: %v", err)
 	}
 }

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -837,6 +837,7 @@ type Action struct {
 	OTPCredentialID     *uint  `gorm:"column:otp_credential_id"` // FK to OTPCredential, nullable; ON DELETE SET NULL
 	SenderAllowlist     string // CSV
 	ArgSchema           string `gorm:"type:text;default:'[]'"` // JSON list
+	ArgMode             string `gorm:"size:16;not null;default:'kv'"`
 	RateLimitSec        int    `gorm:"not null;default:5"`
 	QueueDepth          int    `gorm:"not null;default:8"`
 	Enabled             bool   `gorm:"not null"`

--- a/pkg/webapi/action_test_fire.go
+++ b/pkg/webapi/action_test_fire.go
@@ -62,7 +62,26 @@ func (s *Server) testFireAction(w http.ResponseWriter, r *http.Request) {
 		s.internalError(w, r, "decode arg schema", err)
 		return
 	}
-	clean, sErr := actions.SanitizeFromMap(schema, in.Args)
+	var clean []actions.KeyValue
+	var sErr error
+	switch a.ArgMode {
+	case "freeform":
+		if in.Text == nil {
+			badRequest(w, "text required for freeform action")
+			return
+		}
+		if in.Args != nil {
+			badRequest(w, "args not allowed for freeform action; use text")
+			return
+		}
+		clean, sErr = actions.SanitizeFreeform(schema, *in.Text, actions.FreeformValueCeiling)
+	default:
+		if in.Text != nil {
+			badRequest(w, "text not allowed for kv action; use args")
+			return
+		}
+		clean, sErr = actions.SanitizeFromMap(schema, in.Args)
+	}
 	if sErr != nil {
 		// Match the on-air reply wording so the UI presents the same
 		// failure shape.

--- a/pkg/webapi/action_test_fire_test.go
+++ b/pkg/webapi/action_test_fire_test.go
@@ -159,6 +159,98 @@ func TestFireAction_NoActionsService(t *testing.T) {
 	}
 }
 
+func makeFreeformTestFireAction(t *testing.T, mux *http.ServeMux) uint {
+	t.Helper()
+	in := dto.Action{
+		Name: "tffree", Type: "webhook", WebhookMethod: "GET",
+		WebhookURL: "https://example.test/", TimeoutSec: 5,
+		Enabled:   true,
+		ArgMode:   "freeform",
+		ArgSchema: []dto.ArgSpec{{Key: "arg", Regex: `.+`, MaxLen: 100, Required: true}},
+	}
+	body, _ := json.Marshal(in)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/actions", bytes.NewReader(body)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create freeform: %d %s", rec.Code, rec.Body.String())
+	}
+	var got dto.Action
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	return got.ID
+}
+
+func TestFireAction_FreeformAcceptsText(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	rec := &recordingTestFire{invID: 7}
+	srv.SetActionsService(rec)
+	id := makeFreeformTestFireAction(t, mux)
+
+	body := strings.NewReader(`{"text":"+15555551212 hello world"}`)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/actions/"+strconv.FormatUint(uint64(id), 10)+"/test-fire", body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if len(rec.gotArgs) != 1 || rec.gotArgs[0].Key != actions.FreeformArgKey || rec.gotArgs[0].Value != "+15555551212 hello world" {
+		t.Fatalf("freeform args not forwarded: %+v", rec.gotArgs)
+	}
+}
+
+func TestFireAction_FreeformRejectsArgs(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	rec := &recordingTestFire{}
+	srv.SetActionsService(rec)
+	id := makeFreeformTestFireAction(t, mux)
+
+	body := strings.NewReader(`{"args":{"arg":"+15555551212 hello"}}`)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/actions/"+strconv.FormatUint(uint64(id), 10)+"/test-fire", body))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rr.Code, rr.Body.String())
+	}
+	if rec.testFires.Load() != 0 {
+		t.Fatal("TestFire dispatched despite mismatched payload shape")
+	}
+}
+
+func TestFireAction_FreeformRequiresText(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	rec := &recordingTestFire{}
+	srv.SetActionsService(rec)
+	id := makeFreeformTestFireAction(t, mux)
+
+	body := strings.NewReader(`{}`)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/actions/"+strconv.FormatUint(uint64(id), 10)+"/test-fire", body))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+func TestFireAction_KVRejectsText(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	rec := &recordingTestFire{}
+	srv.SetActionsService(rec)
+	id := makeTestFireAction(t, mux)
+
+	body := strings.NewReader(`{"text":"hello"}`)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/actions/"+strconv.FormatUint(uint64(id), 10)+"/test-fire", body))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rr.Code, rr.Body.String())
+	}
+}
+
 func TestFireAction_NotFound(t *testing.T) {
 	srv, _ := newTestServer(t)
 	mux := http.NewServeMux()

--- a/pkg/webapi/actions.go
+++ b/pkg/webapi/actions.go
@@ -288,13 +288,10 @@ func validateAction(in *dto.Action) error {
 	default:
 		return errors.New("arg_mode: must be 'kv' or 'freeform'")
 	}
-	if in.ArgMode == "freeform" {
-		if len(in.ArgSchema) != 1 {
-			return errors.New("arg_mode=freeform requires exactly one arg_schema entry")
-		}
-		if in.ArgSchema[0].MaxLen > actions.FreeformValueCeiling {
-			return fmt.Errorf("arg_schema[0].max_len: cannot exceed %d", actions.FreeformValueCeiling)
-		}
+	// Structural shape check for freeform must come before per-spec
+	// validation: zero specs would silently skip the loop without it.
+	if in.ArgMode == "freeform" && len(in.ArgSchema) != 1 {
+		return errors.New("arg_mode=freeform requires exactly one arg_schema entry")
 	}
 	for i, a := range in.ArgSchema {
 		if a.Key == "" {
@@ -308,6 +305,11 @@ func validateAction(in *dto.Action) error {
 				return fmt.Errorf("arg_schema[%d]: invalid regex: %w", i, err)
 			}
 		}
+	}
+	// Freeform value-ceiling cap applies to the single (now validated)
+	// spec.
+	if in.ArgMode == "freeform" && in.ArgSchema[0].MaxLen > actions.FreeformValueCeiling {
+		return fmt.Errorf("arg_schema[0].max_len: cannot exceed %d", actions.FreeformValueCeiling)
 	}
 	return nil
 }

--- a/pkg/webapi/actions.go
+++ b/pkg/webapi/actions.go
@@ -15,6 +15,7 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/chrissnell/graywolf/pkg/actions"
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/webapi/dto"
 )
@@ -279,9 +280,28 @@ func validateAction(in *dto.Action) error {
 		// in the form rather than the audit log.
 		return errors.New("otp_credential_id: required when otp_required is true")
 	}
+	switch in.ArgMode {
+	case "":
+		in.ArgMode = "kv"
+	case "kv", "freeform":
+		// ok
+	default:
+		return errors.New("arg_mode: must be 'kv' or 'freeform'")
+	}
+	if in.ArgMode == "freeform" {
+		if len(in.ArgSchema) != 1 {
+			return errors.New("arg_mode=freeform requires exactly one arg_schema entry")
+		}
+		if in.ArgSchema[0].MaxLen > actions.FreeformValueCeiling {
+			return fmt.Errorf("arg_schema[0].max_len: cannot exceed %d", actions.FreeformValueCeiling)
+		}
+	}
 	for i, a := range in.ArgSchema {
 		if a.Key == "" {
 			return fmt.Errorf("arg_schema[%d]: key required", i)
+		}
+		if in.ArgMode == "kv" && a.Key == actions.FreeformArgKey {
+			return fmt.Errorf("arg_schema[%d]: key %q is reserved (freeform mode synthetic value)", i, actions.FreeformArgKey)
 		}
 		if a.Regex != "" {
 			if _, err := regexp.Compile(a.Regex); err != nil {
@@ -375,9 +395,13 @@ func actionToDTO(a *configstore.Action) dto.Action {
 		OTPRequired:         a.OTPRequired,
 		OTPCredentialID:     a.OTPCredentialID,
 		SenderAllowlist:     a.SenderAllowlist,
+		ArgMode:             a.ArgMode,
 		RateLimitSec:        a.RateLimitSec,
 		QueueDepth:          a.QueueDepth,
 		Enabled:             a.Enabled,
+	}
+	if d.ArgMode == "" {
+		d.ArgMode = "kv"
 	}
 	if a.WebhookHeaders != "" {
 		_ = json.Unmarshal([]byte(a.WebhookHeaders), &d.WebhookHeaders)
@@ -423,6 +447,7 @@ func actionFromDTO(d *dto.Action) (*configstore.Action, error) {
 		OTPCredentialID:     d.OTPCredentialID,
 		SenderAllowlist:     d.SenderAllowlist,
 		ArgSchema:           string(schema),
+		ArgMode:             d.ArgMode,
 		RateLimitSec:        d.RateLimitSec,
 		QueueDepth:          d.QueueDepth,
 		Enabled:             d.Enabled,

--- a/pkg/webapi/actions_test.go
+++ b/pkg/webapi/actions_test.go
@@ -398,3 +398,70 @@ func TestActionsCRUD_ListLastInvoked(t *testing.T) {
 		t.Fatalf("last_invoked_* not populated: %+v", list)
 	}
 }
+
+func validBaseAction(t *testing.T) dto.Action {
+	t.Helper()
+	return dto.Action{
+		Name:        "okname",
+		Type:        "command",
+		CommandPath: writeExecScript(t),
+		TimeoutSec:  5,
+		Enabled:     true,
+		ArgSchema:   []dto.ArgSpec{{Key: "k1", Regex: `^[a-z]+$`, MaxLen: 8}},
+	}
+}
+
+func TestValidateActionRejectsBadArgMode(t *testing.T) {
+	in := validBaseAction(t)
+	in.ArgMode = "yolo"
+	if err := validateAction(&in); err == nil {
+		t.Fatal("expected error for unknown arg_mode")
+	}
+}
+
+func TestValidateActionDefaultsKVArgMode(t *testing.T) {
+	in := validBaseAction(t)
+	in.ArgMode = ""
+	if err := validateAction(&in); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if in.ArgMode != "kv" {
+		t.Fatalf("ArgMode = %q, want kv", in.ArgMode)
+	}
+}
+
+func TestValidateActionFreeformRequiresExactlyOneArgSpec(t *testing.T) {
+	in := validBaseAction(t)
+	in.ArgMode = "freeform"
+	in.ArgSchema = []dto.ArgSpec{}
+	if err := validateAction(&in); err == nil {
+		t.Fatal("expected error for empty schema in freeform mode")
+	}
+
+	in.ArgSchema = []dto.ArgSpec{
+		{Key: "arg", Regex: `.+`, MaxLen: 100},
+		{Key: "arg2", Regex: `.+`, MaxLen: 100},
+	}
+	if err := validateAction(&in); err == nil {
+		t.Fatal("expected error for two-spec schema in freeform mode")
+	}
+}
+
+func TestValidateActionFreeformCapsMaxLen(t *testing.T) {
+	in := validBaseAction(t)
+	in.ArgMode = "freeform"
+	in.ArgSchema = []dto.ArgSpec{{Key: "arg", Regex: `.+`, MaxLen: 9999}}
+	if err := validateAction(&in); err == nil {
+		t.Fatal("expected error: max_len above ceiling")
+	}
+}
+
+func TestValidateActionRejectsArgKeyInKVMode(t *testing.T) {
+	// "arg" is reserved as the freeform synthetic key.
+	in := validBaseAction(t)
+	in.ArgMode = "kv"
+	in.ArgSchema = []dto.ArgSpec{{Key: "arg", Regex: `.+`, MaxLen: 32}}
+	if err := validateAction(&in); err == nil {
+		t.Fatal("expected error: 'arg' reserved in kv mode")
+	}
+}

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -7609,6 +7609,10 @@
         "dto.Action": {
             "type": "object",
             "properties": {
+                "arg_mode": {
+                    "description": "\"kv\" (default) | \"freeform\"",
+                    "type": "string"
+                },
                 "arg_schema": {
                     "type": "array",
                     "items": {
@@ -9658,6 +9662,9 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "text": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -566,6 +566,9 @@ definitions:
     type: object
   dto.Action:
     properties:
+      arg_mode:
+        description: '"kv" (default) | "freeform"'
+        type: string
       arg_schema:
         items:
           $ref: '#/definitions/dto.ArgSpec'
@@ -2042,6 +2045,8 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      text:
+        type: string
     type: object
   dto.TestFireResponse:
     properties:

--- a/pkg/webapi/dto/actions.go
+++ b/pkg/webapi/dto/actions.go
@@ -24,6 +24,7 @@ type Action struct {
 	OTPCredentialID     *uint             `json:"otp_credential_id,omitempty"`
 	SenderAllowlist     string            `json:"sender_allowlist"`
 	ArgSchema           []ArgSpec         `json:"arg_schema"`
+	ArgMode             string            `json:"arg_mode"` // "kv" (default) | "freeform"
 	RateLimitSec        int               `json:"rate_limit_sec"`
 	QueueDepth          int               `json:"queue_depth"`
 	Enabled             bool              `json:"enabled"`
@@ -94,8 +95,13 @@ type ActionInvocation struct {
 }
 
 // TestFireRequest is the body accepted by POST /api/actions/{id}/test-fire.
+//
+// Args is used for kv-mode actions; Text is used for freeform-mode
+// actions. The handler rejects requests that mix shapes against the
+// Action's mode.
 type TestFireRequest struct {
-	Args map[string]string `json:"args"`
+	Args map[string]string `json:"args,omitempty"`
+	Text *string           `json:"text,omitempty"`
 }
 
 // TestFireResponse is the body returned by POST /api/actions/{id}/test-fire.

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2009,6 +2009,8 @@ export interface components {
             tactical?: components["schemas"]["dto.TacticalCallsignResponse"];
         };
         "dto.Action": {
+            /** @description "kv" (default) | "freeform" */
+            arg_mode?: string;
             arg_schema?: components["schemas"]["dto.ArgSpec"][];
             command_path?: string;
             description?: string;
@@ -2889,6 +2891,7 @@ export interface components {
             args?: {
                 [key: string]: string;
             };
+            text?: string;
         };
         "dto.TestFireResponse": {
             exit_code?: number;

--- a/web/src/components/actions/ArgModeSelect.svelte
+++ b/web/src/components/actions/ArgModeSelect.svelte
@@ -1,0 +1,57 @@
+<script>
+  import { Select } from '@chrissnell/chonky-ui';
+
+  /** @type {'kv'|'freeform'} */
+  let { value = $bindable('kv') } = $props();
+
+  const options = [
+    { value: 'kv', label: 'Key/value (default)' },
+    { value: 'freeform', label: 'Freeform (everything after the verb is one payload)' },
+  ];
+</script>
+
+<div class="arg-mode">
+  <label class="arg-mode__label" for="arg-mode-select">Argument mode</label>
+  <Select id="arg-mode-select" bind:value {options} />
+  <p class="arg-mode__help">
+    {#if value === 'kv'}
+      Senders write <code>@@&lt;otp&gt;#name k1=v1 k2=v2</code>. Each
+      argument is validated against its own schema row. Use this for
+      structured commands.
+    {:else}
+      Senders write <code>@@&lt;otp&gt;#name &lt;anything&gt;</code> and
+      everything after the verb is one payload. Your handler is
+      responsible for parsing and revalidating it.
+      <a href="/handbook/actions-handler-safety.html#freeform" target="_blank" rel="noopener">
+        Read the safety guide before enabling.
+      </a>
+    {/if}
+  </p>
+</div>
+
+<style>
+  .arg-mode { margin-bottom: 1rem; }
+  .arg-mode__label {
+    display: block;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--color-text-dim, var(--text-muted));
+    margin-bottom: 0.25rem;
+  }
+  .arg-mode__help {
+    font-size: 11px;
+    color: var(--color-text-muted, var(--text-muted));
+    margin: 0.5rem 0 0;
+  }
+  .arg-mode__help code {
+    font-family: ui-monospace, monospace;
+    background: var(--accent-bg, rgba(0, 0, 0, 0.05));
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+  .arg-mode :global(select) {
+    margin: 0 !important;
+  }
+</style>

--- a/web/src/components/actions/ArgModeSelect.svelte
+++ b/web/src/components/actions/ArgModeSelect.svelte
@@ -22,7 +22,7 @@
       Senders write <code>@@&lt;otp&gt;#name &lt;anything&gt;</code> and
       everything after the verb is one payload. Your handler is
       responsible for parsing and revalidating it.
-      <a href="/handbook/actions-handler-safety.html#freeform" target="_blank" rel="noopener">
+      <a href="/handbook/actions-handler-safety-shell.html#freeform" target="_blank" rel="noopener">
         Read the safety guide before enabling.
       </a>
     {/if}

--- a/web/src/components/actions/ArgSchemaEditor.svelte
+++ b/web/src/components/actions/ArgSchemaEditor.svelte
@@ -4,13 +4,24 @@
   // Two-way bound list of arg-spec rows. Parent treats this as the
   // canonical `arg_schema` value; we mutate via `rows = [...]` so
   // Svelte's reactivity tracks every change.
-  let { argSchema = $bindable([]) } = $props();
+  //
+  // `mode` controls layout: 'kv' (default) renders the multi-row
+  // key/regex/required editor; 'freeform' renders a single row with
+  // regex/max_len/required for the implicit `arg` key. The parent
+  // (EditActionModal) is responsible for normalizing argSchema to the
+  // single-row shape when mode flips to freeform.
+  let {
+    argSchema = $bindable([]),
+    mode = 'kv',
+  } = $props();
 
   const DEFAULT_REGEX = '^[A-Za-z0-9,_-]{1,32}$';
+  const FREEFORM_DEFAULT_REGEX = '^[\\x20-\\x7E]+$';
+  const FREEFORM_MAX_CEILING = 200;
 
   // Per-row error state, keyed by row index. A row is "invalid" iff its
   // regex string fails `new RegExp(value)`. The parent reads
-  // `hasErrors()` to block save.
+  // `hasErrors()` to block save. Freeform mode reuses index 0.
   let errors = $state({});
 
   function addRow() {
@@ -52,59 +63,97 @@
 </script>
 
 <div class="arg-schema-editor">
-  {#if argSchema.length > 0}
-    <div class="header-row">
-      <span class="col-key">Key</span>
-      <span class="col-regex">Allowed regex</span>
-      <span class="col-required">Required</span>
-      <span class="col-actions"></span>
+  {#if mode === 'freeform'}
+    {#if argSchema.length === 1}
+      <div class="freeform-row">
+        <label class="freeform-field">
+          <span class="freeform-label">Regex</span>
+          <Input
+            type="text"
+            placeholder={FREEFORM_DEFAULT_REGEX}
+            bind:value={argSchema[0].regex}
+            onblur={() => validateRegex(0)}
+            class={errors[0] ? 'regex-invalid' : ''}
+          />
+          {#if errors[0]}
+            <span class="error-tooltip" role="alert">{errors[0]}</span>
+          {/if}
+        </label>
+        <label class="freeform-field narrow">
+          <span class="freeform-label">Max length (1..{FREEFORM_MAX_CEILING})</span>
+          <Input
+            type="number"
+            min="1"
+            max={FREEFORM_MAX_CEILING}
+            bind:value={argSchema[0].max_len}
+          />
+        </label>
+        <label class="freeform-field toggle-field">
+          <Toggle bind:checked={argSchema[0].required} />
+          <span class="freeform-label inline">Required</span>
+        </label>
+      </div>
+      <p class="explainer">
+        The single freeform value is exposed to your handler as
+        <code>$1</code> (positional argv) and <code>$GW_ARG</code>
+        (env var). Webhooks see the bare token <code>{'{{arg}}'}</code>.
+      </p>
+    {/if}
+  {:else}
+    {#if argSchema.length > 0}
+      <div class="header-row">
+        <span class="col-key">Key</span>
+        <span class="col-regex">Allowed regex</span>
+        <span class="col-required">Required</span>
+        <span class="col-actions"></span>
+      </div>
+
+      {#each argSchema as row, i (i)}
+        <div class="data-row">
+          <div class="col-key">
+            <Input
+              type="text"
+              placeholder="key"
+              bind:value={row.key}
+            />
+          </div>
+          <div class="col-regex">
+            <Input
+              type="text"
+              placeholder={DEFAULT_REGEX}
+              bind:value={row.regex}
+              onblur={() => validateRegex(i)}
+              class={errors[i] ? 'regex-invalid' : ''}
+            />
+            {#if errors[i]}
+              <span class="error-tooltip" role="alert">{errors[i]}</span>
+            {/if}
+          </div>
+          <div class="col-required">
+            <Toggle bind:checked={row.required} />
+          </div>
+          <div class="col-actions">
+            <Button
+              size="sm"
+              variant="danger"
+              onclick={() => removeRow(i)}
+              aria-label={`Remove arg ${row.key || i + 1}`}
+            >Delete</Button>
+          </div>
+        </div>
+      {/each}
+    {/if}
+
+    <div class="add-row">
+      <Button size="sm" variant="ghost" onclick={addRow}>+ Add arg</Button>
     </div>
 
-    {#each argSchema as row, i (i)}
-      <div class="data-row">
-        <div class="col-key">
-          <Input
-            type="text"
-            placeholder="key"
-            bind:value={row.key}
-          />
-        </div>
-        <div class="col-regex">
-          <Input
-            type="text"
-            placeholder={DEFAULT_REGEX}
-            bind:value={row.regex}
-            onblur={() => validateRegex(i)}
-            class={errors[i] ? 'regex-invalid' : ''}
-          />
-          {#if errors[i]}
-            <span class="error-tooltip" role="alert">{errors[i]}</span>
-          {/if}
-        </div>
-        <div class="col-required">
-          <Toggle bind:checked={row.required} />
-        </div>
-        <div class="col-actions">
-          <Button
-            size="sm"
-            variant="danger"
-            onclick={() => removeRow(i)}
-            aria-label={`Remove arg ${row.key || i + 1}`}
-          >Delete</Button>
-        </div>
-      </div>
-    {/each}
+    <p class="explainer">
+      Default regex <code>{DEFAULT_REGEX}</code> allows letters, digits,
+      comma, underscore, hyphen. Override per key when you need different
+      characters. Args failing the regex are rejected.
+    </p>
   {/if}
-
-  <div class="add-row">
-    <Button size="sm" variant="ghost" onclick={addRow}>+ Add arg</Button>
-  </div>
-
-  <p class="explainer">
-    Default regex <code>{DEFAULT_REGEX}</code> allows letters, digits,
-    comma, underscore, hyphen. Override per key when you need different
-    characters. Args failing the regex are rejected.
-  </p>
 </div>
 
 <style>
@@ -137,6 +186,35 @@
   .add-row {
     margin-top: 2px;
   }
+  .freeform-row {
+    display: grid;
+    grid-template-columns: 1fr 200px 120px;
+    gap: 12px;
+    align-items: end;
+  }
+  .freeform-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    position: relative;
+  }
+  .freeform-field.toggle-field {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+  }
+  .freeform-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--color-text-dim, var(--text-muted));
+  }
+  .freeform-label.inline {
+    text-transform: none;
+    letter-spacing: normal;
+    font-weight: 600;
+  }
   .explainer {
     margin: 4px 0 0;
     font-size: 12px;
@@ -162,7 +240,8 @@
   }
   /* Chonky's global input rule adds margin-bottom:1rem; flatten it so
      rows share the same baseline as the Toggle and Delete button. */
-  .data-row :global(input) {
+  .data-row :global(input),
+  .freeform-row :global(input) {
     margin: 0 !important;
   }
 </style>

--- a/web/src/components/actions/ArgSchemaEditor.svelte
+++ b/web/src/components/actions/ArgSchemaEditor.svelte
@@ -24,6 +24,15 @@
   // `hasErrors()` to block save. Freeform mode reuses index 0.
   let errors = $state({});
 
+  // The parent (EditActionModal) overwrites argSchema wholesale on
+  // mode flips, so the row a stale error was indexed against may not
+  // exist anymore. Clear errors whenever mode toggles to keep the UI
+  // honest — fresh validation re-fires on next blur.
+  $effect(() => {
+    mode;
+    errors = {};
+  });
+
   function addRow() {
     argSchema = [
       ...argSchema,

--- a/web/src/components/actions/EditActionModal.svelte
+++ b/web/src/components/actions/EditActionModal.svelte
@@ -4,6 +4,7 @@
   import { actionsApi } from '../../lib/actions/api.js';
   import ConfirmDialog from '../ConfirmDialog.svelte';
   import ArgSchemaEditor from './ArgSchemaEditor.svelte';
+  import ArgModeSelect from './ArgModeSelect.svelte';
   import SenderAllowlistEditor from './SenderAllowlistEditor.svelte';
   import HeadersEditor from './HeadersEditor.svelte';
 
@@ -38,6 +39,7 @@
       otp_credential_id: null,
       sender_allowlist: '',
       arg_schema: [],
+      arg_mode: 'kv',
       rate_limit_sec: 5,
       queue_depth: 8,
       enabled: true,
@@ -66,6 +68,7 @@
     return rows.map((r) => ({
       key: r?.key ?? '',
       regex: r?.regex ?? '',
+      max_len: Number.isFinite(r?.max_len) ? r.max_len : 0,
       required: !!r?.required,
     }));
   }
@@ -94,6 +97,24 @@
   $effect(() => {
     if (form.type === 'webhook' && !form.webhook_method) {
       form.webhook_method = 'GET';
+    }
+  });
+
+  // Freeform mode requires exactly one ArgSpec keyed `arg`. When the
+  // operator flips into freeform, normalize the schema so the editor
+  // and backend agree on the single-row contract. The default regex
+  // `^[\x20-\x7E]+$` is printable-ASCII only (defense in depth alongside
+  // the server's control-char floor); 67 mirrors the APRS message cap.
+  $effect(() => {
+    if (form.arg_mode === 'freeform') {
+      if (form.arg_schema.length !== 1 || form.arg_schema[0].key !== 'arg') {
+        form.arg_schema = [{
+          key: 'arg',
+          regex: '^[\\x20-\\x7E]+$',
+          max_len: 67,
+          required: true,
+        }];
+      }
     }
   });
 
@@ -178,7 +199,7 @@
         'name', 'description', 'type', 'command_path', 'working_dir',
         'webhook_method', 'webhook_url', 'webhook_body_template',
         'timeout_sec', 'otp_required', 'otp_credential_id',
-        'sender_allowlist', 'arg_schema', 'rate_limit_sec', 'queue_depth',
+        'sender_allowlist', 'arg_schema', 'arg_mode', 'rate_limit_sec', 'queue_depth',
       ];
       if (known.includes(field)) {
         // Preserve the original index in the error text so the operator
@@ -443,7 +464,12 @@
 
       <div class="field">
         <span class="label">Allowed args</span>
-        <ArgSchemaEditor bind:argSchema={form.arg_schema} bind:this={argEditor} />
+        <ArgModeSelect bind:value={form.arg_mode} />
+        <ArgSchemaEditor
+          bind:argSchema={form.arg_schema}
+          mode={form.arg_mode}
+          bind:this={argEditor}
+        />
       </div>
 
       <div class="field narrow">

--- a/web/src/components/actions/EditActionModal.svelte
+++ b/web/src/components/actions/EditActionModal.svelte
@@ -73,6 +73,12 @@
     }));
   }
 
+  // Bookkeeping for the kv↔freeform mode-flip effect below. Plain
+  // `let`s (not `$state`) so they don't trigger reactivity; we just need
+  // them to survive across effect runs within one modal instance.
+  let prevArgMode = 'kv';
+  let kvSchemaCache = null;
+
   let prevOpen = false;
   $effect(() => {
     if (open && !prevOpen) {
@@ -86,6 +92,10 @@
       nameError = null;
       topError = null;
       fieldErrors = {};
+      // Sync the mode tracker so reopening a freeform action doesn't
+      // trigger the "leaving freeform" branch of the effect below.
+      prevArgMode = form.arg_mode || 'kv';
+      kvSchemaCache = null;
     }
     prevOpen = open;
   });
@@ -100,22 +110,40 @@
     }
   });
 
-  // Freeform mode requires exactly one ArgSpec keyed `arg`. When the
-  // operator flips into freeform, normalize the schema so the editor
-  // and backend agree on the single-row contract. The default regex
-  // `^[\x20-\x7E]+$` is printable-ASCII only (defense in depth alongside
-  // the server's control-char floor); 67 mirrors the APRS message cap.
+  // Mode-transition effect: keep arg_schema's shape consistent with
+  // arg_mode, and don't lose the operator's kv rows on a kv→freeform→kv
+  // round-trip. Freeform requires exactly one ArgSpec keyed `arg`; the
+  // default regex `^[\x20-\x7E]+$` is printable-ASCII only (defense in
+  // depth alongside the server's control-char floor); 67 mirrors the
+  // APRS message cap.
+  //
+  // The effect re-runs when arg_mode changes; the prevArgMode guard
+  // makes the branch logic edge-triggered (entry vs leave) so the
+  // synthetic freeform row isn't repeatedly rewritten on every other
+  // form mutation. The arg_schema read inside each branch tracks
+  // arg_schema as a dep too, but the next effect run early-exits via
+  // `next === prevArgMode`, so no loop.
   $effect(() => {
-    if (form.arg_mode === 'freeform') {
-      if (form.arg_schema.length !== 1 || form.arg_schema[0].key !== 'arg') {
-        form.arg_schema = [{
-          key: 'arg',
-          regex: '^[\\x20-\\x7E]+$',
-          max_len: 67,
-          required: true,
-        }];
-      }
+    const next = form.arg_mode;
+    if (next === prevArgMode) return;
+    if (next === 'freeform') {
+      // Stash kv rows so flipping back restores them verbatim instead
+      // of leaving the synthetic single-row schema (which would fail
+      // the backend's reserved-`arg`-key kv validator).
+      kvSchemaCache = $state.snapshot(form.arg_schema);
+      form.arg_schema = [{
+        key: 'arg',
+        regex: '^[\\x20-\\x7E]+$',
+        max_len: 67,
+        required: true,
+      }];
+    } else if (next === 'kv') {
+      form.arg_schema = kvSchemaCache
+        ? structuredClone(kvSchemaCache)
+        : [];
+      kvSchemaCache = null;
     }
+    prevArgMode = next;
   });
 
   let isEdit = $derived(!!action?.id);
@@ -187,14 +215,15 @@
   function applyServerError(err) {
     const msg = err?.error ?? err?.message ?? 'Save failed.';
     // The webapi handlers return errors in `{error: "field: detail"}`
-    // shape. Indexed list prefixes like `arg_schema[0]` get stripped to
-    // their root field so the matching input gets a red outline; unknown
+    // shape. Indexed list prefixes like `arg_schema[0]` and indexed
+    // sub-fields like `arg_schema[0].max_len` get stripped to their
+    // root field so the matching input gets a red outline; unknown
     // shapes fall through to the top-of-modal banner.
     if (typeof msg === 'string' && msg.includes(':')) {
       const idx = msg.indexOf(':');
       const raw = msg.slice(0, idx).trim();
       const detail = msg.slice(idx + 1).trim();
-      const field = raw.replace(/\[\d+\]$/, '');
+      const field = raw.replace(/\[\d+\](\.[a-z_]+)?$/, '');
       const known = [
         'name', 'description', 'type', 'command_path', 'working_dir',
         'webhook_method', 'webhook_url', 'webhook_body_template',

--- a/web/src/components/actions/TestActionDialog.svelte
+++ b/web/src/components/actions/TestActionDialog.svelte
@@ -18,8 +18,12 @@
   let view = $state('input');
   let argValues = $state({});
   let argErrors = $state({});
+  let freeformText = $state('');
   let result = $state(null);
   let topError = $state(null);
+
+  let isFreeform = $derived(action?.arg_mode === 'freeform');
+  let freeformMaxLen = $derived(action?.arg_schema?.[0]?.max_len || 200);
 
   let prevOpen = false;
   $effect(() => {
@@ -34,6 +38,7 @@
     argErrors = {};
     topError = null;
     result = null;
+    freeformText = '';
     const seed = {};
     if (action?.arg_schema) {
       for (const a of action.arg_schema) seed[a.key] = '';
@@ -65,11 +70,17 @@
     topError = null;
     view = 'firing';
     try {
-      const args = {};
-      for (const [k, v] of Object.entries(argValues)) {
-        if (v !== '' && v != null) args[k] = String(v);
+      let body;
+      if (isFreeform) {
+        body = { text: freeformText };
+      } else {
+        const args = {};
+        for (const [k, v] of Object.entries(argValues)) {
+          if (v !== '' && v != null) args[k] = String(v);
+        }
+        body = { args };
       }
-      const { data, error } = await actionsApi.testFire(action.id, args);
+      const { data, error } = await actionsApi.testFire(action.id, body);
       if (error) {
         const detail = error?.error ?? error?.message ?? 'Test fire failed.';
         // The handler returns 400 with `{error: "bad arg: <key>"}` on
@@ -170,7 +181,20 @@
       </div>
     {:else}
       <div class="form">
-        {#if !action?.arg_schema || action.arg_schema.length === 0}
+        {#if isFreeform}
+          <div class="field">
+            <label for="test-freeform-text">Payload</label>
+            <textarea
+              id="test-freeform-text"
+              class="textarea"
+              rows="3"
+              maxlength={freeformMaxLen}
+              bind:value={freeformText}
+              placeholder={`everything after @@<otp>#${action?.name ?? 'name'} (no key=value, just the raw text)`}
+            ></textarea>
+            <p class="hint">Max length: {freeformMaxLen} characters.</p>
+          </div>
+        {:else if !action?.arg_schema || action.arg_schema.length === 0}
           <p class="muted">This action accepts no args.</p>
         {:else}
           {#each action.arg_schema as spec (spec.key)}
@@ -269,6 +293,22 @@
     margin: 0;
     color: var(--color-text-muted, var(--text-muted));
     font-size: 13px;
+  }
+  .textarea {
+    width: 100%;
+    padding: 6px 8px;
+    border: 1px solid var(--color-border, var(--border));
+    border-radius: var(--radius, 4px);
+    background: var(--color-bg);
+    color: inherit;
+    font: inherit;
+    font-size: 13px;
+    resize: vertical;
+  }
+  .hint {
+    margin: 0;
+    font-size: 11px;
+    color: var(--color-text-muted, var(--text-muted));
   }
   .result {
     display: flex;

--- a/web/src/lib/actions/api.js
+++ b/web/src/lib/actions/api.js
@@ -8,7 +8,9 @@ export const actionsApi = {
   create:   (body) => api.POST('/actions', { body }),
   update:   (id, body) => api.PUT('/actions/{id}', { params: { path: { id } }, body }),
   remove:   (id) => api.DELETE('/actions/{id}', { params: { path: { id } } }),
-  testFire: (id, args) => api.POST('/actions/{id}/test-fire', { params: { path: { id } }, body: { args } }),
+  // body is `{ args }` for kv-mode actions or `{ text }` for freeform
+  // actions; the handler branches on the Action's stored arg_mode.
+  testFire: (id, body) => api.POST('/actions/{id}/test-fire', { params: { path: { id } }, body }),
 };
 
 export const credsApi = {

--- a/web/src/lib/actions/grammar.js
+++ b/web/src/lib/actions/grammar.js
@@ -1,11 +1,19 @@
 // Build an example "@@<otp>#<action> k=v" message string for help banners
 // and modal previews. Argument insertion order follows Object.entries(),
 // which is fine because operators read the example, not parse it.
+//
+// `mode` selects the wire grammar: 'kv' (default) renders k=v tokens;
+// 'freeform' takes args.arg as the single payload after the verb.
 export function exampleMessage({
   otp = '482910',
   action = 'SetGarageLights',
+  mode = 'kv',
   args = { state: 'on' },
 } = {}) {
+  if (mode === 'freeform') {
+    const value = args?.arg ?? '';
+    return value ? `@@${otp}#${action} ${value}` : `@@${otp}#${action}`;
+  }
   const argsStr = Object.entries(args)
     .map(([k, v]) => `${k}=${v}`)
     .join(' ');

--- a/web/src/lib/actions/grammar.test.js
+++ b/web/src/lib/actions/grammar.test.js
@@ -41,6 +41,44 @@ describe('exampleMessage', () => {
   });
 });
 
+describe('exampleMessage freeform mode', () => {
+  it('formats without key=value tokens', () => {
+    assert.equal(
+      exampleMessage({
+        otp: '482910',
+        action: 'sms',
+        mode: 'freeform',
+        args: { arg: '+15555551212 hello world' },
+      }),
+      '@@482910#sms +15555551212 hello world',
+    );
+  });
+
+  it('omits the trailing space when freeform value is empty', () => {
+    assert.equal(
+      exampleMessage({
+        otp: '482910',
+        action: 'ping',
+        mode: 'freeform',
+        args: {},
+      }),
+      '@@482910#ping',
+    );
+  });
+
+  it('uses args.arg even if other keys are present', () => {
+    assert.equal(
+      exampleMessage({
+        otp: '111111',
+        action: 'echo',
+        mode: 'freeform',
+        args: { arg: 'hello world', state: 'on' },
+      }),
+      '@@111111#echo hello world',
+    );
+  });
+});
+
 describe('parseAllowlist', () => {
   it('returns [] for null/undefined/empty', () => {
     assert.deepEqual(parseAllowlist(null), []);


### PR DESCRIPTION
## Summary

Adds a per-Action \`arg_mode\` toggle so operators can choose between the existing \`kv\` (\`key=value\`) wire grammar and a new \`freeform\` mode where everything after the verb is one untokenized payload. Enables natural-feeling Actions like \`@@<otp>#sms +15555551212 hello world\`.

- **Backend**: \`arg_mode\` column on \`actions\` (migration 16, defaults \`kv\`); parser captures \`RawArgTail\`; new \`SanitizeFreeform\` with control-char floor and 200-byte ceiling; classifier branches on mode; cmd executor passes freeform value as bare positional + \`GW_ARG\` env; webhook templates gain bare \`{{arg}}\` token plus \`|json\` / \`|url\` / \`|html\` filters; webapi validator enforces \`kv|freeform\` and freeform single-spec schema; test-fire accepts \`text\` payload.
- **UI**: ArgModeSelect dropdown in EditActionModal; ArgSchemaEditor renders single-row layout (regex / max_len / required) for freeform; TestActionDialog swaps in a textarea; \`exampleMessage\` formats without \`k=v\` tokens; kv↔freeform mode flips stash and restore the operator's kv schema rows.
- **Examples**: freeform POSIX SMS + Pushover scripts, Python webhook receivers (Flask + aiohttp) with HMAC verify, parameterized SQL, autoescaped render; CI lints shell with shellcheck and Python with ruff + pytest.
- **Docs**: handbook actions page documents \`arg_mode\`; new Actions handler safety walkthrough; wiki updated.

Wire grammar: \`kv\` mode unchanged. \`freeform\` mode treats anything after \`@@<otp>#name\` as one value bound to the implicit key \`arg\`; existing kv consumers keep their per-key schema rows.

## Test plan

- [ ] \`make test\` (Go) green; new tests cover SanitizeFreeform, parser RawArgTail, classifier branch, cmd executor argv, webhook filters, webapi validator, test-fire text payload, migration 16
- [ ] \`cd web && npm test\` green (132 tests including new \`exampleMessage\` freeform cases)
- [ ] Create a kv-mode action via UI; verify per-key inputs and \`@@<otp>#name k=v\` format unchanged
- [ ] Create a freeform-mode action; verify single-row schema editor, textarea in test dialog, server-side enforcement of regex + max_len
- [ ] Toggle kv→freeform→kv on an existing kv action and confirm the original schema rows restore
- [ ] Test-fire a freeform action; verify the bare positional reaches the handler and \`GW_ARG\` matches
- [ ] Webhook test-fire with templates containing \`{{arg}}\`, \`{{arg|json}}\`, \`{{arg|url}}\`, \`{{arg|html}}\`