### PR TITLE
feat(actions/weather): show resolved city name and handle unknown loc…

### DIFF
--- a/examples/actions/posix/weather-freeform.sh
+++ b/examples/actions/posix/weather-freeform.sh
@@ -59,7 +59,7 @@ encoded=$(printf '%s' "$location" | tr ' ' '+')
 # &u forces USCS units. wttr.in returns HTTP 500 with body "location not
 # found: location not found" for unknown ICAO/ZIP, so capture status.
 url="https://wttr.in/${encoded}?format=j1&u"
-raw=$(curl -sSL --max-time 8 -w $'\n__HTTP__%{http_code}' "$url") \
+raw=$(curl -sSL --max-time 8 -w $'\n__HTTP__%{http_code}' -- "$url") \
     || { echo "fetch failed" >&2; exit 1; }
 status="${raw##*__HTTP__}"
 body="${raw%$'\n'__HTTP__*}"

--- a/examples/actions/posix/weather-freeform.sh
+++ b/examples/actions/posix/weather-freeform.sh
@@ -27,7 +27,7 @@
 #        Line 2: "wind <dir><speed>mph hum <hum>% <pressure>hPa"
 #        Unknown location -> single-line helpful message.
 # Source: wttr.in (free, no key, worldwide).
-# Deps:   curl, awk, sed (all standard POSIX)
+# Deps:   curl, jq
 
 set -euo pipefail
 
@@ -55,9 +55,9 @@ if [[ ! "$location" =~ ^[A-Za-z0-9.,_\ -]+$ ]]; then
 fi
 encoded=$(printf '%s' "$location" | tr ' ' '+')
 
-# j1 returns pretty-printed JSON: current_condition + nearest_area
-# (resolved city). &u forces USCS units. wttr.in returns HTTP 500 with
-# body "location not found: location not found" for unknown ICAO/ZIP.
+# j1 returns full JSON: current_condition + nearest_area (resolved city).
+# &u forces USCS units. wttr.in returns HTTP 500 with body "location not
+# found: location not found" for unknown ICAO/ZIP, so capture status.
 url="https://wttr.in/${encoded}?format=j1&u"
 raw=$(curl -sSL --max-time 8 -w $'\n__HTTP__%{http_code}' "$url") \
     || { echo "fetch failed" >&2; exit 1; }
@@ -73,44 +73,20 @@ if [[ "$status" != "200" ]]; then
     exit 1
 fi
 
