### PR TITLE
actions: case-insensitive action names, stored uppercase

### DIFF
--- a/docs/handbook/actions.html
+++ b/docs/handbook/actions.html
@@ -140,8 +140,12 @@
         <strong>Require OTP</strong> toggle is what decides.
       </li>
       <li>
-        <code>&lt;action&gt;</code> is the Action&rsquo;s name. Names are
-        case-sensitive, 1&ndash;32 characters of <code>[A-Za-z0-9._-]</code>.
+        <code>&lt;action&gt;</code> is the Action&rsquo;s name, 1&ndash;32
+        characters of <code>[A-Za-z0-9._-]</code>. Names are
+        <strong>case-insensitive</strong> on the wire and stored
+        uppercase &mdash; senders may type any case, and the
+        <code>$GW_ACTION_NAME</code> / <code>argv[0]</code> values that
+        reach your script always arrive uppercase.
       </li>
       <li>
         <code>[k=v ...]</code> are zero or more space-separated key=value
@@ -236,8 +240,11 @@
     <ul>
       <li>
         <strong>Name.</strong> 1&ndash;32 characters, the token that goes
-        after <code>#</code> in the wire grammar. Case-sensitive.
-        Must be unique across your Actions.
+        after <code>#</code> in the wire grammar.
+        <strong>Case-insensitive</strong> on the wire, stored uppercase.
+        Must be unique across your Actions (case-insensitive
+        uniqueness &mdash; <code>Unlock</code> and <code>UNLOCK</code>
+        collide).
       </li>
       <li>
         <strong>Description.</strong> Free-form, shown in the Actions table

--- a/docs/wiki/actions.md
+++ b/docs/wiki/actions.md
@@ -19,7 +19,12 @@ hooks in [`../../pkg/app/`](../../pkg/app/).
 - `<otp>` is empty (when the matching Action has `OTPRequired = false`)
   or exactly six ASCII digits. `@@123456#unlock`.
 - `<action>` is the Action's `name` (1..32 chars,
-  `[A-Za-z0-9._-]`). Case-sensitive.
+  `[A-Za-z0-9._-]`). **Case-insensitive on the wire** — senders may
+  type any case; the classifier uppercases before lookup, the
+  configstore stores names uppercase (Action.BeforeSave hook), and the
+  case-insensitive `GetActionByName` resolves any case to the
+  canonical row. Audit rows and on-air replies always carry the
+  uppercase form. Migration 18 backfills any pre-change rows.
 - `[k=v ...]` is space-separated key/value tokens, validated against
   the Action's `arg_schema` (a JSON list of `ArgSpec`).
 

--- a/pkg/actions/classifier.go
+++ b/pkg/actions/classifier.go
@@ -118,6 +118,10 @@ func (c *Classifier) Classify(ctx context.Context, pkt *aprs.DecodedAPRSPacket) 
 		}, channel, Result{Status: StatusUnknown})
 		return true
 	}
+	// Action names are case-insensitive on the wire; canonicalize to
+	// uppercase so audit rows and replies use one form regardless of
+	// what the sender typed.
+	parsed.Action = strings.ToUpper(parsed.Action)
 	// A non-nil parsed with a non-nil parseErr means kv tokenization
 	// failed but the action name is valid. Defer the decision: a
 	// freeform Action will recover via RawArgTail; a kv Action will

