### PR TITLE
fix(demod-afsk): bad-FCS slicer dedup; drop 9x amplification

### DIFF
--- a/graywolf-modem/src/demod_afsk.rs
+++ b/graywolf-modem/src/demod_afsk.rs
@@ -709,12 +709,27 @@ impl AfskDemodulator {
         std::mem::take(&mut self.decoded_frames)
     }
 
-    /// Sum of bad-FCS events across every slicer since the last call.
-    /// Each slicer decodes the same bit stream differently, so a single
-    /// corrupted transmission may bump this by up to num_slicers.
+    /// Bad-FCS events for one physical RF event, taken from slicer 0
+    /// only. Other slicers are still drained (so their internal counters
+    /// don't run away) but their counts are dropped.
+    ///
+    /// Summing across slicers multiplied a single noise-shaped flag
+    /// candidate by the slicer count -- 9 on the default 9-slicer
+    /// Profile A. Combined with the triple ensemble that was already
+    /// reduced to its primary sub-demod (see MultiAfskDemodulator::
+    /// take_bad_fcs), the operator-visible counter would still bump up
+    /// to 9x per event, dominating the actual decode rate by an order
+    /// of magnitude on noisy USB-EMI environments. Operators interpret
+    /// bad-FCS as a signal-quality trend, not an absolute count, so
+    /// the slicer-0 sample is a faithful single-decoder approximation.
     #[must_use]
     pub fn take_bad_fcs(&mut self) -> u64 {
-        self.hdlc.iter_mut().map(|d| d.take_bad_fcs()).sum()
+        let mut iter = self.hdlc.iter_mut();
+        let primary = iter.next().map(|d| d.take_bad_fcs()).unwrap_or(0);
+        for d in iter {
+            let _ = d.take_bad_fcs();
+        }
+        primary
     }
 
     /// Number of decoded frames accumulated so far.


### PR DESCRIPTION
The default Profile A demodulator runs 9 slicers (different DC threshold positions) over the same audio. Each slicer feeds an independent HdlcDecoder. Successful frames are already deduped across slicers; bad- FCS counts were summed.

Anguilla (Pi 5 + AIOC + UV5R-induced USB EMI) showed 67342 bad-FCS over 8h48m with 1915 decoded frames -- 35:1 bad-to-good. Earlier ensemble fix (3dba32f) brought 27x -> 9x; this brings 9x -> 1x by counting only slicer 0. Other slicers are still drained so their internal counters do not grow without bound, but their values are dropped.

Operators read bad-FCS as a relative signal-quality trend, not an absolute frame count. Slicer 0 is a faithful single-decoder approximation and matches what an operator would see on a single- slicer Direwolf reference setup.