-# Pull a top-level scalar string out of wttr.in's pretty-printed JSON.
-# Each scalar sits on its own line as: `    "key": "value",`. The first
-# match wins; current_condition is emitted before forecast sections, so
-# fields like "humidity" / "pressure" resolve to the current values.
-scalar() {
-    awk -v k="\"$1\":" '
-        index($0, k) {
-            sub(/^[^"]*"[^"]*":[[:space:]]*"/, "")
-            sub(/".*$/, "")
-            print
-            exit
-        }
-    ' <<<"$body"
-}
+# Pull the seven fields we need as a single tab-separated line.
+parsed=$(printf '%s' "$body" | jq -r '
+    [
+      (.nearest_area[0].areaName[0].value     // ""),
+      (.current_condition[0].weatherDesc[0].value // ""),
+      (.current_condition[0].temp_F           // ""),
+      (.current_condition[0].winddir16Point   // ""),
+      (.current_condition[0].windspeedMiles   // ""),
+      (.current_condition[0].humidity         // ""),
+      (.current_condition[0].pressure         // "")
+    ] | @tsv
+') || { echo "parse failed" >&2; exit 1; }
 
-# Pull the first {"value": "..."} child of an array key (e.g. weatherDesc
-# inside current_condition, or areaName inside nearest_area). Anchor on
-# the parent so we skip unrelated "value" lines.
-nested_value() {
-    awk -v parent="\"$1\":" -v section="\"$2\":" '
-        index($0, parent) { in_p = 1 }
-        in_p && index($0, section) { in_s = 1; next }
-        in_s && /"value"[[:space:]]*:/ {
-            sub(/^[^"]*"value"[[:space:]]*:[[:space:]]*"/, "")
-            sub(/".*$/, "")
-            print
-            exit
-        }
-    ' <<<"$body"
-}
-
-city=$(nested_value nearest_area areaName)
-desc=$(nested_value current_condition weatherDesc)
-tF=$(scalar temp_F)
-wd=$(scalar winddir16Point)
-ws=$(scalar windspeedMiles)
-hum=$(scalar humidity)
-pr=$(scalar pressure)
+IFS=$'\t' read -r city desc tF wd ws hum pr <<<"$parsed"
 
 if [[ -z "$desc" || -z "$tF" ]]; then
     echo "$location: no data"

--- a/examples/actions/posix/weather-freeform.sh
+++ b/examples/actions/posix/weather-freeform.sh
@@ -21,10 +21,13 @@
 #
 # Reply: two-line current conditions in plain English. Set the Action's
 #        MaxReplyLines >= 2 or only the first line ships.
-#        Line 1: "<location>: <condition> <temp>"
-#        Line 2: "wind <wind> hum <hum> <pressure>"
+#        Line 1: "<label>: <condition> <temp>"  (label = "<input>
+#                (<city>)" when wttr.in resolves a different city name
+#                and it fits, else just <input> or <city>)
+#        Line 2: "wind <dir><speed>mph hum <hum>% <pressure>hPa"
+#        Unknown location -> single-line helpful message.
 # Source: wttr.in (free, no key, worldwide).
-# Deps:   curl
+# Deps:   curl, python3
 
 set -euo pipefail
 
@@ -52,24 +55,64 @@ if [[ ! "$location" =~ ^[A-Za-z0-9.,_\ -]+$ ]]; then
 fi
 encoded=$(printf '%s' "$location" | tr ' ' '+')
 
-# %C condition, %t temp, %w wind, %h humidity, %P pressure; &u forces
-# USCS units. The literal "|" splits the response into the two on-air
-# lines; wttr.in passes it through verbatim and "|" never appears in
-# any of these fields.
-url="https://wttr.in/${encoded}?format=%C+%t|wind+%w+hum+%h+%P&u"
-resp=$(curl -fsSL --max-time 8 -- "$url") || { echo "fetch failed" >&2; exit 1; }
+# j1 returns full JSON: current_condition + nearest_area (resolved city).
+# &u forces USCS units. wttr.in returns HTTP 500 with body "location not
+# found: location not found" for unknown ICAO/ZIP/etc, so capture status.
+url="https://wttr.in/${encoded}?format=j1&u"
+raw=$(curl -sSL --max-time 8 -w $'\n__HTTP__%{http_code}' "$url") \
+    || { echo "fetch failed" >&2; exit 1; }
+status="${raw##*__HTTP__}"
+body="${raw%$'\n'__HTTP__*}"
 
-resp=$(printf '%s' "$resp" | tr -d '\r\n')
-if [[ -z "$resp" ]]; then
+if [[ "$status" != "200" ]]; then
+    if printf '%s' "$body" | grep -qi 'location not found'; then
+        echo "unknown location '$location'. Try city, ZIP, ICAO, or lat,lon"
+        exit 0
+    fi
+    echo "fetch failed" >&2
+    exit 1
+fi
+
+parsed=$(printf '%s' "$body" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+def first(xs):
+    return (xs or [{}])[0].get("value", "").strip() if isinstance(xs, list) else ""
+c = (d.get("current_condition") or [{}])[0]
+a = (d.get("nearest_area") or [{}])[0]
+print(first(a.get("areaName")))
+print(first(c.get("weatherDesc")))
+print(c.get("temp_F", ""))
+print(c.get("winddir16Point", ""))
+print(c.get("windspeedMiles", ""))
+print(c.get("humidity", ""))
+print(c.get("pressure", ""))
+') || { echo "parse failed" >&2; exit 1; }
+
+mapfile -t F <<<"$parsed"
+city="${F[0]:-}"; desc="${F[1]:-}"; tF="${F[2]:-}"
+wd="${F[3]:-}"; ws="${F[4]:-}"; hum="${F[5]:-}"; pr="${F[6]:-}"
+
+if [[ -z "$desc" || -z "$tF" ]]; then
     echo "$location: no data"
     exit 0
 fi
 
-line1="${resp%%|*}"
-line2="${resp#*|}"
-echo "${location}: ${line1}"
-# Drop line 2 if the delimiter was missing (no "|" in resp leaves
-# line2 == resp, which would duplicate line 1).
-if [[ "$line2" != "$resp" ]]; then
-    echo "$line2"
+# Prefer "<input> (<city>)" when wttr.in resolved a different city name
+# and the combined label fits in 28 chars (leaves room for conditions on
+# a 67-char APRS line). Otherwise fall back to just <input> or <city>.
+loc_lc=$(printf '%s' "$location" | tr '[:upper:]' '[:lower:]')
+city_lc=$(printf '%s' "$city" | tr '[:upper:]' '[:lower:]')
+if [[ -z "$city" || "$loc_lc" == "$city_lc" ]]; then
+    label="$location"
+else
+    combined="${location} (${city})"
+    if (( ${#combined} <= 28 )); then
+        label="$combined"
+    else
+        label="$city"
+    fi
 fi
+
+echo "${label}: ${desc} ${tF}°F"
+echo "wind ${wd}${ws}mph hum ${hum}% ${pr}hPa"

--- a/examples/actions/posix/weather-freeform.sh
+++ b/examples/actions/posix/weather-freeform.sh
@@ -27,7 +27,7 @@
 #        Line 2: "wind <dir><speed>mph hum <hum>% <pressure>hPa"
 #        Unknown location -> single-line helpful message.
 # Source: wttr.in (free, no key, worldwide).
-# Deps:   curl, python3
+# Deps:   curl, awk, sed (all standard POSIX)
 
 set -euo pipefail
 
@@ -55,9 +55,9 @@ if [[ ! "$location" =~ ^[A-Za-z0-9.,_\ -]+$ ]]; then
 fi
 encoded=$(printf '%s' "$location" | tr ' ' '+')
 
-# j1 returns full JSON: current_condition + nearest_area (resolved city).
-# &u forces USCS units. wttr.in returns HTTP 500 with body "location not
-# found: location not found" for unknown ICAO/ZIP/etc, so capture status.
+# j1 returns pretty-printed JSON: current_condition + nearest_area
+# (resolved city). &u forces USCS units. wttr.in returns HTTP 500 with
+# body "location not found: location not found" for unknown ICAO/ZIP.
 url="https://wttr.in/${encoded}?format=j1&u"
 raw=$(curl -sSL --max-time 8 -w $'\n__HTTP__%{http_code}' "$url") \
     || { echo "fetch failed" >&2; exit 1; }
@@ -73,25 +73,44 @@ if [[ "$status" != "200" ]]; then
     exit 1
 fi
 
-parsed=$(printf '%s' "$body" | python3 -c '
-import json, sys
-d = json.load(sys.stdin)
-def first(xs):
-    return (xs or [{}])[0].get("value", "").strip() if isinstance(xs, list) else ""
-c = (d.get("current_condition") or [{}])[0]
-a = (d.get("nearest_area") or [{}])[0]
-print(first(a.get("areaName")))
-print(first(c.get("weatherDesc")))
-print(c.get("temp_F", ""))
-print(c.get("winddir16Point", ""))
-print(c.get("windspeedMiles", ""))
-print(c.get("humidity", ""))
-print(c.get("pressure", ""))
-') || { echo "parse failed" >&2; exit 1; }
+# Pull a top-level scalar string out of wttr.in's pretty-printed JSON.
+# Each scalar sits on its own line as: `    "key": "value",`. The first
+# match wins; current_condition is emitted before forecast sections, so
+# fields like "humidity" / "pressure" resolve to the current values.
+scalar() {
+    awk -v k="\"$1\":" '
+        index($0, k) {
+            sub(/^[^"]*"[^"]*":[[:space:]]*"/, "")
+            sub(/".*$/, "")
+            print
+            exit
+        }
+    ' <<<"$body"
+}
 
-mapfile -t F <<<"$parsed"
-city="${F[0]:-}"; desc="${F[1]:-}"; tF="${F[2]:-}"
-wd="${F[3]:-}"; ws="${F[4]:-}"; hum="${F[5]:-}"; pr="${F[6]:-}"
+# Pull the first {"value": "..."} child of an array key (e.g. weatherDesc
+# inside current_condition, or areaName inside nearest_area). Anchor on
+# the parent so we skip unrelated "value" lines.
+nested_value() {
+    awk -v parent="\"$1\":" -v section="\"$2\":" '
+        index($0, parent) { in_p = 1 }
+        in_p && index($0, section) { in_s = 1; next }
+        in_s && /"value"[[:space:]]*:/ {
+            sub(/^[^"]*"value"[[:space:]]*:[[:space:]]*"/, "")
+            sub(/".*$/, "")
+            print
+            exit
+        }
+    ' <<<"$body"
+}
+
+city=$(nested_value nearest_area areaName)
+desc=$(nested_value current_condition weatherDesc)
+tF=$(scalar temp_F)
+wd=$(scalar winddir16Point)
+ws=$(scalar windspeedMiles)
+hum=$(scalar humidity)
+pr=$(scalar pressure)
 
 if [[ -z "$desc" || -z "$tF" ]]; then
     echo "$location: no data"

--- a/examples/actions/posix/weather.sh
+++ b/examples/actions/posix/weather.sh
@@ -33,7 +33,7 @@ encoded=$(printf '%s' "$location" | tr ' ' '+')
 # &u forces USCS units. wttr.in returns HTTP 500 with body "location not
 # found: location not found" for unknown ICAO/ZIP, so capture status.
 url="https://wttr.in/${encoded}?format=j1&u"
-raw=$(curl -sSL --max-time 8 -w $'\n__HTTP__%{http_code}' "$url") \
+raw=$(curl -sSL --max-time 8 -w $'\n__HTTP__%{http_code}' -- "$url") \
   || { echo "fetch failed" >&2; exit 1; }
 status="${raw##*__HTTP__}"
 body="${raw%$'\n'__HTTP__*}"

--- a/examples/actions/posix/weather.sh
+++ b/examples/actions/posix/weather.sh
@@ -12,7 +12,7 @@
 #           Line 2: "wind <dir><speed>mph hum <hum>% <pressure>hPa"
 #           Unknown location -> single-line helpful message.
 # Source:   wttr.in (free, no key, worldwide)
-# Deps:     curl, awk, sed (all standard POSIX)
+# Deps:     curl, jq
 set -euo pipefail
 
 location="${GW_ARG_LOCATION:-}"
@@ -29,9 +29,9 @@ if [[ ! "$location" =~ ^[A-Za-z0-9.,_\ -]+$ ]]; then
 fi
 encoded=$(printf '%s' "$location" | tr ' ' '+')
 
-# j1 returns pretty-printed JSON: current_condition + nearest_area
-# (resolved city). &u forces USCS units. wttr.in returns HTTP 500 with
-# body "location not found: location not found" for unknown ICAO/ZIP.
+# j1 returns full JSON: current_condition + nearest_area (resolved city).
+# &u forces USCS units. wttr.in returns HTTP 500 with body "location not
+# found: location not found" for unknown ICAO/ZIP, so capture status.
 url="https://wttr.in/${encoded}?format=j1&u"
 raw=$(curl -sSL --max-time 8 -w $'\n__HTTP__%{http_code}' "$url") \
   || { echo "fetch failed" >&2; exit 1; }
@@ -47,44 +47,20 @@ if [[ "$status" != "200" ]]; then
   exit 1
 fi
 
-# Pull a top-level scalar string out of wttr.in's pretty-printed JSON.
-# Each scalar sits on its own line as: `    "key": "value",`. The first
-# match wins; current_condition is emitted before forecast sections, so
-# fields like "humidity" / "pressure" resolve to the current values.
-scalar() {
-  awk -v k="\"$1\":" '
-    index($0, k) {
-      sub(/^[^"]*"[^"]*":[[:space:]]*"/, "")
-      sub(/".*$/, "")
-      print
-      exit
-    }
-  ' <<<"$body"
-}
+# Pull the seven fields we need as a single tab-separated line.
+parsed=$(printf '%s' "$body" | jq -r '
+  [
+    (.nearest_area[0].areaName[0].value     // ""),
+    (.current_condition[0].weatherDesc[0].value // ""),
+    (.current_condition[0].temp_F           // ""),
+    (.current_condition[0].winddir16Point   // ""),
+    (.current_condition[0].windspeedMiles   // ""),
+    (.current_condition[0].humidity         // ""),
+    (.current_condition[0].pressure         // "")
+  ] | @tsv
+') || { echo "parse failed" >&2; exit 1; }
 
-# Pull the first {"value": "..."} child of an array key (e.g. weatherDesc
-# inside current_condition, or areaName inside nearest_area). Anchor on
-# the parent so we skip unrelated "value" lines.
-nested_value() {
-  awk -v parent="\"$1\":" -v section="\"$2\":" '
-    index($0, parent) { in_p = 1 }
-    in_p && index($0, section) { in_s = 1; next }
-    in_s && /"value"[[:space:]]*:/ {
-      sub(/^[^"]*"value"[[:space:]]*:[[:space:]]*"/, "")
-      sub(/".*$/, "")
-      print
-      exit
-    }
-  ' <<<"$body"
-}
-
-city=$(nested_value nearest_area areaName)
-desc=$(nested_value current_condition weatherDesc)
-tF=$(scalar temp_F)
-wd=$(scalar winddir16Point)
-ws=$(scalar windspeedMiles)
-hum=$(scalar humidity)
-pr=$(scalar pressure)
+IFS=$'\t' read -r city desc tF wd ws hum pr <<<"$parsed"
 
 if [[ -z "$desc" || -z "$tF" ]]; then
   echo "$location: no data"

--- a/examples/actions/posix/weather.sh
+++ b/examples/actions/posix/weather.sh
@@ -6,10 +6,13 @@
 #                                   "39.7,-105.0")
 # Reply:    two-line current conditions in plain English. Set the
 #           Action's MaxReplyLines >= 2 or only the first line ships.
-#           Line 1: "<location>: <condition> <temp>"
-#           Line 2: "wind <wind> hum <hum> <pressure>"
+#           Line 1: "<label>: <condition> <temp>"  (label = "<input>
+#                   (<city>)" when wttr.in resolves a different city
+#                   name and it fits, else just <input> or <city>)
+#           Line 2: "wind <dir><speed>mph hum <hum>% <pressure>hPa"
+#           Unknown location -> single-line helpful message.
 # Source:   wttr.in (free, no key, worldwide)
-# Deps:     curl
+# Deps:     curl, python3
 set -euo pipefail
 
 location="${GW_ARG_LOCATION:-}"
@@ -26,24 +29,64 @@ if [[ ! "$location" =~ ^[A-Za-z0-9.,_\ -]+$ ]]; then
 fi
 encoded=$(printf '%s' "$location" | tr ' ' '+')
 
-# %C condition, %t temp, %w wind, %h humidity, %P pressure; &u forces
-# USCS units. The literal "|" splits the response into the two on-air
-# lines; wttr.in passes it through verbatim and "|" never appears in
-# any of these fields.
-url="https://wttr.in/${encoded}?format=%C+%t|wind+%w+hum+%h+%P&u"
-resp=$(curl -fsSL --max-time 8 -- "$url") || { echo "fetch failed" >&2; exit 1; }
+# j1 returns full JSON: current_condition + nearest_area (resolved city).
+# &u forces USCS units. wttr.in returns HTTP 500 with body "location not
+# found: location not found" for unknown ICAO/ZIP/etc, so capture status.
+url="https://wttr.in/${encoded}?format=j1&u"
+raw=$(curl -sSL --max-time 8 -w $'\n__HTTP__%{http_code}' "$url") \
+  || { echo "fetch failed" >&2; exit 1; }
+status="${raw##*__HTTP__}"
+body="${raw%$'\n'__HTTP__*}"
 
-resp=$(printf '%s' "$resp" | tr -d '\r\n')
-if [[ -z "$resp" ]]; then
+if [[ "$status" != "200" ]]; then
+  if printf '%s' "$body" | grep -qi 'location not found'; then
+    echo "unknown location '$location'. Try city, ZIP, ICAO, or lat,lon"
+    exit 0
+  fi
+  echo "fetch failed" >&2
+  exit 1
+fi
+
+parsed=$(printf '%s' "$body" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+def first(xs):
+    return (xs or [{}])[0].get("value", "").strip() if isinstance(xs, list) else ""
+c = (d.get("current_condition") or [{}])[0]
+a = (d.get("nearest_area") or [{}])[0]
+print(first(a.get("areaName")))
+print(first(c.get("weatherDesc")))
+print(c.get("temp_F", ""))
+print(c.get("winddir16Point", ""))
+print(c.get("windspeedMiles", ""))
+print(c.get("humidity", ""))
+print(c.get("pressure", ""))
+') || { echo "parse failed" >&2; exit 1; }
+
+mapfile -t F <<<"$parsed"
+city="${F[0]:-}"; desc="${F[1]:-}"; tF="${F[2]:-}"
+wd="${F[3]:-}"; ws="${F[4]:-}"; hum="${F[5]:-}"; pr="${F[6]:-}"
+
+if [[ -z "$desc" || -z "$tF" ]]; then
   echo "$location: no data"
   exit 0
 fi
 
-line1="${resp%%|*}"
-line2="${resp#*|}"
-echo "${location}: ${line1}"
-# Drop line 2 if the delimiter was missing (no "|" in resp leaves
-# line2 == resp, which would duplicate line 1).
-if [[ "$line2" != "$resp" ]]; then
-  echo "$line2"
+# Prefer "<input> (<city>)" when wttr.in resolved a different city name
+# and the combined label fits in 28 chars (leaves room for conditions on
+# a 67-char APRS line). Otherwise fall back to just <input> or <city>.
+loc_lc=$(printf '%s' "$location" | tr '[:upper:]' '[:lower:]')
+city_lc=$(printf '%s' "$city" | tr '[:upper:]' '[:lower:]')
+if [[ -z "$city" || "$loc_lc" == "$city_lc" ]]; then
+  label="$location"
+else
+  combined="${location} (${city})"
+  if (( ${#combined} <= 28 )); then
+    label="$combined"
+  else
+    label="$city"
+  fi
 fi
+
+echo "${label}: ${desc} ${tF}°F"
+echo "wind ${wd}${ws}mph hum ${hum}% ${pr}hPa"

--- a/examples/actions/posix/weather.sh
+++ b/examples/actions/posix/weather.sh
@@ -12,7 +12,7 @@
 #           Line 2: "wind <dir><speed>mph hum <hum>% <pressure>hPa"
 #           Unknown location -> single-line helpful message.
 # Source:   wttr.in (free, no key, worldwide)
-# Deps:     curl, python3
+# Deps:     curl, awk, sed (all standard POSIX)
 set -euo pipefail
 
 location="${GW_ARG_LOCATION:-}"
@@ -29,9 +29,9 @@ if [[ ! "$location" =~ ^[A-Za-z0-9.,_\ -]+$ ]]; then
 fi
 encoded=$(printf '%s' "$location" | tr ' ' '+')
 
-# j1 returns full JSON: current_condition + nearest_area (resolved city).
-# &u forces USCS units. wttr.in returns HTTP 500 with body "location not
-# found: location not found" for unknown ICAO/ZIP/etc, so capture status.
+# j1 returns pretty-printed JSON: current_condition + nearest_area
+# (resolved city). &u forces USCS units. wttr.in returns HTTP 500 with
+# body "location not found: location not found" for unknown ICAO/ZIP.
 url="https://wttr.in/${encoded}?format=j1&u"
 raw=$(curl -sSL --max-time 8 -w $'\n__HTTP__%{http_code}' "$url") \
   || { echo "fetch failed" >&2; exit 1; }
@@ -47,25 +47,44 @@ if [[ "$status" != "200" ]]; then
   exit 1
 fi
 
-parsed=$(printf '%s' "$body" | python3 -c '
-import json, sys
-d = json.load(sys.stdin)
-def first(xs):
-    return (xs or [{}])[0].get("value", "").strip() if isinstance(xs, list) else ""
-c = (d.get("current_condition") or [{}])[0]
-a = (d.get("nearest_area") or [{}])[0]
-print(first(a.get("areaName")))
-print(first(c.get("weatherDesc")))
-print(c.get("temp_F", ""))
-print(c.get("winddir16Point", ""))
-print(c.get("windspeedMiles", ""))
-print(c.get("humidity", ""))
-print(c.get("pressure", ""))
-') || { echo "parse failed" >&2; exit 1; }
+# Pull a top-level scalar string out of wttr.in's pretty-printed JSON.
+# Each scalar sits on its own line as: `    "key": "value",`. The first
+# match wins; current_condition is emitted before forecast sections, so
+# fields like "humidity" / "pressure" resolve to the current values.
+scalar() {
+  awk -v k="\"$1\":" '
+    index($0, k) {
+      sub(/^[^"]*"[^"]*":[[:space:]]*"/, "")
+      sub(/".*$/, "")
+      print
+      exit
+    }
+  ' <<<"$body"
+}
 
-mapfile -t F <<<"$parsed"
-city="${F[0]:-}"; desc="${F[1]:-}"; tF="${F[2]:-}"
-wd="${F[3]:-}"; ws="${F[4]:-}"; hum="${F[5]:-}"; pr="${F[6]:-}"
+# Pull the first {"value": "..."} child of an array key (e.g. weatherDesc
+# inside current_condition, or areaName inside nearest_area). Anchor on
+# the parent so we skip unrelated "value" lines.
+nested_value() {
+  awk -v parent="\"$1\":" -v section="\"$2\":" '
+    index($0, parent) { in_p = 1 }
+    in_p && index($0, section) { in_s = 1; next }
+    in_s && /"value"[[:space:]]*:/ {
+      sub(/^[^"]*"value"[[:space:]]*:[[:space:]]*"/, "")
+      sub(/".*$/, "")
+      print
+      exit
+    }
+  ' <<<"$body"
+}
+
+city=$(nested_value nearest_area areaName)
+desc=$(nested_value current_condition weatherDesc)
+tF=$(scalar temp_F)
+wd=$(scalar winddir16Point)
+ws=$(scalar windspeedMiles)
+hum=$(scalar humidity)
+pr=$(scalar pressure)
 
 if [[ -z "$desc" || -z "$tF" ]]; then
   echo "$location: no data"

--- a/examples/actions/windows/weather.ps1
+++ b/examples/actions/windows/weather.ps1
@@ -5,8 +5,11 @@
 #                                   "39.7,-105.0")
 # Reply:    two-line current conditions in plain English. Set the
 #           Action's MaxReplyLines >= 2 or only the first line ships.
-#           Line 1: "<location>: <condition> <temp>"
-#           Line 2: "wind <wind> hum <hum> <pressure>"
+#           Line 1: "<label>: <condition> <temp>"  (label = "<input>
+#                   (<city>)" when wttr.in resolves a different city
+#                   name and it fits, else just <input> or <city>)
+#           Line 2: "wind <dir><speed>mph hum <hum>% <pressure>hPa"
+#           Unknown location -> single-line helpful message.
 # Source:   wttr.in (free, no key, worldwide)
 
 Set-StrictMode -Version Latest
@@ -26,27 +29,68 @@ if ($location -notmatch '^[A-Za-z0-9.,_ -]+$') {
 }
 
 $encoded = [System.Uri]::EscapeDataString($location)
-# %C condition, %t temp, %w wind, %h humidity, %P pressure; &u forces
-# USCS units. The literal "|" splits the response into the two on-air
-# lines; wttr.in passes it through verbatim and "|" never appears in
-# any of these fields.
-$url = "https://wttr.in/${encoded}?format=%C+%t|wind+%w+hum+%h+%P&u"
+# j1 returns full JSON: current_condition + nearest_area (resolved city).
+# &u forces USCS units. wttr.in returns HTTP 500 with body "location not
+# found: location not found" for unknown ICAO/ZIP/etc.
+$url = "https://wttr.in/${encoded}?format=j1&u"
 
+$content = $null
 try {
-  $resp = (Invoke-WebRequest -UseBasicParsing -TimeoutSec 8 -Uri $url).Content.Trim()
+  $content = (Invoke-WebRequest -UseBasicParsing -TimeoutSec 8 -Uri $url).Content
 } catch {
+  $errResp = $null
+  try { $errResp = $_.Exception.Response } catch {}
+  if ($errResp -and ($errResp.StatusCode.value__ -eq 500)) {
+    $errBody = ''
+    try {
+      $reader = [System.IO.StreamReader]::new($errResp.GetResponseStream())
+      $errBody = $reader.ReadToEnd()
+      $reader.Dispose()
+    } catch {}
+    if ($errBody -match 'location not found') {
+      "unknown location '$location'. Try city, ZIP, ICAO, or lat,lon"
+      exit 0
+    }
+  }
   [Console]::Error.WriteLine('fetch failed')
   exit 1
 }
 
-if (-not $resp) {
+if (-not $content) {
   "${location}: no data"
   exit 0
 }
 
-$parts = $resp.Split('|', 2)
-"${location}: $($parts[0])"
-# Drop line 2 if the delimiter was missing.
-if ($parts.Length -eq 2) {
-  $parts[1]
+try {
+  $j = $content | ConvertFrom-Json
+} catch {
+  [Console]::Error.WriteLine('parse failed')
+  exit 1
 }
+
+$c = $j.current_condition[0]
+$a = $j.nearest_area[0]
+$city = if ($a -and $a.areaName) { $a.areaName[0].value.Trim() } else { '' }
+$desc = if ($c.weatherDesc) { $c.weatherDesc[0].value.Trim() } else { '' }
+$tF   = $c.temp_F
+$wd   = $c.winddir16Point
+$ws   = $c.windspeedMiles
+$hum  = $c.humidity
+$pr   = $c.pressure
+
+if (-not $desc -or -not $tF) {
+  "${location}: no data"
+  exit 0
+}
+
+# Prefer "<input> (<city>)" when wttr.in resolved a different city name
+# and the combined label fits in 28 chars (leaves room for conditions on
+# a 67-char APRS line). Otherwise fall back to just <input> or <city>.
+$label = $location
+if ($city -and ($location.ToLower() -ne $city.ToLower())) {
+  $combined = "$location ($city)"
+  if ($combined.Length -le 28) { $label = $combined } else { $label = $city }
+}
+
+"${label}: $desc ${tF}°F"
+"wind ${wd}${ws}mph hum ${hum}% ${pr}hPa"


### PR DESCRIPTION
…ations

Switch wttr.in fetch from compact format string to j1 JSON so the script can pick up nearest_area.areaName in the same request. Line 1 now reads "<input> (<city>): <cond> <temp>" when wttr.in resolves a different city and the label fits in 28 chars; falls back to <city> or <input> alone.

Detect HTTP 500 + "location not found" body and return a single-line helpful reply ("unknown location 'KBXM'. Try city, ZIP, ICAO, or lat,lon") instead of a generic fetch failure.

Adds python3 dependency to the POSIX scripts; PowerShell uses native ConvertFrom-Json. The .cmd launcher is unchanged.