### PR TITLE
actions: ACK + dedup @@ packets via shared messages.Preflight

### DIFF
--- a/docs/wiki/actions.md
+++ b/docs/wiki/actions.md
@@ -75,11 +75,38 @@ uses is exported precisely so the classifier and the router agree on
 RF or IS frame
   -> aprs.Parse
   -> classifier.Classify(pkt)
-       hit?  -> runner.Submit (or Reply for short-circuits)
-                -> executor.Execute
-                -> reply + audit
+       hit on @@ + addressed-to-us?
+         -> messages.Preflight.SendAutoAck (every copy)
+         -> messages.Preflight.CheckDedup
+              hit?  -> consumed, no Submit (first copy already replied)
+              miss? -> runner.Submit (or Reply for short-circuits)
+                       -> executor.Execute
+                       -> reply + audit
        miss? -> messages.Router (normal inbox)
+                -> messages.Preflight.SendAutoAck (same instance)
+                -> messages.Preflight.CheckDedup (same window)
+                -> persist + reply-ack correlation
 ```
+
+## Preflight: shared auto-ACK + dedup
+
+`messages.Preflight` (`pkg/messages/preflight.go`) owns the
+(from, msg_id, text_hash) dedup ring and the auto-ACK transport
+(RF via `txgovernor.TxSink`, IS via `IGateLineSender`). One instance
+is constructed by `messages.Service.NewService` and shared between
+`messages.Router` and `actions.Classifier`. This is the only place
+auto-ACK and dedup are implemented for inbound APRS messages -- both
+subsystems consult the same window so an `@@`-prefixed action and a
+plain DM with the same `(from, msgid, text)` would (in the
+hypothetical case of overlap) collapse into one ACK and one execution.
+
+Operational consequence: prior to this hookup, `@@` packets bypassed
+the router entirely, so the action sender never saw an ACK and kept
+retrying every 30 s for ~5 min. iGate fan-out compounded the problem
+by delivering 3-10 identical copies. Each copy executed the action
+(or, after the first, bounced as `rate_limited`). The preflight
+collapses the storm: every copy is acked (APRS101 §14.2), but only
+the first copy reaches the runner.
 
 Classifier hooks live in:
 - RF: [`../../pkg/app/rxfanout.go`](../../pkg/app/rxfanout.go)
@@ -146,6 +173,7 @@ the default. Tracked as a follow-up.
 
 | Concern | Mechanism | Source |
 |---|---|---|
+| Inbound preflight (auto-ACK + dedup) | shared `messages.Preflight` constructed by `messages.Service`, consulted by both `messages.Router` and `actions.Classifier` (mutex-guarded `dedupMap`, atomic auto-ACK channel). Default 5-min window. | `pkg/messages/preflight.go` |
 | Per-Action queue + worker | `actionQueue` in runner; lazily spawned on first `Submit`; `q.mu` held across rate-limit reservation and channel send | `pkg/actions/runner.go` |
 | Listener-addressee snapshot | `atomic.Pointer[map[string]struct{}]`, mirrors `messages.TacticalSet` semantics | `pkg/actions/addressees.go` |
 | OTP replay ring | per-(credID, step, sha256(code)) entry with TTL = 3 steps + 30s; ±1-step probe covers boundary | `pkg/actions/otp.go` |
@@ -251,8 +279,9 @@ results.
   [`../../pkg/actions/parser.go`](../../pkg/actions/parser.go); the
   classifier never reparses on its own.
 - The `@@` sentinel is the sole hot-path discriminator; if you add
-  another trigger, update this page and `pkg/actions/classifier.go`
-  in the same change.
+  another trigger, update this page, `pkg/actions/classifier.go`,
+  and ensure the new path also calls into `messages.Preflight` so
+  duplicates do not slip past dedup.
 - Outbound counterpart (macro/credential CRUD + Messages drawer):
   [`remote-actions.md`](remote-actions.md). The two subsystems share
   only `parser.go` (exported `ValidActionName`, `MaxActionNameLen`).

--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -75,7 +75,7 @@ The TX-funnel rule lives in [invariant 16](invariants.md).
 | `digipeater` | WIDEn-N / TRACEn-N digipeater with preemptive digi and per-channel dedup | [`../handbook/digipeater.html`](../handbook/digipeater.html) |
 | `igate` | APRS-IS bidirectional gateway: client/login/filter, RF<->IS gating, third-party encap, TNC2 | [`../handbook/igate.html`](../handbook/igate.html) |
 | `igate/filters` | IS->RF rule engine (priority-ordered, deny by default) | [`../handbook/igate.html`](../handbook/igate.html) |
-| `messages` | APRS messaging domain: router, store (GORM), sender, retry, invite, tactical_set, bots, preferences, event_hub, local_tx_ring | [`../handbook/messaging.html`](../handbook/messaging.html) |
+| `messages` | APRS messaging domain: router, store (GORM), sender, retry, invite, tactical_set, bots, preferences, event_hub, local_tx_ring, **preflight** (shared auto-ACK + dedup transport, owned by `messages.Service`, consulted by both `messages.Router` and `actions.Classifier`) | [`../handbook/messaging.html`](../handbook/messaging.html) |
 | `actions` | `@@`-prefixed APRS message Actions: classifier, parser, OTP verifier, per-Action runner with rate limit + queue, command/webhook executors, source-aware reply, audit pruner | [`actions.md`](actions.md) |
 | `remoteactions` | OUTBOUND counterpart: macro + remote-OTP credential stores, base32/target-call/action-name validators, RFC 6238 TOTP generator, service composition root. Sibling, not fork, of `pkg/actions/` (shares only the wire grammar via exported `actions.ValidActionName`). | [`remote-actions.md`](remote-actions.md) |
 | `gps` | GPSD client + serial NMEA reader + cache + station-position layered cache + enumerate | [`../handbook/gps.html`](../handbook/gps.html) |

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -244,28 +244,40 @@ authoring guide),
 When the Actions classifier matches an inbound APRS message (addressee
 in the trigger surface AND info-field begins with `@@`), the packet is
 consumed before the messages router sees it. No `messages.in` row is
-written for that packet. Because the auto-ACK lives inside
-[`pkg/messages/router.go`](../../pkg/messages/router.go) (`Router.classify` /
-`sendAutoAck`) and the classifier short-circuits before the messages
-router runs, **the standard auto-ACK frame is NOT emitted** for
-consumed Actions packets — the on-air reply text (routed through
-`messages.Sender`) is what the sender sees, and a sender's APRS client
-that retries on missing-ACK will keep retrying until its retry budget
-is reached. The design spec at
-[`../superpowers/specs/2026-05-02-graywolf-actions-design.md`](../superpowers/specs/2026-05-02-graywolf-actions-design.md)
-(§8) calls for the auto-ACK to fire in addition to the reply; that is a
-known gap tracked as a follow-up.
+written for that packet. The classifier and the messages router share
+one [`messages.Preflight`](../../pkg/messages/preflight.go) instance
+constructed by `messages.Service`, so a consumed Actions packet still
+gets an auto-ACK on every copy and a `(from, msgid, text_hash)` dedup
+verdict — the first copy reaches the runner, every subsequent copy
+within the dedup window is ACKed and silently dropped (APRS101 §14.2).
 
 *Why:* Actions are operator-controlled command channels, not
 correspondence; surfacing every Action invocation in the inbox would
 clutter the operator's message view and break the audit-log-as-source-of-truth
-contract for Actions traffic. Consumption is the cleanest cut.
+contract for Actions traffic. Consumption is the cleanest cut. Sharing
+the preflight closes the prior gap where action senders kept retrying
+because no ACK ever arrived, and where iGate fan-out delivered N copies
+that each fired the executor.
 
 Source: [`../../pkg/actions/classifier.go`](../../pkg/actions/classifier.go),
 [`../../pkg/app/rxfanout.go`](../../pkg/app/rxfanout.go)
 (`dispatchRxFrame`),
 [`../../pkg/app/wiring.go`](../../pkg/app/wiring.go)
-(`onIGateIsRxPacket`),
+(`onIGateIsRxPacket`, `wireActions`),
+[`../../pkg/messages/preflight.go`](../../pkg/messages/preflight.go),
 [`../../pkg/messages/router.go`](../../pkg/messages/router.go)
-(`Router.classify` / `sendAutoAck`),
-[`actions.md`](actions.md) ("Hot path" section).
+(`Router.classify`),
+[`actions.md`](actions.md) ("Hot path", "Preflight" sections).
+
+### 27. Inbound dedup + auto-ACK is centralized in `messages.Preflight`
+
+Any new inbound discriminator that diverts traffic before
+`messages.Router` (today only `actions.Classifier`) MUST send an
+auto-ACK and consult the dedup ring via `messages.Preflight`, or
+iGate-relayed duplicates will re-fire its handlers and the original
+sender will retry forever.
+
+Source: [`../../pkg/messages/preflight.go`](../../pkg/messages/preflight.go),
+[`../../pkg/messages/service.go`](../../pkg/messages/service.go)
+(`(*Service).Preflight()`),
+[`actions.md`](actions.md) ("Preflight: shared auto-ACK + dedup").

--- a/pkg/actions/classifier.go
+++ b/pkg/actions/classifier.go
@@ -46,6 +46,12 @@ type ClassifierConfig struct {
 	CredStore   CredentialLookup
 	OTPVerifier *OTPVerifier
 	Runner      Submitter
+	// Preflight is the shared auto-ACK + dedup component owned by
+	// messages.Service. When non-nil, every consumed @@ packet sends an
+	// auto-ACK before any executor work and a duplicate (same from, msg
+	// id, text hash) within the dedup window short-circuits without
+	// re-submitting. Nil disables the hookup (test-only).
+	Preflight *messages.Preflight
 }
 
 // Classifier inspects inbound APRS messages and decides whether they
@@ -92,6 +98,17 @@ func (c *Classifier) Classify(ctx context.Context, pkt *aprs.DecodedAPRSPacket) 
 	}
 	sender := strings.ToUpper(strings.TrimSpace(innerSource))
 	channel := uint32(pkt.Channel)
+
+	// Preflight: send auto-ACK on every copy (APRS101 §14.2 — ack each
+	// retry/duplicate so the sender stops resending). Then dedup on
+	// (from, msgid, text_hash). A dedup hit consumes the packet without
+	// running the executor again — the first copy already replied.
+	if c.cfg.Preflight != nil {
+		c.cfg.Preflight.SendAutoAck(ctx, pkt, sender, innerMsg.MessageID)
+		if innerMsg.MessageID != "" && c.cfg.Preflight.CheckDedup(sender, innerMsg.MessageID, innerMsg.Text) {
+			return true
+		}
+	}
 
 	parsed, parseErr := Parse(innerMsg.Text)
 	if parseErr != nil && parsed == nil {

--- a/pkg/actions/classifier_test.go
+++ b/pkg/actions/classifier_test.go
@@ -706,3 +706,26 @@ func TestClassifierMissingMsgIDSkipsACKAndDedup(t *testing.T) {
 		t.Fatalf("no msgID must still Submit (no dedup key), got %d", got)
 	}
 }
+
+// TestClassifierThreeIdenticalCopiesACKThriceFireOnce models the
+// operational failure: an action sender retries while iGate fan-out
+// delivers extra copies. The classifier must ACK every copy (so the
+// sender stops retrying) but only fire the executor on the first copy.
+func TestClassifierThreeIdenticalCopiesACKThriceFireOnce(t *testing.T) {
+	pf, sink, _ := newClassifierTestPreflight(t)
+	c, sub := newClassifierWithPreflight(t, pf)
+
+	for i := 0; i < 3; i++ {
+		pkt := makeActionPacket("W1ABC", "N0CALL", "@@#unlock", "042", aprs.DirectionRF)
+		if !c.Classify(context.Background(), pkt) {
+			t.Fatalf("copy %d not consumed", i)
+		}
+	}
+
+	if got := len(sink.list()); got != 3 {
+		t.Fatalf("auto-ACK count after 3 copies = %d, want 3", got)
+	}
+	if got := len(sub.submits); got != 1 {
+		t.Fatalf("Submit count after 3 copies = %d, want 1", got)
+	}
+}

--- a/pkg/actions/classifier_test.go
+++ b/pkg/actions/classifier_test.go
@@ -3,7 +3,10 @@ package actions
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,8 +14,10 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/chrissnell/graywolf/pkg/aprs"
+	"github.com/chrissnell/graywolf/pkg/ax25"
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/messages"
+	"github.com/chrissnell/graywolf/pkg/txgovernor"
 )
 
 type stubSubmitter struct {
@@ -550,5 +555,154 @@ func TestSenderAllowed(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("senderAllowed(%q,%q)=%v want %v", tc.sender, tc.csv, got, tc.want)
 		}
+	}
+}
+
+// classifierTxSink captures Submit calls for the preflight integration
+// tests. Mirrors the pkg/messages fakeTxSink, redefined here because Go
+// scopes test fakes per-package.
+type classifierTxSink struct {
+	mu     sync.Mutex
+	frames []classifierSubmit
+}
+
+type classifierSubmit struct {
+	Channel uint32
+	Frame   *ax25.Frame
+	Src     txgovernor.SubmitSource
+}
+
+func (f *classifierTxSink) Submit(_ context.Context, ch uint32, frame *ax25.Frame, src txgovernor.SubmitSource) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.frames = append(f.frames, classifierSubmit{Channel: ch, Frame: frame, Src: src})
+	return nil
+}
+
+func (f *classifierTxSink) list() []classifierSubmit {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]classifierSubmit, len(f.frames))
+	copy(out, f.frames)
+	return out
+}
+
+type classifierIGate struct {
+	mu sync.Mutex
+	ll []string
+}
+
+func (f *classifierIGate) SendLine(line string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ll = append(f.ll, line)
+	return nil
+}
+
+// newClassifierTestPreflight builds a real messages.Preflight wired
+// over package-local fakes so the classifier's auto-ACK path is
+// exercised end to end.
+func newClassifierTestPreflight(t *testing.T) (*messages.Preflight, *classifierTxSink, *classifierIGate) {
+	t.Helper()
+	sink := &classifierTxSink{}
+	igs := &classifierIGate{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pf, err := messages.NewPreflight(messages.PreflightConfig{
+		OurCall:        func() string { return "N0CALL" },
+		TxSink:         sink,
+		IGateSender:    igs,
+		Logger:         logger,
+		AutoAckChannel: 1,
+	})
+	if err != nil {
+		t.Fatalf("NewPreflight: %v", err)
+	}
+	return pf, sink, igs
+}
+
+// newClassifierWithPreflight wires a Classifier with a Preflight and
+// the OTP-free "unlock" action. Returns the classifier and its
+// stubSubmitter so tests can assert on Submit count.
+func newClassifierWithPreflight(t *testing.T, pf *messages.Preflight) (*Classifier, *stubSubmitter) {
+	t.Helper()
+	a := &configstore.Action{
+		ID: 1, Name: "unlock", Type: "command",
+		Enabled: true, OTPRequired: false,
+	}
+	sub := &stubSubmitter{}
+	c := NewClassifier(ClassifierConfig{
+		OurCall:     ourCallProvider("N0CALL"),
+		TacticalSet: messages.NewTacticalSet(),
+		Listeners:   NewAddresseeSet(),
+		ActionStore: &stubActionStore{byName: map[string]*configstore.Action{"unlock": a}},
+		CredStore:   &stubCredStore{},
+		OTPVerifier: NewOTPVerifier(OTPVerifierConfig{Now: time.Now}),
+		Runner:      sub,
+		Preflight:   pf,
+	})
+	return c, sub
+}
+
+func makeActionPacket(sender, addressee, body, msgID string, dir aprs.Direction) *aprs.DecodedAPRSPacket {
+	return &aprs.DecodedAPRSPacket{
+		Source:    sender,
+		Type:      aprs.PacketMessage,
+		Direction: dir,
+		Channel:   1,
+		Message: &aprs.Message{
+			Addressee: addressee,
+			Text:      body,
+			MessageID: msgID,
+		},
+	}
+}
+
+func TestClassifierFiresAutoAckOnFirstCopy(t *testing.T) {
+	pf, sink, _ := newClassifierTestPreflight(t)
+	c, sub := newClassifierWithPreflight(t, pf)
+
+	pkt := makeActionPacket("W1ABC", "N0CALL", "@@#unlock", "042", aprs.DirectionRF)
+	if !c.Classify(context.Background(), pkt) {
+		t.Fatal("classifier must consume @@-prefixed packet")
+	}
+	if got := len(sink.list()); got != 1 {
+		t.Fatalf("auto-ACK count = %d, want 1", got)
+	}
+	if got := len(sub.submits); got != 1 {
+		t.Fatalf("Submit call count = %d, want 1", got)
+	}
+}
+
+func TestClassifierDedupSecondCopyNoSubmit(t *testing.T) {
+	pf, sink, _ := newClassifierTestPreflight(t)
+	c, sub := newClassifierWithPreflight(t, pf)
+
+	pkt := makeActionPacket("W1ABC", "N0CALL", "@@#unlock", "042", aprs.DirectionRF)
+	_ = c.Classify(context.Background(), pkt)
+
+	dup := makeActionPacket("W1ABC", "N0CALL", "@@#unlock", "042", aprs.DirectionRF)
+	if !c.Classify(context.Background(), dup) {
+		t.Fatal("dup must still be consumed")
+	}
+	// APRS101 §14.2 — every copy is acked.
+	if got := len(sink.list()); got != 2 {
+		t.Fatalf("auto-ACK count after dup = %d, want 2", got)
+	}
+	if got := len(sub.submits); got != 1 {
+		t.Fatalf("Submit count after dup = %d, want 1 (dedup must suppress)", got)
+	}
+}
+
+func TestClassifierMissingMsgIDSkipsACKAndDedup(t *testing.T) {
+	pf, sink, _ := newClassifierTestPreflight(t)
+	c, sub := newClassifierWithPreflight(t, pf)
+
+	pkt := makeActionPacket("W1ABC", "N0CALL", "@@#unlock", "", aprs.DirectionRF)
+	_ = c.Classify(context.Background(), pkt)
+	if got := len(sink.list()); got != 0 {
+		t.Fatalf("no msgID must skip auto-ACK, got %d", got)
+	}
+	if got := len(sub.submits); got != 1 {
+		t.Fatalf("no msgID must still Submit (no dedup key), got %d", got)
 	}
 }

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -48,6 +48,10 @@ type ServiceConfig struct {
 	// TacticalSet is the live tactical-alias set; the classifier
 	// matches against it on every inbound packet. Required.
 	TacticalSet *messages.TacticalSet
+	// Preflight is the shared messages preflight (auto-ACK + dedup).
+	// Required when running inside the wired app; tests may pass nil
+	// to opt out of preflight integration.
+	Preflight *messages.Preflight
 	// Logger is optional; nil falls back to slog.Default().
 	Logger *slog.Logger
 	// AuditPruner overrides the audit-log retention defaults. Zero
@@ -120,6 +124,7 @@ func NewService(ctx context.Context, cfg ServiceConfig) (*Service, error) {
 		CredStore:   cfg.Store,
 		OTPVerifier: verifier,
 		Runner:      runner,
+		Preflight:   cfg.Preflight,
 	})
 
 	stop := StartAuditPruner(ctx, cfg.Store, cfg.AuditPruner)

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -830,6 +830,7 @@ func (a *App) wireActions(ctx context.Context) error {
 		Messages:    a.msgSvc,
 		OurCall:     ourCall,
 		TacticalSet: a.msgSvc.TacticalSet(),
+		Preflight:   a.msgSvc.Preflight(),
 		Logger:      a.logger.With("component", "actions"),
 	})
 	if err != nil {

--- a/pkg/messages/preflight.go
+++ b/pkg/messages/preflight.go
@@ -1,9 +1,11 @@
 package messages
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -12,6 +14,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/chrissnell/graywolf/pkg/aprs"
+	"github.com/chrissnell/graywolf/pkg/ax25"
 	"github.com/chrissnell/graywolf/pkg/txgovernor"
 )
 
@@ -170,4 +174,87 @@ func (p *Preflight) CheckDedup(fromCall, msgID, text string) bool {
 func preflightDedupKey(fromCall, msgID, text string) string {
 	h := sha1.Sum([]byte(text))
 	return strings.ToUpper(fromCall) + "|" + msgID + "|" + hex.EncodeToString(h[:8])
+}
+
+// SendAutoAck builds and submits an auto-ACK for an inbound message.
+// The ack follows the path the message arrived on: RF inbound acks
+// over RF (on the receiving channel when known, configured fallback
+// otherwise); IS inbound acks via IGateSender. Empty msgID is a
+// no-op. Mirroring an IS-sourced ack onto RF would waste local
+// airtime on a channel the correspondent cannot hear.
+func (p *Preflight) SendAutoAck(
+	ctx context.Context,
+	pkt *aprs.DecodedAPRSPacket,
+	peerCall, msgID string,
+) {
+	if msgID == "" {
+		return
+	}
+	ourCall := p.cfg.OurCall()
+	if ourCall == "" {
+		p.logger.Debug("preflight skipping auto-ACK: our_call empty")
+		return
+	}
+	if pkt.Direction == aprs.DirectionIS {
+		if p.cfg.IGateSender == nil {
+			return
+		}
+		line := preflightAckTNC2(ourCall, peerCall, msgID)
+		if err := p.cfg.IGateSender.SendLine(line); err != nil {
+			p.logger.Debug("preflight auto-ACK IS mirror failed",
+				"error", err, "peer", peerCall, "msgid", msgID)
+			return
+		}
+		p.mAutoAckSent.Inc()
+		return
+	}
+	frame, err := preflightAckFrame(ourCall, peerCall, msgID)
+	if err != nil {
+		p.logger.Warn("preflight auto-ACK encode failed",
+			"error", err, "peer", peerCall, "msgid", msgID)
+		return
+	}
+	ch := p.autoAckCh.Load()
+	if pkt.Direction == aprs.DirectionRF && pkt.Channel > 0 {
+		ch = uint32(pkt.Channel)
+	}
+	src := txgovernor.SubmitSource{
+		Kind:      "messages-autoack",
+		Priority:  txgovernor.PriorityIGateMsg,
+		SkipDedup: true,
+	}
+	if err := p.cfg.TxSink.Submit(ctx, ch, frame, src); err != nil {
+		p.logger.Warn("preflight auto-ACK submit failed",
+			"error", err, "peer", peerCall, "msgid", msgID)
+		return
+	}
+	p.mAutoAckSent.Inc()
+}
+
+func preflightAckFrame(ourCall, peerCall, msgID string) (*ax25.Frame, error) {
+	info, err := aprs.EncodeMessageAck(peerCall, msgID)
+	if err != nil {
+		return nil, err
+	}
+	src, err := ax25.ParseAddress(ourCall)
+	if err != nil {
+		return nil, fmt.Errorf("messages: ack source: %w", err)
+	}
+	dest, err := ax25.ParseAddress("APGRWO")
+	if err != nil {
+		return nil, fmt.Errorf("messages: ack dest: %w", err)
+	}
+	return ax25.NewUIFrame(src, dest, nil, info)
+}
+
+func preflightAckTNC2(ourCall, peerCall, msgID string) string {
+	addr := peerCall
+	if len(addr) > 9 {
+		addr = addr[:9]
+	}
+	if len(addr) < 9 {
+		addr = addr + strings.Repeat(" ", 9-len(addr))
+	}
+	info := ":" + addr + ":ack" + msgID
+	return aprs.FormatTNC2(ourCall, "APGRWO", nil, []byte(info))
 }

--- a/pkg/messages/preflight.go
+++ b/pkg/messages/preflight.go
@@ -1,8 +1,11 @@
 package messages
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -140,3 +143,31 @@ func (p *Preflight) DedupHits() prometheus.Counter { return p.mDedupHits }
 
 // AutoAcksSent returns the live auto-ACK counter for tests.
 func (p *Preflight) AutoAcksSent() prometheus.Counter { return p.mAutoAckSent }
+
+// CheckDedup consults the (from, msg_id, text_hash) cache. Returns
+// true on a hit. Always records the current tuple so the next
+// identical packet within the window also hits. Expired entries are
+// evicted during the pass.
+func (p *Preflight) CheckDedup(fromCall, msgID, text string) bool {
+	key := preflightDedupKey(fromCall, msgID, text)
+	p.dedupMu.Lock()
+	defer p.dedupMu.Unlock()
+	now := p.clock.Now()
+	for k, exp := range p.dedupMap {
+		if now.After(exp) {
+			delete(p.dedupMap, k)
+		}
+	}
+	exp, hit := p.dedupMap[key]
+	p.dedupMap[key] = now.Add(p.dedupWin)
+	if hit && !now.After(exp) {
+		p.mDedupHits.Inc()
+		return true
+	}
+	return false
+}
+
+func preflightDedupKey(fromCall, msgID, text string) string {
+	h := sha1.Sum([]byte(text))
+	return strings.ToUpper(fromCall) + "|" + msgID + "|" + hex.EncodeToString(h[:8])
+}

--- a/pkg/messages/preflight.go
+++ b/pkg/messages/preflight.go
@@ -1,0 +1,142 @@
+package messages
+
+import (
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/chrissnell/graywolf/pkg/txgovernor"
+)
+
+// Preflight is the inbound-message preflight: a shared cache of
+// (from, msg_id, text_hash) tuples plus the transport for auto-ACKs.
+// Both messages.Router and actions.Classifier consult the same
+// instance so an @@-prefixed packet that the classifier consumes
+// still gets ACKed and dedup-suppressed exactly the way a normal
+// message would. APRS101 §14.2 — every copy is acked even when the
+// original was already deduped.
+type Preflight struct {
+	cfg PreflightConfig
+
+	logger    *slog.Logger
+	clock     RouterClock
+	dedupWin  time.Duration
+	autoAckCh atomic.Uint32
+
+	dedupMu  sync.Mutex
+	dedupMap map[string]time.Time
+
+	mAutoAckSent prometheus.Counter
+	mDedupHits   prometheus.Counter
+}
+
+// PreflightConfig captures the preflight's collaborators.
+type PreflightConfig struct {
+	// OurCall returns our primary callsign (possibly with SSID). Required.
+	OurCall func() string
+	// TxSink is the governor used to submit RF auto-ACK frames. Required.
+	TxSink txgovernor.TxSink
+	// IGateSender is the IS-side line sender used to mirror auto-ACKs
+	// when the inbound was IS-sourced. Optional — IS auto-ACKs are
+	// skipped when nil.
+	IGateSender IGateLineSender
+	// Logger is optional; nil falls back to slog.Default().
+	Logger *slog.Logger
+	// Registerer is optional; nil disables metric registration but the
+	// counters are still created so callers can read them in tests.
+	Registerer prometheus.Registerer
+	// Clock is optional; nil falls back to wall clock.
+	Clock RouterClock
+	// AutoAckChannel is the RF channel used when submitting auto-ACKs
+	// for IS-sourced inbound. Defaults to 1.
+	AutoAckChannel uint32
+	// DedupWindow overrides the (from, msg_id, text_hash) dedup window.
+	// <= 0 falls back to DefaultRouterDedupWindow.
+	DedupWindow time.Duration
+}
+
+// NewPreflight constructs a Preflight from cfg. Returns an error if
+// any required field is missing.
+func NewPreflight(cfg PreflightConfig) (*Preflight, error) {
+	if cfg.OurCall == nil {
+		return nil, errors.New("messages: preflight requires OurCall")
+	}
+	if cfg.TxSink == nil {
+		return nil, errors.New("messages: preflight requires TxSink")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = realRouterClock{}
+	}
+	win := cfg.DedupWindow
+	if win <= 0 {
+		win = DefaultRouterDedupWindow
+	}
+	ch := cfg.AutoAckChannel
+	if ch == 0 {
+		ch = 1
+	}
+	p := &Preflight{
+		cfg:      cfg,
+		logger:   logger,
+		clock:    clock,
+		dedupWin: win,
+		dedupMap: make(map[string]time.Time),
+	}
+	p.autoAckCh.Store(ch)
+	if err := p.initMetrics(cfg.Registerer); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (p *Preflight) initMetrics(reg prometheus.Registerer) error {
+	p.mAutoAckSent = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "messages_preflight_autoack_sent_total",
+		Help: "Auto-ACK frames submitted by the messages preflight.",
+	})
+	p.mDedupHits = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "messages_preflight_dedup_hits_total",
+		Help: "Inbound APRS message packets suppressed by the preflight (from,msgid,text_hash) dedup window.",
+	})
+	if reg == nil {
+		return nil
+	}
+	for _, c := range []prometheus.Collector{p.mAutoAckSent, p.mDedupHits} {
+		if err := reg.Register(c); err != nil {
+			are := prometheus.AlreadyRegisteredError{}
+			if !errors.As(err, &are) {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// AutoAckChannel returns the live RF channel ID used for auto-ACKs
+// when the inbound was IS-sourced. Reads are lock-free.
+func (p *Preflight) AutoAckChannel() uint32 { return p.autoAckCh.Load() }
+
+// SetAutoAckChannel updates the IS-fallback auto-ACK channel. Zero is
+// ignored. Safe to call concurrently.
+func (p *Preflight) SetAutoAckChannel(ch uint32) {
+	if ch == 0 {
+		return
+	}
+	p.autoAckCh.Store(ch)
+}
+
+// DedupHits returns the live dedup-hit metric so callers can read it
+// in tests without standing up a registry.
+func (p *Preflight) DedupHits() prometheus.Counter { return p.mDedupHits }
+
+// AutoAcksSent returns the live auto-ACK counter for tests.
+func (p *Preflight) AutoAcksSent() prometheus.Counter { return p.mAutoAckSent }

--- a/pkg/messages/preflight_test.go
+++ b/pkg/messages/preflight_test.go
@@ -1,10 +1,14 @@
 package messages
 
 import (
+	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/chrissnell/graywolf/pkg/aprs"
 )
 
 func newPreflightForTest(t *testing.T) (*Preflight, *fakeTxSink, *fakeIGateSender, *fakeClock) {
@@ -93,5 +97,63 @@ func TestPreflightCheckDedupKeyDistinct(t *testing.T) {
 	}
 	if hit := p.CheckDedup("W1ABC", "001", "world"); hit {
 		t.Fatal("different text-hash must miss")
+	}
+}
+
+func TestPreflightSendAutoAckRFSubmitsFrame(t *testing.T) {
+	p, sink, _, _ := newPreflightForTest(t)
+	pkt := &aprs.DecodedAPRSPacket{Direction: aprs.DirectionRF, Channel: 3}
+	p.SendAutoAck(context.Background(), pkt, "W1ABC", "001")
+
+	subs := sink.list()
+	if len(subs) != 1 {
+		t.Fatalf("want 1 RF submit, got %d", len(subs))
+	}
+	if subs[0].Channel != 3 {
+		t.Fatalf("RF auto-ACK channel = %d, want pkt.Channel=3", subs[0].Channel)
+	}
+	if !subs[0].Src.SkipDedup {
+		t.Fatal("auto-ACK must SkipDedup")
+	}
+}
+
+func TestPreflightSendAutoAckISMirrorsViaIGate(t *testing.T) {
+	p, sink, igs, _ := newPreflightForTest(t)
+	pkt := &aprs.DecodedAPRSPacket{Direction: aprs.DirectionIS}
+	p.SendAutoAck(context.Background(), pkt, "W1ABC", "001")
+
+	if got := len(sink.list()); got != 0 {
+		t.Fatalf("IS auto-ACK must not submit RF, got %d", got)
+	}
+	lines := igs.list()
+	if len(lines) != 1 {
+		t.Fatalf("want 1 IS line, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], ":ack001") {
+		t.Fatalf("IS line missing ack token: %q", lines[0])
+	}
+}
+
+func TestPreflightSendAutoAckEmptyMsgIDNoOp(t *testing.T) {
+	p, sink, igs, _ := newPreflightForTest(t)
+	pkt := &aprs.DecodedAPRSPacket{Direction: aprs.DirectionRF, Channel: 1}
+	p.SendAutoAck(context.Background(), pkt, "W1ABC", "")
+	if got := len(sink.list()); got != 0 {
+		t.Fatalf("empty msgID must not emit RF: %d", got)
+	}
+	if got := len(igs.list()); got != 0 {
+		t.Fatalf("empty msgID must not emit IS: %d", got)
+	}
+}
+
+func TestPreflightSendAutoAckRFFallsBackToConfiguredChannel(t *testing.T) {
+	p, sink, _, _ := newPreflightForTest(t)
+	p.SetAutoAckChannel(7)
+	pkt := &aprs.DecodedAPRSPacket{Direction: aprs.DirectionRF, Channel: 0}
+	p.SendAutoAck(context.Background(), pkt, "W1ABC", "001")
+
+	subs := sink.list()
+	if len(subs) != 1 || subs[0].Channel != 7 {
+		t.Fatalf("RF fallback channel: got %+v, want channel=7", subs)
 	}
 }

--- a/pkg/messages/preflight_test.go
+++ b/pkg/messages/preflight_test.go
@@ -57,3 +57,41 @@ func TestPreflightAutoAckChannelDefaultOne(t *testing.T) {
 		t.Fatalf("SetAutoAckChannel(0) must be ignored, got %d", got)
 	}
 }
+
+func TestPreflightCheckDedupFirstCallMisses(t *testing.T) {
+	p, _, _, _ := newPreflightForTest(t)
+	if hit := p.CheckDedup("W1ABC", "001", "hello"); hit {
+		t.Fatal("first call must not be a dedup hit")
+	}
+}
+
+func TestPreflightCheckDedupSecondCallHits(t *testing.T) {
+	p, _, _, _ := newPreflightForTest(t)
+	_ = p.CheckDedup("W1ABC", "001", "hello")
+	if hit := p.CheckDedup("W1ABC", "001", "hello"); !hit {
+		t.Fatal("second identical call must hit")
+	}
+}
+
+func TestPreflightCheckDedupExpiresAfterWindow(t *testing.T) {
+	p, _, _, clock := newPreflightForTest(t)
+	_ = p.CheckDedup("W1ABC", "001", "hello")
+	clock.now = clock.now.Add(DefaultRouterDedupWindow + time.Second)
+	if hit := p.CheckDedup("W1ABC", "001", "hello"); hit {
+		t.Fatal("expired entry must miss")
+	}
+}
+
+func TestPreflightCheckDedupKeyDistinct(t *testing.T) {
+	p, _, _, _ := newPreflightForTest(t)
+	_ = p.CheckDedup("W1ABC", "001", "hello")
+	if hit := p.CheckDedup("W1ABC", "002", "hello"); hit {
+		t.Fatal("different msgid must miss")
+	}
+	if hit := p.CheckDedup("W2XYZ", "001", "hello"); hit {
+		t.Fatal("different sender must miss")
+	}
+	if hit := p.CheckDedup("W1ABC", "001", "world"); hit {
+		t.Fatal("different text-hash must miss")
+	}
+}

--- a/pkg/messages/preflight_test.go
+++ b/pkg/messages/preflight_test.go
@@ -1,0 +1,59 @@
+package messages
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func newPreflightForTest(t *testing.T) (*Preflight, *fakeTxSink, *fakeIGateSender, *fakeClock) {
+	t.Helper()
+	sink := &fakeTxSink{}
+	igs := &fakeIGateSender{}
+	clock := &fakeClock{now: time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p, err := NewPreflight(PreflightConfig{
+		OurCall:        func() string { return "N0CALL" },
+		TxSink:         sink,
+		IGateSender:    igs,
+		Clock:          clock,
+		Logger:         logger,
+		AutoAckChannel: 1,
+	})
+	if err != nil {
+		t.Fatalf("NewPreflight: %v", err)
+	}
+	return p, sink, igs, clock
+}
+
+func TestNewPreflightRequiresOurCall(t *testing.T) {
+	if _, err := NewPreflight(PreflightConfig{
+		TxSink: &fakeTxSink{},
+	}); err == nil {
+		t.Fatal("NewPreflight without OurCall must error")
+	}
+}
+
+func TestNewPreflightRequiresTxSink(t *testing.T) {
+	if _, err := NewPreflight(PreflightConfig{
+		OurCall: func() string { return "N0CALL" },
+	}); err == nil {
+		t.Fatal("NewPreflight without TxSink must error")
+	}
+}
+
+func TestPreflightAutoAckChannelDefaultOne(t *testing.T) {
+	p, _, _, _ := newPreflightForTest(t)
+	if got := p.AutoAckChannel(); got != 1 {
+		t.Fatalf("AutoAckChannel default = %d, want 1", got)
+	}
+	p.SetAutoAckChannel(5)
+	if got := p.AutoAckChannel(); got != 5 {
+		t.Fatalf("AutoAckChannel after Set = %d, want 5", got)
+	}
+	p.SetAutoAckChannel(0)
+	if got := p.AutoAckChannel(); got != 5 {
+		t.Fatalf("SetAutoAckChannel(0) must be ignored, got %d", got)
+	}
+}

--- a/pkg/messages/router.go
+++ b/pkg/messages/router.go
@@ -2,10 +2,7 @@ package messages
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"errors"
-	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -15,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/chrissnell/graywolf/pkg/aprs"
-	"github.com/chrissnell/graywolf/pkg/ax25"
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/txgovernor"
 )
@@ -50,29 +46,34 @@ type RouterConfig struct {
 	Registerer    prometheus.Registerer
 	Clock         RouterClock
 	// AutoAckChannel is the RF channel used when submitting auto-ACKs.
-	// Defaults to 1 (mirrors IGateConfig.TxChannel semantics).
+	// Defaults to 1 (mirrors IGateConfig.TxChannel semantics). Forwarded
+	// into Preflight when Preflight is nil.
 	AutoAckChannel uint32
 	// QueueCapacity overrides the internal packet-queue capacity. <= 0
 	// uses DefaultRouterQueueCapacity.
 	QueueCapacity int
 	// DedupWindow overrides the (from_call, msg_id, text_hash) dedup
-	// window. <= 0 uses DefaultRouterDedupWindow.
+	// window forwarded into Preflight when Preflight is nil. <= 0 uses
+	// DefaultRouterDedupWindow.
 	DedupWindow time.Duration
+	// Preflight is the shared auto-ACK + dedup component. When nil the
+	// router constructs a private one from the OurCall/TxSink/etc fields
+	// for backward compatibility with standalone callers (tests).
+	Preflight *Preflight
 }
 
 // AutoAckChannel returns the live RF channel ID used for auto-ACKs
 // when the inbound was IS-sourced (RF-sourced packets reuse pkt.Channel).
-// Reads are lock-free.
-func (r *Router) AutoAckChannel() uint32 { return r.autoAckCh.Load() }
+// Reads are lock-free. Delegates to the shared Preflight.
+func (r *Router) AutoAckChannel() uint32 { return r.preflight.AutoAckChannel() }
 
 // SetAutoAckChannel updates the IS-fallback auto-ACK channel. Zero is
 // ignored. Safe to call concurrently with the consumer goroutine.
-func (r *Router) SetAutoAckChannel(ch uint32) {
-	if ch == 0 {
-		return
-	}
-	r.autoAckCh.Store(ch)
-}
+func (r *Router) SetAutoAckChannel(ch uint32) { r.preflight.SetAutoAckChannel(ch) }
+
+// Preflight returns the shared auto-ACK + dedup component the router
+// is using.
+func (r *Router) Preflight() *Preflight { return r.preflight }
 
 // Defaults for the router.
 const (
@@ -109,8 +110,7 @@ type Router struct {
 	logger    *slog.Logger
 	clock     RouterClock
 	queueCap  int
-	dedupWin  time.Duration
-	autoAckCh atomic.Uint32
+	preflight *Preflight
 
 	queue chan *aprs.DecodedAPRSPacket
 
@@ -124,16 +124,10 @@ type Router struct {
 	// drop-log throttle.
 	lastDropLog atomic.Int64
 
-	// Pre-insert dedup cache: keyed by "from|msgid|texthash" → expiry
-	// nanos.
-	dedupMu   sync.Mutex
-	dedupMap  map[string]time.Time
-
-	// Metrics.
+	// Metrics owned by the router. The dedup + auto-ACK metrics live on
+	// Preflight now.
 	mDropped       prometheus.Counter
 	mClassified    *prometheus.CounterVec
-	mAutoAckSent   prometheus.Counter
-	mDedupHits     prometheus.Counter
 	mAckCorrelated prometheus.Counter
 }
 
@@ -171,26 +165,34 @@ func NewRouter(cfg RouterConfig) (*Router, error) {
 	if qcap <= 0 {
 		qcap = DefaultRouterQueueCapacity
 	}
-	dedupWin := cfg.DedupWindow
-	if dedupWin <= 0 {
-		dedupWin = DefaultRouterDedupWindow
-	}
-	ch := cfg.AutoAckChannel
-	if ch == 0 {
-		ch = 1
+
+	pf := cfg.Preflight
+	if pf == nil {
+		var err error
+		pf, err = NewPreflight(PreflightConfig{
+			OurCall:        cfg.OurCall,
+			TxSink:         cfg.TxSink,
+			IGateSender:    cfg.IGateSender,
+			Logger:         logger,
+			Registerer:     cfg.Registerer,
+			Clock:          clock,
+			AutoAckChannel: cfg.AutoAckChannel,
+			DedupWindow:    cfg.DedupWindow,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	r := &Router{
-		cfg:      cfg,
-		logger:   logger,
-		clock:    clock,
-		queueCap: qcap,
-		dedupWin: dedupWin,
-		queue:    make(chan *aprs.DecodedAPRSPacket, qcap),
-		stopped:  make(chan struct{}),
-		dedupMap: make(map[string]time.Time),
+		cfg:       cfg,
+		logger:    logger,
+		clock:     clock,
+		queueCap:  qcap,
+		preflight: pf,
+		queue:     make(chan *aprs.DecodedAPRSPacket, qcap),
+		stopped:   make(chan struct{}),
 	}
-	r.autoAckCh.Store(ch)
 	if err := r.initMetrics(cfg.Registerer); err != nil {
 		return nil, err
 	}
@@ -206,14 +208,6 @@ func (r *Router) initMetrics(reg prometheus.Registerer) error {
 		Name: "messages_router_classified_total",
 		Help: "Inbound APRS message packets classified by the router, by outcome.",
 	}, []string{"outcome"})
-	r.mAutoAckSent = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "messages_router_autoack_sent_total",
-		Help: "Auto-ACK frames submitted by the router.",
-	})
-	r.mDedupHits = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "messages_router_dedup_hits_total",
-		Help: "Inbound APRS message packets suppressed by the router's pre-insert (from,msgid,text_hash) dedup window.",
-	})
 	r.mAckCorrelated = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "messages_router_ack_correlated_total",
 		Help: "Inbound ack/rej packets that matched an outstanding outbound row.",
@@ -221,7 +215,7 @@ func (r *Router) initMetrics(reg prometheus.Registerer) error {
 	if reg == nil {
 		return nil
 	}
-	collectors := []prometheus.Collector{r.mDropped, r.mClassified, r.mAutoAckSent, r.mDedupHits, r.mAckCorrelated}
+	collectors := []prometheus.Collector{r.mDropped, r.mClassified, r.mAckCorrelated}
 	for _, c := range collectors {
 		if err := reg.Register(c); err != nil {
 			are := prometheus.AlreadyRegisteredError{}
@@ -396,10 +390,7 @@ func (r *Router) classify(ctx context.Context, pkt *aprs.DecodedAPRSPacket) {
 	// Insert but still emits auto-ACK (APRS101 §14.2: ack every copy).
 	dedupHit := false
 	if effMsg.MessageID != "" {
-		if r.checkDedup(source, effMsg.MessageID, effMsg.Text) {
-			dedupHit = true
-			r.mDedupHits.Inc()
-		}
+		dedupHit = r.preflight.CheckDedup(source, effMsg.MessageID, effMsg.Text)
 	}
 
 	if !dedupHit {
@@ -426,7 +417,7 @@ func (r *Router) classify(ctx context.Context, pkt *aprs.DecodedAPRSPacket) {
 		effMsg.MessageID != "" &&
 		!effMsg.IsAck && !effMsg.IsRej &&
 		!effMsg.IsBulletin && !effMsg.IsNWS {
-		r.sendAutoAck(ctx, pkt, source, effMsg.MessageID)
+		r.preflight.SendAutoAck(ctx, pkt, source, effMsg.MessageID)
 	}
 
 	if dedupHit {
@@ -621,127 +612,6 @@ func (r *Router) correlateReplyAck(ctx context.Context, peerCall, replyAckID str
 			})
 		}
 	}
-}
-
-// sendAutoAck builds and submits an auto-ACK for an inbound DM. The
-// ack follows the path the message arrived on: RF inbound acks over
-// RF (on the receiving channel), IS inbound acks over APRS-IS only.
-// Mirroring an IS-sourced ack onto RF would waste local airtime on a
-// channel the correspondent cannot hear, since IS peers are by
-// definition not RF-reachable from our station.
-func (r *Router) sendAutoAck(
-	ctx context.Context,
-	pkt *aprs.DecodedAPRSPacket,
-	peerCall, msgID string,
-) {
-	if msgID == "" {
-		return
-	}
-	ourCall := r.cfg.OurCall()
-	if ourCall == "" {
-		r.logger.Debug("messages router skipping auto-ACK: our_call empty")
-		return
-	}
-	if pkt.Direction == aprs.DirectionIS {
-		if r.cfg.IGateSender == nil {
-			return
-		}
-		line := buildAckTNC2(ourCall, peerCall, msgID)
-		if err := r.cfg.IGateSender.SendLine(line); err != nil {
-			r.logger.Debug("messages router auto-ACK IS mirror failed",
-				"error", err, "peer", peerCall, "msgid", msgID)
-			return
-		}
-		r.mAutoAckSent.Inc()
-		return
-	}
-	frame, err := buildAckFrame(ourCall, peerCall, msgID)
-	if err != nil {
-		r.logger.Warn("messages router auto-ACK encode failed",
-			"error", err, "peer", peerCall, "msgid", msgID)
-		return
-	}
-	ch := r.autoAckCh.Load()
-	if pkt.Direction == aprs.DirectionRF && pkt.Channel > 0 {
-		ch = uint32(pkt.Channel)
-	}
-	src := txgovernor.SubmitSource{
-		Kind:      "messages-autoack",
-		Priority:  txgovernor.PriorityIGateMsg,
-		SkipDedup: true,
-	}
-	if err := r.cfg.TxSink.Submit(ctx, ch, frame, src); err != nil {
-		r.logger.Warn("messages router auto-ACK submit failed",
-			"error", err, "peer", peerCall, "msgid", msgID)
-		return
-	}
-	r.mAutoAckSent.Inc()
-}
-
-// buildAckFrame constructs a ready-to-submit ax25.Frame carrying the
-// ack info field. Uses APGRWO as the destination (graywolf's APRS
-// software identifier) and no digipeater path — auto-ACKs reply
-// directly to the sender.
-func buildAckFrame(ourCall, peerCall, msgID string) (*ax25.Frame, error) {
-	info, err := aprs.EncodeMessageAck(peerCall, msgID)
-	if err != nil {
-		return nil, err
-	}
-	src, err := ax25.ParseAddress(ourCall)
-	if err != nil {
-		return nil, fmt.Errorf("messages: ack source: %w", err)
-	}
-	dest, err := ax25.ParseAddress("APGRWO")
-	if err != nil {
-		return nil, fmt.Errorf("messages: ack dest: %w", err)
-	}
-	return ax25.NewUIFrame(src, dest, nil, info)
-}
-
-// buildAckTNC2 renders the TNC-2 text representation of an ack for
-// APRS-IS. Mirrors the format APRS-IS expects: SRC>DEST::PEER     :ack123
-// Wire-format glue is delegated to aprs.FormatTNC2.
-func buildAckTNC2(ourCall, peerCall, msgID string) string {
-	// Pad peer to 9 chars (APRS101 §14.1 addressee field width).
-	addr := peerCall
-	if len(addr) > 9 {
-		addr = addr[:9]
-	}
-	if len(addr) < 9 {
-		addr = addr + strings.Repeat(" ", 9-len(addr))
-	}
-	info := ":" + addr + ":ack" + msgID
-	return aprs.FormatTNC2(ourCall, "APGRWO", nil, []byte(info))
-}
-
-// checkDedup consults the 30-second (from, msgid, text_hash) cache.
-// Returns true on a hit. Always records the current tuple so the
-// next identical packet within the window also hits. Expired entries
-// are evicted during the pass.
-func (r *Router) checkDedup(fromCall, msgID, text string) bool {
-	key := dedupKey(fromCall, msgID, text)
-	r.dedupMu.Lock()
-	defer r.dedupMu.Unlock()
-	now := r.clock.Now()
-	// Lazy eviction: walk the map and drop expired entries. The map
-	// stays small (one entry per live dedup window) so a linear pass
-	// is cheap.
-	for k, exp := range r.dedupMap {
-		if now.After(exp) {
-			delete(r.dedupMap, k)
-		}
-	}
-	exp, hit := r.dedupMap[key]
-	r.dedupMap[key] = now.Add(r.dedupWin)
-	if hit && !now.After(exp) {
-		return true
-	}
-	return false
-}
-
-func dedupKey(fromCall, msgID, text string) string {
-	h := sha1.Sum([]byte(text))
-	return strings.ToUpper(fromCall) + "|" + msgID + "|" + hex.EncodeToString(h[:8])
 }
 
 // --- helpers -----------------------------------------------------------------

--- a/pkg/messages/router_test.go
+++ b/pkg/messages/router_test.go
@@ -1261,9 +1261,9 @@ func TestBuildAckTNC2(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildAckTNC2(tc.ourCall, tc.peerCall, tc.msgID)
+			got := preflightAckTNC2(tc.ourCall, tc.peerCall, tc.msgID)
 			if got != tc.want {
-				t.Fatalf("buildAckTNC2 = %q, want %q", got, tc.want)
+				t.Fatalf("preflightAckTNC2 = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/pkg/messages/service.go
+++ b/pkg/messages/service.go
@@ -88,13 +88,14 @@ type Service struct {
 	logger *slog.Logger
 	ctx    context.Context
 
-	router  *Router
-	sender  *Sender
-	retry   *RetryManager
-	prefs   *Preferences
-	hub     *EventHub
-	ring    *LocalTxRing
-	tactSet *TacticalSet
+	router    *Router
+	sender    *Sender
+	retry     *RetryManager
+	prefs     *Preferences
+	hub       *EventHub
+	ring      *LocalTxRing
+	tactSet   *TacticalSet
+	preflight *Preflight
 
 	// TxHook unregister closure — nil before Start, set in Start.
 	unregTxHook func()
@@ -159,6 +160,18 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		autoAckCh = txCh
 	}
 
+	pf, err := NewPreflight(PreflightConfig{
+		OurCall:        cfg.OurCall,
+		TxSink:         cfg.TxSink,
+		IGateSender:    cfg.IGate,
+		Logger:         logger.With("component", "messages-preflight"),
+		Clock:          clock,
+		AutoAckChannel: autoAckCh,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	sender, err := NewSender(SenderConfig{
 		Store:         cfg.Store,
 		TxSink:        cfg.TxSink,
@@ -190,31 +203,32 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	}
 
 	router, err := NewRouter(RouterConfig{
-		Store:          cfg.Store,
-		TxSink:         cfg.TxSink,
-		IGateSender:    cfg.IGate,
-		OurCall:        cfg.OurCall,
-		LocalTxRing:    ring,
-		TacticalSet:    tactSet,
-		EventHub:       hub,
-		Logger:         logger.With("component", "messages-router"),
-		Clock:          clock,
-		AutoAckChannel: autoAckCh,
+		Store:       cfg.Store,
+		TxSink:      cfg.TxSink,
+		IGateSender: cfg.IGate,
+		OurCall:     cfg.OurCall,
+		LocalTxRing: ring,
+		TacticalSet: tactSet,
+		EventHub:    hub,
+		Logger:      logger.With("component", "messages-router"),
+		Clock:       clock,
+		Preflight:   pf,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &Service{
-		cfg:     cfg,
-		logger:  logger,
-		router:  router,
-		sender:  sender,
-		retry:   retry,
-		prefs:   prefs,
-		hub:     hub,
-		ring:    ring,
-		tactSet: tactSet,
+		cfg:       cfg,
+		logger:    logger,
+		router:    router,
+		sender:    sender,
+		retry:     retry,
+		prefs:     prefs,
+		hub:       hub,
+		ring:      ring,
+		tactSet:   tactSet,
+		preflight: pf,
 	}, nil
 }
 
@@ -284,6 +298,10 @@ func (s *Service) LocalTxRing() *LocalTxRing { return s.ring }
 // TacticalSet returns the live tactical-set snapshot (read-only).
 // Tests use it to observe reload results.
 func (s *Service) TacticalSet() *TacticalSet { return s.tactSet }
+
+// Preflight returns the shared inbound preflight (auto-ACK + dedup),
+// safe to share across subsystems that consume inbound APRS messages.
+func (s *Service) Preflight() *Preflight { return s.preflight }
 
 // ReloadConfig re-resolves the TX channel via the configured
 // TxChannelResolver and pushes the new value into the live Sender +


### PR DESCRIPTION
## Summary

- Lift auto-ACK and pre-insert dedup ring out of `messages.Router` into a shared `messages.Preflight` component owned by `messages.Service`.
- Wire `actions.Classifier` through the same Preflight so duplicate `@@`-prefixed packets get a single execution + ACK on the first copy and silent dedup on subsequent copies.
- Closes the operational gap where action senders kept retrying every 30 s for ~5 min because no ACK ever arrived, and where iGate fan-out delivered 3-10 copies that each fired the executor (or bounced as `rate_limited`).

## Behavior

- Every copy is acked (APRS101 14.2 -- sender stops retrying).
- Only the first copy reaches the runner; subsequent copies inside the 5-min `(from, msgid, text_hash)` window are silently dropped.
- Existing `messages.Router` behavior preserved (router tests unchanged).

## Test plan

- [x] `go test ./pkg/messages/... ./pkg/actions/... ./pkg/app/... -count=1 -race`
- [x] `go test ./... -count=1 -race`
- [x] `go vet ./...`
- [x] New unit coverage in `pkg/messages/preflight_test.go` (constructor, dedup window, RF/IS auto-ACK branches, msgid-less no-op, channel fallback)
- [x] New classifier coverage in `pkg/actions/classifier_test.go` (ACK on first copy, dedup hit suppresses Submit, msgid-less skips both)
- [x] 3-copy integration test (`TestClassifierThreeIdenticalCopiesACKThriceFireOnce`) locks in the ACK-thrice / fire-once invariant.
- [ ] Operator smoke test (post-deploy): peer station sends `@@<otp>#testecho` twice within 60 s with iGate fan-out active. Verify one ACK per inbound copy (`messages_preflight_autoack_sent_total`), exactly one `action_invocations` row, `messages_preflight_dedup_hits_total` advances by `(num_copies - 1)`, sender's outbound row transitions to `acked` after the first ACK.

## Notes

- Metric rename: `messages_router_dedup_hits_total` -> `messages_preflight_dedup_hits_total`, `messages_router_autoack_sent_total` -> `messages_preflight_autoack_sent_total`. No dashboards or alerts under `docs/` or `packaging/` reference the old names.
- Plan: `docs/superpowers/plans/2026-05-04-actions-preflight-dedup.md`.
- Wiki updated: invariant 26 now reflects the fix; new invariant 27 codifies "any new inbound diverter must consult Preflight."
