### PR TITLE
IS-only station setup: zero-channel iGate save + fallback policy UI

### DIFF
--- a/docs/handbook/igate.html
+++ b/docs/handbook/igate.html
@@ -75,6 +75,20 @@
       and from the internet back to RF.
     </p>
 
+    <div class="callout info">
+      <span class="callout-icon">&#9432;</span>
+      <div class="callout-body">
+        <p>
+          <strong>Running APRS-IS only (no radio)?</strong> You don't need a
+          radio channel to send and receive APRS Messages. Set your station
+          callsign, enable the iGate, and skip the Channels page. On the
+          Preferences page, set <em>Messages &rarr; Send path</em> to
+          <em>APRS-IS only</em> if you want graywolf to skip the RF-first
+          attempt.
+        </p>
+      </div>
+    </div>
+
     <h2>RF &rarr; APRS-IS (Connection)</h2>
 
     <div class="screenshot">
@@ -117,8 +131,8 @@
             </tr>
             <tr>
               <td>Passcode</td>
-              <td><code>-1</code></td>
-              <td>APRS-IS passcode. <code>-1</code> = receive-only (no TX to IS).</td>
+              <td>&mdash;</td>
+              <td>Computed automatically from your station callsign. Set the callsign on the Callsign page; graywolf derives the passcode at startup. A station callsign of <code>N0CALL</code> (the unset sentinel) yields the read-only passcode <code>-1</code>, which disables APRS-IS transmits.</td>
             </tr>
           </tbody>
         </table>
@@ -129,10 +143,10 @@
       <span class="callout-icon">&#9432;</span>
       <div class="callout-body">
         <p>
-          The APRS-IS passcode authenticates your station for sending data
-          to the network. Use <code>-1</code> for a receive-only iGate that
-          monitors APRS-IS without contributing. To generate a valid passcode,
-          use an APRS passcode calculator with your callsign (without SSID).
+          graywolf computes the APRS-IS passcode from your station callsign at
+          startup; you do not enter it manually. To run a receive-only station
+          that listens to APRS-IS without contributing, leave the station
+          callsign as <code>N0CALL</code> or disable the iGate entirely.
         </p>
       </div>
     </div>

--- a/docs/handbook/messaging.html
+++ b/docs/handbook/messaging.html
@@ -78,6 +78,22 @@
       are split into numbered segments and reassembled on receive.
     </p>
 
+    <div class="callout info">
+      <span class="callout-icon">&#9432;</span>
+      <div class="callout-body">
+        <p>
+          <strong>APRS-IS only operation.</strong> You can run a Messages-only
+          station with no radio channel: set your station callsign, enable
+          the iGate, and leave the Channels page empty. Outbound messages
+          ride APRS-IS via the default <em>Try RF first, fall back to
+          APRS-IS</em> policy, or set Preferences &rarr; Messages &rarr;
+          Send path to <em>APRS-IS only</em> to skip the RF-first attempt.
+          DM acks delivered over APRS-IS terminate as
+          <code>awaiting_ack</code> until the peer replies.
+        </p>
+      </div>
+    </div>
+
     <p>
       The conversation list is always sectioned: <strong>Tactical</strong>
       chats first, then <strong>Direct Messages</strong>. A

