### PR TITLE
examples: human-readable weather action

### DIFF
--- a/examples/actions/README.md
+++ b/examples/actions/README.md
@@ -73,7 +73,7 @@ not** put secrets in the script itself or pass them as Action args.
 - `msg` — required, regex `.+`
 
 `weather`:
-- `station` — required, regex `^[A-Za-z0-9]{4}$` (ICAO airport code)
+- `location` — required, regex `^[A-Za-z0-9 ,.\-_]{1,64}$` (city name, ZIP, ICAO airport, or "lat,lon")
 
 `sms`:
 - `to` — required, regex `^\+[1-9][0-9]{6,14}$`
@@ -95,8 +95,8 @@ not** put secrets in the script itself or pass them as Action args.
 > @@123456#echo msg=hello
 < ok: KE0XYZ said: hello
 
-> @@123456#weather station=KDEN
-< ok: KDEN 030253Z 27008KT 10SM CLR 22/M01 A3025
+> @@123456#weather location=Denver
+< ok: Denver: Partly cloudy +63°F ↓19mph 28%
 
 > @@123456#solar
 < ok: SFI 142 A 8 K 2 SN 78

--- a/examples/actions/posix/weather-freeform.sh
+++ b/examples/actions/posix/weather-freeform.sh
@@ -1,25 +1,27 @@
 #!/usr/bin/env bash
-# weather-freeform.sh -- Fetch latest METAR for an ICAO station.
+# weather-freeform.sh -- Fetch current conditions for a place.
 # Freeform Action variant.
 #
 # Wire it as an Action with arg_mode=freeform. Senders write:
 #
+#     @@<otp>#weather Denver
+#     @@<otp>#weather 80202
 #     @@<otp>#weather KDEN
 #
 # The runner invokes this script as:
 #
-#     weather-freeform.sh weather KE0XYZ true "KDEN"
+#     weather-freeform.sh weather KE0XYZ true "Denver"
 #                         ^       ^      ^    ^
 #                         |       |      |    GW_ARG (positional $4): the
 #                         |       |      |    entire freeform payload --
-#                         |       |      |    here, just the ICAO code
+#                         |       |      |    here, the location string
 #                         |       |      OTP_VERIFIED: "true" or "false"
 #                         |       GW_SENDER_CALL: APRS callsign
 #                         GW_ACTION_NAME: always "weather" here
 #
-# Reply: raw METAR observation, snipped to 50 chars on-air.
-# Source: aviationweather.gov (free, no key, worldwide METAR coverage).
-# Deps:   curl, jq
+# Reply: one-line current conditions in plain English.
+# Source: wttr.in (free, no key, worldwide).
+# Deps:   curl
 
 set -euo pipefail
 
@@ -32,34 +34,28 @@ OTP_VERIFIED="$3"
 PAYLOAD="$4"
 
 # Trim leading/trailing whitespace, collapse internal runs to one space.
-# Freeform payload is sanitized by the runtime, but be defensive: a
-# stray trailing newline or doubled space would otherwise break the
-# regex below.
-station=$(printf '%s' "$PAYLOAD" | awk '{$1=$1; print}')
+location=$(printf '%s' "$PAYLOAD" | awk '{$1=$1; print}')
 
-# ICAO codes are 4 letters; some military/regional sites use 3-4
-# alphanumerics. Be strict: letters only, 3 or 4 chars, nothing else.
-# A single anchored match is the validation AND the split.
-if [[ ! "$station" =~ ^[A-Za-z]{3,4}$ ]]; then
-    echo "expected ICAO code (3-4 letters)" >&2
+if [[ -z "$location" ]]; then
+    echo "location required" >&2
     exit 64
 fi
 
-station=$(printf '%s' "$station" | tr '[:lower:]' '[:upper:]')
+# Whitelist input so URL/shell metacharacters can't be smuggled into the
+# request. Allow letters, digits, space, comma, dot, underscore, hyphen.
+if [[ ! "$location" =~ ^[A-Za-z0-9.,_\ -]+$ ]]; then
+    echo "invalid location" >&2
+    exit 64
+fi
+encoded=$(printf '%s' "$location" | tr ' ' '+')
 
