### PR TITLE
Actions: multi-line on-air replies

### DIFF
--- a/docs/handbook/actions-handler-safety-shell.html
+++ b/docs/handbook/actions-handler-safety-shell.html
@@ -319,6 +319,30 @@ graywolf's parser.</p>
 <a href="actions-handler-safety.html#kv-vs-freeform">kv vs freeform
 &mdash; when to pick which</a> on the overview page.</p>
 
+<h2 id="multi-line-reply">Multi-line replies</h2>
+
+<p>If the operator sets <code>Max reply lines</code> to a value
+greater than 1 in the action's settings, each non-empty stdout line
+your script writes becomes a separate outbound APRS message (up to
+the configured maximum, ceiling 5).</p>
+
+<p>Example: a three-line weather snapshot.</p>
+
+<pre><code class="language-bash">#!/bin/bash
+# Configure Max reply lines = 3 in the UI for this Action.
+set -euo pipefail
+echo "temp 72F"
+echo "wind 5mph N"
+echo "baro 30.10"
+</code></pre>
+
+<p>Each line is capped at 67 characters and stripped of control
+characters. Lines beyond <code>Max reply lines</code> are dropped
+and the audit row's <code>Truncated</code> flag is set. Default is
+1; the ceiling is 5. Each extra line costs one RF frame plus its
+own ack and retry budget &mdash; keep this at 1 unless multiple
+short messages are genuinely needed.</p>
+
     <nav class="page-nav">
       <a href="actions-handler-safety.html">
         <span class="label">Previous</span>

--- a/docs/handbook/actions-handler-safety.html
+++ b/docs/handbook/actions-handler-safety.html
@@ -203,6 +203,23 @@ template body if you set one). Default form fields:</p>
       handlers page</a> for worked examples.</li>
 </ul>
 
+<h2 id="reply">Reply policy and multi-line output</h2>
+
+<p>For successful invocations (status <code>ok</code>) graywolf may
+emit up to the Action's <code>Max reply lines</code> setting (default
+1, ceiling 5) as separate APRS messages. Each non-empty stdout line
+becomes one outbound DM with its own message id, ack, and retries.
+Lines are capped at 67 characters; longer lines are truncated with
+<code>&hellip;</code>. Blank lines are dropped.</p>
+
+<p>Failure statuses (bad_arg, timeout, denied, etc.) always collapse
+to a single reply regardless of <code>Max reply lines</code> &mdash;
+fanning out a failure across multiple frames is never useful.</p>
+
+<p>Each extra line is one extra RF frame plus its own ack and retry
+window. Keep <code>Max reply lines</code> at 1 unless your handler
+genuinely needs to deliver multiple short messages.</p>
+
 <h2 id="checklist">Final safety checklist</h2>
 
 <p>Before deploying any Action handler:</p>

--- a/docs/handbook/actions.html
+++ b/docs/handbook/actions.html
@@ -742,6 +742,31 @@ https://hass.local:8123/api/services/light/turn_on?room={{arg.room}}
       the full capture remains in the audit log.
     </p>
 
+    <h3>Multi-line replies</h3>
+
+    <p>
+      Each Action carries a <strong>Max reply lines</strong> setting
+      (defaults to 1, hard ceiling 5). Leave it at 1 and the on-air
+      reply is the single legacy frame described above. Raise it and
+      stdout lines 2..N each ride an additional APRS message, capped
+      at 67 runes per line; the <code>ok:</code> prefix only rides
+      the first frame. Lines past the cap are silently dropped and
+      <code>Truncated</code> is set on the audit row.
+    </p>
+
+    <p>
+      <strong>Airtime cost is real.</strong> Every extra line is one
+      more RF frame plus its own ack and retries on a shared channel.
+      An Action set to 5 turns one trigger into five outbound frames
+      back-to-back, which is antisocial on 144.39 even if it works.
+      Reach for multi-line only when the operator genuinely needs
+      structured output (a multi-field weather summary, a short
+      status block); single-line is the right default for almost
+      every Action. Failure replies (<code>denied</code>,
+      <code>bad_arg</code>, <code>timeout</code>, etc.) always
+      collapse to one frame regardless of the setting.
+    </p>
+
     <h2>Audit log</h2>
 
     <p>
@@ -765,7 +790,8 @@ https://hass.local:8123/api/services/light/turn_on?room={{arg.room}}
       <li>Status and a short detail string</li>
       <li>Exit code (commands) or HTTP status (webhooks)</li>
       <li>Output capture (up to 4 KiB of merged stdout/stderr for commands, ~1 KiB of response body for webhooks)</li>
-      <li>The exact reply text that went out on the air</li>
+      <li>The exact reply text that went out on the air, newline-joined when the Action ran multi-line</li>
+      <li>Reply line count (how many APRS frames actually reached the transport for this invocation)</li>
     </ul>
 
     <p>

--- a/docs/wiki/actions.md
+++ b/docs/wiki/actions.md
@@ -148,6 +148,41 @@ Source:
 [`../../pkg/actions/classifier.go`](../../pkg/actions/classifier.go),
 [`../../pkg/actions/runner.go`](../../pkg/actions/runner.go).
 
+## Multi-line replies
+
+Actions can emit up to `Action.MaxReplyLines` separate APRS messages
+on success. Each non-empty stdout line becomes one outbound DM with
+its own message id, ack ladder, and retry budget. Default 1; hard
+ceiling `actions.MaxReplyLinesCeiling = 5` enforced by `validateAction`.
+
+- Only `Status == ok` paths fan out. Failure statuses (`bad_arg`,
+  `timeout`, `error`, `denied`, `bad_otp`, `disabled`, `unknown`,
+  `no_credential`, `busy`, `rate_limited`) always collapse to a
+  single reply — multi-line is meaningful only for executor success
+  output.
+- Line 1 carries the `ok: ` prefix; lines 2..N are bare. Each line
+  is sanitized of control chars and capped at `MaxReplyLen = 67`
+  runes; longer lines are truncated with the `…` rune and
+  `Truncated = true` on the audit row. Blank lines are dropped.
+- Source-aware reply transport (RF inbound → IS-fallback override;
+  IS inbound → IS-only override) is applied to every line
+  independently because each `SendReply` call constructs its own
+  `messages.SendMessageRequest`.
+- Audit row stores `\n`-joined text in `ReplyText` and the count of
+  produced lines in `ReplyLineCount`. The audit row reflects what
+  the runner formatted and dispatched; per-line transport ack state
+  lives in the messages thread, not in the invocation row.
+
+Source:
+[`../../pkg/actions/reply.go`](../../pkg/actions/reply.go) `FormatReplies`,
+[`../../pkg/actions/runner.go`](../../pkg/actions/runner.go) `replyAndAudit`.
+
+**Airtime warning surfaced in the operator UI:** an Action set to 5
+lines turns one trigger into 5 outbound RF frames plus per-line acks
+and retries. Operators should keep `MaxReplyLines` at 1 unless the
+script genuinely needs to deliver multiple short messages (e.g.
+weather summaries).
+
 ## Source-aware reply transport
 
 `MessagesReplySender` echoes the inbound transport back to the
@@ -214,10 +249,10 @@ AutoMigrate). Four tables:
 
 | Table | Notes |
 |---|---|
-| `actions` | unique `name`, FK `otp_credential_id -> otp_credentials(id)` ON DELETE SET NULL. The `Enabled` and `OTPRequired` columns deliberately omit `default:true` from their gorm tags even though the SQL DDL keeps `DEFAULT 1` (downgrade-safety). Reason: gorm uses the gorm-tag default as the value to send when the Go field is its zero value, which would conflate a genuine `false` from the wire with "field not set" and silently flip a freshly-created disabled action back to enabled. Application layer always provides the explicit value. |
+| `actions` | unique `name`, FK `otp_credential_id -> otp_credentials(id)` ON DELETE SET NULL. The `Enabled` and `OTPRequired` columns deliberately omit `default:true` from their gorm tags even though the SQL DDL keeps `DEFAULT 1` (downgrade-safety). Reason: gorm uses the gorm-tag default as the value to send when the Go field is its zero value, which would conflate a genuine `false` from the wire with "field not set" and silently flip a freshly-created disabled action back to enabled. Application layer always provides the explicit value. Also carries a per-Action `MaxReplyLines` column (1..5; default 1) gating the multi-line on-air reply fan-out. |
 | `otp_credentials` | unique `name`, plaintext `secret_b32` (per spec — UI surfaces it once at create time, never reads back) |
 | `action_listener_addressees` | unique `addressee` (uppercase, 1..9 chars) |
-| `action_invocations` | append-only audit; FK `action_id -> actions(id)` ON DELETE SET NULL; FK `otp_credential_id -> otp_credentials(id)` ON DELETE SET NULL; `action_name_at` and `OTPCredName` are denormalized so a row stays readable after deletion |
+| `action_invocations` | append-only audit; FK `action_id -> actions(id)` ON DELETE SET NULL; FK `otp_credential_id -> otp_credentials(id)` ON DELETE SET NULL; `action_name_at` and `OTPCredName` are denormalized so a row stays readable after deletion. Also carries a `ReplyLineCount` column tracking the number of reply lines the runner produced for this invocation. |
 
 All four models are deliberately *not* in the AutoMigrate list — the
 migration is the single source of truth for their schema.

--- a/docs/wiki/actions.md
+++ b/docs/wiki/actions.md
@@ -169,9 +169,13 @@ ceiling `actions.MaxReplyLinesCeiling = 5` enforced by `validateAction`.
   independently because each `SendReply` call constructs its own
   `messages.SendMessageRequest`.
 - Audit row stores `\n`-joined text in `ReplyText` and the count of
-  produced lines in `ReplyLineCount`. The audit row reflects what
-  the runner formatted and dispatched; per-line transport ack state
-  lives in the messages thread, not in the invocation row.
+  lines actually handed to the transport in `ReplyLineCount`. If a
+  `SendReply` call fails partway through the burst the runner stops
+  fanning further frames and `ReplyLineCount` reflects only what
+  reached the transport — `Truncated` still marks formatter-side
+  clipping (source had more lines than `MaxReplyLines` allowed) and
+  is independent of transport failures. Per-line transport ack
+  state lives in the messages thread, not in the invocation row.
 
 Source:
 [`../../pkg/actions/reply.go`](../../pkg/actions/reply.go) `FormatReplies`,
@@ -252,7 +256,7 @@ AutoMigrate). Four tables:
 | `actions` | unique `name`, FK `otp_credential_id -> otp_credentials(id)` ON DELETE SET NULL. The `Enabled` and `OTPRequired` columns deliberately omit `default:true` from their gorm tags even though the SQL DDL keeps `DEFAULT 1` (downgrade-safety). Reason: gorm uses the gorm-tag default as the value to send when the Go field is its zero value, which would conflate a genuine `false` from the wire with "field not set" and silently flip a freshly-created disabled action back to enabled. Application layer always provides the explicit value. Also carries a per-Action `MaxReplyLines` column (1..5; default 1) gating the multi-line on-air reply fan-out. |
 | `otp_credentials` | unique `name`, plaintext `secret_b32` (per spec — UI surfaces it once at create time, never reads back) |
 | `action_listener_addressees` | unique `addressee` (uppercase, 1..9 chars) |