--- a/docs/wiki/system-topology.md
+++ b/docs/wiki/system-topology.md
@@ -129,6 +129,30 @@ PMTiles infra (manifest gen, R2 sync, origin Worker) lives in `~/dev/graywolf-ma
 not here. Integration spec: `~/dev/graywolf-maps/.context/graywolf-client-integration.md`.
 See [invariant 7](invariants.md).
 
+### IS-only station
+
+A graywolf station can send and receive APRS Messages over APRS-IS
+without any RF channel configured. The minimum setup:
+
+1. Set the station callsign on the Callsign page.
+2. Enable the iGate on the iGate page (TX channel = none / `0`, RF
+   channel = none / `0` — the form defaults to those when no channels
+   exist, and [`pkg/webapi/dto/channel_refs.go`](../../pkg/webapi/dto/channel_refs.go)
+   short-circuits validation on `0`).
+3. (Optional) On the Preferences page, set the Messages send path to
+   `is_only` to skip the RF-first attempt. The default `is_fallback`
+   already degrades to APRS-IS when no modem is running, but the
+   explicit setting silences the "RF unavailable" log line on every
+   send.
+
+The APRS-IS passcode is auto-derived from the callsign by
+[`pkg/callsign/passcode.go`](../../pkg/callsign/passcode.go); operators
+do not enter it. A station with callsign `N0CALL` (the unset sentinel)
+gets passcode `-1` and the sender's `readOnlyIS` gate at
+[`pkg/messages/sender.go`](../../pkg/messages/sender.go) refuses IS
+transmits, which is what makes "set a real callsign" the meaningful
+gate on outbound IS messages.
+
 ### Offline maps catalog
 
 The Worker exposes `GET /manifest.json` (auth-gated) returning the

--- a/pkg/aprs/tnc2.go
+++ b/pkg/aprs/tnc2.go
@@ -1,0 +1,42 @@
+package aprs
+
+import "strings"
+
+// FormatTNC2 renders a TNC-2 wire line: source>dest[,path...]:info.
+//
+// Used by both originated traffic (locally-built APRS-IS submissions
+// such as outbound messages or beacons) and gated traffic (RF packets
+// re-emitted to APRS-IS). Each caller owns the path and info bytes;
+// this helper only owns the structural glue:
+//
+//   - the `>` between source and dest
+//   - the `,` between path elements
+//   - the `:` between the path field and the info field
+//
+// The path-terminator `:` is the load-bearing detail. APRS-IS consumers
+// (aprs.fi and the like) reject lines missing it as "Unsupported packet
+// format" — a class of bug that bit graywolf in May 2026 when the
+// originating-side encoder was emitting only a single colon. Both
+// encoders going through this helper makes that recurrence impossible.
+//
+// Empty path elements are silently dropped. The info bytes are written
+// verbatim — the caller is responsible for any APRS data-type
+// identifier that has to lead them (`:` for messages, `!` for position,
+// etc.).
+func FormatTNC2(source, dest string, path []string, info []byte) string {
+	var b strings.Builder
+	b.Grow(len(source) + 1 + len(dest) + 16 + len(info))
+	b.WriteString(source)
+	b.WriteByte('>')
+	b.WriteString(dest)
+	for _, p := range path {
+		if p == "" {
+			continue
+		}
+		b.WriteByte(',')
+		b.WriteString(p)
+	}
+	b.WriteByte(':')
+	b.Write(info)
+	return b.String()
+}

--- a/pkg/aprs/tnc2_test.go
+++ b/pkg/aprs/tnc2_test.go
@@ -1,0 +1,55 @@
+package aprs
+
+import "testing"
+
+func TestFormatTNC2(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		dest   string
+		path   []string
+		info   []byte
+		want   string
+	}{
+		{
+			name:   "originated message (TCPIP* convention)",
+			source: "NW5W-13",
+			dest:   "APGRWO",
+			path:   []string{"TCPIP*"},
+			info:   []byte(":NW5W-5   :TEST{015"),
+			want:   "NW5W-13>APGRWO,TCPIP*::NW5W-5   :TEST{015",
+		},
+		{
+			name:   "gated RF packet (qAR construct)",
+			source: "K1ABC",
+			dest:   "APRS",
+			path:   []string{"WIDE1-1", "WIDE2-1", "qAR", "NW5W-13"},
+			info:   []byte("!4012.34N/10500.56W>"),
+			want:   "K1ABC>APRS,WIDE1-1,WIDE2-1,qAR,NW5W-13:!4012.34N/10500.56W>",
+		},
+		{
+			name:   "no path",
+			source: "K1ABC",
+			dest:   "APRS",
+			path:   nil,
+			info:   []byte(">status"),
+			want:   "K1ABC>APRS:>status",
+		},
+		{
+			name:   "empty path elements skipped",
+			source: "K1ABC",
+			dest:   "APRS",
+			path:   []string{"", "WIDE1-1", ""},
+			info:   []byte("hello"),
+			want:   "K1ABC>APRS,WIDE1-1:hello",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatTNC2(tc.source, tc.dest, tc.path, tc.info)
+			if got != tc.want {
+				t.Fatalf("FormatTNC2 = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -312,7 +312,7 @@ type IGateConfig struct {
 	SimulationMode  bool      `gorm:"not null;default:false" json:"simulation_mode"`
 	GateRfToIs      bool      `gorm:"not null;default:true" json:"gate_rf_to_is"`
 	GateIsToRf      bool      `gorm:"not null;default:false" json:"gate_is_to_rf"`
-	RfChannel       uint32    `gorm:"not null;default:1" json:"rf_channel"`             // channel used when gating IS->RF
+	RfChannel       uint32    `gorm:"not null;default:0" json:"rf_channel"`             // channel used when gating IS->RF; 0 = unset
 	MaxMsgHops      uint32    `gorm:"not null;default:2" json:"max_msg_hops"`           // WIDE hops for IS->RF messages
 	SoftwareName    string    `gorm:"not null;default:'graywolf'" json:"software_name"` // APRS-IS login banner software name
 	SoftwareVersion string    `gorm:"not null;default:'0.1'" json:"software_version"`   // APRS-IS login banner version
@@ -322,7 +322,7 @@ type IGateConfig struct {
 	// run to seed MessagesConfig. Do not remove without first deleting
 	// that migration -- operators upgrading from older builds will
 	// silently lose their messages TX channel otherwise.
-	TxChannel       uint32    `gorm:"not null;default:1" json:"tx_channel"`             // radio channel for IS->RF submissions
+	TxChannel       uint32    `gorm:"not null;default:0" json:"tx_channel"`             // radio channel for IS->RF submissions; 0 = unset
 	CreatedAt       time.Time `json:"-"`
 	UpdatedAt       time.Time `json:"-"`
 }

--- a/pkg/configstore/store_test.go
+++ b/pkg/configstore/store_test.go
@@ -830,3 +830,29 @@ func TestUpdateChannelModeRoundTrip(t *testing.T) {
 		t.Fatalf("ModeForChannel = %q, want %q", mode, ChannelModePacket)
 	}
 }
+
+// TestIGateConfigDefaults_ZeroChannels verifies that a freshly upserted
+// IGateConfig with no explicit channel fields lands rf_channel=0 and
+// tx_channel=0. The 0 sentinel is what every consumer (sender, igate,
+// dto.ValidateChannelRef) treats as "unset" -- non-zero defaults trap an
+// IS-only operator who has no channels yet on the very first iGate save.
+func TestIGateConfigDefaults_ZeroChannels(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	if err := s.UpsertIGateConfig(ctx, &IGateConfig{
+		Server: "rotate.aprs2.net", Port: 14580,
+		MaxMsgHops: 2, SoftwareName: "graywolf", SoftwareVersion: "0.1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetIGateConfig(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RfChannel != 0 {
+		t.Errorf("RfChannel default = %d, want 0", got.RfChannel)
+	}
+	if got.TxChannel != 0 {
+		t.Errorf("TxChannel default = %d, want 0", got.TxChannel)
+	}
+}

--- a/pkg/igate/tnc2.go
+++ b/pkg/igate/tnc2.go
@@ -10,10 +10,12 @@ import (
 )
 
 // encodeTNC2 renders a decoded APRS packet as a TNC2-monitor line suitable
-// for APRS-IS uplink, WITHOUT the trailing CRLF. The qAR construct and
-// iGate callsign are appended by the caller (the APRS-IS convention is
-// to replace the last path element or append ",qAR,IGATECALL" before the
-// colon).
+// for APRS-IS uplink, WITHOUT the trailing CRLF. The path has its
+// trailing `*` H-bit markers stripped and a `,qAR,IGATECALL` construct
+// appended (APRS-IS convention identifying the gating station).
+// Wire-format glue is delegated to aprs.FormatTNC2 so this encoder
+// shares structural rules with the originating-side encoder in
+// pkg/messages.
 func encodeTNC2(pkt *aprs.DecodedAPRSPacket, igateCall string) (string, error) {
 	if pkt == nil {
 		return "", errors.New("igate: nil packet")
@@ -25,25 +27,15 @@ func encodeTNC2(pkt *aprs.DecodedAPRSPacket, igateCall string) (string, error) {
 	if len(info) == 0 {
 		return "", errors.New("igate: packet has no info field")
 	}
-	var b strings.Builder
-	b.WriteString(pkt.Source)
-	b.WriteByte('>')
-	b.WriteString(pkt.Dest)
+	path := make([]string, 0, len(pkt.Path)+2)
 	for _, p := range pkt.Path {
 		if p == "" {
 			continue
 		}
-		// Strip any trailing '*' H-bit markers; APRS-IS wants the
-		// unmarked path with a qAR construct appended.
-		p = strings.TrimSuffix(p, "*")
-		b.WriteByte(',')
-		b.WriteString(p)
+		path = append(path, strings.TrimSuffix(p, "*"))
 	}
-	b.WriteString(",qAR,")
-	b.WriteString(igateCall)
-	b.WriteByte(':')
-	b.Write(info)
-	return b.String(), nil
+	path = append(path, "qAR", igateCall)
+	return aprs.FormatTNC2(pkt.Source, pkt.Dest, path, info), nil
 }
 
 // infoBytes returns the AX.25 info field for a decoded packet. Prefer

--- a/pkg/messages/router.go
+++ b/pkg/messages/router.go
@@ -700,6 +700,7 @@ func buildAckFrame(ourCall, peerCall, msgID string) (*ax25.Frame, error) {
 
 // buildAckTNC2 renders the TNC-2 text representation of an ack for
 // APRS-IS. Mirrors the format APRS-IS expects: SRC>DEST::PEER     :ack123
+// Wire-format glue is delegated to aprs.FormatTNC2.
 func buildAckTNC2(ourCall, peerCall, msgID string) string {
 	// Pad peer to 9 chars (APRS101 §14.1 addressee field width).
 	addr := peerCall
@@ -709,7 +710,8 @@ func buildAckTNC2(ourCall, peerCall, msgID string) string {
 	if len(addr) < 9 {
 		addr = addr + strings.Repeat(" ", 9-len(addr))
 	}
-	return fmt.Sprintf("%s>APGRWO::%s:ack%s", ourCall, addr, msgID)
+	info := ":" + addr + ":ack" + msgID
+	return aprs.FormatTNC2(ourCall, "APGRWO", nil, []byte(info))
 }
 
 // checkDedup consults the 30-second (from, msgid, text_hash) cache.

--- a/pkg/messages/router_test.go
+++ b/pkg/messages/router_test.go
@@ -1232,3 +1232,39 @@ func TestRouterInboundRFInviteNoSpecialHandling(t *testing.T) {
 		t.Errorf("Source = %q, want rf", row.Source)
 	}
 }
+
+// TestBuildAckTNC2 pins the TNC-2 wire format for outbound IS acks.
+// Two colons after APGRWO: the path-terminator and the message DTI.
+// Without both, APRS-IS consumers reject the line as unsupported.
+func TestBuildAckTNC2(t *testing.T) {
+	tests := []struct {
+		name     string
+		ourCall  string
+		peerCall string
+		msgID    string
+		want     string
+	}{
+		{
+			name:     "padded short peer",
+			ourCall:  "NW5W-13",
+			peerCall: "NW5W-5",
+			msgID:    "015",
+			want:     "NW5W-13>APGRWO::NW5W-5   :ack015",
+		},
+		{
+			name:     "9-char peer (no padding)",
+			ourCall:  "K1ABC",
+			peerCall: "WB6VVV-15",
+			msgID:    "001",
+			want:     "K1ABC>APGRWO::WB6VVV-15:ack001",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildAckTNC2(tc.ourCall, tc.peerCall, tc.msgID)
+			if got != tc.want {
+				t.Fatalf("buildAckTNC2 = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/messages/sender.go
+++ b/pkg/messages/sender.go
@@ -546,13 +546,11 @@ func parsePath(p string) ([]ax25.Address, error) {
 }
 
 // buildMessageTNC2 renders the TNC-2 text line for APRS-IS. Uses
-// APGRWO as the destination (software identifier) and TCPIP as the
+// APGRWO as the destination (software identifier) and TCPIP* as the
 // digipeater path (APRS-IS convention for locally-originated traffic).
-// Addressee is padded to 9 chars. The line carries two colons between
-// the path and the addressee: the first is the AX.25 path/data
-// separator, the second is the APRS message data-type identifier.
-// Without both, APRS-IS consumers reject the line as an unsupported
-// packet format.
+// Addressee is padded to 9 chars. Wire-format glue (the path-terminator
+// colon, the message DTI colon) lives in aprs.FormatTNC2 — both
+// encoders share that helper so neither can drop a structural byte.
 func buildMessageTNC2(row *configstore.Message) string {
 	addr := row.ToCall
 	if len(addr) > 9 {
@@ -561,11 +559,11 @@ func buildMessageTNC2(row *configstore.Message) string {
 	if len(addr) < 9 {
 		addr = addr + strings.Repeat(" ", 9-len(addr))
 	}
-	body := ":" + addr + ":" + row.Text
+	info := ":" + addr + ":" + row.Text
 	if row.MsgID != "" {
-		body = body + "{" + row.MsgID
+		info = info + "{" + row.MsgID
 	}
-	return fmt.Sprintf("%s>APGRWO,TCPIP*:%s", row.FromCall, body)
+	return aprs.FormatTNC2(row.FromCall, "APGRWO", []string{"TCPIP*"}, []byte(info))
 }
 
 // recordPending stores metadata keyed by frame pointer for the TxHook.

--- a/pkg/messages/sender.go
+++ b/pkg/messages/sender.go
@@ -548,7 +548,11 @@ func parsePath(p string) ([]ax25.Address, error) {
 // buildMessageTNC2 renders the TNC-2 text line for APRS-IS. Uses
 // APGRWO as the destination (software identifier) and TCPIP as the
 // digipeater path (APRS-IS convention for locally-originated traffic).
-// Addressee is padded to 9 chars.
+// Addressee is padded to 9 chars. The line carries two colons between
+// the path and the addressee: the first is the AX.25 path/data
+// separator, the second is the APRS message data-type identifier.
+// Without both, APRS-IS consumers reject the line as an unsupported
+// packet format.
 func buildMessageTNC2(row *configstore.Message) string {
 	addr := row.ToCall
 	if len(addr) > 9 {
@@ -561,7 +565,7 @@ func buildMessageTNC2(row *configstore.Message) string {
 	if row.MsgID != "" {
 		body = body + "{" + row.MsgID
 	}
-	return fmt.Sprintf("%s>APGRWO,TCPIP*%s", row.FromCall, body)
+	return fmt.Sprintf("%s>APGRWO,TCPIP*:%s", row.FromCall, body)
 }
 
 // recordPending stores metadata keyed by frame pointer for the TxHook.

--- a/pkg/messages/sender_test.go
+++ b/pkg/messages/sender_test.go
@@ -731,3 +731,39 @@ func TestSender_AprsModeChannel_Permits(t *testing.T) {
 		t.Fatalf("sink got %d frames, want 1", got)
 	}
 }
+
+// TestBuildMessageTNC2 verifies the line carries the path-terminator
+// colon AND the message DTI colon (two colons between the path and
+// the addressee). Without both, APRS-IS consumers like aprs.fi reject
+// the packet as "Unsupported packet format".
+func TestBuildMessageTNC2(t *testing.T) {
+	tests := []struct {
+		name string
+		row  *configstore.Message
+		want string
+	}{
+		{
+			name: "padded addressee with msg id",
+			row:  &configstore.Message{FromCall: "NW5W-13", ToCall: "NW5W-5", Text: "TEST", MsgID: "015"},
+			want: "NW5W-13>APGRWO,TCPIP*::NW5W-5   :TEST{015",
+		},
+		{
+			name: "no msg id",
+			row:  &configstore.Message{FromCall: "N0CAL", ToCall: "W1ABC", Text: "hi"},
+			want: "N0CAL>APGRWO,TCPIP*::W1ABC    :hi",
+		},
+		{
+			name: "9-char addressee (no padding)",
+			row:  &configstore.Message{FromCall: "K1ABC", ToCall: "WB6VVV-15", Text: "x", MsgID: "001"},
+			want: "K1ABC>APGRWO,TCPIP*::WB6VVV-15:x{001",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildMessageTNC2(tc.row)
+			if got != tc.want {
+				t.Fatalf("buildMessageTNC2 = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/webapi/igate_config_test.go
+++ b/pkg/webapi/igate_config_test.go
@@ -262,3 +262,28 @@ func TestIGateConfig_AllowsNonTxCapableChannelWhenDisabled(t *testing.T) {
 		t.Fatalf("expected 200 (disabled escape hatch), got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
+// TestIGateConfig_NoChannelsISOnlySaveSucceeds covers the IS-only
+// operator flow: an enabled iGate must save when rf_channel=0 and
+// tx_channel=0 (the canonical "unset" sentinel that
+// dto.ValidateChannelRef short-circuits on). Before the
+// default-channel-id change, GORM seeded 1/1 and the UI's first save
+// 400'd on "channel 1 does not exist" for fresh installs.
+func TestIGateConfig_NoChannelsISOnlySaveSucceeds(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	ctx := context.Background()
+
+	if err := srv.store.UpsertStationConfig(ctx, configstore.StationConfig{Callsign: "N0CAL"}); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"enabled":true,"server":"rotate.aprs2.net","port":14580,"rf_channel":0,"tx_channel":0,"max_msg_hops":2,"software_name":"graywolf","software_version":"0.1"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/igate/config", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/web/src/lib/settings/messages-preferences-store.svelte.js
+++ b/web/src/lib/settings/messages-preferences-store.svelte.js
@@ -44,6 +44,21 @@ function normalizeOverride(v) {
   return 0;
 }
 
+// Build the full preferences PUT payload from a hydrated baseline plus a
+// per-setter patch. The five-field shape is enumerated explicitly so that
+// adding a sixth field forces every setter to opt in (vs. silently
+// inheriting via spread). Always normalizes max_message_text_override.
+function buildPayload(baseline, patch) {
+  const merged = { ...baseline, ...patch };
+  return {
+    default_path: merged.default_path,
+    fallback_policy: merged.fallback_policy,
+    retention_days: merged.retention_days,
+    retry_max_attempts: merged.retry_max_attempts,
+    max_message_text_override: normalizeOverride(merged.max_message_text_override),
+  };
+}
+
 export const messagesPreferencesState = (() => {
   // Full preferences payload, so PUTs can round-trip sibling fields
   // without dropping them. Populated by fetchPreferences; `null` until
@@ -109,14 +124,7 @@ export const messagesPreferencesState = (() => {
     saving = true;
     error = null;
     try {
-      const payload = {
-        default_path: baseline.default_path,
-        fallback_policy: baseline.fallback_policy,
-        retention_days: baseline.retention_days,
-        retry_max_attempts: baseline.retry_max_attempts,
-        max_message_text_override: normalized,
-      };
-      const resp = await putPreferences(payload);
+      const resp = await putPreferences(buildPayload(baseline, { max_message_text_override: normalized }));
       const next = resp ?? optimistic;
       next.max_message_text_override = normalizeOverride(next.max_message_text_override);
       prefs = next;
@@ -152,14 +160,7 @@ export const messagesPreferencesState = (() => {
     saving = true;
     error = null;
     try {
-      const payload = {
-        default_path: baseline.default_path,
-        fallback_policy: policy,
-        retention_days: baseline.retention_days,
-        retry_max_attempts: baseline.retry_max_attempts,
-        max_message_text_override: normalizeOverride(baseline.max_message_text_override),
-      };
-      const resp = await putPreferences(payload);
+      const resp = await putPreferences(buildPayload(baseline, { fallback_policy: policy }));
       const next = resp ?? optimistic;
       next.max_message_text_override = normalizeOverride(next.max_message_text_override);
       prefs = next;

--- a/web/src/lib/settings/messages-preferences-store.svelte.js
+++ b/web/src/lib/settings/messages-preferences-store.svelte.js
@@ -31,6 +31,8 @@ import { getPreferences, putPreferences } from '../../api/messages.js';
 const DEFAULT_CAP = 67;
 const UNSAFE_CAP = 200;
 
+const VALID_FALLBACK_POLICIES = new Set(['rf_only', 'is_fallback', 'is_only', 'both']);
+
 // Normalize a value from the wire into a valid override:
 //   0          -> 0 (default enforced)
 //   68..200    -> itself (raised cap)
@@ -133,6 +135,44 @@ export const messagesPreferencesState = (() => {
     return setOverride(allow ? UNSAFE_CAP : 0);
   }
 
+  async function setFallbackPolicy(policy) {
+    if (!VALID_FALLBACK_POLICIES.has(policy)) return;
+    if (!hydrated) {
+      await fetchPreferences();
+      if (!hydrated) {
+        toasts.error("Couldn't load preferences — try again in a moment.");
+        return;
+      }
+    }
+    if (prefs?.fallback_policy === policy) return;
+    const baseline = prefs;
+    const prev = baseline;
+    const optimistic = { ...baseline, fallback_policy: policy };
+    prefs = optimistic;
+    saving = true;
+    error = null;
+    try {
+      const payload = {
+        default_path: baseline.default_path,
+        fallback_policy: policy,
+        retention_days: baseline.retention_days,
+        retry_max_attempts: baseline.retry_max_attempts,
+        max_message_text_override: normalizeOverride(baseline.max_message_text_override),
+      };
+      const resp = await putPreferences(payload);
+      const next = resp ?? optimistic;
+      next.max_message_text_override = normalizeOverride(next.max_message_text_override);
+      prefs = next;
+      toasts.success('Saved');
+    } catch (e) {
+      prefs = prev;
+      error = e?.message || String(e);
+      toasts.error("Couldn't save fallback policy — try again.");
+    } finally {
+      saving = false;
+    }
+  }
+
   return {
     get loaded() { return loaded; },
     get saving() { return saving; },
@@ -147,6 +187,7 @@ export const messagesPreferencesState = (() => {
     get allowLong() {
       return normalizeOverride(prefs?.max_message_text_override) > 0;
     },
+    get fallbackPolicy() { return prefs?.fallback_policy || 'is_fallback'; },
     // Effective cap the compose bar should enforce. Mirrors the server's
     // sender gate: 0 => 67, otherwise => the override value itself.
     get maxMessageText() {
@@ -157,6 +198,7 @@ export const messagesPreferencesState = (() => {
     fetchPreferences,
     setOverride,
     setAllowLong,
+    setFallbackPolicy,
   };
 })();
 

--- a/web/src/lib/settings/messages-preferences-store.test.js
+++ b/web/src/lib/settings/messages-preferences-store.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../api/messages.js', () => ({
+  getPreferences: vi.fn(),
+  putPreferences: vi.fn(),
+}));
+vi.mock('../stores.js', () => ({
+  toasts: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { messagesPreferencesState } from './messages-preferences-store.svelte.js';
+import { getPreferences, putPreferences } from '../../api/messages.js';
+
+describe('messagesPreferencesState.setFallbackPolicy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends the new policy and preserves sibling fields', async () => {
+    getPreferences.mockResolvedValueOnce({
+      default_path: 'auto',
+      fallback_policy: 'is_fallback',
+      retention_days: 30,
+      retry_max_attempts: 3,
+      max_message_text_override: 0,
+    });
+    putPreferences.mockResolvedValueOnce({
+      default_path: 'auto',
+      fallback_policy: 'is_only',
+      retention_days: 30,
+      retry_max_attempts: 3,
+      max_message_text_override: 0,
+    });
+
+    await messagesPreferencesState.fetchPreferences();
+    await messagesPreferencesState.setFallbackPolicy('is_only');
+
+    expect(putPreferences).toHaveBeenCalledWith({
+      default_path: 'auto',
+      fallback_policy: 'is_only',
+      retention_days: 30,
+      retry_max_attempts: 3,
+      max_message_text_override: 0,
+    });
+    expect(messagesPreferencesState.fallbackPolicy).toBe('is_only');
+  });
+
+  it('rejects unknown policies', async () => {
+    getPreferences.mockResolvedValueOnce({
+      default_path: 'auto',
+      fallback_policy: 'is_fallback',
+      retention_days: 30,
+      retry_max_attempts: 3,
+      max_message_text_override: 0,
+    });
+    await messagesPreferencesState.fetchPreferences();
+    await messagesPreferencesState.setFallbackPolicy('garbage');
+    expect(putPreferences).not.toHaveBeenCalled();
+    expect(messagesPreferencesState.fallbackPolicy).toBe('is_fallback');
+  });
+});

--- a/web/src/routes/Channels.svelte
+++ b/web/src/routes/Channels.svelte
@@ -422,7 +422,15 @@
 </PageHeader>
 
 {#if channels.length === 0}
-  <div class="empty-state">No channels configured. Add a channel to start decoding packets.</div>
+  <div class="empty-state">
+    No channels configured. Add a channel to start decoding RF packets.
+    <br />
+    <span class="empty-state-hint">
+      Running an APRS-IS-only station? You don't need a channel — set your
+      <a href="#/callsign">station callsign</a>, then enable the
+      <a href="#/igate">iGate</a>. Messages will route over APRS-IS automatically.
+    </span>
+  </div>
 {:else}
   <div class="channel-grid">
     {#each channels as ch}
@@ -777,6 +785,16 @@
     padding: 32px;
     border: 1px dashed var(--border-color);
     border-radius: var(--radius);
+  }
+  .empty-state-hint {
+    display: inline-block;
+    margin-top: 8px;
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .empty-state-hint a {
+    color: var(--color-primary);
+    text-decoration: underline;
   }
 
   .channel-grid {

--- a/web/src/routes/Igate.svelte
+++ b/web/src/routes/Igate.svelte
@@ -24,7 +24,7 @@
     enabled: true, server: 'rotate.aprs2.net', port: '14580',
     server_filter: '', tx_channel: 0,
     simulation_mode: false, gate_rf_to_is: true, gate_is_to_rf: false,
-    rf_channel: 1, max_msg_hops: 2, software_name: 'graywolf', software_version: '0.1',
+    rf_channel: 0, max_msg_hops: 2, software_name: 'graywolf', software_version: '0.1',
   });
   let loading = $state(false);
 

--- a/web/src/routes/Preferences.svelte
+++ b/web/src/routes/Preferences.svelte
@@ -12,6 +12,13 @@
 
   const themeOptions = THEMES.map((t) => ({ value: t.id, label: t.name }));
 
+  const fallbackPolicyOptions = [
+    { value: 'is_fallback', label: 'Try RF first, fall back to APRS-IS' },
+    { value: 'is_only', label: 'APRS-IS only' },
+    { value: 'rf_only', label: 'RF only' },
+    { value: 'both', label: 'Send on RF and APRS-IS' },
+  ];
+
   let txChannel = $state(0);
 
   onMount(async () => {
@@ -112,6 +119,19 @@
   <p class="messages-hint">
     Where graywolf sends outbound APRS messages. Auto picks the first
     APRS-eligible channel at send time.
+  </p>
+  <p class="tx-channel-label">Send path</p>
+  <Select
+    value={messagesPreferencesState.fallbackPolicy}
+    onValueChange={(v) => messagesPreferencesState.setFallbackPolicy(v)}
+    options={fallbackPolicyOptions}
+    aria-label="Message send path"
+    disabled={!messagesPreferencesState.loaded || messagesPreferencesState.saving}
+  />
+  <p class="messages-hint">
+    Choose APRS-IS only if you have no radio channel configured. The
+    default tries RF first and silently falls back to APRS-IS when no
+    modem is available.
   </p>
 </Box>
 


### PR DESCRIPTION
## Summary
- Default `IGateConfig.RfChannel` and `TxChannel` to `0` (unset sentinel) so a fresh install can save an enabled iGate before any channel exists.
- Add `Send path` selector on Preferences (rf_only / is_fallback / is_only / both) backed by a new `setFallbackPolicy` on the messages-preferences store.
- Add IS-only hint to the Channels empty state with links to the Callsign and iGate pages.
- Refresh the wiki (`docs/wiki/system-topology.md`) and handbook (`igate.html`, `messaging.html`) to document the auto-derived passcode and the IS-only flow.

## Test Plan
- [x] `go test ./pkg/configstore/... ./pkg/webapi/... ./pkg/app/... ./pkg/igate/... ./pkg/messages/...` (all pass)
- [x] `npx vitest run src/lib/settings/messages-preferences-store.test.js` (2 cases pass)
- [x] `npm run build` (web bundle builds clean)
- [ ] Manual smoke on a fresh DB: set callsign, leave Channels empty, enable iGate, switch Preferences send path to `is_only`, send a message; confirm 200 on iGate save and `message.sent_is` event.