### PR TITLE
fix(aprs): reject DEL sentinel + post-offset overflow in Mic-E lon (#76)

### DIFF
--- a/pkg/aprs/mice.go
+++ b/pkg/aprs/mice.go
@@ -323,15 +323,16 @@ func isMicEHighBit(c byte) bool {
 	return false
 }
 
-// ErrMicELonAmbiguous reports that one of the three longitude bytes is a
-// SPACE (0x20), which APRS101 ch 10 reserves as the "no/ambiguous data"
-// marker for the Mic-E info-field longitude field. Some encoders (Yaesu
-// FT-2D/FT-3D, Kenwood TH-D72) emit this state before GPS lock; the
-// receiver MUST NOT combine the SPACE byte with the destination's
-// longitude offset bit and pretend the result is a position. parseMicE
-// surfaces this as a warn-and-drop rather than plotting the station
-// 8000+ km from its actual location.
-var ErrMicELonAmbiguous = errors.New("mic-e: longitude ambiguous (SPACE in info field)")
+// ErrMicELonAmbiguous reports that the Mic-E info-field longitude
+// decodes to an invalid value: either one of the three bytes is a
+// "no data" sentinel (0x20 SPACE or 0x7f DEL — both observed in the
+// wild from Yaesu / Kenwood / PicoAPRS firmware that beacons before
+// GPS lock), or the degrees byte combined with the destination's
+// +100° longitude offset bit yields a value outside the 0..179°
+// range the spec allows. The receiver MUST NOT plot any of these
+// states; doing so drops the station thousands of km from its real
+// position. parseMicE surfaces this as a warn-and-drop.
+var ErrMicELonAmbiguous = errors.New("mic-e: longitude ambiguous or out of range")
 
 // decodeMicELon decodes the 3-byte info-field longitude into decimal
 // degrees and applies the offset / hemisphere.
@@ -342,11 +343,15 @@ func decodeMicELon(b []byte, offset int, sign float64) (float64, error) {
 	// APRS101 ch 10: a SPACE (0x20) in any of the three longitude
 	// bytes flags that field as unknown — the convention used when GPS
 	// has not locked or the encoder is otherwise unwilling to assert a
-	// value. Combining it with the dest-byte-4 +100° offset would
-	// otherwise yield lon = (b[0]-28)+100 = 104° from a 0x20 byte and
-	// drop a German station onto Mongolia.
-	if b[0] == ' ' || b[1] == ' ' || b[2] == ' ' {
-		return 0, ErrMicELonAmbiguous
+	// value. Some firmware (PicoAPRS, certain Yaesu builds) uses DEL
+	// (0x7f) for the same purpose; both must be rejected. Combining
+	// either with the dest-byte-4 +100° offset would otherwise yield
+	// nonsense longitudes (104°E from a SPACE byte; 199° from a DEL
+	// byte → wraps to ~-161° and drops a German station off Alaska).
+	for _, c := range b[:3] {
+		if c == ' ' || c == 0x7f {
+			return 0, ErrMicELonAmbiguous
+		}
 	}
 	// Degrees byte (0x1C..0x7F after +28 offset).
 	d := int(b[0]) - 28
@@ -359,6 +364,14 @@ func decodeMicELon(b []byte, offset int, sign float64) (float64, error) {
 		return 0, errors.New("mic-e: lon degrees range")
 	}
 	d += offset
+	// Belt and suspenders: even with both bytes individually in range,
+	// the spec only allows a final degrees value in 0..179. A radio
+	// that asserts the +100° offset bit while encoding a degrees byte
+	// in 80..99 (raw) produces 180..199 and would otherwise be plotted
+	// past the antimeridian on the wrong side of the planet.
+	if d > 179 {
+		return 0, ErrMicELonAmbiguous
+	}
 
 	m := int(b[1]) - 28
 	if m >= 60 {

--- a/pkg/aprs/mice_test.go
+++ b/pkg/aprs/mice_test.go
@@ -152,6 +152,81 @@ func TestParseMicEAmbiguousLonRejected(t *testing.T) {
 	}
 }
 
+// TestParseMicEDelInLonRejected covers a pattern reported in graywolf
+// issue #76: PicoAPRS-class hardware (DL8XI, DL9DAK, others) emits
+// 0x7f (DEL) in the Mic-E info-field longitude when GPS has not yet
+// locked, while still asserting the destination's +100° offset bit.
+// Raw lon byte 0 = 0x7f → d = 99; combined with offset 100 → 199°,
+// which wraps to ~-161° and drops a German station off Alaska. The
+// SPACE (0x20) check from the previous fix did not catch it.
+func TestParseMicEDelInLonRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		dest string
+		info []byte
+	}{
+		{
+			// 2026-05-05 DL9DAK>U3SUY8: '<7f>Uhl <1c>-/>
+			name: "DL9DAK",
+			src:  "DL9DAK",
+			dest: "U3SUY8",
+			info: []byte{'\'', 0x7f, 'U', 'h', 'l', 0x20, 0x1c, '-', '/', '>'},
+		},
+		{
+			// 2026-05-05 DL8XI>US3XQ4: `<7f>(<7f>l<1f>L-/"3u}Ingo
+			name: "DL8XI",
+			src:  "DL8XI",
+			dest: "US3XQ4",
+			info: []byte{'`', 0x7f, '(', 0x7f, 'l', 0x1f, 'L', '-', '/', '"', '3', 'u', '}'},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srcAddr, err := ax25.ParseAddress(tc.src)
+			if err != nil {
+				t.Fatal(err)
+			}
+			destAddr, err := ax25.ParseAddress(tc.dest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f, err := ax25.NewUIFrame(srcAddr, destAddr, nil, tc.info)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pkt, err := Parse(f)
+			if err == nil {
+				t.Fatalf("expected error, got pkt %+v", pkt.MicE)
+			}
+			if !errors.Is(err, ErrMicELonAmbiguous) {
+				t.Fatalf("wrong error: %v (want ErrMicELonAmbiguous)", err)
+			}
+		})
+	}
+}
+
+// TestParseMicELonOverflowRejected covers the post-offset range guard
+// independently of the sentinel-byte check. A radio that encodes raw
+// degrees 80..99 with the +100° offset bit set produces 180..199 — a
+// value the spec does not allow. Reject rather than wrap to the
+// antimeridian.
+func TestParseMicELonOverflowRejected(t *testing.T) {
+	srcAddr, _ := ax25.ParseAddress("N0CALL")
+	destAddr, _ := ax25.ParseAddress("U3SUY8") // offset bit set on dest[4]='Y'
+	// Raw degrees byte = 80 + 28 = 108 ('l'). With offset +100 = 180,
+	// out of range. Use printable bytes so the sentinel check does not
+	// fire first.
+	info := []byte{'`', 'l', 'A', 'A', 'A', 'A', 'A', '-', '/'}
+	f, err := ax25.NewUIFrame(srcAddr, destAddr, nil, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Parse(f); !errors.Is(err, ErrMicELonAmbiguous) {
+		t.Fatalf("wrong error: %v", err)
+	}
+}
+
 func abs(x float64) float64 {
 	if x < 0 {
 		return -x


### PR DESCRIPTION
Closes #76.

## Problem

Issue reporter sees German stations (DL8XI, DL9DAK, SM5WXF, DK1JAN-7, DF9EU-6) plotted ~8000 km from their actual location, off the Aleutians. The previous Mic-E fix ([ae09632](https://github.com/chrissnell/graywolf/commit/ae09632)) caught one cause (SPACE in the info-field longitude bytes) but misses a second one observed in the wild.

## Root cause

Two real packets captured 2026-05-05:

```
DL9DAK>U3SUY8,...:'<7f>Uhl <1c>-/>
DL8XI>US3XQ4,...:`<7f>(<7f>l<1f>L-/"3u}Ingo
```

Both encode `0x7f` (DEL) in the Mic-E info-field longitude byte 0. The destination's `Y` / `Q` at byte 4 sets the +100° longitude offset bit. Math:

| step | DL9DAK | DL8XI |
|---|---|---|
| raw byte | `0x7f` (127) | `0x7f` (127) |
| `byte - 28` | 99 | 99 |
| in 0..179? | yes (passes existing range check) | yes |
| `+ offset` | 99 + 100 = **199** | 99 + 100 = **199** |
| with minutes/hundredths | 199.96° | 199.21° |
| wraps to | **−160.04°** | **−160.79°** |

That puts both stations off the Alaska coast.

PicoAPRS-class firmware (DL8XI announces "PicoAPRS - World's smallest APRS Transceiver" in its `>` packets) uses `0x7f` as the "no GPS lock yet" sentinel — same role SPACE plays in older Yaesu / Kenwood firmware. Both should be rejected before they reach the position store.

## Fix

`pkg/aprs/mice.go` `decodeMicELon`:
- Sentinel check now matches both `0x20` (SPACE) and `0x7f` (DEL) on any of the three longitude bytes.
- Adds a post-offset range guard: even when each byte is individually in spec, a raw degrees byte in 80..99 combined with the +100° offset yields 180..199 — out of the 0..179° range the spec allows — and is rejected as `ErrMicELonAmbiguous` rather than wrapping past the antimeridian.

`ErrMicELonAmbiguous` description updated; the existing single-purpose error gets reused for the broader "ambiguous or out of range" set.

## Test plan

- [x] `go test -count=1 ./pkg/aprs/...` green
- [x] `go vet ./...` clean
- [x] Two new tests carry the literal info-field bytes from the captured DL9DAK and DL8XI packets and assert `errors.Is(err, ErrMicELonAmbiguous)`
- [x] Synthetic post-offset overflow test pins the second guard independently of the sentinel check
- [ ] Reviewer to confirm reporter's stations fall off the map after upgrade (operator step)

## Release note

Operator-facing fix — needs a `notes.yaml` entry at release time (style: info, link `#/map`, body explaining "ghost German stations off Alaska are gone after upgrade; existing bad rows still need to age out of the station history DB or be cleared manually"). Did not preempt the version number; the multi-line replies branch (#75) is also pending and version sequencing depends on merge order.