-url="https://aviationweather.gov/api/data/metar?ids=${station}&format=json&taf=false&hours=2"
+# %C condition, %t temperature, %w wind, %h humidity; &u forces USCS units.
+url="https://wttr.in/${encoded}?format=%C+%t+%w+%h&u"
 resp=$(curl -fsSL --max-time 8 -- "$url") || { echo "fetch failed" >&2; exit 1; }
 
-raw=$(printf '%s' "$resp" | jq -r 'if length==0 then "" else .[0].rawOb // "" end')
-if [[ -z "$raw" ]]; then
-    echo "$station: no recent METAR"
+resp=$(printf '%s' "$resp" | tr -d '\r\n')
+if [[ -z "$resp" ]]; then
+    echo "$location: no data"
     exit 0
 fi
-
-# Strip leading "METAR " / "SPECI " so the on-air 50-char snippet
-# starts with the ICAO + observation time.
-if [[ "$raw" =~ ^(METAR|SPECI)\ (.+)$ ]]; then
-    echo "${BASH_REMATCH[2]}"
-else
-    echo "$raw"
-fi
+echo "${location}: ${resp}"

--- a/examples/actions/posix/weather.sh
+++ b/examples/actions/posix/weather.sh
@@ -1,34 +1,35 @@
 #!/usr/bin/env bash
 # Action: weather
-# Grammar:  @@<otp>#weather station=<ICAO>
-# Args:     station  (required) -- 4-letter ICAO airport code
-#                                   (KDEN, EGLL, RJTT, YSSY ...)
-# Reply:    raw METAR observation, snipped to 50 chars on-air
-# Source:   aviationweather.gov (free, no key, worldwide METAR coverage)
-# Deps:     curl, jq
+# Grammar:  @@<otp>#weather location=<place>
+# Args:     location  (required) -- city name, ZIP, ICAO airport, or
+#                                   "lat,lon"  (Denver, 80202, KDEN,
+#                                   "39.7,-105.0")
+# Reply:    one-line current conditions in plain English
+# Source:   wttr.in (free, no key, worldwide)
+# Deps:     curl
 set -euo pipefail
 
-station="${GW_ARG_STATION:-}"
-if [[ -z "$station" ]]; then
-  echo "station required" >&2
+location="${GW_ARG_LOCATION:-}"
+if [[ -z "$location" ]]; then
+  echo "location required" >&2
   exit 1
 fi
-station=$(printf '%s' "$station" | tr '[:lower:]' '[:upper:]')
 
-url="https://aviationweather.gov/api/data/metar?ids=${station}&format=json&taf=false&hours=2"
-resp=$(curl -fsSL --max-time 8 "$url") || { echo "fetch failed" >&2; exit 1; }
+# Whitelist input so URL/shell metacharacters can't be smuggled into the
+# request. Allow letters, digits, space, comma, dot, underscore, hyphen.
+if [[ ! "$location" =~ ^[A-Za-z0-9.,_\ -]+$ ]]; then
+  echo "invalid location" >&2
+  exit 64
+fi
+encoded=$(printf '%s' "$location" | tr ' ' '+')
 
-raw=$(printf '%s' "$resp" | jq -r 'if length==0 then "" else .[0].rawOb // "" end')
-if [[ -z "$raw" ]]; then
-  echo "$station: no recent METAR"
+# %C condition, %t temperature, %w wind, %h humidity; &u forces USCS units.
+url="https://wttr.in/${encoded}?format=%C+%t+%w+%h&u"
+resp=$(curl -fsSL --max-time 8 -- "$url") || { echo "fetch failed" >&2; exit 1; }
+
+resp=$(printf '%s' "$resp" | tr -d '\r\n')
+if [[ -z "$resp" ]]; then
+  echo "$location: no data"
   exit 0
 fi