-| `action_invocations` | append-only audit; FK `action_id -> actions(id)` ON DELETE SET NULL; FK `otp_credential_id -> otp_credentials(id)` ON DELETE SET NULL; `action_name_at` and `OTPCredName` are denormalized so a row stays readable after deletion. Also carries a `ReplyLineCount` column tracking the number of reply lines the runner produced for this invocation. |
+| `action_invocations` | append-only audit; FK `action_id -> actions(id)` ON DELETE SET NULL; FK `otp_credential_id -> otp_credentials(id)` ON DELETE SET NULL; `action_name_at` and `OTPCredName` are denormalized so a row stays readable after deletion. Also carries a `ReplyLineCount` column tracking the number of reply lines actually dispatched to the transport for this invocation (a transport failure mid-burst lowers the count; formatter-side clipping is recorded in `Truncated`). |
 
 All four models are deliberately *not* in the AutoMigrate list — the
 migration is the single source of truth for their schema.

--- a/examples/actions/README.md
+++ b/examples/actions/README.md
@@ -46,6 +46,10 @@ short stderr/stdout to surface as `error: <detail>`.
    - **Sender allowlist**: also recommended.
    - **Timeout**: 10s default; bump for SMS/HA round-trips if your
      network is slow.
+   - **Max reply lines**: 1 by default. Bump to 2 for `weather`
+     (line 1: condition + temp; line 2: wind + humidity + pressure).
+     Each extra line is one extra RF frame, so leave it at 1 for
+     scripts that emit a single line.
 4. **Test** with the per-row Test dialog before letting it loose
    on-air. Test bypasses OTP + allowlist but exercises the executor.
 
@@ -96,7 +100,8 @@ not** put secrets in the script itself or pass them as Action args.
 < ok: KE0XYZ said: hello
 
 > @@123456#weather location=Denver
-< ok: Denver: Partly cloudy +63°F ↓19mph 28%
+< ok: Denver: Partly cloudy +63°F
+< wind ↓19mph hum 28% 1016hPa
 
 > @@123456#solar
 < ok: SFI 142 A 8 K 2 SN 78

--- a/examples/actions/posix/weather-freeform.sh
+++ b/examples/actions/posix/weather-freeform.sh
@@ -19,7 +19,10 @@
 #                         |       GW_SENDER_CALL: APRS callsign
 #                         GW_ACTION_NAME: always "weather" here
 #
-# Reply: one-line current conditions in plain English.
+# Reply: two-line current conditions in plain English. Set the Action's
+#        MaxReplyLines >= 2 or only the first line ships.
+#        Line 1: "<location>: <condition> <temp>"
+#        Line 2: "wind <wind> hum <hum> <pressure>"
 # Source: wttr.in (free, no key, worldwide).
 # Deps:   curl
 
@@ -49,8 +52,11 @@ if [[ ! "$location" =~ ^[A-Za-z0-9.,_\ -]+$ ]]; then
 fi
 encoded=$(printf '%s' "$location" | tr ' ' '+')
 
-# %C condition, %t temperature, %w wind, %h humidity; &u forces USCS units.
-url="https://wttr.in/${encoded}?format=%C+%t+%w+%h&u"
+# %C condition, %t temp, %w wind, %h humidity, %P pressure; &u forces
+# USCS units. The literal "|" splits the response into the two on-air
+# lines; wttr.in passes it through verbatim and "|" never appears in
+# any of these fields.
+url="https://wttr.in/${encoded}?format=%C+%t|wind+%w+hum+%h+%P&u"
 resp=$(curl -fsSL --max-time 8 -- "$url") || { echo "fetch failed" >&2; exit 1; }
 
 resp=$(printf '%s' "$resp" | tr -d '\r\n')
@@ -58,4 +64,12 @@ if [[ -z "$resp" ]]; then
     echo "$location: no data"
     exit 0
 fi
-echo "${location}: ${resp}"
+
+line1="${resp%%|*}"
+line2="${resp#*|}"
+echo "${location}: ${line1}"
+# Drop line 2 if the delimiter was missing (no "|" in resp leaves
+# line2 == resp, which would duplicate line 1).
+if [[ "$line2" != "$resp" ]]; then
+    echo "$line2"
+fi

--- a/examples/actions/posix/weather.sh
+++ b/examples/actions/posix/weather.sh
@@ -4,7 +4,10 @@
 # Args:     location  (required) -- city name, ZIP, ICAO airport, or
 #                                   "lat,lon"  (Denver, 80202, KDEN,
 #                                   "39.7,-105.0")
-# Reply:    one-line current conditions in plain English
+# Reply:    two-line current conditions in plain English. Set the
+#           Action's MaxReplyLines >= 2 or only the first line ships.
+#           Line 1: "<location>: <condition> <temp>"
+#           Line 2: "wind <wind> hum <hum> <pressure>"
 # Source:   wttr.in (free, no key, worldwide)
 # Deps:     curl
 set -euo pipefail
@@ -23,8 +26,11 @@ if [[ ! "$location" =~ ^[A-Za-z0-9.,_\ -]+$ ]]; then
 fi
 encoded=$(printf '%s' "$location" | tr ' ' '+')
 
-# %C condition, %t temperature, %w wind, %h humidity; &u forces USCS units.
-url="https://wttr.in/${encoded}?format=%C+%t+%w+%h&u"
+# %C condition, %t temp, %w wind, %h humidity, %P pressure; &u forces
+# USCS units. The literal "|" splits the response into the two on-air
+# lines; wttr.in passes it through verbatim and "|" never appears in
+# any of these fields.
+url="https://wttr.in/${encoded}?format=%C+%t|wind+%w+hum+%h+%P&u"
 resp=$(curl -fsSL --max-time 8 -- "$url") || { echo "fetch failed" >&2; exit 1; }
 
 resp=$(printf '%s' "$resp" | tr -d '\r\n')
@@ -32,4 +38,12 @@ if [[ -z "$resp" ]]; then
   echo "$location: no data"
   exit 0
 fi
-echo "${location}: ${resp}"
+
+line1="${resp%%|*}"
+line2="${resp#*|}"
+echo "${location}: ${line1}"
+# Drop line 2 if the delimiter was missing (no "|" in resp leaves
+# line2 == resp, which would duplicate line 1).
+if [[ "$line2" != "$resp" ]]; then
+  echo "$line2"
+fi

--- a/examples/actions/windows/weather.ps1
+++ b/examples/actions/windows/weather.ps1
@@ -3,7 +3,10 @@
 # Args:     location  (required) -- city name, ZIP, ICAO airport, or
 #                                   "lat,lon" (Denver, 80202, KDEN,
 #                                   "39.7,-105.0")
-# Reply:    one-line current conditions in plain English
+# Reply:    two-line current conditions in plain English. Set the
+#           Action's MaxReplyLines >= 2 or only the first line ships.
+#           Line 1: "<location>: <condition> <temp>"
+#           Line 2: "wind <wind> hum <hum> <pressure>"
 # Source:   wttr.in (free, no key, worldwide)
 
 Set-StrictMode -Version Latest
@@ -23,8 +26,11 @@ if ($location -notmatch '^[A-Za-z0-9.,_ -]+$') {
 }
 
 $encoded = [System.Uri]::EscapeDataString($location)
-# %C condition, %t temperature, %w wind, %h humidity; &u forces USCS units.
-$url = "https://wttr.in/${encoded}?format=%C+%t+%w+%h&u"
+# %C condition, %t temp, %w wind, %h humidity, %P pressure; &u forces
+# USCS units. The literal "|" splits the response into the two on-air
+# lines; wttr.in passes it through verbatim and "|" never appears in
+# any of these fields.
+$url = "https://wttr.in/${encoded}?format=%C+%t|wind+%w+hum+%h+%P&u"
 
 try {
   $resp = (Invoke-WebRequest -UseBasicParsing -TimeoutSec 8 -Uri $url).Content.Trim()
@@ -38,4 +44,9 @@ if (-not $resp) {
   exit 0
 }
 
-"${location}: $resp"
+$parts = $resp.Split('|', 2)
+"${location}: $($parts[0])"
+# Drop line 2 if the delimiter was missing.
+if ($parts.Length -eq 2) {
+  $parts[1]
+}

--- a/examples/skills/writing-graywolf-action-handlers/SKILL.md
+++ b/examples/skills/writing-graywolf-action-handlers/SKILL.md
@@ -427,6 +427,15 @@ the local idiom.
    `Markup(...)`, never `|safe`, never `{{ ...|safe }}`.
 8. **Reply on the first line of stdout, ≤50 runes** (graywolf snippets
    it for the on-air `ok: <snippet>` reply). Diagnostics go to stderr.
+   An Action's `Max reply lines` defaults to 1; raising it (up to a
+   hard ceiling of 5) lets stdout lines 2..N ride additional APRS
+   frames without the `ok: ` prefix. Each extra line is one more RF
+   frame plus its own ack and retries, so multi-line is for cases
+   where the operator genuinely needs structured output (e.g. a
+   short weather summary). Default to one line; reach for two or
+   three only when you can defend the airtime. Never rely on lines
+   above the cap arriving — anything beyond `Max reply lines` is
+   silently dropped and `Truncated` is set on the audit row.
 9. **Exit non-zero on failure** with a short stderr line. Graywolf
    echoes the snippet as `error: <detail>` on-air.
 10. **Run the linter for the language.** `shellcheck` for bash,
@@ -621,7 +630,11 @@ alternative. Do not generate the unsafe form.
 
 ## Final checklist (run before showing the script)
 
-- [ ] First line of stdout is the on-air reply, ≤50 runes.
+- [ ] First line of stdout is the on-air reply, ≤50 runes. If the
+      Action sets `Max reply lines > 1`, additional stdout lines (each
+      ≤67 runes) ride extra APRS frames; keep the count as low as the
+      use case allows because every extra line costs an RF frame plus
+      its own ack and retries.
 - [ ] Every error path writes a short stderr line and exits non-zero.
 - [ ] Every external command receives user data via argv, not concatenation.
 - [ ] Every regex is anchored with `^` and `$`.

--- a/examples/skills/writing-graywolf-action-handlers/reference-posix.md
+++ b/examples/skills/writing-graywolf-action-handlers/reference-posix.md
@@ -208,6 +208,15 @@ echo "twilio rejected: ..." >&2   # failure: stderr
 exit 1
 ```
 
+If the Action's `Max reply lines` is raised above 1 (hard ceiling 5),
+stdout lines 2..N each ride an additional APRS frame (≤67 runes per
+line, no `ok: ` prefix on the follow-up frames). Each extra line
+costs one RF frame plus its own ack and retries, so reach for it only
+when the operator genuinely needs structured output — a short
+weather summary, a multi-field status. Default to one line and stay
+there unless you can defend the airtime. Anything past `Max reply
+lines` is silently dropped.
+
 Standard exit codes (loosely follow `sysexits.h`):
 
 | Exit | Meaning |

--- a/examples/skills/writing-graywolf-action-handlers/reference-powershell.md
+++ b/examples/skills/writing-graywolf-action-handlers/reference-powershell.md
@@ -230,6 +230,13 @@ exit 0
 exit 1
 ```
 
+When the Action's `Max reply lines` is raised above 1 (hard ceiling 5),
+extra stdout lines ride additional APRS frames (≤67 runes each, no
+`ok: ` prefix on the follow-up frames). Each extra line costs an RF
+frame plus its own ack and retries, so default to one line and only
+reach for multi-line replies when the operator genuinely needs
+structured output. Lines past the cap are silently dropped.
+
 Same exit-code conventions as POSIX (`64` usage, `65` data,
 `69` service unavailable, `75` retry hint).
 

--- a/pkg/actions/reply.go
+++ b/pkg/actions/reply.go
@@ -7,11 +7,24 @@ import (
 	"unicode/utf8"
 )
 
