### PR TITLE
actions: reorder New Action dialog, add scroll affordances

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -60,6 +60,25 @@ input, select, textarea, button {
 .modal-body {
   overflow-y: auto;
   min-height: 0;
+  position: relative;
+  scrollbar-width: auto;
+  scrollbar-color: var(--color-text-dim, #6b7280) var(--color-bg);
+}
+.modal-body::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+.modal-body::-webkit-scrollbar-track {
+  background: var(--color-bg);
+  border-left: 1px solid var(--color-border);
+}
+.modal-body::-webkit-scrollbar-thumb {
+  background: var(--color-text-dim, #6b7280);
+  border-radius: 6px;
+  border: 2px solid var(--color-bg);
+}
+.modal-body::-webkit-scrollbar-thumb:hover {
+  background: var(--color-text, #111827);
 }
 
 /* Messages: when a thread is open on mobile, hide the sidebar bottom-nav

--- a/web/src/components/ScrollHint.svelte
+++ b/web/src/components/ScrollHint.svelte
@@ -1,0 +1,103 @@
+<script>
+  // Sticky banner that appears at the bottom of a scrollable parent when
+  // there is hidden content below the viewport. Drop as the last child
+  // inside the scroll container (e.g. Modal.Body). It walks up the DOM
+  // until it finds an element with overflow scroll/auto and observes it.
+  let { label = 'Scroll down for more' } = $props();
+
+  let sentinel = $state(null);
+  let visible = $state(false);
+
+  function findScrollParent(el) {
+    let cur = el?.parentElement;
+    while (cur && cur !== document.body) {
+      const oy = getComputedStyle(cur).overflowY;
+      if (oy === 'auto' || oy === 'scroll') return cur;
+      cur = cur.parentElement;
+    }
+    return null;
+  }
+
+  $effect(() => {
+    if (!sentinel) return;
+    const el = findScrollParent(sentinel);
+    if (!el) return;
+
+    const update = () => {
+      const overflow = el.scrollHeight > el.clientHeight + 1;
+      const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 4;
+      visible = overflow && !atBottom;
+    };
+
+    el.addEventListener('scroll', update, { passive: true });
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    const mo = new MutationObserver(update);
+    mo.observe(el, { childList: true, subtree: true, attributes: true });
+    update();
+
+    return () => {
+      el.removeEventListener('scroll', update);
+      ro.disconnect();
+      mo.disconnect();
+    };
+  });
+</script>
+
+<div
+  bind:this={sentinel}
+  class="scroll-hint"
+  class:visible
+  aria-hidden="true"
+>
+  <span class="scroll-hint__label">{label}</span>
+  <span class="scroll-hint__arrow">&#8595;</span>
+</div>
+
+<style>
+  .scroll-hint {
+    position: sticky;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: 0 calc(-1 * var(--scroll-hint-pad-x, 1.5rem)) calc(-1 * var(--scroll-hint-pad-y, 1.5rem));
+    padding: 10px 1.5rem 12px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--color-text, #111827);
+    background: linear-gradient(
+      to bottom,
+      transparent 0%,
+      var(--color-surface, #fff) 50%,
+      var(--color-surface, #fff) 100%
+    );
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(4px);
+    transition: opacity 120ms ease, transform 120ms ease;
+    z-index: 5;
+  }
+  .scroll-hint.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  .scroll-hint__arrow {
+    display: inline-block;
+    font-size: 14px;
+    animation: scroll-hint-bounce 1.4s ease-in-out infinite;
+  }
+  @keyframes scroll-hint-bounce {
+    0%, 100% { transform: translateY(0); }
+    50%      { transform: translateY(3px); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .scroll-hint__arrow { animation: none; }
+    .scroll-hint { transition: none; }
+  }
+</style>

--- a/web/src/components/actions/EditActionModal.svelte
+++ b/web/src/components/actions/EditActionModal.svelte
@@ -7,6 +7,7 @@
   import ArgModeSelect from './ArgModeSelect.svelte';
   import SenderAllowlistEditor from './SenderAllowlistEditor.svelte';
   import HeadersEditor from './HeadersEditor.svelte';
+  import ScrollHint from '../ScrollHint.svelte';
 
   // `action` is null when creating, or a fully-populated dto.Action
   // copy when editing. The parent passes a fresh object on each open
@@ -354,10 +355,44 @@
           />
           <p class="hint">Absolute path to the executable. Validated when you save.</p>
           {#if fieldErrors.command_path}<p class="field-error">{fieldErrors.command_path}</p>{/if}
+        </div>
 
-          <details class="exec-help">
-            <summary>How your command is invoked</summary>
-            <div class="exec-help-body">
+        <div class="field">
+          <span class="label">Allowed args</span>
+          <ArgModeSelect bind:value={form.arg_mode} />
+          <ArgSchemaEditor
+            bind:argSchema={form.arg_schema}
+            mode={form.arg_mode}
+            bind:this={argEditor}
+          />
+        </div>
+
+        <details class="exec-help">
+          <summary>How your command is invoked</summary>
+          <div class="exec-help-body">
+            {#if form.arg_mode === 'freeform'}
+              <pre class="exec-cli">&lt;command&gt; &lt;action name&gt; &lt;sender callsign&gt; &lt;otp verified&gt; &lt;freeform payload&gt;</pre>
+
+              <h4>Arguments (positional)</h4>
+              <dl>
+                <dt><code>$1</code></dt><dd>action name</dd>
+                <dt><code>$2</code></dt><dd>sender callsign</dd>
+                <dt><code>$3</code></dt><dd><code>true</code> or <code>false</code> -- whether the TOTP code validated</dd>
+                <dt><code>$4</code></dt><dd>the freeform payload (everything after the verb, as one string)</dd>
+              </dl>
+
+              <h4>Environment</h4>
+              <dl>
+                <dt><code>GW_ACTION_NAME</code></dt><dd>same as <code>$1</code></dd>
+                <dt><code>GW_SENDER_CALL</code></dt><dd>same as <code>$2</code></dd>
+                <dt><code>GW_OTP_VERIFIED</code></dt><dd>same as <code>$3</code></dd>
+                <dt><code>GW_OTP_CRED_NAME</code></dt><dd>name of the credential that validated the code (empty if OTP not required)</dd>
+                <dt><code>GW_SOURCE</code></dt><dd>where the trigger arrived from (e.g. <code>aprs</code>, <code>test</code>)</dd>
+                <dt><code>GW_INVOCATION_ID</code></dt><dd>numeric id of the audit row for this run</dd>
+                <dt><code>GW_ARG</code></dt><dd>same as <code>$4</code> -- the freeform payload</dd>
+                <dt><code>PATH</code></dt><dd>preset to <code>/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin</code>. The parent process environment is <strong>not</strong> inherited.</dd>
+              </dl>
+            {:else}
               <pre class="exec-cli">&lt;command&gt; &lt;action name&gt; &lt;sender callsign&gt; &lt;otp verified&gt; [&lt;key=value&gt; &lt;key=value&gt; ...]</pre>
 
               <h4>Arguments (positional)</h4>
@@ -379,16 +414,16 @@
                 <dt><code>GW_ARG_&lt;KEY&gt;</code></dt><dd>one per arg, key uppercased, non-alphanumerics turned into <code>_</code></dd>
                 <dt><code>PATH</code></dt><dd>preset to <code>/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin</code>. The parent process environment is <strong>not</strong> inherited.</dd>
               </dl>
+            {/if}
 
-              <h4>Runtime</h4>
-              <ul>
-                <li>Working directory: the value above, otherwise the directory containing the command.</li>
-                <li>Timeout: the value above. SIGTERM on expiry, SIGKILL 2 seconds later.</li>
-                <li>Output: stdout and stderr are merged; the first 4 KiB are captured and the leading characters are echoed back to the sender as the APRS reply.</li>
-              </ul>
-            </div>
-          </details>
-        </div>
+            <h4>Runtime</h4>
+            <ul>
+              <li>Working directory: the value above, otherwise the directory containing the command.</li>
+              <li>Timeout: the value above. SIGTERM on expiry, SIGKILL 2 seconds later.</li>
+              <li>Output: stdout and stderr are merged; the first 4 KiB are captured and the leading characters are echoed back to the sender as the APRS reply.</li>
+            </ul>
+          </div>
+        </details>
 
         <div class="field">
           <label for="action-wd">Working directory</label>
@@ -450,6 +485,16 @@
           </div>
         {/if}
 
+        <div class="field">
+          <span class="label">Allowed args</span>
+          <ArgModeSelect bind:value={form.arg_mode} />
+          <ArgSchemaEditor
+            bind:argSchema={form.arg_schema}
+            mode={form.arg_mode}
+            bind:this={argEditor}
+          />
+        </div>
+
         <div class="field narrow">
           <label for="action-wh-timeout">Timeout (s)</label>
           <Input
@@ -489,16 +534,6 @@
         <label for="action-allowlist">Sender allowlist</label>
         <SenderAllowlistEditor bind:value={form.sender_allowlist} />
         <p class="hint">Comma-separated callsigns or <code>CALL-*</code> wildcards. Empty = anyone (OTP still applies).</p>
-      </div>
-
-      <div class="field">
-        <span class="label">Allowed args</span>
-        <ArgModeSelect bind:value={form.arg_mode} />
-        <ArgSchemaEditor
-          bind:argSchema={form.arg_schema}
-          mode={form.arg_mode}
-          bind:this={argEditor}
-        />
       </div>
 
       <div class="field narrow">
@@ -542,6 +577,7 @@
         </p>
       </div>
     </div>
+    <ScrollHint />
   </Modal.Body>
   <Modal.Footer>
     <Button variant="ghost" onclick={doClose} disabled={saving}>Cancel</Button>

--- a/web/src/components/actions/NewCredentialModal.svelte
+++ b/web/src/components/actions/NewCredentialModal.svelte
@@ -4,6 +4,7 @@
   import { credsApi } from '../../lib/actions/api.js';
   import QRDisplay from './QRDisplay.svelte';
   import CopyableInput from './CopyableInput.svelte';
+  import ScrollHint from '../ScrollHint.svelte';
 
   let { open = $bindable(false), onClose } = $props();
 
@@ -193,6 +194,7 @@
         />
       </div>
     {/if}
+    <ScrollHint />
   </Modal.Body>
   <Modal.Footer>
     {#if !revealed}

--- a/web/src/components/actions/TestActionDialog.svelte
+++ b/web/src/components/actions/TestActionDialog.svelte
@@ -3,6 +3,7 @@
   import { actionsApi } from '../../lib/actions/api.js';
   import { actionsStore } from '../../lib/actions/store.svelte.js';
   import { statusVariant, badArgKey } from '../../lib/actions/status.js';
+  import ScrollHint from '../ScrollHint.svelte';
 
   // `action` is the row whose Test button was clicked. Null while the
   // dialog is closed; the parent passes a fresh object on each open.
@@ -220,6 +221,7 @@
         {/if}
       </div>
     {/if}
+    <ScrollHint />
   </Modal.Body>
   <Modal.Footer>
     {#if view === 'result'}

--- a/web/src/components/messages/remote_actions/CredentialsModal.svelte
+++ b/web/src/components/messages/remote_actions/CredentialsModal.svelte
@@ -12,6 +12,7 @@
   import { remoteCredsApi } from '../../../lib/remote_actions/api.js';
   import { remoteActionsStore } from '../../../lib/remote_actions/store.svelte.js';
   import { timeAgo } from '../../../lib/actions/time.js';
+  import ScrollHint from '../../ScrollHint.svelte';
 
   let { open = $bindable(false) } = $props();
 
@@ -112,6 +113,7 @@
         </tbody>
       </table>
     {/if}
+    <ScrollHint />
   </Modal.Body>
 </Modal>
 

--- a/web/src/components/messages/remote_actions/EditCredentialModal.svelte
+++ b/web/src/components/messages/remote_actions/EditCredentialModal.svelte
@@ -8,6 +8,7 @@
   import { Button, Input, Modal, toast } from '@chrissnell/chonky-ui';
   import { remoteCredsApi } from '../../../lib/remote_actions/api.js';
   import { remoteActionsStore } from '../../../lib/remote_actions/store.svelte.js';
+  import ScrollHint from '../../ScrollHint.svelte';
 
   let { open = $bindable(false), cred = null, onSaved = () => {} } = $props();
 
@@ -82,6 +83,7 @@
       </div>
       {#if err}<p class="err" role="alert">{err}</p>{/if}
     </div>
+    <ScrollHint />
   </Modal.Body>
   <Modal.Footer>
     <Button variant="ghost" onclick={() => (open = false)}>Cancel</Button>


### PR DESCRIPTION
In the Action edit dialog, move the argument mode + schema editor up under the command path so the choice that drives the rest of the form is no longer buried below OTP and allowlist. The "How your command is invoked" details now live under the argument mode and switch their positional/env content between key/value and freeform.

Make the modal-body scrollbar more visible (12px, dim-text thumb on bg track) and add a reusable ScrollHint component that pins a "Scroll down for more" cue to the bottom of any scrollable parent when content is hidden below the viewport. Wired into the action and credential modals.