--- a/pkg/actions/classifier_test.go
+++ b/pkg/actions/classifier_test.go
@@ -54,11 +54,19 @@ func (s *stubActionStore) GetActionByName(_ context.Context, name string) (*conf
 	if s.err != nil {
 		return nil, s.err
 	}
-	a, ok := s.byName[name]
-	if !ok {
-		return nil, nil
+	// Mirror configstore.Store.GetActionByName: lookup is case-insensitive
+	// because action names are stored uppercase. Tests can populate byName
+	// using either casing.
+	canonical := strings.ToUpper(strings.TrimSpace(name))
+	if a, ok := s.byName[canonical]; ok {
+		return a, nil
 	}
-	return a, nil
+	for k, a := range s.byName {
+		if strings.EqualFold(k, name) {
+			return a, nil
+		}
+	}
+	return nil, nil
 }
 
 type stubCredStore struct {
@@ -183,6 +191,29 @@ func TestClassifyParseErrorRepliesUnknown(t *testing.T) {
 	}
 	if len(sub.submits) != 0 {
 		t.Fatal("must not submit a parse-failed invocation")
+	}
+}
+
+// Action names are case-insensitive on the wire. The configured action
+// is "PING" (uppercase, the canonical form). A sender that types
+// "@@#ping", "@@#Ping", or "@@#PING" must all dispatch to the same
+// action, and the resulting Invocation.ActionName must be uppercase.
+func TestClassifyActionNameCaseInsensitive(t *testing.T) {
+	a := &configstore.Action{ID: 1, Name: "PING", Type: "command", Enabled: true}
+	for _, body := range []string{"@@#ping", "@@#Ping", "@@#PING", "@@#pInG"} {
+		sub := &stubSubmitter{}
+		c := newClassifierForTest(t, sub, &stubActionStore{byName: map[string]*configstore.Action{"PING": a}}, &stubCredStore{}, nil, nil)
+		pkt := makeMessagePkt(aprs.DirectionRF, "OTHER", "N0CALL", body, 0)
+		if !c.Classify(context.Background(), pkt) {
+			t.Fatalf("%q: expected consumed", body)
+		}
+		if len(sub.submits) != 1 {
+			t.Fatalf("%q: expected 1 submit, got %d (replies=%+v)", body, len(sub.submits), sub.replies)
+		}
+		if sub.submits[0].inv.ActionName != "PING" {
+			t.Fatalf("%q: invocation should carry uppercase canonical name, got %q",
+				body, sub.submits[0].inv.ActionName)
+		}
 	}
 }
 

--- a/pkg/actions/parser.go
+++ b/pkg/actions/parser.go
@@ -75,7 +75,9 @@ func Parse(body string) (*ParsedInvocation, error) {
 // ValidActionName reports whether s is a legal action name. Mirrors the
 // inbound parser's grammar so outbound macro creation rejects names the
 // receiver would refuse. Charset: ASCII letters, digits, dot, dash,
-// underscore. Case-sensitive.
+// underscore. The character-class check accepts both cases; lookup is
+// case-insensitive (configstore.Store.GetActionByName uppercases the
+// query) and storage is uppercase (Action.BeforeSave).
 func ValidActionName(s string) bool {
 	for i := 0; i < len(s); i++ {
 		c := s[i]

--- a/pkg/actions/service_test.go
+++ b/pkg/actions/service_test.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -32,11 +33,18 @@ func newFakeServiceStore() *fakeServiceStore {
 func (f *fakeServiceStore) GetActionByName(_ context.Context, name string) (*configstore.Action, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	a, ok := f.actions[name]
-	if !ok {
-		return nil, nil
+	// Mirror configstore.Store.GetActionByName: case-insensitive lookup
+	// because action names are stored uppercase.
+	canonical := strings.ToUpper(strings.TrimSpace(name))
+	if a, ok := f.actions[canonical]; ok {
+		return a, nil
 	}
-	return a, nil
+	for k, a := range f.actions {
+		if strings.EqualFold(k, name) {
+			return a, nil
+		}
+	}
+	return nil, nil
 }
 
 func (f *fakeServiceStore) GetOTPCredential(_ context.Context, id uint) (*configstore.OTPCredential, error) {

--- a/pkg/configstore/actions.go
+++ b/pkg/configstore/actions.go
@@ -3,6 +3,7 @@ package configstore
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -32,9 +33,13 @@ func (s *Store) GetAction(ctx context.Context, id uint) (*Action, error) {
 	return &a, nil
 }
 
+// GetActionByName returns the Action with the given name. Matching is
+// case-insensitive — Action.Name is stored uppercase (see BeforeSave),
+// so an inbound `@@otp#unlock` resolves to the row created as `Unlock`.
 func (s *Store) GetActionByName(ctx context.Context, name string) (*Action, error) {
 	var a Action
-	if err := s.db.WithContext(ctx).Where("name = ?", name).First(&a).Error; err != nil {
+	canonical := strings.ToUpper(strings.TrimSpace(name))
+	if err := s.db.WithContext(ctx).Where("name = ?", canonical).First(&a).Error; err != nil {
 		return nil, err
 	}
 	return &a, nil

--- a/pkg/configstore/actions_test.go
+++ b/pkg/configstore/actions_test.go
@@ -135,3 +135,33 @@ func TestActionDuplicateName(t *testing.T) {
 		t.Fatal("expected unique-violation on duplicate name")
 	}
 }
+
+// Action.Name is normalized to uppercase on save and GetActionByName
+// matches case-insensitively. Mixed-case create + any-case lookup must
+// resolve to the same row, and the persisted Name must be uppercase.
+func TestActionNameUppercaseNormalization(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	a := &Action{Name: "  Unlock  ", Type: "command", CommandPath: "/bin/true"}
+	if err := s.CreateAction(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	if a.Name != "UNLOCK" {
+		t.Fatalf("BeforeSave should uppercase + trim; got %q", a.Name)
+	}
+	for _, q := range []string{"unlock", "UNLOCK", "Unlock", "  unlock"} {
+		got, err := s.GetActionByName(ctx, q)
+		if err != nil {
+			t.Fatalf("GetActionByName(%q): %v", q, err)
+		}
+		if got.ID != a.ID || got.Name != "UNLOCK" {
+			t.Fatalf("lookup %q returned %+v", q, got)
+		}
+	}
+	// A second insert that differs only in case must collide on the
+	// unique index because both normalize to the same canonical form.
+	dup := &Action{Name: "unlock", Type: "command", CommandPath: "/bin/true"}
+	if err := s.CreateAction(ctx, dup); err == nil {
+		t.Fatal("expected unique-violation on case-only-different name")
+	}
+}

--- a/pkg/configstore/migrate.go
+++ b/pkg/configstore/migrate.go
@@ -151,6 +151,15 @@ type migration struct {
 //	    for their schema. See
 //	    docs/superpowers/plans/2026-05-03-messages-action-sender.md
 //	    Phase A.
+//	17 — actions_arg_mode: add the actions.arg_mode column with the
+//	    default 'kv' so existing rows behave identically; the column is
+//	    NOT NULL so application code never has to check a sentinel.
+//	18 — actions_uppercase_names: canonicalize existing actions.name,
+//	    remote_action_macros.action_name, and
+//	    action_invocations.action_name_at to UPPER(...). Inbound and
+//	    outbound paths now treat action names case-insensitively and
+//	    normalize to uppercase on save; this backfills any pre-change
+//	    rows so case-normalized lookups still hit them.
 var schemaMigrations = []migration{
 	{version: 1, name: "beacon_compress_default", phase: postAutoMigrate, run: migrateBeaconCompressDefault},
 	{version: 2, name: "channel_device_fields", phase: preAutoMigrate, run: migrateChannelDeviceFields},
@@ -169,6 +178,7 @@ var schemaMigrations = []migration{
 	{version: 15, name: "actions_tables", phase: postAutoMigrate, run: migrateActionsTables},
 	{version: 16, name: "remote_actions_tables", phase: postAutoMigrate, run: migrateRemoteActionsTables},
 	{version: 17, name: "actions_arg_mode", phase: postAutoMigrate, run: migrateActionsArgMode},
+	{version: 18, name: "actions_uppercase_names", phase: postAutoMigrate, run: migrateActionsUppercaseNames},
 }
 
 // runMigrations applies every pending migration in the given phase,

--- a/pkg/configstore/migrate_actions_argmode_test.go
+++ b/pkg/configstore/migrate_actions_argmode_test.go
@@ -41,7 +41,8 @@ func TestMigration17AddsArgModeColumn(t *testing.T) {
 		t.Fatalf("create freeform action: %v", err)
 	}
 	var got Action
-	if err := s.DB().Where("name = ?", "fm").First(&got).Error; err != nil {
+	// Action.BeforeSave canonicalizes Name to uppercase.
+	if err := s.DB().Where("name = ?", "FM").First(&got).Error; err != nil {
 		t.Fatalf("read back: %v", err)
 	}
 	if got.ArgMode != "freeform" {

--- a/pkg/configstore/migrate_actions_uppercase.go
+++ b/pkg/configstore/migrate_actions_uppercase.go
@@ -1,0 +1,39 @@
+package configstore
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// migrateActionsUppercaseNames canonicalizes existing action and remote
+// macro names to uppercase. The on-air Action grammar treats names
+// case-insensitively (see pkg/configstore Action.BeforeSave and
+// pkg/remoteactions RemoteActionMacro.BeforeSave); existing rows from
+// before that change may carry mixed-case values that would now miss
+// case-normalized lookups.
+//
+// Idempotent: re-running uppercases already-uppercase strings to the
+// same value. The unique index on actions.name could theoretically
+// fail if two pre-existing rows differ only in case ("Unlock" and
+// "unlock"), but the field's character class is small enough and the
+// feature young enough that this collision is not expected in any
+// shipped database.
+func migrateActionsUppercaseNames(tx *gorm.DB) error {
+	if err := tx.Exec(`UPDATE actions SET name = UPPER(name) WHERE name <> UPPER(name)`).Error; err != nil {
+		return fmt.Errorf("uppercase actions.name: %w", err)
+	}
+	// Pre-migration-16 databases lack the remote_action_macros table; the
+	// migration runner applies in version order so by the time we get
+	// here the table exists. Still gate on a probe to be defensive.
+	hasTable := tx.Migrator().HasTable("remote_action_macros")
+	if hasTable {
+		if err := tx.Exec(`UPDATE remote_action_macros SET action_name = UPPER(action_name) WHERE action_name <> UPPER(action_name)`).Error; err != nil {
+			return fmt.Errorf("uppercase remote_action_macros.action_name: %w", err)
+		}
+	}
+	if err := tx.Exec(`UPDATE action_invocations SET action_name_at = UPPER(action_name_at) WHERE action_name_at <> UPPER(action_name_at)`).Error; err != nil {
+		return fmt.Errorf("uppercase action_invocations.action_name_at: %w", err)
+	}
+	return nil
+}

--- a/pkg/configstore/migrate_actions_uppercase_test.go
+++ b/pkg/configstore/migrate_actions_uppercase_test.go
@@ -1,0 +1,68 @@
+package configstore
+
+import (
+	"testing"
+)
+
+// TestMigration18UppercasesExistingNames inserts mixed-case rows via raw
+// SQL (bypassing the Action.BeforeSave hook), invokes the migration
+// body directly, and asserts every action_name-bearing column is
+// canonicalized to uppercase. Idempotence is also exercised.
+func TestMigration18UppercasesExistingNames(t *testing.T) {
+	s := newTestStore(t)
+	db := s.DB()
+
+	// Mixed-case actions row. The model hook would normalize this on
+	// .Create(); raw SQL bypasses it to simulate the pre-migration
+	// state.
+	if err := db.Exec(`INSERT INTO actions
+		(name, type, command_path, timeout_sec, otp_required,
+		 sender_allowlist, arg_schema, rate_limit_sec, queue_depth,
+		 enabled, arg_mode, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,datetime('now'),datetime('now'))`,
+		"MixedCase", "command", "/bin/true", 10, 0, "", "[]", 5, 8, 1, "kv",
+	).Error; err != nil {
+		t.Fatalf("insert action: %v", err)
+	}
+
+	if err := db.Exec(`INSERT INTO remote_action_macros
+		(target_call, label, action_name, args_string, position,
+		 created_at, updated_at)
+		VALUES (?,?,?,?,?, datetime('now'), datetime('now'))`,
+		"K1ABC-9", "label", "Unlock", "", 0,
+	).Error; err != nil {
+		t.Fatalf("insert macro: %v", err)
+	}
+
+	if err := db.Exec(`INSERT INTO action_invocations
+		(action_name_at, sender_call, source, status, created_at)
+		VALUES (?,?,?,?, datetime('now'))`,
+		"PingMe", "K7XYZ", "rf", "ok",
+	).Error; err != nil {
+		t.Fatalf("insert audit: %v", err)
+	}
+
+	if err := migrateActionsUppercaseNames(db); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+
+	check := func(query, want string) {
+		t.Helper()
+		var got string
+		if err := db.Raw(query).Scan(&got).Error; err != nil {
+			t.Fatalf("scan %q: %v", query, err)
+		}
+		if got != want {
+			t.Fatalf("%q -> %q, want %q", query, got, want)
+		}
+	}
+	check(`SELECT name FROM actions LIMIT 1`, "MIXEDCASE")
+	check(`SELECT action_name FROM remote_action_macros LIMIT 1`, "UNLOCK")
+	check(`SELECT action_name_at FROM action_invocations LIMIT 1`, "PINGME")
+
+	// Idempotent: re-run is a no-op.
+	if err := migrateActionsUppercaseNames(db); err != nil {
+		t.Fatalf("rerun: %v", err)
+	}
+	check(`SELECT name FROM actions LIMIT 1`, "MIXEDCASE")
+}

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -845,6 +845,16 @@ type Action struct {
 	UpdatedAt           time.Time
 }
 
+// BeforeSave normalizes Name to uppercase and trims whitespace before
+// insert or update. The on-air Action grammar treats names as
+// case-insensitive; canonical form on the wire and in the audit log is
+// uppercase. Normalizing on write keeps the unique index on `name`
+// collision-free across mixed-case operator input.
+func (a *Action) BeforeSave(_ *gorm.DB) error {
+	a.Name = strings.ToUpper(strings.TrimSpace(a.Name))
+	return nil
+}
+
 // OTPCredential is one TOTP secret. Stored plaintext; UI surfaces
 // the secret only once at create time and never reads it back.
 type OTPCredential struct {

--- a/pkg/remoteactions/models.go
+++ b/pkg/remoteactions/models.go
@@ -1,6 +1,11 @@
 package remoteactions
 
-import "time"
+import (
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
 
 // RemoteOTPCredential is one named TOTP secret used to fire macros at a
 // remote station. Stored plaintext per the single-user-station design;
@@ -52,3 +57,16 @@ type RemoteActionMacro struct {
 }
 
 func (*RemoteActionMacro) TableName() string { return "remote_action_macros" }
+
+// BeforeSave normalizes ActionName to uppercase so outbound fires send
+// the canonical wire form. The receiver treats names case-insensitively
+// (see pkg/configstore Action.BeforeSave) but storing the canonical
+// uppercase form here keeps the audit/inspection surface consistent.
+//
+// This hook fires for Create. The Update path uses gorm's map-based
+// Updates which bypasses model hooks; the webapi handler uppercases
+// in.ActionName before calling MacroStore.Update.
+func (m *RemoteActionMacro) BeforeSave(_ *gorm.DB) error {
+	m.ActionName = strings.ToUpper(strings.TrimSpace(m.ActionName))
+	return nil
+}

--- a/pkg/remoteactions/store_macros_test.go
+++ b/pkg/remoteactions/store_macros_test.go
@@ -75,6 +75,23 @@ func TestMacroStoreReorder(t *testing.T) {
 	}
 }
 
+// RemoteActionMacro.BeforeSave normalizes ActionName to uppercase so
+// outbound fires send the canonical wire form. Mixed-case input must
+// round-trip as uppercase regardless of how the operator typed it.
+func TestMacroStoreUppercasesActionName(t *testing.T) {
+	db := newTestDB(t)
+	ms := NewMacroStore(db)
+	ctx := context.Background()
+	m := &RemoteActionMacro{TargetCall: "KK7XYZ-9", Label: "x", ActionName: "  Unlock  "}
+	if err := ms.Create(ctx, m); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, _ := ms.Get(ctx, m.ID)
+	if got.ActionName != "UNLOCK" {
+		t.Fatalf("ActionName = %q, want UNLOCK", got.ActionName)
+	}
+}
+
 func TestMacroStoreDelete(t *testing.T) {
 	db := newTestDB(t)
 	ms := NewMacroStore(db)

--- a/pkg/webapi/actions_test.go
+++ b/pkg/webapi/actions_test.go
@@ -58,7 +58,8 @@ func TestActionsCRUD_Create(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatal(err)
 	}
-	if got.ID == 0 || got.Name != "foo" || got.Type != "command" {
+	// Name is normalized to uppercase by the configstore BeforeSave hook.
+	if got.ID == 0 || got.Name != "FOO" || got.Type != "command" {
 		t.Fatalf("unexpected response: %+v", got)
 	}
 }

--- a/pkg/webapi/otp_credentials_test.go
+++ b/pkg/webapi/otp_credentials_test.go
@@ -151,7 +151,8 @@ func TestOTPCredentials_UsedByPopulated(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 || len(got[0].UsedBy) != 1 || got[0].UsedBy[0] != "ref" {
+	// Action.Name is canonicalized to uppercase on save.
+	if len(got) != 1 || len(got[0].UsedBy) != 1 || got[0].UsedBy[0] != "REF" {
 		t.Fatalf("used_by mismatch: %+v", got)
 	}
 }

--- a/pkg/webapi/remote_actions_macros.go
+++ b/pkg/webapi/remote_actions_macros.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -142,7 +143,7 @@ func (s *Server) updateRemoteActionMacro(w http.ResponseWriter, r *http.Request)
 			badRequest(w, err.Error())
 			return
 		}
-		cur.ActionName = in.ActionName
+		cur.ActionName = strings.ToUpper(strings.TrimSpace(in.ActionName))
 	}
 	// ArgsString and RemoteOTPCredentialID always overwrite. Empty
 	// string clears args; nil unbinds the credential. Callers must

--- a/web/src/components/actions/EditActionModal.svelte
+++ b/web/src/components/actions/EditActionModal.svelte
@@ -172,6 +172,9 @@
   ];
 
   function validateName() {
+    // The name input's `oninput` handler is the single source of truth
+    // for canonicalization (live uppercase). validateName only reads.
+    // buildBody() does a final defensive trim+toUpperCase before POST.
     const v = form.name.trim();
     if (!v) {
       nameError = 'Name is required.';
@@ -193,7 +196,7 @@
     delete out.id;
     delete out.last_invoked_at;
     delete out.last_invoked_by;
-    out.name = out.name.trim();
+    out.name = out.name.trim().toUpperCase();
     out.description = out.description.trim();
     if (out.type === 'command') {
       out.webhook_method = '';
@@ -318,10 +321,11 @@
               id="action-name"
               type="text"
               bind:value={form.name}
+              oninput={(e) => { form.name = e.currentTarget.value.toUpperCase(); }}
               onblur={validateName}
               class={nameError || fieldErrors.name ? 'field-invalid' : ''}
             />
-            <p class="hint">Used as keyword in the message. Letters, digits, dot, dash, underscore.</p>
+            <p class="hint">Used as keyword in the message. Letters, digits, dot, dash, underscore. Stored uppercase; case-insensitive on the wire.</p>
             {#if nameError}<p class="field-error">{nameError}</p>{/if}
             {#if fieldErrors.name}<p class="field-error">{fieldErrors.name}</p>{/if}
           </div>

--- a/web/src/components/messages/remote_actions/FreeFormSender.svelte
+++ b/web/src/components/messages/remote_actions/FreeFormSender.svelte
@@ -38,12 +38,14 @@
     }
   });
 
-  // Split cmd into actionName + argsString at the first space.
+  // Split cmd into actionName + argsString at the first space. Action
+  // names are case-insensitive on the wire and stored uppercase
+  // server-side, so canonicalize here too.
   const parsed = $derived.by(() => {
     const trimmed = cmd.trim();
     const sp = trimmed.indexOf(' ');
-    if (sp < 0) return { actionName: trimmed, argsString: '' };
-    return { actionName: trimmed.slice(0, sp), argsString: trimmed.slice(sp + 1) };
+    if (sp < 0) return { actionName: trimmed.toUpperCase(), argsString: '' };
+    return { actionName: trimmed.slice(0, sp).toUpperCase(), argsString: trimmed.slice(sp + 1) };
   });
 
   const otpToUse = $derived(credId == null ? manualOtp : code);
@@ -104,7 +106,7 @@
   <CredentialPicker bind:value={credId} label="Active OTP" />
   <div class="field">
     <label for="ff-cmd">Command</label>
-    <Input id="ff-cmd" bind:value={cmd} placeholder="unlock door=front" />
+    <Input id="ff-cmd" bind:value={cmd} placeholder="UNLOCK door=front" />
     <p class="hint">Enter command and optional args -- no @@ prefix needed.</p>
   </div>
   {#if credId == null}

--- a/web/src/components/messages/remote_actions/MacroEditRow.svelte
+++ b/web/src/components/messages/remote_actions/MacroEditRow.svelte
@@ -77,7 +77,12 @@
     <div class="cmd-row">
       <div class="field">
         <label for={`mer-action-${macro.id ?? 'new'}`}>Action</label>
-        <Input id={`mer-action-${macro.id ?? 'new'}`} bind:value={actionName} onblur={commit} />
+        <Input
+          id={`mer-action-${macro.id ?? 'new'}`}
+          bind:value={actionName}
+          oninput={(e) => { actionName = e.currentTarget.value.toUpperCase(); }}
+          onblur={commit}
+        />
       </div>
       <div class="field">
         <label for={`mer-args-${macro.id ?? 'new'}`}>Args (k=v ...)</label>


### PR DESCRIPTION
## Summary

- Action names case-insensitive on the wire; canonical uppercase on save and replay. Senders may type `@@otp#unlock`, `@@otp#Unlock`, or `@@otp#UNLOCK` -- all dispatch to the same Action; audit rows and on-air replies always carry the uppercase form.
- Layered normalization: classifier uppercase-after-parse, `Action.BeforeSave`, `RemoteActionMacro.BeforeSave`, case-insensitive `GetActionByName`, webapi PUT belt-and-suspenders, and live `oninput` uppercase in EditActionModal / MacroEditRow / FreeFormSender.
- Migration 18 (`actions_uppercase_names`) backfills existing `actions.name`, `remote_action_macros.action_name`, and `action_invocations.action_name_at` to UPPER(). Idempotent. Wiki + handbook updated.

## Operator-visible behavior change

Command executor scripts receive `argv[0]` and `$GW_ACTION_NAME` uppercase after upgrade. Any operator script that pattern-matches a hard-coded lowercase literal (`case "$GW_ACTION_NAME" in unlock)`) silently stops firing post-migration. Webhook executors get `action=<UPPERCASE>` in their form payload.

## Test plan

- [x] `go test ./...` -- all packages green; new tests for BeforeSave normalization, case-insensitive classifier dispatch, RemoteActionMacro uppercase on Create, and migration 18 backfill + idempotence.
- [x] `node --test web/src/lib/actions/grammar.test.js web/src/lib/remote_actions/send.test.js` -- all 17 pass.
- [ ] Manual: create Action with mixed-case name; observe stored uppercase. Send `@@otp#mixedCase` from another station; verify dispatch + uppercase audit row + uppercase reply.
- [ ] Manual: upgrade existing DB containing mixed-case Action; observe migration 18 fires once and leaves rows uppercase.
- [ ] Manual: macro drawer free-form input -- type lowercase, observe live-uppercase; placeholder reads `UNLOCK door=front`.