-const MaxReplyLen = 67 // APRS message text limit
+// MaxReplyLen is the per-message APRS text cap (one frame).
+const MaxReplyLen = 67
+
+// MaxReplyLinesCeiling is the hard upper bound enforced by the
+// validator on Action.MaxReplyLines. Operators choose 1..ceiling; the
+// runtime clamps anything outside that range. The cap exists because
+// each extra line is one extra RF frame plus its own ack/retry budget;
+// >5 turns a single trigger into an airtime storm.
+const MaxReplyLinesCeiling = 5
+
+// DefaultMaxReplyLines is the value used when an Action row pre-dates
+// the column or the operator left it at zero.
+const DefaultMaxReplyLines = 1
 
 // ReplySender dispatches one reply back to the originator over the
 // matching transport. The RF/IS routing is the implementation's
-// concern; the runner just hands over the addressee + text.
+// concern; the runner just hands over the addressee + text. One call
+// per line — the runner loops when MaxReplyLines > 1.
 type ReplySender interface {
 	SendReply(ctx context.Context, channel uint32, source Source, toCall, text string) error
 }
@@ -43,30 +56,147 @@ func statusWord(s Status) string {
 	}
 }
 
-// FormatReply produces the on-air reply text and reports whether any
-// truncation occurred (either the snippet was shortened to fit the
-// 50-char per-line cap, or the assembled reply exceeded MaxReplyLen).
-// The bool is what gets stored in ActionInvocation.Truncated.
+// FormatReplies produces up to maxLines on-air reply strings from a
+// Result. Line 1 carries the status-word prefix ("ok: ..."); lines 2..N
+// are plain output lines (no prefix). Each line is sanitized of control
+// characters and capped at MaxReplyLen runes. Non-OK statuses always
+// collapse to a single line — there is no point fanning a bad-arg or
+// timeout failure across multiple frames.
+//
+// maxLines <= 0 is treated as 1. Blank lines in the captured output
+// are dropped. Returns the produced lines and a bool that is true when
+// any data was dropped: line count exceeded maxLines, an individual
+// line was clamped to MaxReplyLen, or the assembled status+detail was
+// truncated.
+func FormatReplies(r Result, maxLines int) ([]string, bool) {
+	if maxLines <= 0 {
+		maxLines = 1
+	}
+
+	// Non-OK paths surface a single-line reply with the status-word
+	// detail. Multi-line is meaningful only for executor success
+	// output; failures should be tight.
+	if r.Status != StatusOK {
+		return []string{formatStatusLine(r)}, false
+	}
+
+	if maxLines == 1 {
+		rawLines := splitNonEmptyLines(r.OutputCapture)
+		if len(rawLines) == 0 {
+			return []string{statusWord(StatusOK)}, false
+		}
+		line, tr := formatOKSingle(rawLines[0])
+		if len(rawLines) > 1 {
+			tr = true
+		}
+		return []string{line}, tr
+	}
+
+	rawLines := splitNonEmptyLines(r.OutputCapture)
+	if len(rawLines) == 0 {
+		return []string{statusWord(StatusOK)}, false
+	}
+
+	out := make([]string, 0, maxLines)
+	truncated := false
+
+	// Line 1 wears the status-word prefix.
+	first, tr := assembleOKLine(rawLines[0])
+	out = append(out, first)
+	if tr {
+		truncated = true
+	}
+
+	for i := 1; i < len(rawLines) && len(out) < maxLines; i++ {
+		line, lt := clampLine(sanitizeReplyText(rawLines[i]))
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+		if lt {
+			truncated = true
+		}
+	}
+
+	if len(rawLines) > maxLines {
+		truncated = true
+	}
+	return out, truncated
+}
+
+// FormatReply preserves the legacy single-line API. New code should
+// call FormatReplies; this wrapper is kept so call sites that have not
+// been updated keep working (the two production callers — runner +
+// service test-fire audit — are switched to FormatReplies in this
+// change; this wrapper exists for anything else, e.g. webapi
+// test-fire which still reports a single primary line in addition to
+// the full slice).
 func FormatReply(r Result) (string, bool) {
+	lines, tr := FormatReplies(r, 1)
+	if len(lines) == 0 {
+		return "", tr
+	}
+	return lines[0], tr
+}
+
+// formatStatusLine builds the legacy one-line status reply for any
+// non-OK Result. Equivalent to the pre-multi-line FormatReply body.
+func formatStatusLine(r Result) string {
 	word := statusWord(r.Status)
-	var (
-		detail    string
-		truncated bool
-	)
+	var detail string
 	switch r.Status {
-	case StatusOK:
-		detail, truncated = firstLineSnippet(r.OutputCapture)
 	case StatusBadArg, StatusError, StatusTimeout:
 		detail = sanitizeReplyText(r.StatusDetail)
 	}
 	if detail == "" {
-		return word, truncated
+		return word
 	}
 	full := word + ": " + detail
 	if utf8.RuneCountInString(full) <= MaxReplyLen {
-		return full, truncated
+		return full
+	}
+	return truncateReply(full)
+}
+
+// formatOKSingle is the single-line OK path — same shape as the legacy
+// FormatReply for callers that opt out of multi-line. Uses the
+// 50-rune snippet so the legacy "compact reply" budget is preserved.
+func formatOKSingle(output string) (string, bool) {
+	detail, tr := firstLineSnippet(output)
+	if detail == "" {
+		return statusWord(StatusOK), tr
+	}
+	full := "ok: " + detail
+	if utf8.RuneCountInString(full) <= MaxReplyLen {
+		return full, tr
 	}
 	return truncateReply(full), true
+}
+
+// assembleOKLine wraps a stdout line as the first line of a multi-line
+// OK reply, applying the "ok: " prefix and the per-line cap. Reports
+// truncation when either the prefix overflowed or the input itself was
+// clamped.
+func assembleOKLine(s string) (string, bool) {
+	clean, tr := clampLine(sanitizeReplyText(s))
+	if clean == "" {
+		return statusWord(StatusOK), tr
+	}
+	full := "ok: " + clean
+	if utf8.RuneCountInString(full) <= MaxReplyLen {
+		return full, tr
+	}
+	return truncateReply(full), true
+}
+
+// clampLine sanitizes and length-caps a single output line. Empty
+// input returns "" with no truncation.
+func clampLine(s string) (string, bool) {
+	if utf8.RuneCountInString(s) > MaxReplyLen {
+		runes := []rune(s)
+		return string(runes[:MaxReplyLen-1]) + "…", true
+	}
+	return s, false
 }
 
 func firstLineSnippet(s string) (string, bool) {
@@ -78,14 +208,56 @@ func firstLineSnippet(s string) (string, bool) {
 	return s, false
 }
 
+// splitNonEmptyLines splits on "\n" or "\r\n" and drops blank lines
+// after sanitizing whitespace. Order is preserved.
+func splitNonEmptyLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	parts := strings.Split(s, "\n")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		clean := strings.TrimSpace(stripControlChars(p))
+		if clean == "" {
+			continue
+		}
+		out = append(out, clean)
+	}
+	return out
+}
+
+// stripControlChars removes ASCII C0 + DEL but leaves printable bytes
+// (and multi-byte UTF-8) intact. Used by both single-line snippet and
+// multi-line splitter.
+func stripControlChars(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if (r < 0x20 && r != '\n' && r != '\r' && r != '\t') || r == 0x7F {
+			continue
+		}
+		if r == '\t' {
+			b.WriteByte(' ')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// sanitizeReplyText collapses CR/LF to space and strips control chars
+// for single-line use. Multi-line callers split first, then call this
+// per line via clampLine.
 func sanitizeReplyText(s string) string {
 	s = strings.ReplaceAll(s, "\r", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
+	s = stripControlChars(s)
 	return strings.TrimSpace(s)
 }
 
 func truncateReply(s string) string {
-	limit := MaxReplyLen - 1 // leave room for the … rune
+	limit := MaxReplyLen - 1
 	runes := []rune(s)
 	if len(runes) <= limit {
 		return s

--- a/pkg/actions/reply.go
+++ b/pkg/actions/reply.go
@@ -72,6 +72,12 @@ func FormatReplies(r Result, maxLines int) ([]string, bool) {
 	if maxLines <= 0 {
 		maxLines = 1
 	}
+	// Defense in depth: even if a row escaped the validator (raw SQL,
+	// migration glitch, future schema bug) the dispatch chokepoint
+	// must never fan out more frames than the airtime ceiling allows.
+	if maxLines > MaxReplyLinesCeiling {
+		maxLines = MaxReplyLinesCeiling
+	}
 
 	// Non-OK paths surface a single-line reply with the status-word
 	// detail. Multi-line is meaningful only for executor success
@@ -81,14 +87,12 @@ func FormatReplies(r Result, maxLines int) ([]string, bool) {
 	}
 
 	if maxLines == 1 {
-		rawLines := splitNonEmptyLines(r.OutputCapture)
-		if len(rawLines) == 0 {
-			return []string{statusWord(StatusOK)}, false
-		}
-		line, tr := formatOKSingle(rawLines[0])
-		if len(rawLines) > 1 {
-			tr = true
-		}
+		// Legacy single-line semantics: collapse newlines to spaces,
+		// prefix with "ok: ", clamp to MaxReplyLen. An Action whose
+		// stdout already had multiple lines used to ship as one
+		// joined frame; preserve that so toggling MaxReplyLines==1
+		// stays bug-for-bug identical to the pre-multi-line path.
+		line, tr := formatOKSingle(r.OutputCapture)
 		return []string{line}, tr
 	}
 

--- a/pkg/actions/reply_test.go
+++ b/pkg/actions/reply_test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestFormatReplyOK(t *testing.T) {
@@ -43,5 +44,117 @@ func TestFormatReplyStripsControlChars(t *testing.T) {
 	got, _ := FormatReply(Result{Status: StatusOK, OutputCapture: "a\nb\rc"})
 	if strings.ContainsAny(got, "\n\r") {
 		t.Fatalf("control chars leaked: %q", got)
+	}
+}
+
+func TestFormatRepliesSingleLineOK(t *testing.T) {
+	lines, tr := FormatReplies(Result{Status: StatusOK, OutputCapture: "lights on"}, 1)
+	if len(lines) != 1 || lines[0] != "ok: lights on" {
+		t.Fatalf("got %#v", lines)
+	}
+	if tr {
+		t.Fatalf("unexpected truncation flag")
+	}
+}
+
+func TestFormatRepliesMultiLineOK(t *testing.T) {
+	out := "temp 72F\nwind 5mph N\nbaro 30.10\""
+	lines, tr := FormatReplies(Result{Status: StatusOK, OutputCapture: out}, 3)
+	if len(lines) != 3 {
+		t.Fatalf("want 3 lines, got %d: %#v", len(lines), lines)
+	}
+	if lines[0] != "ok: temp 72F" {
+		t.Fatalf("line 0: %q", lines[0])
+	}
+	if lines[1] != "wind 5mph N" {
+		t.Fatalf("line 1: %q", lines[1])
+	}
+	if lines[2] != `baro 30.10"` {
+		t.Fatalf("line 2: %q", lines[2])
+	}
+	if tr {
+		t.Fatalf("unexpected truncation")
+	}
+}
+
+func TestFormatRepliesDropsBlankLines(t *testing.T) {
+	out := "first\n\n\nsecond\n"
+	lines, _ := FormatReplies(Result{Status: StatusOK, OutputCapture: out}, 5)
+	if len(lines) != 2 {
+		t.Fatalf("want 2, got %d: %#v", len(lines), lines)
+	}
+	if lines[0] != "ok: first" || lines[1] != "second" {
+		t.Fatalf("got %#v", lines)
+	}
+}
+
+func TestFormatRepliesRespectsMax(t *testing.T) {
+	out := "a\nb\nc\nd\ne\nf"
+	lines, tr := FormatReplies(Result{Status: StatusOK, OutputCapture: out}, 3)
+	if len(lines) != 3 {
+		t.Fatalf("want 3, got %d", len(lines))
+	}
+	if !tr {
+		t.Fatalf("expected truncation flag (3 of 6 lines)")
+	}
+}
+
+func TestFormatRepliesClampsLineLength(t *testing.T) {
+	out := strings.Repeat("x", 200) + "\nshort"
+	lines, tr := FormatReplies(Result{Status: StatusOK, OutputCapture: out}, 2)
+	if len(lines) != 2 {
+		t.Fatalf("want 2, got %d", len(lines))
+	}
+	if utf8.RuneCountInString(lines[0]) > MaxReplyLen {
+		t.Fatalf("line 0 over cap: %d", utf8.RuneCountInString(lines[0]))
+	}
+	if !strings.HasSuffix(lines[0], "…") {
+		t.Fatalf("missing truncation marker")
+	}
+	if !tr {
+		t.Fatalf("expected truncation flag")
+	}
+}
+
+func TestFormatRepliesNonOKAlwaysSingleLine(t *testing.T) {
+	lines, _ := FormatReplies(
+		Result{Status: StatusBadArg, StatusDetail: "state"},
+		5,
+	)
+	if len(lines) != 1 || lines[0] != "bad arg: state" {
+		t.Fatalf("got %#v", lines)
+	}
+}
+
+func TestFormatRepliesEmptyOutputOK(t *testing.T) {
+	lines, _ := FormatReplies(Result{Status: StatusOK, OutputCapture: ""}, 3)
+	if len(lines) != 1 || lines[0] != "ok" {
+		t.Fatalf("got %#v", lines)
+	}
+}
+
+func TestFormatRepliesStripsControlChars(t *testing.T) {
+	out := "a\x07b\nc\x1bd"
+	lines, _ := FormatReplies(Result{Status: StatusOK, OutputCapture: out}, 2)
+	if len(lines) != 2 {
+		t.Fatalf("want 2, got %d", len(lines))
+	}
+	for _, l := range lines {
+		for _, r := range l {
+			if r < 0x20 || r == 0x7F {
+				t.Fatalf("control char %q in line %q", r, l)
+			}
+		}
+	}
+}
+
+func TestFormatRepliesMaxLinesZeroDefaultsToOne(t *testing.T) {
+	out := "a\nb"
+	lines, tr := FormatReplies(Result{Status: StatusOK, OutputCapture: out}, 0)
+	if len(lines) != 1 || lines[0] != "ok: a" {
+		t.Fatalf("got %#v", lines)
+	}
+	if !tr {
+		t.Fatalf("expected truncation flag (b dropped)")
 	}
 }

--- a/pkg/actions/reply_test.go
+++ b/pkg/actions/reply_test.go
@@ -149,12 +149,56 @@ func TestFormatRepliesStripsControlChars(t *testing.T) {
 }
 
 func TestFormatRepliesMaxLinesZeroDefaultsToOne(t *testing.T) {
+	// maxLines==0 falls through to maxLines==1, which uses legacy
+	// single-line semantics: newlines collapse to spaces, the whole
+	// string joins under one "ok: " prefix.
 	out := "a\nb"
 	lines, tr := FormatReplies(Result{Status: StatusOK, OutputCapture: out}, 0)
-	if len(lines) != 1 || lines[0] != "ok: a" {
+	if len(lines) != 1 || lines[0] != "ok: a b" {
 		t.Fatalf("got %#v", lines)
 	}
+	if tr {
+		t.Fatalf("unexpected truncation flag")
+	}
+}
+
+func TestFormatRepliesClampsToCeiling(t *testing.T) {
+	// Even if a row stores a corrupt MaxReplyLines (e.g. raw SQL
+	// edit), the dispatcher must never emit more frames than the
+	// airtime ceiling.
+	out := "a\nb\nc\nd\ne\nf\ng\nh\ni\nj"
+	lines, tr := FormatReplies(Result{Status: StatusOK, OutputCapture: out}, 100)
+	if len(lines) != MaxReplyLinesCeiling {
+		t.Fatalf("want %d lines, got %d: %#v", MaxReplyLinesCeiling, len(lines), lines)
+	}
 	if !tr {
-		t.Fatalf("expected truncation flag (b dropped)")
+		t.Fatalf("expected truncation flag (10 of 5 lines)")
+	}
+}
+
+func TestFormatRepliesBoundaryLineLengths(t *testing.T) {
+	// Pin the off-by-one boundary on the per-line clamp.
+	exactlyAtCap := strings.Repeat("x", MaxReplyLen)            // 67
+	oneOverCap := strings.Repeat("x", MaxReplyLen+1)            // 68
+	short := "y"
+	out := exactlyAtCap + "\n" + oneOverCap + "\n" + short
+	lines, tr := FormatReplies(Result{Status: StatusOK, OutputCapture: out}, 3)
+	if len(lines) != 3 {
+		t.Fatalf("want 3, got %d", len(lines))
+	}
+	// Line 0 wears "ok: " prefix → 67-char input gets truncated.
+	if !strings.HasSuffix(lines[0], "…") {
+		t.Fatalf("line 0 should be truncated by prefix overflow: %q", lines[0])
+	}
+	// Line 1: 68 chars over the per-line cap → ellipsis.
+	if !strings.HasSuffix(lines[1], "…") || utf8.RuneCountInString(lines[1]) != MaxReplyLen {
+		t.Fatalf("line 1 should clamp to cap with ellipsis: %q (len=%d)", lines[1], utf8.RuneCountInString(lines[1]))
+	}
+	// Line 2 unchanged.
+	if lines[2] != short {
+		t.Fatalf("line 2: got %q want %q", lines[2], short)
+	}
+	if !tr {
+		t.Fatalf("expected truncation flag")
 	}
 }

--- a/pkg/actions/runner.go
+++ b/pkg/actions/runner.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -103,15 +104,15 @@ func (r *Runner) Submit(ctx context.Context, inv Invocation, a *configstore.Acti
 		return
 	}
 	if a == nil {
-		r.replyAndAudit(ctx, inv, channel, Result{Status: StatusUnknown})
+		r.replyAndAudit(ctx, inv, channel, Result{Status: StatusUnknown}, 1)
 		return
 	}
 	if !a.Enabled {
-		r.replyAndAudit(ctx, inv, channel, Result{Status: StatusDisabled})
+		r.replyAndAudit(ctx, inv, channel, Result{Status: StatusDisabled}, 1)
 		return
 	}
 	if a.OTPRequired && a.OTPCredentialID == nil {
-		r.replyAndAudit(ctx, inv, channel, Result{Status: StatusNoCredential})
+		r.replyAndAudit(ctx, inv, channel, Result{Status: StatusNoCredential}, 1)
 		return
 	}
 
@@ -137,7 +138,7 @@ func (r *Runner) Submit(ctx context.Context, inv Invocation, a *configstore.Acti
 	prev := q.lastFire
 	if a.RateLimitSec > 0 && !prev.IsZero() && r.now().Sub(prev) < time.Duration(a.RateLimitSec)*time.Second {
 		q.mu.Unlock()
-		r.replyAndAudit(ctx, inv, channel, Result{Status: StatusRateLimited})
+		r.replyAndAudit(ctx, inv, channel, Result{Status: StatusRateLimited}, 1)
 		return
 	}
 	if a.RateLimitSec > 0 {
@@ -154,7 +155,7 @@ func (r *Runner) Submit(ctx context.Context, inv Invocation, a *configstore.Acti
 			q.lastFire = prev
 		}
 		q.mu.Unlock()
-		r.replyAndAudit(ctx, inv, channel, Result{Status: StatusBusy})
+		r.replyAndAudit(ctx, inv, channel, Result{Status: StatusBusy}, 1)
 	}
 }
 
@@ -187,7 +188,7 @@ func (r *Runner) runOne(ctx context.Context, it workItem) {
 	if !ok {
 		r.replyAndAudit(ctx, it.inv, it.channel, Result{
 			Status: StatusError, StatusDetail: fmt.Sprintf("no executor for type %q", it.action.Type),
-		})
+		}, 1)
 		return
 	}
 	timeout := time.Duration(it.action.TimeoutSec) * time.Second
@@ -197,7 +198,7 @@ func (r *Runner) runOne(ctx context.Context, it workItem) {
 	res := r.executeWithRecover(ctx, exe, ExecRequest{
 		Action: it.action, Invocation: it.inv, Timeout: timeout,
 	})
-	r.replyAndAudit(ctx, it.inv, it.channel, res)
+	r.replyAndAudit(ctx, it.inv, it.channel, res, it.action.MaxReplyLines)
 }
 
 // executeWithRecover invokes the executor with a panic guard so a
@@ -223,35 +224,44 @@ func (r *Runner) executeWithRecover(ctx context.Context, exe Executor, req ExecR
 // flow through the normal reply + audit pipeline without exercising
 // the per-Action queue or executor.
 func (r *Runner) Reply(ctx context.Context, inv Invocation, channel uint32, res Result) {
-	r.replyAndAudit(ctx, inv, channel, res)
+	r.replyAndAudit(ctx, inv, channel, res, 1)
 }
 
-func (r *Runner) replyAndAudit(ctx context.Context, inv Invocation, channel uint32, res Result) {
-	text, truncated := FormatReply(res)
+func (r *Runner) replyAndAudit(ctx context.Context, inv Invocation, channel uint32, res Result, maxLines int) {
+	if maxLines <= 0 {
+		maxLines = DefaultMaxReplyLines
+	}
+	lines, truncated := FormatReplies(res, maxLines)
 	if r.cfg.Replies != nil {
-		if err := r.cfg.Replies.SendReply(ctx, channel, inv.Source, inv.SenderCall, text); err != nil {
-			r.logger.Error("actions: reply send failed",
-				"action", inv.ActionName,
-				"sender", inv.SenderCall,
-				"status", string(res.Status),
-				"err", err)
+		for _, line := range lines {
+			if err := r.cfg.Replies.SendReply(ctx, channel, inv.Source, inv.SenderCall, line); err != nil {
+				r.logger.Error("actions: reply send failed",
+					"action", inv.ActionName,
+					"sender", inv.SenderCall,
+					"status", string(res.Status),
+					"err", err)
+				// Stop on first failure so we don't fan out further
+				// frames after a transport-level error.
+				break
+			}
 		}
 	}
 	if r.cfg.Audit != nil {
 		row := &configstore.ActionInvocation{
-			ActionNameAt:  inv.ActionName,
-			SenderCall:    inv.SenderCall,
-			Source:        string(inv.Source),
-			OTPVerified:   inv.OTPVerified,
-			RawArgsJSON:   marshalArgs(inv.Args),
-			Status:        string(res.Status),
-			StatusDetail:  res.StatusDetail,
-			ExitCode:      res.ExitCode,
-			HTTPStatus:    res.HTTPStatus,
-			OutputCapture: res.OutputCapture,
-			ReplyText:     text,
-			Truncated:     truncated,
-			CreatedAt:     r.now(),
+			ActionNameAt:   inv.ActionName,
+			SenderCall:     inv.SenderCall,
+			Source:         string(inv.Source),
+			OTPVerified:    inv.OTPVerified,
+			RawArgsJSON:    marshalArgs(inv.Args),
+			Status:         string(res.Status),
+			StatusDetail:   res.StatusDetail,
+			ExitCode:       res.ExitCode,
+			HTTPStatus:     res.HTTPStatus,
+			OutputCapture:  res.OutputCapture,
+			ReplyText:      strings.Join(lines, "\n"),
+			Truncated:      truncated,
+			ReplyLineCount: len(lines),
+			CreatedAt:      r.now(),
 		}
 		if inv.ActionID != 0 {
 			id := inv.ActionID

--- a/pkg/actions/runner.go
+++ b/pkg/actions/runner.go
@@ -232,7 +232,12 @@ func (r *Runner) replyAndAudit(ctx context.Context, inv Invocation, channel uint
 		maxLines = DefaultMaxReplyLines
 	}
 	lines, truncated := FormatReplies(res, maxLines)
+	// sent is the count of lines that actually made it onto the wire.
+	// When Replies is nil (audit-only test path) there is no transport
+	// to fail, so the audit row reflects the formatter's full output.
+	sent := len(lines)
 	if r.cfg.Replies != nil {
+		sent = 0
 		for _, line := range lines {
 			if err := r.cfg.Replies.SendReply(ctx, channel, inv.Source, inv.SenderCall, line); err != nil {
 				r.logger.Error("actions: reply send failed",
@@ -244,6 +249,7 @@ func (r *Runner) replyAndAudit(ctx context.Context, inv Invocation, channel uint
 				// frames after a transport-level error.
 				break
 			}
+			sent++
 		}
 	}
 	if r.cfg.Audit != nil {
@@ -260,7 +266,7 @@ func (r *Runner) replyAndAudit(ctx context.Context, inv Invocation, channel uint
 			OutputCapture:  res.OutputCapture,
 			ReplyText:      strings.Join(lines, "\n"),
 			Truncated:      truncated,
-			ReplyLineCount: len(lines),
+			ReplyLineCount: sent,
 			CreatedAt:      r.now(),
 		}
 		if inv.ActionID != 0 {

--- a/pkg/actions/runner_test.go
+++ b/pkg/actions/runner_test.go
@@ -273,3 +273,115 @@ func TestMarshalArgsFreeformKeepsFullCeiling(t *testing.T) {
 		t.Fatalf("freeform truncation: len=%d want %d", len(m[FreeformArgKey]), FreeformValueCeiling)
 	}
 }
+
+type staticExecutor struct{ res Result }
+
+func (s staticExecutor) Execute(_ context.Context, _ ExecRequest) Result { return s.res }
+
+func TestRunnerMultiLineDispatch(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	sink := &fakeReplySink{}
+	audit := &fakeAudit{}
+	reg := NewExecutorRegistry()
+	_ = reg.Register("command", staticExecutor{
+		res: Result{
+			Status:        StatusOK,
+			OutputCapture: "line one\nline two\nline three",
+		},
+	})
+
+	r := NewRunner(RunnerConfig{
+		Registry: reg, Replies: sink, Audit: audit,
+		Now: func() time.Time { return now },
+	})
+	defer r.Stop()
+
+	a := &configstore.Action{
+		ID: 1, Name: "MULTI", Type: "command", CommandPath: "/bin/true",
+		Enabled: true, MaxReplyLines: 3, QueueDepth: 0, TimeoutSec: 5,
+	}
+	r.Submit(context.Background(),
+		Invocation{ActionID: 1, ActionName: "MULTI", SenderCall: "N0CALL", Source: SourceRF},
+		a, 0)
+
+	waitFor(t, func() bool { return len(sink.snapshot()) == 3 })
+
+	got := sink.snapshot()
+	if got[0] != "ok: line one" {
+		t.Fatalf("call 0: %q", got[0])
+	}
+	if got[1] != "line two" {
+		t.Fatalf("call 1: %q", got[1])
+	}
+	if got[2] != "line three" {
+		t.Fatalf("call 2: %q", got[2])
+	}
+
+	if audit.count() != 1 {
+		t.Fatalf("want 1 audit row, got %d", audit.count())
+	}
+	audit.mu.Lock()
+	row := audit.rows[0]
+	audit.mu.Unlock()
+	if row.ReplyLineCount != 3 {
+		t.Fatalf("ReplyLineCount: want 3, got %d", row.ReplyLineCount)
+	}
+	if !strings.Contains(row.ReplyText, "\n") {
+		t.Fatalf("ReplyText should be newline-joined: %q", row.ReplyText)
+	}
+}
+
+func TestRunnerSingleLineDispatchUnchanged(t *testing.T) {
+	sink := &fakeReplySink{}
+	audit := &fakeAudit{}
+	reg := NewExecutorRegistry()
+	_ = reg.Register("command", staticExecutor{
+		res: Result{Status: StatusOK, OutputCapture: "lights on\nignored second line"},
+	})
+	r := NewRunner(RunnerConfig{Registry: reg, Replies: sink, Audit: audit})
+	defer r.Stop()
+
+	a := &configstore.Action{
+		ID: 2, Name: "SINGLE", Type: "command", CommandPath: "/bin/true",
+		Enabled: true, MaxReplyLines: 1, QueueDepth: 0, TimeoutSec: 5,
+	}
+	r.Submit(context.Background(), Invocation{
+		ActionID: 2, ActionName: "SINGLE", SenderCall: "N0CALL", Source: SourceRF,
+	}, a, 0)
+
+	waitFor(t, func() bool { return len(sink.snapshot()) == 1 && audit.count() == 1 })
+	got := sink.snapshot()
+	if got[0] != "ok: lights on" {
+		t.Fatalf("got %q", got[0])
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 reply, got %d", len(got))
+	}
+	audit.mu.Lock()
+	row := audit.rows[0]
+	audit.mu.Unlock()
+	if row.ReplyLineCount != 1 {
+		t.Fatalf("ReplyLineCount: want 1, got %d", row.ReplyLineCount)
+	}
+}
+
+func TestRunnerNonOKAlwaysSingleLine(t *testing.T) {
+	sink := &fakeReplySink{}
+	audit := &fakeAudit{}
+	r := NewRunner(RunnerConfig{Registry: NewExecutorRegistry(), Replies: sink, Audit: audit})
+	defer r.Stop()
+
+	a := &configstore.Action{
+		ID: 3, Name: "DIS", Type: "command", CommandPath: "/bin/true",
+		Enabled: false, MaxReplyLines: 5, QueueDepth: 0, TimeoutSec: 5,
+	}
+	r.Submit(context.Background(), Invocation{
+		ActionID: 3, ActionName: "DIS", SenderCall: "N0CALL", Source: SourceRF,
+	}, a, 0)
+
+	waitFor(t, func() bool { return len(sink.snapshot()) == 1 })
+	got := sink.snapshot()
+	if got[0] != "disabled" {
+		t.Fatalf("got %q", got[0])
+	}
+}

--- a/pkg/actions/runner_test.go
+++ b/pkg/actions/runner_test.go
@@ -351,7 +351,9 @@ func TestRunnerSingleLineDispatchUnchanged(t *testing.T) {
 
 	waitFor(t, func() bool { return len(sink.snapshot()) == 1 && audit.count() == 1 })
 	got := sink.snapshot()
-	if got[0] != "ok: lights on" {
+	// Single-line dispatch preserves legacy semantics: newlines in
+	// stdout collapse to spaces and the whole thing rides one frame.
+	if got[0] != "ok: lights on ignored second line" {
 		t.Fatalf("got %q", got[0])
 	}
 	if len(got) != 1 {
@@ -362,6 +364,77 @@ func TestRunnerSingleLineDispatchUnchanged(t *testing.T) {
 	audit.mu.Unlock()
 	if row.ReplyLineCount != 1 {
 		t.Fatalf("ReplyLineCount: want 1, got %d", row.ReplyLineCount)
+	}
+}
+
+// failingAfterReplySink rejects every line past the first, simulating a
+// transport that dies mid-burst. Used to pin "ReplyLineCount records
+// what actually went out, not the formatter's intent."
+type failingAfterReplySink struct {
+	mu      sync.Mutex
+	replies []string
+	limit   int
+}
+
+func (f *failingAfterReplySink) SendReply(_ context.Context, _ uint32, _ Source, _ string, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.replies) >= f.limit {
+		return errSinkClosed
+	}
+	f.replies = append(f.replies, text)
+	return nil
+}
+
+func (f *failingAfterReplySink) snapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.replies))
+	copy(out, f.replies)
+	return out
+}
+
+var errSinkClosed = &sinkError{msg: "transport closed"}
+
+type sinkError struct{ msg string }
+
+func (e *sinkError) Error() string { return e.msg }
+
+func TestRunnerReplyLineCountReflectsTransportFailure(t *testing.T) {
+	sink := &failingAfterReplySink{limit: 2}
+	audit := &fakeAudit{}
+	reg := NewExecutorRegistry()
+	_ = reg.Register("command", staticExecutor{
+		res: Result{Status: StatusOK, OutputCapture: "alpha\nbravo\ncharlie\ndelta"},
+	})
+	r := NewRunner(RunnerConfig{Registry: reg, Replies: sink, Audit: audit})
+	defer r.Stop()
+
+	a := &configstore.Action{
+		// MaxReplyLines=3 against 4-line source: formatter clips
+		// delta (Truncated=true), transport limit clips again to 2
+		// (ReplyLineCount=2). The two truncations are independent.
+		ID: 9, Name: "PARTIAL", Type: "command", CommandPath: "/bin/true",
+		Enabled: true, MaxReplyLines: 3, QueueDepth: 0, TimeoutSec: 5,
+	}
+	r.Submit(context.Background(), Invocation{
+		ActionID: 9, ActionName: "PARTIAL", SenderCall: "N0CALL", Source: SourceRF,
+	}, a, 0)
+
+	waitFor(t, func() bool { return audit.count() == 1 })
+	if got := len(sink.snapshot()); got != 2 {
+		t.Fatalf("transport dispatched %d, want 2", got)
+	}
+	audit.mu.Lock()
+	row := audit.rows[0]
+	audit.mu.Unlock()
+	if row.ReplyLineCount != 2 {
+		t.Fatalf("ReplyLineCount: want 2 (sent), got %d", row.ReplyLineCount)
+	}
+	// Truncated stays true because the formatter clipped 4 lines from
+	// the source — that fact is independent of the transport failure.
+	if !row.Truncated {
+		t.Fatalf("Truncated should reflect formatter clipping")
 	}
 }
 

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/chrissnell/graywolf/pkg/configstore"
@@ -254,23 +255,28 @@ func (s *Service) runTestFireExecutor(ctx context.Context, a *configstore.Action
 }
 
 func (s *Service) writeTestFireAudit(ctx context.Context, a *configstore.Action, kvs []KeyValue, res Result) uint {
-	text, truncated := FormatReply(res)
+	maxLines := a.MaxReplyLines
+	if maxLines <= 0 {
+		maxLines = DefaultMaxReplyLines
+	}
+	lines, truncated := FormatReplies(res, maxLines)
 	aid := a.ID
 	row := &configstore.ActionInvocation{
-		ActionID:      &aid,
-		ActionNameAt:  a.Name,
-		SenderCall:    TestFireSenderCall,
-		Source:        string(SourceRF),
-		OTPVerified:   false,
-		RawArgsJSON:   marshalArgs(kvs),
-		Status:        string(res.Status),
-		StatusDetail:  res.StatusDetail,
-		ExitCode:      res.ExitCode,
-		HTTPStatus:    res.HTTPStatus,
-		OutputCapture: res.OutputCapture,
-		ReplyText:     text,
-		Truncated:     truncated,
-		CreatedAt:     time.Now().UTC(),
+		ActionID:       &aid,
+		ActionNameAt:   a.Name,
+		SenderCall:     TestFireSenderCall,
+		Source:         string(SourceRF),
+		OTPVerified:    false,
+		RawArgsJSON:    marshalArgs(kvs),
+		Status:         string(res.Status),
+		StatusDetail:   res.StatusDetail,
+		ExitCode:       res.ExitCode,
+		HTTPStatus:     res.HTTPStatus,
+		OutputCapture:  res.OutputCapture,
+		ReplyText:      strings.Join(lines, "\n"),
+		Truncated:      truncated,
+		ReplyLineCount: len(lines),
+		CreatedAt:      time.Now().UTC(),
 	}
 	if err := s.store.InsertActionInvocation(ctx, row); err != nil {
 		s.logger.Error("actions: test-fire audit insert failed",

--- a/pkg/actions/service_test.go
+++ b/pkg/actions/service_test.go
@@ -280,6 +280,49 @@ func TestServiceTestFireRunsExecutorAndAudits(t *testing.T) {
 	}
 }
 
+func TestServiceTestFireMultiLineAudit(t *testing.T) {
+	store := newFakeServiceStore()
+	replies := newCapturingReplies()
+	tac := messages.NewTacticalSet()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc := newServiceForTest(ctx, store, replies, func() string { return "N0CALL" }, tac, nil)
+	defer svc.Stop()
+
+	if err := svc.Registry().Register("fake", &fakeExecutor{res: Result{
+		Status:        StatusOK,
+		OutputCapture: "alpha\nbravo\ncharlie",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &configstore.Action{
+		ID: 11, Name: "MULTI", Type: "fake",
+		Enabled: true, MaxReplyLines: 3, TimeoutSec: 5,
+	}
+	res, invID := svc.TestFire(ctx, a, nil)
+	if res.Status != StatusOK {
+		t.Fatalf("status: %s (%s)", res.Status, res.StatusDetail)
+	}
+	if invID == 0 {
+		t.Fatalf("expected non-zero invocation id")
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.invocations) != 1 {
+		t.Fatalf("want 1 audit row, got %d", len(store.invocations))
+	}
+	row := store.invocations[0]
+	if row.ReplyLineCount != 3 {
+		t.Fatalf("ReplyLineCount: want 3, got %d", row.ReplyLineCount)
+	}
+	want := "ok: alpha\nbravo\ncharlie"
+	if row.ReplyText != want {
+		t.Fatalf("ReplyText: want %q, got %q", want, row.ReplyText)
+	}
+}
+
 func TestServiceStopIsIdempotent(t *testing.T) {
 	store := newFakeServiceStore()
 	replies := newCapturingReplies()

--- a/pkg/configstore/migrate.go
+++ b/pkg/configstore/migrate.go
@@ -160,6 +160,10 @@ type migration struct {
 //	    outbound paths now treat action names case-insensitively and
 //	    normalize to uppercase on save; this backfills any pre-change
 //	    rows so case-normalized lookups still hit them.
+//	19 — actions_max_reply_lines: add actions.max_reply_lines and
+//	    action_invocations.reply_line_count columns. Defaults 1 so
+//	    existing rows behave identically to the single-reply era.
+//	    Both NOT NULL so application code never sees NULL.
 var schemaMigrations = []migration{
 	{version: 1, name: "beacon_compress_default", phase: postAutoMigrate, run: migrateBeaconCompressDefault},
 	{version: 2, name: "channel_device_fields", phase: preAutoMigrate, run: migrateChannelDeviceFields},
@@ -179,6 +183,7 @@ var schemaMigrations = []migration{
 	{version: 16, name: "remote_actions_tables", phase: postAutoMigrate, run: migrateRemoteActionsTables},
 	{version: 17, name: "actions_arg_mode", phase: postAutoMigrate, run: migrateActionsArgMode},
 	{version: 18, name: "actions_uppercase_names", phase: postAutoMigrate, run: migrateActionsUppercaseNames},
+	{version: 19, name: "actions_max_reply_lines", phase: postAutoMigrate, run: migrateActionsMaxReplyLines},
 }
 
 // runMigrations applies every pending migration in the given phase,

--- a/pkg/configstore/migrate_actions_max_reply_lines.go
+++ b/pkg/configstore/migrate_actions_max_reply_lines.go
@@ -1,0 +1,39 @@
+package configstore
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// migrateActionsMaxReplyLines adds two columns:
+//
+//   - actions.max_reply_lines: per-Action ceiling on the number of
+//     stdout lines that get sent as separate APRS messages on success.
+//     Default 1 preserves pre-change behavior. NOT NULL so the
+//     application layer never has to check a sentinel.
+//   - action_invocations.reply_line_count: how many lines were actually
+//     dispatched for the audit row. Default 1 backfills legacy rows.
+//
+// Idempotent in the same shape as migrateActionsArgMode: a column
+// probe via columnExists short-circuits the ALTER on rerun.
+func migrateActionsMaxReplyLines(tx *gorm.DB) error {
+	type colDef struct{ table, col, sql string }
+	defs := []colDef{
+		{"actions", "max_reply_lines", `ALTER TABLE actions ADD COLUMN max_reply_lines INTEGER NOT NULL DEFAULT 1`},
+		{"action_invocations", "reply_line_count", `ALTER TABLE action_invocations ADD COLUMN reply_line_count INTEGER NOT NULL DEFAULT 1`},
+	}
+	for _, d := range defs {
+		hasCol, err := columnExists(tx, d.table, d.col)
+		if err != nil {
+			return fmt.Errorf("probe %s.%s: %w", d.table, d.col, err)
+		}
+		if hasCol {
+			continue
+		}
+		if err := tx.Exec(d.sql).Error; err != nil {
+			return fmt.Errorf("add %s.%s: %w", d.table, d.col, err)
+		}
+	}
+	return nil
+}

--- a/pkg/configstore/migrate_actions_max_reply_lines_test.go
+++ b/pkg/configstore/migrate_actions_max_reply_lines_test.go
@@ -1,0 +1,79 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMigrateActionsMaxReplyLines(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	a := &Action{
+		Name:           "MULTILINE",
+		Type:           "command",
+		CommandPath:    "/bin/echo",
+		ArgSchema:      "[]",
+		ArgMode:        "kv",
+		WebhookHeaders: "{}",
+		TimeoutSec:     5,
+		Enabled:        true,
+	}
+	if err := s.CreateAction(ctx, a); err != nil {
+		t.Fatalf("create action: %v", err)
+	}
+
+	got, err := s.GetActionByName(ctx, "MULTILINE")
+	if err != nil {
+		t.Fatalf("get action: %v", err)
+	}
+	if got.MaxReplyLines != 1 {
+		t.Fatalf("default MaxReplyLines: want 1, got %d", got.MaxReplyLines)
+	}
+
+	got.MaxReplyLines = 3
+	if err := s.UpdateAction(ctx, got); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	again, err := s.GetActionByName(ctx, "MULTILINE")
+	if err != nil {
+		t.Fatalf("re-get: %v", err)
+	}
+	if again.MaxReplyLines != 3 {
+		t.Fatalf("MaxReplyLines round-trip: want 3, got %d", again.MaxReplyLines)
+	}
+
+	inv := &ActionInvocation{
+		ActionID:       &again.ID,
+		ActionNameAt:   again.Name,
+		SenderCall:     "N0CALL",
+		Source:         "rf",
+		Status:         "ok",
+		ReplyText:      "ok: a\nb\nc",
+		ReplyLineCount: 3,
+		CreatedAt:      time.Now(),
+	}
+	if err := s.InsertActionInvocation(ctx, inv); err != nil {
+		t.Fatalf("insert invocation: %v", err)
+	}
+
+	// Read back via the listing API to confirm gorm round-trips ReplyLineCount.
+	rows, err := s.ListActionInvocations(ctx, ActionInvocationFilter{Limit: 10})
+	if err != nil {
+		t.Fatalf("list invocations: %v", err)
+	}
+	var found *ActionInvocation
+	for i := range rows {
+		if rows[i].ID == inv.ID {
+			found = &rows[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("invocation row %d not in listing", inv.ID)
+	}
+	if found.ReplyLineCount != 3 {
+		t.Fatalf("ReplyLineCount round-trip: want 3, got %d", found.ReplyLineCount)
+	}
+}

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -840,6 +840,7 @@ type Action struct {
 	ArgMode             string `gorm:"size:16;not null;default:'kv'"`
 	RateLimitSec        int    `gorm:"not null;default:5"`
 	QueueDepth          int    `gorm:"not null;default:8"`
+	MaxReplyLines       int    `gorm:"not null;default:1"`
 	Enabled             bool   `gorm:"not null"`
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
@@ -899,5 +900,6 @@ type ActionInvocation struct {
 	OutputCapture   string `gorm:"type:text"`
 	ReplyText       string
 	Truncated       bool
+	ReplyLineCount  int       `gorm:"not null;default:1"`
 	CreatedAt       time.Time `gorm:"index"`
 }

--- a/pkg/releasenotes/notes.yaml
+++ b/pkg/releasenotes/notes.yaml
@@ -7,6 +7,25 @@
 # route the body references via [text](link) markdown; renderer only
 # accepts internal #/... routes.
 
+- version: "0.13.1"
+  date: "2026-05-05"
+  style: info
+  schema_version: 1
+  title: "Actions: longer replies across multiple APRS messages"
+  link: "#/actions"
+  body: |
+    An Action's reply can now span more than one APRS message. Open
+    an Action and set Max reply lines to anywhere from 1 to 5. Each
+    line of your script's output above the first is sent as its own
+    on-air message.
+
+    Heads up: every extra line is one more RF frame plus its own
+    ack and retries, so multi-message replies cost real airtime on
+    a shared channel. Keep the count low for chatty scripts.
+
+    Existing Actions are unchanged. They keep returning a single
+    line until you raise the limit yourself.
+
 - version: "0.13.0"
   date: "2026-05-03"
   style: info

--- a/pkg/webapi/action_invocations.go
+++ b/pkg/webapi/action_invocations.go
@@ -98,22 +98,27 @@ func (s *Server) clearActionInvocations(w http.ResponseWriter, r *http.Request) 
 }
 
 func invocationToDTO(row *configstore.ActionInvocation) dto.ActionInvocation {
+	count := row.ReplyLineCount
+	if count <= 0 {
+		count = 1
+	}
 	d := dto.ActionInvocation{
-		ID:            row.ID,
-		ActionID:      row.ActionID,
-		ActionName:    row.ActionNameAt,
-		SenderCall:    row.SenderCall,
-		Source:        row.Source,
-		OTPCredID:     row.OTPCredentialID,
-		OTPVerified:   row.OTPVerified,
-		Status:        row.Status,
-		StatusDetail:  row.StatusDetail,
-		ExitCode:      row.ExitCode,
-		HTTPStatus:    row.HTTPStatus,
-		OutputCapture: row.OutputCapture,
-		ReplyText:     row.ReplyText,
-		Truncated:     row.Truncated,
-		CreatedAt:     row.CreatedAt.UTC().Format(time.RFC3339),
+		ID:             row.ID,
+		ActionID:       row.ActionID,
+		ActionName:     row.ActionNameAt,
+		SenderCall:     row.SenderCall,
+		Source:         row.Source,
+		OTPCredID:      row.OTPCredentialID,
+		OTPVerified:    row.OTPVerified,
+		Status:         row.Status,
+		StatusDetail:   row.StatusDetail,
+		ExitCode:       row.ExitCode,
+		HTTPStatus:     row.HTTPStatus,
+		OutputCapture:  row.OutputCapture,
+		ReplyText:      row.ReplyText,
+		ReplyLineCount: count,
+		Truncated:      row.Truncated,
+		CreatedAt:      row.CreatedAt.UTC().Format(time.RFC3339),
 	}
 	if row.RawArgsJSON != "" {
 		_ = json.Unmarshal([]byte(row.RawArgsJSON), &d.Args)

--- a/pkg/webapi/action_invocations_test.go
+++ b/pkg/webapi/action_invocations_test.go
@@ -158,3 +158,45 @@ func TestInvocations_ArgsRoundtrip(t *testing.T) {
 		t.Fatalf("args lost on read: %+v", got)
 	}
 }
+
+func TestListActionInvocationsSurfacesReplyLineCount(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	row := &configstore.ActionInvocation{
+		ActionNameAt:   "MULTI",
+		SenderCall:     "N0CALL",
+		Source:         "rf",
+		Status:         "ok",
+		ReplyText:      "ok: alpha\nbravo\ncharlie\ndelta",
+		ReplyLineCount: 4,
+		CreatedAt:      time.Now(),
+	}
+	if err := srv.store.InsertActionInvocation(context.Background(), row); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/actions/invocations", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rr.Code, rr.Body.String())
+	}
+	var got []dto.ActionInvocation
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	var found *dto.ActionInvocation
+	for i := range got {
+		if got[i].ID == row.ID {
+			found = &got[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("inserted row %d not present in listing", row.ID)
+	}
+	if found.ReplyLineCount != 4 {
+		t.Fatalf("reply_line_count=%d, want 4", found.ReplyLineCount)
+	}
+}

--- a/pkg/webapi/action_test_fire.go
+++ b/pkg/webapi/action_test_fire.go
@@ -3,6 +3,7 @@ package webapi
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"gorm.io/gorm"
 
@@ -94,15 +95,21 @@ func (s *Server) testFireAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	res, invID := s.actions.TestFire(r.Context(), a, clean)
-	reply, truncated := actions.FormatReply(res)
+	maxLines := a.MaxReplyLines
+	if maxLines <= 0 {
+		maxLines = actions.DefaultMaxReplyLines
+	}
+	lines, truncated := actions.FormatReplies(res, maxLines)
 	writeJSON(w, http.StatusOK, dto.TestFireResponse{
-		Status:        string(res.Status),
-		StatusDetail:  res.StatusDetail,
-		OutputCapture: res.OutputCapture,
-		ReplyText:     reply,
-		Truncated:     truncated,
-		ExitCode:      res.ExitCode,
-		HTTPStatus:    res.HTTPStatus,
-		InvocationID:  invID,
+		Status:         string(res.Status),
+		StatusDetail:   res.StatusDetail,
+		OutputCapture:  res.OutputCapture,
+		ReplyText:      strings.Join(lines, "\n"),
+		ReplyLines:     lines,
+		ReplyLineCount: len(lines),
+		Truncated:      truncated,
+		ExitCode:       res.ExitCode,
+		HTTPStatus:     res.HTTPStatus,
+		InvocationID:   invID,
 	})
 }

--- a/pkg/webapi/action_test_fire_test.go
+++ b/pkg/webapi/action_test_fire_test.go
@@ -62,6 +62,31 @@ func makeTestFireAction(t *testing.T, mux *http.ServeMux) uint {
 	return got.ID
 }
 
+// makeTestFireActionWithMaxLines is like makeTestFireAction but
+// configures MaxReplyLines on the persisted Action so the handler can
+// emit multi-line replies.
+func makeTestFireActionWithMaxLines(t *testing.T, mux *http.ServeMux, maxLines int) uint {
+	t.Helper()
+	in := dto.Action{
+		Name: "tfm", Type: "webhook", WebhookMethod: "GET",
+		WebhookURL: "https://example.test/", TimeoutSec: 5,
+		Enabled:       true,
+		MaxReplyLines: maxLines,
+		ArgSchema:     []dto.ArgSpec{{Key: "k", MaxLen: 8}},
+	}
+	body, _ := json.Marshal(in)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/actions", bytes.NewReader(body)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rec.Code, rec.Body.String())
+	}
+	var got dto.Action
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	return got.ID
+}
+
 func TestFireAction_Success(t *testing.T) {
 	srv, _ := newTestServer(t)
 	mux := http.NewServeMux()
@@ -248,6 +273,45 @@ func TestFireAction_KVRejectsText(t *testing.T) {
 	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/actions/"+strconv.FormatUint(uint64(id), 10)+"/test-fire", body))
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status=%d body=%s, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+func TestFireAction_MultipleReplyLines(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	rec := &recordingTestFire{
+		invID: 7,
+		result: actions.Result{
+			Status:        actions.StatusOK,
+			OutputCapture: "alpha\nbravo\ncharlie",
+		},
+	}
+	srv.SetActionsService(rec)
+	id := makeTestFireActionWithMaxLines(t, mux, 3)
+
+	body := strings.NewReader(`{"args":{"k":"v"}}`)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodPost,
+		"/api/actions/"+strconv.FormatUint(uint64(id), 10)+"/test-fire", body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var got dto.TestFireResponse
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ReplyLineCount != 3 {
+		t.Fatalf("ReplyLineCount=%d, want 3", got.ReplyLineCount)
+	}
+	if len(got.ReplyLines) != 3 {
+		t.Fatalf("ReplyLines len=%d, want 3", len(got.ReplyLines))
+	}
+	if got.ReplyLines[0] != "ok: alpha" || got.ReplyLines[1] != "bravo" || got.ReplyLines[2] != "charlie" {
+		t.Fatalf("ReplyLines: %#v", got.ReplyLines)
+	}
+	if got.ReplyText != "ok: alpha\nbravo\ncharlie" {
+		t.Fatalf("ReplyText=%q", got.ReplyText)
 	}
 }
 

--- a/pkg/webapi/actions.go
+++ b/pkg/webapi/actions.go
@@ -274,6 +274,15 @@ func validateAction(in *dto.Action) error {
 	if in.QueueDepth < 0 {
 		return errors.New("queue_depth: must be >= 0")
 	}
+	if in.MaxReplyLines < 0 {
+		return errors.New("max_reply_lines: must be >= 0")
+	}
+	if in.MaxReplyLines == 0 {
+		in.MaxReplyLines = 1
+	}
+	if in.MaxReplyLines > actions.MaxReplyLinesCeiling {
+		return fmt.Errorf("max_reply_lines: must be <= %d", actions.MaxReplyLinesCeiling)
+	}
 	if in.OTPRequired && in.OTPCredentialID == nil {
 		// The runner would surface StatusNoCredential at dispatch time;
 		// reject at save time so the operator sees the misconfiguration
@@ -400,7 +409,11 @@ func actionToDTO(a *configstore.Action) dto.Action {
 		ArgMode:             a.ArgMode,
 		RateLimitSec:        a.RateLimitSec,
 		QueueDepth:          a.QueueDepth,
+		MaxReplyLines:       a.MaxReplyLines,
 		Enabled:             a.Enabled,
+	}
+	if d.MaxReplyLines == 0 {
+		d.MaxReplyLines = 1
 	}
 	if d.ArgMode == "" {
 		d.ArgMode = "kv"
@@ -452,6 +465,7 @@ func actionFromDTO(d *dto.Action) (*configstore.Action, error) {
 		ArgMode:             d.ArgMode,
 		RateLimitSec:        d.RateLimitSec,
 		QueueDepth:          d.QueueDepth,
+		MaxReplyLines:       d.MaxReplyLines,
 		Enabled:             d.Enabled,
 	}, nil
 }

--- a/pkg/webapi/actions_test.go
+++ b/pkg/webapi/actions_test.go
@@ -466,3 +466,46 @@ func TestValidateActionRejectsArgKeyInKVMode(t *testing.T) {
 		t.Fatal("expected error: 'arg' reserved in kv mode")
 	}
 }
+
+func TestValidateActionMaxReplyLinesCeiling(t *testing.T) {
+	cases := []struct {
+		name    string
+		max     int
+		wantErr bool
+	}{
+		{"zero coerces", 0, false},
+		{"one ok", 1, false},
+		{"five ok (ceiling)", 5, false},
+		{"six rejected", 6, true},
+		{"negative rejected", -1, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			in := validBaseAction(t)
+			in.MaxReplyLines = c.max
+			err := validateAction(&in)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("max=%d: err=%v, wantErr=%v", c.max, err, c.wantErr)
+			}
+			if c.max == 0 && err == nil && in.MaxReplyLines != 1 {
+				t.Fatalf("expected coercion to 1, got %d", in.MaxReplyLines)
+			}
+		})
+	}
+}
+
+func TestActionRoundTripMaxReplyLines(t *testing.T) {
+	d := validBaseAction(t)
+	d.MaxReplyLines = 3
+	model, err := actionFromDTO(&d)
+	if err != nil {
+		t.Fatalf("from dto: %v", err)
+	}
+	if model.MaxReplyLines != 3 {
+		t.Fatalf("model.MaxReplyLines: want 3, got %d", model.MaxReplyLines)
+	}
+	back := actionToDTO(model)
+	if back.MaxReplyLines != 3 {
+		t.Fatalf("dto.MaxReplyLines: want 3, got %d", back.MaxReplyLines)
+	}
+}

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -7637,6 +7637,9 @@
                 "last_invoked_by": {
                     "type": "string"
                 },
+                "max_reply_lines": {
+                    "type": "integer"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -7717,6 +7720,9 @@
                 },
                 "output_capture": {
                     "type": "string"
+                },
+                "reply_line_count": {
+                    "type": "integer"
                 },
                 "reply_text": {
                     "type": "string"
@@ -9682,6 +9688,15 @@
                 },
                 "output_capture": {
                     "type": "string"
+                },
+                "reply_line_count": {
+                    "type": "integer"
+                },
+                "reply_lines": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "reply_text": {
                     "type": "string"

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -585,6 +585,8 @@ definitions:
         type: string
       last_invoked_by:
         type: string
+      max_reply_lines:
+        type: integer
       name:
         type: string
       otp_credential_id:
@@ -639,6 +641,8 @@ definitions:
         type: boolean
       output_capture:
         type: string
+      reply_line_count:
+        type: integer
       reply_text:
         type: string
       sender_call:
@@ -2058,6 +2062,12 @@ definitions:
         type: integer
       output_capture:
         type: string
+      reply_line_count:
+        type: integer
+      reply_lines:
+        items:
+          type: string
+        type: array
       reply_text:
         type: string
       status:

--- a/pkg/webapi/dto/actions.go
+++ b/pkg/webapi/dto/actions.go
@@ -27,6 +27,7 @@ type Action struct {
 	ArgMode             string            `json:"arg_mode"` // "kv" (default) | "freeform"
 	RateLimitSec        int               `json:"rate_limit_sec"`
 	QueueDepth          int               `json:"queue_depth"`
+	MaxReplyLines       int               `json:"max_reply_lines"`
 	Enabled             bool              `json:"enabled"`
 	LastInvokedAt       *string           `json:"last_invoked_at,omitempty"`
 	LastInvokedBy       string            `json:"last_invoked_by,omitempty"`
@@ -76,22 +77,23 @@ type ActionListenerAddressee struct {
 
 // ActionInvocation is one audit row.
 type ActionInvocation struct {
-	ID            uint              `json:"id"`
-	ActionID      *uint             `json:"action_id,omitempty"`
-	ActionName    string            `json:"action_name"`
-	SenderCall    string            `json:"sender_call"`
-	Source        string            `json:"source"`
-	OTPCredID     *uint             `json:"otp_credential_id,omitempty"`
-	OTPVerified   bool              `json:"otp_verified"`
-	Args          map[string]string `json:"args"`
-	Status        string            `json:"status"`
-	StatusDetail  string            `json:"status_detail,omitempty"`
-	ExitCode      *int              `json:"exit_code,omitempty"`
-	HTTPStatus    *int              `json:"http_status,omitempty"`
-	OutputCapture string            `json:"output_capture,omitempty"`
-	ReplyText     string            `json:"reply_text"`
-	Truncated     bool              `json:"truncated"`
-	CreatedAt     string            `json:"created_at"`
+	ID             uint              `json:"id"`
+	ActionID       *uint             `json:"action_id,omitempty"`
+	ActionName     string            `json:"action_name"`
+	SenderCall     string            `json:"sender_call"`
+	Source         string            `json:"source"`
+	OTPCredID      *uint             `json:"otp_credential_id,omitempty"`
+	OTPVerified    bool              `json:"otp_verified"`
+	Args           map[string]string `json:"args"`
+	Status         string            `json:"status"`
+	StatusDetail   string            `json:"status_detail,omitempty"`
+	ExitCode       *int              `json:"exit_code,omitempty"`
+	HTTPStatus     *int              `json:"http_status,omitempty"`
+	OutputCapture  string            `json:"output_capture,omitempty"`
+	ReplyText      string            `json:"reply_text"`
+	ReplyLineCount int               `json:"reply_line_count"`
+	Truncated      bool              `json:"truncated"`
+	CreatedAt      string            `json:"created_at"`
 }
 
 // TestFireRequest is the body accepted by POST /api/actions/{id}/test-fire.
@@ -110,12 +112,14 @@ type TestFireRequest struct {
 // real on-air invocation, so the UI can warn the operator that their
 // reply got chopped to fit the 67-char APRS message cap.
 type TestFireResponse struct {
-	Status        string `json:"status"`
-	StatusDetail  string `json:"status_detail,omitempty"`
-	OutputCapture string `json:"output_capture,omitempty"`
-	ReplyText     string `json:"reply_text"`
-	Truncated     bool   `json:"truncated"`
-	ExitCode      *int   `json:"exit_code,omitempty"`
-	HTTPStatus    *int   `json:"http_status,omitempty"`
-	InvocationID  uint   `json:"invocation_id"`
+	Status         string   `json:"status"`
+	StatusDetail   string   `json:"status_detail,omitempty"`
+	OutputCapture  string   `json:"output_capture,omitempty"`
+	ReplyText      string   `json:"reply_text"`
+	ReplyLines     []string `json:"reply_lines"`
+	ReplyLineCount int      `json:"reply_line_count"`
+	Truncated      bool     `json:"truncated"`
+	ExitCode       *int     `json:"exit_code,omitempty"`
+	HTTPStatus     *int     `json:"http_status,omitempty"`
+	InvocationID   uint     `json:"invocation_id"`
 }

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2018,6 +2018,7 @@ export interface components {
             id?: number;
             last_invoked_at?: string;
             last_invoked_by?: string;
+            max_reply_lines?: number;
             name?: string;
             otp_credential_id?: number;
             otp_required?: boolean;
@@ -2048,6 +2049,7 @@ export interface components {
             otp_credential_id?: number;
             otp_verified?: boolean;
             output_capture?: string;
+            reply_line_count?: number;
             reply_text?: string;
             sender_call?: string;
             source?: string;
@@ -2898,6 +2900,8 @@ export interface components {
             http_status?: number;
             invocation_id?: number;
             output_capture?: string;
+            reply_line_count?: number;
+            reply_lines?: string[];
             reply_text?: string;
             status?: string;
             status_detail?: string;

--- a/web/src/components/actions/EditActionModal.svelte
+++ b/web/src/components/actions/EditActionModal.svelte
@@ -43,6 +43,7 @@
       arg_mode: 'kv',
       rate_limit_sec: 5,
       queue_depth: 8,
+      max_reply_lines: 1,
       enabled: true,
     };
   }
@@ -213,6 +214,10 @@
     out.timeout_sec = Number(out.timeout_sec) || 10;
     out.rate_limit_sec = Number(out.rate_limit_sec) || 0;
     out.queue_depth = Number(out.queue_depth) || 0;
+    let maxLines = Number(out.max_reply_lines);
+    if (!Number.isFinite(maxLines) || maxLines < 1) maxLines = 1;
+    if (maxLines > 5) maxLines = 5;
+    out.max_reply_lines = maxLines;
     return out;
   }
 
@@ -233,6 +238,7 @@
         'webhook_method', 'webhook_url', 'webhook_body_template',
         'timeout_sec', 'otp_required', 'otp_credential_id',
         'sender_allowlist', 'arg_schema', 'arg_mode', 'rate_limit_sec', 'queue_depth',
+        'max_reply_lines',
       ];
       if (known.includes(field)) {
         // Preserve the original index in the error text so the operator
@@ -605,6 +611,28 @@
               read-only commands).
             </p>
           </div>
+
+          <div class="field narrow">
+            <label for="action-max-reply-lines">Max reply lines</label>
+            <Input
+              id="action-max-reply-lines"
+              type="number"
+              min="1"
+              max="5"
+              bind:value={form.max_reply_lines}
+              class={fieldErrors.max_reply_lines ? 'field-invalid' : ''}
+            />
+            <p class="hint">
+              Maximum number of stdout lines this Action's command may
+              return as separate APRS messages. Default 1. Hard ceiling 5.
+              <strong>Each line is one extra RF frame plus its own ack
+              and retries</strong> — keep this at 1 unless your script
+              genuinely needs to reply with multiple short messages.
+            </p>
+            {#if fieldErrors.max_reply_lines}
+              <p class="field-error">{fieldErrors.max_reply_lines}</p>
+            {/if}
+          </div>
         </div>
       </section>
 
@@ -620,7 +648,7 @@
           <div class="field">
             <span class="label">Reply policy</span>
             <p class="readonly-summary">
-              Always replies; reply may include the first ~50 chars of stdout/response.
+              Always replies. Up to {form.max_reply_lines} APRS message{form.max_reply_lines === 1 ? '' : 's'} per invocation; each line is capped at 67 characters.
             </p>
           </div>
         </div>

--- a/web/src/components/actions/InvocationsPanel.svelte
+++ b/web/src/components/actions/InvocationsPanel.svelte
@@ -195,6 +195,9 @@
               </td>
               <td>
                 {#if detail}
+                  {#if inv.reply_line_count > 1}
+                    <span class="msg-count" title="{inv.reply_line_count} APRS messages">×{inv.reply_line_count}</span>
+                  {/if}
                   <button
                     type="button"
                     class="detail"
@@ -292,5 +295,15 @@
   .muted {
     color: var(--text-muted);
     font-size: 12px;
+  }
+  .msg-count {
+    display: inline-block;
+    margin-right: 4px;
+    padding: 0 5px;
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--color-accent, var(--color-primary, #6366f1));
+    background: var(--accent-bg, rgba(99, 102, 241, 0.1));
+    border-radius: 3px;
   }
 </style>

--- a/web/src/components/actions/TestActionDialog.svelte
+++ b/web/src/components/actions/TestActionDialog.svelte
@@ -168,7 +168,14 @@
         {/if}
         <div class="result-row stacked">
           <span class="result-label">Reply</span>
-          <pre class="block reply" class:truncated={result.truncated}>{result.reply_text || '(no reply text)'}</pre>
+          <div class="reply-block">
+            {#if result.reply_line_count > 1}
+              <p class="reply-meta">
+                <strong>{result.reply_line_count}</strong> APRS messages will be sent (one per line)
+              </p>
+            {/if}
+            <pre class="block reply" class:truncated={result.truncated}>{result.reply_text || '(no reply text)'}</pre>
+          </div>
           {#if result.truncated}
             <span class="hint">Trimmed to fit the 67-char APRS reply cap.</span>
           {/if}
@@ -370,5 +377,13 @@
   :global(.test-action-dialog) {
     max-width: 560px;
     width: calc(100% - 32px);
+  }
+  .reply-meta {
+    margin: 0 0 4px;
+    font-size: 11px;
+    color: var(--color-text-muted, var(--text-muted));
+  }
+  .reply-meta strong {
+    color: var(--color-accent, var(--color-primary, #6366f1));
   }
 </style>


### PR DESCRIPTION
## Summary

Lets an Action's reply span more than one APRS message. Adds a per-Action **Max reply lines** knob (default 1, hard ceiling 5). Each non-empty stdout line above the first rides its own outbound APRS frame, capped at 67 runes per line; the `ok:` prefix only rides frame 1. Failure statuses always collapse to a single frame. Lines past the cap are silently dropped and `Truncated` is set on the audit row.

The ceiling exists because every extra line costs one RF frame plus its own ack and retries on a shared channel — multi-line is for cases where the operator genuinely needs structured output (a multi-field weather summary, a short status block), not chatter.

## What changed

- **Formatter** (`pkg/actions/reply.go`): new `FormatReplies(r, maxLines)` — clamp at `MaxReplyLinesCeiling` at the dispatch chokepoint (defense in depth past the validator), legacy single-line semantics preserved bug-for-bug for `MaxReplyLines=1` so existing Actions don't change.
- **Schema** (`pkg/configstore/`, migration 19): new `Action.MaxReplyLines` and `ActionInvocation.ReplyLineCount` columns, NOT NULL DEFAULT 1, idempotent migration.
- **Runner** (`pkg/actions/runner.go`): per-line dispatch loop preserves source-aware-transport invariants (each frame builds its own `SendMessageRequest`, so RF/IS routing, msg-id, ack ladder, and `FallbackPolicyOverride` apply per line). `ReplyLineCount` records lines that actually reached the transport (a transport failure mid-burst lowers the count); `Truncated` records formatter-side clipping independently.
- **REST + DTO** (`pkg/webapi/`): `Action.max_reply_lines` round-trips through CRUD with bounds-check validation; test-fire returns the full reply slice; invocations listing exposes `reply_line_count`.
- **UI** (`web/src/components/actions/`): Edit dialog grows a Max reply lines field with the airtime warning hint; Test dialog and Recent Invocations panel surface a multi-message badge / line count.
- **Docs**: wiki (`docs/wiki/actions.md`), operator handbook (`docs/handbook/actions.html` plus the handler-safety subpages), and the `writing-graywolf-action-handlers` skill all updated to teach the new knob with consistent "default to one line; raise it only when the airtime is justified" framing.
- **Release note**: `pkg/releasenotes/notes.yaml` carries a `0.13.1` info-style entry for operators.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./pkg/actions/... ./pkg/webapi/... ./pkg/configstore/... ./pkg/releasenotes/...` green (with `-count=1`)
- [x] `web` build clean
- [x] Boundary tests pin 67/68-rune line clamp and the ceiling clamp
- [x] Partial-failure runner test pins `ReplyLineCount` = lines actually transmitted, independent of formatter `Truncated`
- [ ] Manual smoke through the Test dialog with `Max reply lines = 1` (legacy path) and `= 3` (multi-frame path)
- [ ] Watch a real RF round-trip on a station once merged (operator step)