-
-# Strip leading "METAR " / "SPECI " so the on-air 50-char snippet
-# starts with the ICAO + observation time. Bash regex captures the
-# tail in BASH_REMATCH[2]; if neither prefix matches, echo raw as-is.
-if [[ "$raw" =~ ^(METAR|SPECI)\ (.+)$ ]]; then
-  echo "${BASH_REMATCH[2]}"
-else
-  echo "$raw"
-fi
+echo "${location}: ${resp}"

--- a/examples/actions/windows/weather.ps1
+++ b/examples/actions/windows/weather.ps1
@@ -1,33 +1,41 @@
 # Action: weather
-# Grammar:  @@<otp>#weather station=<ICAO>
-# Args:     station  (required) -- 4-letter ICAO airport code
-# Reply:    raw METAR observation, snipped to 50 chars on-air
-# Source:   aviationweather.gov (free, no key, worldwide)
+# Grammar:  @@<otp>#weather location=<place>
+# Args:     location  (required) -- city name, ZIP, ICAO airport, or
+#                                   "lat,lon" (Denver, 80202, KDEN,
+#                                   "39.7,-105.0")
+# Reply:    one-line current conditions in plain English
+# Source:   wttr.in (free, no key, worldwide)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$station = $env:GW_ARG_STATION
-if (-not $station) {
-  [Console]::Error.WriteLine('station required')
+$location = $env:GW_ARG_LOCATION
+if (-not $location) {
+  [Console]::Error.WriteLine('location required')
   exit 1
 }
-$station = $station.ToUpper()
+
+# Whitelist input so URL/shell metacharacters can't be smuggled into the
+# request. Allow letters, digits, space, comma, dot, underscore, hyphen.
+if ($location -notmatch '^[A-Za-z0-9.,_ -]+$') {
+  [Console]::Error.WriteLine('invalid location')
+  exit 64
+}
+
+$encoded = [System.Uri]::EscapeDataString($location)
+# %C condition, %t temperature, %w wind, %h humidity; &u forces USCS units.
+$url = "https://wttr.in/${encoded}?format=%C+%t+%w+%h&u"
 
 try {
-  $resp = Invoke-RestMethod -TimeoutSec 8 `
-    "https://aviationweather.gov/api/data/metar?ids=$station&format=json&taf=false&hours=2"
+  $resp = (Invoke-WebRequest -UseBasicParsing -TimeoutSec 8 -Uri $url).Content.Trim()
 } catch {
   [Console]::Error.WriteLine('fetch failed')
   exit 1
 }
 
-if (-not $resp -or $resp.Count -eq 0 -or -not $resp[0].rawOb) {
-  "$station no recent METAR"
+if (-not $resp) {
+  "${location}: no data"
   exit 0
 }
 
-# Strip leading "METAR " / "SPECI " so the on-air 50-char snippet
-# starts with the ICAO + observation time.
-$raw = $resp[0].rawOb -replace '^(METAR|SPECI)\s+', ''
-$raw
+"${location}: $resp"


### PR DESCRIPTION
## Summary
- Swap aviationweather.gov METAR for wttr.in plain-text format in all weather example scripts (POSIX `weather.sh`, POSIX `weather-freeform.sh`, Windows `weather.ps1`).
- Rename Action arg `station` -> `location`. Now accepts city name, ZIP, ICAO airport, or `lat,lon`.
- Reply format: `<location>: <Condition> <temp> <wind> <humidity>` (e.g. `Denver: Partly cloudy +63F 19mph 28%`).
- Drop `jq` dep from POSIX scripts. Whitelist regex blocks shell/URL metacharacters.
- README arg schema + example session updated to match.

## Test plan
- [x] `bash -n` syntax check on both POSIX scripts
- [x] Live: `GW_ARG_LOCATION=Denver bash weather.sh` -> human-readable line
- [x] Live: `GW_ARG_LOCATION=KDEN bash weather.sh` -> ICAO still works via wttr.in
- [x] Live: freeform variant with payload `Denver`
- [x] Error paths: empty location -> exit 1, metacharacter input -> exit 64
- [ ] Windows `weather.ps1` syntax (pwsh unavailable locally; logic mirrors POSIX)