### PR TITLE
fix(modem): output meter idle silence + test tone survives busy device

### DIFF
--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -237,6 +237,7 @@ impl Modem {
             // Periodic status push
             if self.last_status_tx.elapsed() >= status_interval {
                 self.emit_status(false);
+                self.emit_idle_output_levels();
                 self.last_status_tx = Instant::now();
             }
 
@@ -741,6 +742,43 @@ impl Modem {
         }
     }
 
+    /// Emit a -60 dBFS DeviceLevelUpdate for each configured output
+    /// device that hasn't had a TX-driven update in the last ~750ms.
+    /// The TX path emits a real peak per transmission and bumps
+    /// last_level_tx for the output device; this idle-silence ticker
+    /// fills the gap between transmissions so the operator's per-device
+    /// meter on the Audio Devices page falls back to silence when the
+    /// radio is idle instead of staying at the last TX peak forever.
+    /// Without this the output bar shows stale data after each beacon
+    /// or test tone -- operator-misleading.
+    fn emit_idle_output_levels(&mut self) {
+        let now = Instant::now();
+        let stale_after = Duration::from_millis(750);
+        let mut output_ids: HashSet<u32> = HashSet::new();
+        for ccfg in self.channel_configs.values() {
+            if ccfg.output_device_id != 0 {
+                output_ids.insert(ccfg.output_device_id);
+            }
+        }
+        for id in output_ids {
+            let stale = self.last_level_tx
+                .get(&id)
+                .map(|t| now.duration_since(*t) >= stale_after)
+                .unwrap_or(true);
+            if !stale {
+                continue;
+            }
+            let msg = IpcMessage::device_level_update(DeviceLevelUpdate {
+                device_id: id,
+                peak_dbfs: -60.0,
+                rms_dbfs: -60.0,
+                clipping: false,
+            });
+            let _ = self.handle.send(&msg);
+            self.last_level_tx.insert(id, now);
+        }
+    }
+
     fn channel_audio_state(&self, channel: u32) -> (f32, f32, f32, bool) {
         for pipe in self.active_devices.values() {
             for cp in &pipe.channels {
@@ -907,6 +945,10 @@ impl Modem {
                 clipping,
             });
             let _ = self.handle.send(&msg);
+            // Mark this output device's level as freshly emitted so the
+            // idle-silence ticker doesn't immediately overwrite this real
+            // TX peak with -60 dBFS on its next pass.
+            self.last_level_tx.insert(ccfg.output_device_id, Instant::now());
         }
 
         let job = tx_worker::TxJob {
@@ -1621,58 +1663,59 @@ fn play_test_tone_blocking(
     gain_atom: &Arc<AtomicU32>,
     cached_device: Option<cpal::Device>,
 ) -> TestToneResult {
-    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use cpal::traits::{DeviceTrait, StreamTrait};
     use std::sync::atomic::{AtomicBool, AtomicU64};
 
     // Use a pre-resolved device if available (resolved before input
-    // streams opened). Falls back to runtime enumeration which may fail
-    // on Linux/ALSA when a capture stream holds the hardware device.
-    let device = match cached_device {
-        Some(d) => d,
-        None => {
-            let host = cpal::default_host();
-            let found = match host.output_devices() {
-                Ok(devs) => audio::soundcard::find_device_by_id(devs, &req.device_name),
-                Err(e) => {
-                    return TestToneResult {
-                        request_id: req.request_id,
-                        success: false,
-                        error: format!("enumerate output devices: {}", e),
-                    };
-                }
-            };
-            match found {
-                Some(d) => d,
-                None => {
-                    return TestToneResult {
-                        request_id: req.request_id,
-                        success: false,
-                        error: format!("output device not found: {}", req.device_name),
-                    };
-                }
-            }
-        }
-    };
-
+    // streams opened). When the cached handle is stale -- e.g. after a
+    // USB EMI event has reset the hub bus and reassigned the AIOC's
+    // device number -- supported_output_configs() fails with "device no
+    // longer available". Re-enumerate to pick up the new handle so the
+    // operator's test-tone click survives the bus shock.
     let sample_rate = if req.sample_rate > 0 { req.sample_rate } else { 48000 };
-    // Fall back to the device's smallest supported channel count when the
-    // configured count isn't available (e.g. stereo-only USB sound cards
-    // when the operator picked mono). The tone is written identically to
-    // every channel in the frame, so stereo output is in-phase mono.
-    let channels = match audio::soundcard::negotiate_channels(
-        &device,
-        sample_rate,
-        req.channels.max(1) as u16,
-        "output",
-        |d| d.supported_output_configs(),
-    ) {
-        Ok(c) => c,
-        Err(e) => {
-            return TestToneResult {
-                request_id: req.request_id,
-                success: false,
-                error: e,
-            };
+    let preferred_ch = req.channels.max(1) as u16;
+
+    fn resolve_fresh(name: &str) -> Result<cpal::Device, String> {
+        use cpal::traits::HostTrait;
+        let host = cpal::default_host();
+        let devs = host.output_devices()
+            .map_err(|e| format!("enumerate output devices: {}", e))?;
+        audio::soundcard::find_device_by_id(devs, name)
+            .ok_or_else(|| format!("output device not found: {}", name))
+    }
+
+    let (device, channels) = {
+        let attempt = |dev: cpal::Device| -> Result<(cpal::Device, u16), String> {
+            let ch = audio::soundcard::negotiate_channels(
+                &dev,
+                sample_rate,
+                preferred_ch,
+                "output",
+                |d| d.supported_output_configs(),
+            )?;
+            Ok((dev, ch))
+        };
+
+        match cached_device {
+            Some(d) => match attempt(d) {
+                Ok(pair) => pair,
+                Err(_) => match resolve_fresh(&req.device_name).and_then(attempt) {
+                    Ok(pair) => pair,
+                    Err(e) => return TestToneResult {
+                        request_id: req.request_id,
+                        success: false,
+                        error: e,
+                    },
+                },
+            },
+            None => match resolve_fresh(&req.device_name).and_then(attempt) {
+                Ok(pair) => pair,
+                Err(e) => return TestToneResult {
+                    request_id: req.request_id,
+                    success: false,
+                    error: e,
+                },
+            },
         }
     };
 

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -159,6 +159,14 @@ pub struct Modem {
     // hardware, so these must be resolved while the device is idle.
     output_devices: HashMap<u32, cpal::Device>,
 
+    // Pre-negotiated output stream params (channels + sample_format),
+    // cached at start_audio time when the device is idle. The test-
+    // tone path uses these to avoid calling supported_output_configs()
+    // on a device cpal has lost the ability to enumerate (e.g. while a
+    // capture stream is active on the same AIOC hardware, or after a
+    // USB-EMI hub event invalidates the cached handle).
+    output_configs_cache: HashMap<u32, (u16, cpal::SampleFormat)>,
+
     // Active audio pipelines, keyed by device_id
     active_devices: HashMap<u32, DevicePipeline>,
 
@@ -200,6 +208,7 @@ impl Modem {
             dcd_transitions: HashMap::new(),
             last_status_tx: Instant::now(),
             last_level_tx: HashMap::new(),
+            output_configs_cache: HashMap::new(),
         })
     }
 
@@ -364,8 +373,13 @@ impl Modem {
 
         // Pre-resolve output devices before opening input streams.
         // This lets the TX worker and test-tone path use cached Device
-        // handles without enumerating at transmit time.
+        // handles without enumerating at transmit time. Also pre-
+        // negotiate channel count + sample format while the device is
+        // idle, so later test-tone clicks don't have to call
+        // supported_output_configs() (which fails once an input capture
+        // stream holds the same hardware).
         self.output_devices.clear();
+        self.output_configs_cache.clear();
         let mut seen_outputs = std::collections::HashSet::new();
         for ccfg in self.channel_configs.values() {
             let dev_id = ccfg.output_device_id;
@@ -375,6 +389,29 @@ impl Modem {
             if let Some(acfg) = self.audio_configs.get(&dev_id) {
                 match audio::soundcard::resolve_output_device(&acfg.device_name) {
                     Ok(device) => {
+                        // Pre-negotiate the (channels, sample_format) pair
+                        // while the device is idle. supported_output_configs()
+                        // tends to fail later when the AIOC's input PCM is
+                        // actively captured. negotiate_channels() falls back
+                        // gracefully if the configured channel count isn't
+                        // supported (e.g. stereo-only USB cards).
+                        let preferred_ch = acfg.channels.max(1) as u16;
+                        let neg = audio::soundcard::negotiate_channels(
+                            &device, acfg.sample_rate, preferred_ch, "output",
+                            |d| { use cpal::traits::DeviceTrait; d.supported_output_configs() },
+                        );
+                        let fmt = {
+                            use cpal::traits::DeviceTrait;
+                            device.default_output_config().ok().map(|c| c.sample_format())
+                        };
+                        if let (Ok(ch), Some(f)) = (neg, fmt) {
+                            self.output_configs_cache.insert(dev_id, (ch, f));
+                        } else {
+                            eprintln!(
+                                "graywolf-modem: failed to pre-negotiate output configs for device_id={} ({}); test-tone may fail later if device gets busy",
+                                dev_id, acfg.device_name
+                            );
+                        }
                         self.tx_worker.prepare_output(dev_id, device.clone());
                         self.output_devices.insert(dev_id, device);
                     }
@@ -671,10 +708,13 @@ impl Modem {
             .unwrap_or_else(|| Arc::new(AtomicU32::new(0f32.to_bits())));
         let handle = self.handle.clone();
         let cached_device = self.output_devices.get(&device_id).cloned();
+        let cached_config = self.output_configs_cache.get(&device_id).copied();
         std::thread::Builder::new()
             .name("test-tone".into())
             .spawn(move || {
-                let result = play_test_tone_blocking(&req, &handle, device_id, &gain_atom, cached_device);
+                let result = play_test_tone_blocking(
+                    &req, &handle, device_id, &gain_atom, cached_device, cached_config,
+                );
                 let msg = IpcMessage::test_tone_result(result);
                 let _ = handle.send(&msg);
             })
@@ -1662,16 +1702,22 @@ fn play_test_tone_blocking(
     device_id: u32,
     gain_atom: &Arc<AtomicU32>,
     cached_device: Option<cpal::Device>,
+    cached_config: Option<(u16, cpal::SampleFormat)>,
 ) -> TestToneResult {
     use cpal::traits::{DeviceTrait, StreamTrait};
     use std::sync::atomic::{AtomicBool, AtomicU64};
 
-    // Use a pre-resolved device if available (resolved before input
-    // streams opened). When the cached handle is stale -- e.g. after a
-    // USB EMI event has reset the hub bus and reassigned the AIOC's
-    // device number -- supported_output_configs() fails with "device no
-    // longer available". Re-enumerate to pick up the new handle so the
-    // operator's test-tone click survives the bus shock.
+    // Resolve the cpal Device + channel count for the test tone.
+    //
+    // The cpal supported_output_configs() call fails with "device no
+    // longer available" when called while another stream (input
+    // capture) is already active on the same hardware (e.g. AIOC's
+    // shared input/output PCM). For that reason we prefer the
+    // pre-negotiated channel count cached at start_audio time, when
+    // the device was idle and queryable. Falls back to runtime
+    // negotiation only when no cached config exists (e.g. fresh
+    // ConfigureAudio for a device that hadn't been part of any
+    // channel yet).
     let sample_rate = if req.sample_rate > 0 { req.sample_rate } else { 48000 };
     let preferred_ch = req.channels.max(1) as u16;
 
@@ -1684,38 +1730,41 @@ fn play_test_tone_blocking(
             .ok_or_else(|| format!("output device not found: {}", name))
     }
 
-    let (device, channels) = {
-        let attempt = |dev: cpal::Device| -> Result<(cpal::Device, u16), String> {
-            let ch = audio::soundcard::negotiate_channels(
-                &dev,
+    let device = match cached_device {
+        Some(d) => d,
+        None => match resolve_fresh(&req.device_name) {
+            Ok(d) => d,
+            Err(e) => return TestToneResult {
+                request_id: req.request_id,
+                success: false,
+                error: e,
+            },
+        },
+    };
+
+    let channels = match cached_config {
+        Some((ch, _fmt)) => ch,
+        None => {
+            // No cached config -- either device wasn't pre-resolved
+            // (legacy path) or pre-negotiation failed at start_audio.
+            // Fall back to a live supported_output_configs probe;
+            // this is the path that fails when the device is busy,
+            // but it is also the only path that can recover for
+            // configurations the cache doesn't cover.
+            match audio::soundcard::negotiate_channels(
+                &device,
                 sample_rate,
                 preferred_ch,
                 "output",
                 |d| d.supported_output_configs(),
-            )?;
-            Ok((dev, ch))
-        };
-
-        match cached_device {
-            Some(d) => match attempt(d) {
-                Ok(pair) => pair,
-                Err(_) => match resolve_fresh(&req.device_name).and_then(attempt) {
-                    Ok(pair) => pair,
-                    Err(e) => return TestToneResult {
-                        request_id: req.request_id,
-                        success: false,
-                        error: e,
-                    },
-                },
-            },
-            None => match resolve_fresh(&req.device_name).and_then(attempt) {
-                Ok(pair) => pair,
+            ) {
+                Ok(c) => c,
                 Err(e) => return TestToneResult {
                     request_id: req.request_id,
                     success: false,
                     error: e,
                 },
-            },
+            }
         }
     };
 


### PR DESCRIPTION
## Summary

Two fixes for issues operators on Pi + AIOC saw after the audio-modem-storms fix landed:

- **Output level meter froze on last TX peak**: modem now emits a -60 dBFS DeviceLevelUpdate every ~500ms for any output device that hasn't had a TX-driven update in the last 750ms. Bar drops to silence between transmissions, lights up during.
- **Test tone hit "device no longer available"**: cpal supported_output_configs() fails when called after an input capture stream is already open on the same shared-PCM hardware (AIOC). Pre-negotiate (channels, sample_format) at start_audio time when the device is idle, cache on the Modem struct, hand to the test tone path.

## Test plan

- [x] 151 unit tests pass
- [x] Live on anguilla (Pi 5 + AIOC): output bar tracks silence/TX correctly, test tone works repeatedly even with active modem RX