### PR TITLE
fix(webapi/igate): stop seeding rf_channel/tx_channel default to 1

### DIFF
--- a/pkg/webapi/dto/igate.go
+++ b/pkg/webapi/dto/igate.go
@@ -14,14 +14,23 @@ import (
 // explicitly save these fields as zero will see them overwritten on the
 // next GET; this is acceptable for singleton config where "no row yet"
 // and "saved as zero" are not meaningfully distinguishable anyway.
+//
+// rf_channel and tx_channel are deliberately NOT defaulted here. Both
+// are soft-FKs onto configstore.Channel.ID and there is no guarantee
+// any specific ID exists (channels can be created/deleted, leaving
+// non-contiguous IDs). Defaulting to "1" caused a write-time validation
+// failure when the operator saved an unrelated change: the response
+// echoed rf_channel=1, the UI round-tripped it back, and the handler's
+// non-idempotent ValidateChannelRef path 400'd with "rf_channel:
+// channel 1 does not exist". Passing 0 (the documented "unset"
+// sentinel) lets the UI's defaultCh fallback pick the lowest live
+// channel for tx_channel and lets idempotent-skip absorb rf_channel.
 const (
 	DefaultIGateServer          = "rotate.aprs2.net"
 	DefaultIGatePort            = 14580
-	DefaultIGateRfChannel       = 1
 	DefaultIGateMaxMsgHops      = 2
 	DefaultIGateSoftwareName    = "graywolf"
 	DefaultIGateSoftwareVersion = "0.1"
-	DefaultIGateTxChannel       = 1
 )
 
 // IGateConfigRequest is the body accepted by PUT /api/igate/config.
@@ -91,10 +100,6 @@ func IGateConfigFromModel(m configstore.IGateConfig) IGateConfigResponse {
 	if port == 0 {
 		port = DefaultIGatePort
 	}
-	rfChannel := m.RfChannel
-	if rfChannel == 0 {
-		rfChannel = DefaultIGateRfChannel
-	}
 	maxMsgHops := m.MaxMsgHops
 	if maxMsgHops == 0 {
 		maxMsgHops = DefaultIGateMaxMsgHops
@@ -107,10 +112,6 @@ func IGateConfigFromModel(m configstore.IGateConfig) IGateConfigResponse {
 	if softwareVersion == "" {
 		softwareVersion = DefaultIGateSoftwareVersion
 	}
-	txChannel := m.TxChannel
-	if txChannel == 0 {
-		txChannel = DefaultIGateTxChannel
-	}
 	return IGateConfigResponse{
 		ID: m.ID,
 		IGateConfigRequest: IGateConfigRequest{
@@ -121,11 +122,11 @@ func IGateConfigFromModel(m configstore.IGateConfig) IGateConfigResponse {
 			SimulationMode:  m.SimulationMode,
 			GateRfToIs:      m.GateRfToIs,
 			GateIsToRf:      m.GateIsToRf,
-			RfChannel:       rfChannel,
+			RfChannel:       m.RfChannel,
 			MaxMsgHops:      maxMsgHops,
 			SoftwareName:    softwareName,
 			SoftwareVersion: softwareVersion,
-			TxChannel:       txChannel,
+			TxChannel:       m.TxChannel,
 		},
 	}
 }

--- a/pkg/webapi/dto/igate_test.go
+++ b/pkg/webapi/dto/igate_test.go
@@ -18,8 +18,18 @@ func TestIGateConfigFromModel_EmptyModelSeedsDefaults(t *testing.T) {
 	if got.Port != DefaultIGatePort {
 		t.Errorf("Port = %d, want %d", got.Port, DefaultIGatePort)
 	}
-	if got.RfChannel != DefaultIGateRfChannel {
-		t.Errorf("RfChannel = %d, want %d", got.RfChannel, DefaultIGateRfChannel)
+	// rf_channel and tx_channel must pass through 0 (sentinel "unset"),
+	// NOT a hardcoded "1". Soft-FK references onto channels.id have no
+	// safe default — channel 1 may not exist on systems where channels
+	// were created and deleted, leaving non-contiguous IDs. The UI
+	// substitutes the lowest live channel for tx_channel when the
+	// response is 0; rf_channel has no UI surface and round-trips 0
+	// through to the idempotent-skip branch in the PUT handler.
+	if got.RfChannel != 0 {
+		t.Errorf("RfChannel = %d, want 0 (no default)", got.RfChannel)
+	}
+	if got.TxChannel != 0 {
+		t.Errorf("TxChannel = %d, want 0 (no default)", got.TxChannel)
 	}
 	if got.MaxMsgHops != DefaultIGateMaxMsgHops {
 		t.Errorf("MaxMsgHops = %d, want %d", got.MaxMsgHops, DefaultIGateMaxMsgHops)
@@ -29,9 +39,6 @@ func TestIGateConfigFromModel_EmptyModelSeedsDefaults(t *testing.T) {
 	}
 	if got.SoftwareVersion != DefaultIGateSoftwareVersion {
 		t.Errorf("SoftwareVersion = %q, want %q", got.SoftwareVersion, DefaultIGateSoftwareVersion)
-	}
-	if got.TxChannel != DefaultIGateTxChannel {
-		t.Errorf("TxChannel = %d, want %d", got.TxChannel, DefaultIGateTxChannel)
 	}
 
 	// Booleans intentionally stay zero-valued: the UI needs to


### PR DESCRIPTION
## Summary
- iGate Save returned `400 "rf_channel: channel 1 does not exist"` when an operator picked a TX channel on a system whose only channel had `id != 1` and whose persisted `rf_channel` was 0.
- Root cause: `IGateConfigFromModel` substituted `1` for `rf_channel`/`tx_channel` whenever the persisted value was 0. The UI round-tripped that fake value back, the request value (1) no longer matched the persisted value (0), and `ValidateChannelRef` rejected the orphan FK before the idempotent-skip branch could absorb it.
- Fix: pass `m.RfChannel` and `m.TxChannel` through unchanged. `0` is the documented "unset" sentinel that `ChannelExists` and `ValidateChannelRef` already special-case, and the Svelte form already substitutes the lowest live channel for `tx_channel=0` via its existing `data.tx_channel || defaultCh` fallback.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/webapi/dto/... ./pkg/webapi/...`
- [ ] Manual: on anguilla.local (channels: only id=5, i_gate_configs.rf_channel=0), open iGate page, pick channel 5 as TX, click Save. Expect 200 and toast "iGate config saved" (previously 400).
- [ ] Manual: confirm fresh-install GET `/api/igate/config` now returns `rf_channel:0,tx_channel:0`, UI still renders a sensible TX selection (lowest live channel) via the existing fallback.