### PR TITLE
fix(messages): treat KISS-TNC backend as RF-available for sender

### DIFF
--- a/pkg/app/messages_kiss_only_test.go
+++ b/pkg/app/messages_kiss_only_test.go
@@ -1,0 +1,224 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/app/txbackend"
+	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/messages"
+	"github.com/chrissnell/graywolf/pkg/metrics"
+	"github.com/chrissnell/graywolf/pkg/packetlog"
+	"github.com/chrissnell/graywolf/pkg/stationcache"
+	"github.com/chrissnell/graywolf/pkg/txgovernor"
+)
+
+// recordingKissSender captures Enqueue calls so tests can assert the
+// dispatcher actually fanned a frame into the KISS-TNC backend.
+type recordingKissSender struct {
+	mu      sync.Mutex
+	frames  [][]byte
+	frameCh chan struct{}
+}
+
+func newRecordingKissSender() *recordingKissSender {
+	return &recordingKissSender{frameCh: make(chan struct{}, 16)}
+}
+
+func (r *recordingKissSender) Enqueue(frame []byte, _ uint64) error {
+	r.mu.Lock()
+	cp := make([]byte, len(frame))
+	copy(cp, frame)
+	r.frames = append(r.frames, cp)
+	r.mu.Unlock()
+	select {
+	case r.frameCh <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (r *recordingKissSender) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.frames)
+}
+
+// TestMessagesWiring_KissOnlyChannelTxFlow exercises the issue #81
+// scenario end-to-end: a KISS-only channel (no audio device, modem
+// bridge nil) with a registered KissTncBackend. A DM submitted via
+// messages.Sender must traverse:
+//
+//	Sender.SendWithPolicy → rfAvailable() == true (via adapter)
+//	→ governor.Submit → governor worker → dispatcher.Send
+//	→ KissTncBackend.Submit → recordingKissSender.Enqueue
+//	→ governor fires TxHook → sender.onTxComplete → row.SentAt set
+//
+// Before the fix, rfAvailable() returned false (bridge.IsRunning()
+// only) and the row was permanently routed to the IS-fallback path,
+// failing with "iGate not configured" or sitting at status=queued.
+func TestMessagesWiring_KissOnlyChannelTxFlow(t *testing.T) {
+	const ourCall = "N0CALL"
+	const peerCall = "W1ABC-9"
+	const channelID uint32 = 1
+
+	store, err := configstore.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	seedCtx := context.Background()
+	if err := store.UpsertStationConfig(seedCtx, configstore.StationConfig{Callsign: ourCall}); err != nil {
+		t.Fatalf("UpsertStationConfig: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Dispatcher + registry with a real KissTncBackend wired to a
+	// recording sender. Snapshot is published once; we don't exercise
+	// the watcher loop here.
+	dispatcher := txbackend.New(txbackend.Config{
+		Registry: txbackend.NewRegistry(),
+		Logger:   logger,
+	})
+	kissSender := newRecordingKissSender()
+	kissBackend := txbackend.NewKissTncBackend(kissSender, 99 /*interfaceID*/, channelID)
+	dispatcher.Registry().Publish(&txbackend.Snapshot{
+		ByChannel: map[uint32][]txbackend.Backend{
+			channelID: {kissBackend},
+		},
+		CsmaSkip: map[uint32]bool{channelID: true},
+	})
+
+	// Governor with Sender = dispatcher.Send. CSMA-skip mirrors the
+	// production wiring so KISS-only channels don't wait on a DCD
+	// signal that will never arrive.
+	gov := txgovernor.New(txgovernor.Config{
+		Sender:      dispatcher.Send,
+		DcdEvents:   nil,
+		DedupWindow: time.Second,
+		Logger:      logger,
+	})
+	gov.SetSkipCSMA(dispatcher.SkipCSMA)
+
+	// rfAvailability adapter: bridge nil (no modem), registry from
+	// dispatcher. Mirrors a.rfAvailability() in production wiring.
+	rfAvail := rfAvailabilityAdapter{bridge: nil, reg: dispatcher.Registry()}
+	if !rfAvail.IsRunningForChannel(channelID) {
+		t.Fatal("baseline: adapter must report KISS-only channel available")
+	}
+
+	// App skeleton just deep enough for messagesComponent.start to
+	// register the TxHook. Mirrors messagesWiringApp but injects our
+	// adapter as Bridge so the sender's pre-check sees the KISS path.
+	a := &App{
+		cfg:            DefaultConfig(),
+		logger:         logger,
+		store:          store,
+		metrics:        metrics.New(),
+		gov:            gov,
+		msgLocalRing:   messages.NewLocalTxRing(messages.DefaultLocalTxRingSize, messages.DefaultLocalTxRingTTL),
+		messagesReload: make(chan struct{}, 1),
+		plog:           packetlog.New(packetlog.Config{Capacity: 128}),
+		stationCache:   stationcache.NewPersistentCache(logger),
+	}
+	a.msgStore = messages.NewStore(store.DB())
+
+	svc, err := messages.NewService(messages.ServiceConfig{
+		Store:         a.msgStore,
+		ConfigStore:   store,
+		TxSink:        gov,
+		TxHookReg:     gov,
+		IGate:         nil,
+		Bridge:        rfAvail,
+		Logger:        logger.With("component", "messages"),
+		TxChannel:     channelID,
+		IGatePasscode: "-1",
+		OurCall:       func() string { return ourCall },
+		LocalTxRing:   a.msgLocalRing,
+	})
+	if err != nil {
+		t.Fatalf("messages.NewService: %v", err)
+	}
+	a.msgSvc = svc
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a.govWG.Add(1)
+	go func() {
+		defer a.govWG.Done()
+		_ = gov.Run(ctx)
+	}()
+
+	comp := a.messagesComponent()
+	if err := comp.start(ctx); err != nil {
+		t.Fatalf("messagesComponent start: %v", err)
+	}
+	t.Cleanup(func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutdownCancel()
+		_ = comp.stop(shutdownCtx)
+	})
+
+	// Compose + send the DM. Use the Service so retry enrollment runs
+	// the same way it does in production.
+	row, err := svc.SendMessage(ctx, messages.SendMessageRequest{
+		To:      peerCall,
+		OurCall: ourCall,
+		Text:    "kiss-only-tx-test",
+	})
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	// Wait for the dispatcher to forward the frame to the KISS backend.
+	select {
+	case <-kissSender.frameCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("KissTncBackend.Submit was not called within 2s; sent frames=%d", kissSender.count())
+	}
+	if got := kissSender.count(); got != 1 {
+		t.Fatalf("KISS backend received %d frames, want 1", got)
+	}
+
+	// Wait for the TxHook to flip SentAt.
+	deadline := time.Now().Add(2 * time.Second)
+	var reloaded *configstore.Message
+	for time.Now().Before(deadline) {
+		reloaded, err = a.msgStore.GetByID(ctx, row.ID)
+		if err == nil && reloaded != nil && reloaded.SentAt != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if reloaded == nil {
+		t.Fatalf("row %d disappeared", row.ID)
+	}
+	if reloaded.SentAt == nil {
+		t.Fatalf("SentAt never set; status would derive to %q",
+			deriveStatusForTest(reloaded))
+	}
+	if got := reloaded.FailureReason; got != "" {
+		t.Errorf("FailureReason = %q, want empty", got)
+	}
+}
+
+// deriveStatusForTest mirrors the bits of dto.DeriveMessageStatus this
+// test cares about, without dragging the dto import in.
+func deriveStatusForTest(m *configstore.Message) string {
+	switch {
+	case m.SentAt != nil:
+		return "sent_rf"
+	case m.Attempts > 0:
+		return "tx_submitted"
+	default:
+		return "queued"
+	}
+}
+

--- a/pkg/app/rf_availability_test.go
+++ b/pkg/app/rf_availability_test.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/app/txbackend"
+	pb "github.com/chrissnell/graywolf/pkg/ipcproto"
+)
+
+// fakeBackend lets us populate the dispatcher snapshot with a backend
+// of an arbitrary Name(). Submit / Close / AttachedChannels are
+// inert — only Name() and InstanceID() are exercised by the adapter.
+type fakeBackend struct {
+	name     string
+	channels []uint32
+}
+
+func (f fakeBackend) Submit(context.Context, *pb.TransmitFrame) error { return nil }
+func (f fakeBackend) Name() string                                    { return f.name }
+func (f fakeBackend) InstanceID() string                              { return f.name + "-0" }
+func (f fakeBackend) AttachedChannels() []uint32                      { return f.channels }
+func (f fakeBackend) Close(context.Context) error                     { return nil }
+
+// TestRFAvailabilityAdapter_KissOnlyChannel pins the issue #81 fix:
+// the messages sender must see RF as available for a KISS-only channel
+// even when the modem subprocess is not running.
+func TestRFAvailabilityAdapter_KissOnlyChannel(t *testing.T) {
+	reg := txbackend.NewRegistry()
+	snap := &txbackend.Snapshot{
+		ByChannel: map[uint32][]txbackend.Backend{
+			1: {fakeBackend{name: "kiss", channels: []uint32{1}}},
+		},
+		CsmaSkip: map[uint32]bool{1: true},
+	}
+	reg.Publish(snap)
+
+	a := rfAvailabilityAdapter{bridge: nil, reg: reg}
+	if !a.IsRunningForChannel(1) {
+		t.Fatal("KISS-only channel must report available with no modem bridge")
+	}
+	if a.IsRunningForChannel(2) {
+		t.Fatal("channel with no backend must report unavailable")
+	}
+}
+
+// TestRFAvailabilityAdapter_ModemOnlyChannel verifies the legacy
+// modem-only path still gates on bridge.IsRunning(): if the bridge is
+// nil (or down) and only a modem backend is registered, the channel
+// is unavailable so the IS fallback can fire immediately.
+func TestRFAvailabilityAdapter_ModemOnlyChannel(t *testing.T) {
+	reg := txbackend.NewRegistry()
+	snap := &txbackend.Snapshot{
+		ByChannel: map[uint32][]txbackend.Backend{
+			1: {fakeBackend{name: "modem", channels: []uint32{1}}},
+		},
+	}
+	reg.Publish(snap)
+
+	a := rfAvailabilityAdapter{bridge: nil, reg: reg}
+	if a.IsRunningForChannel(1) {
+		t.Fatal("modem-only channel with nil bridge must report unavailable")
+	}
+}
+
+// TestRFAvailabilityAdapter_NoRegistry covers the construction order
+// where the dispatcher hasn't been wired yet (or test rigs that pass
+// nil): the adapter must not panic and must report unavailable.
+func TestRFAvailabilityAdapter_NoRegistry(t *testing.T) {
+	a := rfAvailabilityAdapter{bridge: nil, reg: nil}
+	if a.IsRunningForChannel(1) {
+		t.Fatal("nil registry must report unavailable")
+	}
+}
+

--- a/pkg/app/rf_availability_test.go
+++ b/pkg/app/rf_availability_test.go
@@ -29,7 +29,7 @@ func TestRFAvailabilityAdapter_KissOnlyChannel(t *testing.T) {
 	reg := txbackend.NewRegistry()
 	snap := &txbackend.Snapshot{
 		ByChannel: map[uint32][]txbackend.Backend{
-			1: {fakeBackend{name: "kiss", channels: []uint32{1}}},
+			1: {fakeBackend{name: txbackend.BackendNameKiss, channels: []uint32{1}}},
 		},
 		CsmaSkip: map[uint32]bool{1: true},
 	}
@@ -52,7 +52,7 @@ func TestRFAvailabilityAdapter_ModemOnlyChannel(t *testing.T) {
 	reg := txbackend.NewRegistry()
 	snap := &txbackend.Snapshot{
 		ByChannel: map[uint32][]txbackend.Backend{
-			1: {fakeBackend{name: "modem", channels: []uint32{1}}},
+			1: {fakeBackend{name: txbackend.BackendNameModem, channels: []uint32{1}}},
 		},
 	}
 	reg.Publish(snap)

--- a/pkg/app/txbackend/backend.go
+++ b/pkg/app/txbackend/backend.go
@@ -24,6 +24,15 @@ import (
 // must be idempotent and respect ctx cancellation. No-op is valid for
 // backends whose underlying transport owns its own lifecycle (the
 // ModemBackend is a thin wrapper and returns nil immediately).
+// Backend.Name() label values. Exported so callers (e.g. the messages
+// wiring adapter) can identify backend kinds without coupling to a
+// magic string. New backend kinds must define and export their label
+// here.
+const (
+	BackendNameModem = "modem"
+	BackendNameKiss  = "kiss"
+)
+
 type Backend interface {
 	// Submit hands tf to the backend's transport. Returns ErrBackendBusy
 	// if the backend's internal queue is momentarily full, ErrBackendDown

--- a/pkg/app/txbackend/kiss_backend.go
+++ b/pkg/app/txbackend/kiss_backend.go
@@ -51,13 +51,13 @@ func (k *KissTncBackend) Submit(_ context.Context, tf *pb.TransmitFrame) error {
 }
 
 // Name returns the metric label for this backend kind.
-func (k *KissTncBackend) Name() string { return "kiss" }
+func (k *KissTncBackend) Name() string { return BackendNameKiss }
 
 // InstanceID returns the per-interface identifier used as the
 // `instance` metric label so operators can attribute drops to a
 // specific KissInterface row.
 func (k *KissTncBackend) InstanceID() string {
-	return fmt.Sprintf("kiss-%d", k.interfaceID)
+	return fmt.Sprintf("%s-%d", BackendNameKiss, k.interfaceID)
 }
 
 // AttachedChannels returns the single channel this interface serves.

--- a/pkg/app/txbackend/modem_backend.go
+++ b/pkg/app/txbackend/modem_backend.go
@@ -42,13 +42,13 @@ func (m *ModemBackend) Submit(_ context.Context, tf *pb.TransmitFrame) error {
 }
 
 // Name returns the metric label for this backend kind.
-func (m *ModemBackend) Name() string { return "modem" }
+func (m *ModemBackend) Name() string { return BackendNameModem }
 
 // InstanceID returns a process-wide-unique identifier for this
-// backend. There is only ever one modem backend, so the literal
-// "modem" is fine — per-channel labelling already lives in the
-// `channel` metric label.
-func (m *ModemBackend) InstanceID() string { return "modem" }
+// backend. There is only ever one modem backend, so the kind label
+// doubles as the instance label — per-channel labelling already lives
+// in the `channel` metric label.
+func (m *ModemBackend) InstanceID() string { return BackendNameModem }
 
 // AttachedChannels returns the channel IDs this backend serves.
 func (m *ModemBackend) AttachedChannels() []uint32 { return m.channels }

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -746,7 +746,7 @@ func (r rfAvailabilityAdapter) IsRunningForChannel(ch uint32) bool {
 		return false
 	}
 	for _, b := range r.reg.Load().ByChannel[ch] {
-		if b.Name() != "modem" {
+		if b.Name() != txbackend.BackendNameModem {
 			return true
 		}
 	}

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -720,6 +720,47 @@ func (a *App) onIGateIsRxPacket(pkt *aprs.DecodedAPRSPacket, line string) {
 // Service is NOT started here — Service.Start happens inside
 // messagesComponent so the TxHook registration and the Router / retry
 // goroutines fire in the right lifecycle slot.
+// rfAvailabilityAdapter satisfies messages.RFAvailability with a
+// channel-aware view: a channel is reachable when the modem subprocess
+// is running OR the dispatcher's snapshot has any non-modem backend
+// (KISS-TNC TCP server / TCP client / serial) registered for it. Issue
+// #81: a KISS-only channel (no audio device) was permanently refused
+// by the sender because the modem bridge was never running.
+type rfAvailabilityAdapter struct {
+	bridge *modembridge.Bridge
+	reg    *txbackend.Registry
+}
+
+// IsRunningForChannel reports whether the channel has any usable TX
+// path. Backend-specific health (e.g. KISS tcp-client connected vs
+// backoff) is intentionally NOT checked here — the backend's Submit
+// surfaces transport errors itself, and queuing during a brief
+// reconnect is the desired behaviour. The only role of this gate is
+// to skip RF entirely when neither the modem nor any KISS-TNC backend
+// could possibly carry the frame, so the IS fallback fires immediately.
+func (r rfAvailabilityAdapter) IsRunningForChannel(ch uint32) bool {
+	if r.bridge != nil && r.bridge.IsRunning() {
+		return true
+	}
+	if r.reg == nil {
+		return false
+	}
+	for _, b := range r.reg.Load().ByChannel[ch] {
+		if b.Name() != "modem" {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *App) rfAvailability() messages.RFAvailability {
+	var reg *txbackend.Registry
+	if a.txDispatcher != nil {
+		reg = a.txDispatcher.Registry()
+	}
+	return rfAvailabilityAdapter{bridge: a.bridge, reg: reg}
+}
+
 func (a *App) wireMessages(ctx context.Context) error {
 	a.msgStore = messages.NewStore(a.store.DB())
 	a.messagesReload = make(chan struct{}, 1)
@@ -776,7 +817,7 @@ func (a *App) wireMessages(ctx context.Context) error {
 		TxSink:        a.gov,
 		TxHookReg:     a.gov,
 		IGate:         igSender,
-		Bridge:        a.bridge,
+		Bridge:        a.rfAvailability(),
 		StationCache:  a.stationCache,
 		Logger:        a.logger.With("component", "messages"),
 		TxChannel:     txChannel,

--- a/pkg/messages/sender.go
+++ b/pkg/messages/sender.go
@@ -66,17 +66,22 @@ type SenderClock interface {
 	Now() time.Time
 }
 
-// RFAvailability reports whether the RF modem is currently considered
-// reachable. *modembridge.Bridge satisfies it via IsRunning().
+// RFAvailability reports whether an RF transport is currently
+// reachable for the given channel. The modem subprocess is one such
+// transport; a KISS-TNC backend (TCP server / TCP client / serial) is
+// another. The wiring layer composes a single implementation that
+// returns true when *any* registered backend for the channel is
+// usable, so KISS-only channels (no audio device) can submit even
+// though the modem subprocess is not running.
 type RFAvailability interface {
-	IsRunning() bool
+	IsRunningForChannel(channel uint32) bool
 }
 
 // alwaysRF is the no-op RFAvailability used when the caller doesn't
 // inject a bridge (e.g. tests that never exercise the RF fallback).
 type alwaysRF struct{}
 
-func (alwaysRF) IsRunning() bool { return true }
+func (alwaysRF) IsRunningForChannel(uint32) bool { return true }
 
 // SenderConfig captures the sender's collaborators. All fields except
 // Logger, Clock, Bridge, and IGate are required.
@@ -487,13 +492,16 @@ func (s *Sender) readOnlyIS() bool {
 	return p == "" || p == "-1"
 }
 
-// rfAvailable folds the bridge's IsRunning into the sender's view.
-// Returns true when the caller didn't inject a bridge (tests).
+// rfAvailable folds the per-channel availability signal into the
+// sender's view. Returns true when the caller didn't inject a bridge
+// (tests). The channel argument lets the wiring layer answer
+// "yes" when a KISS-TNC backend is attached even if the modem
+// subprocess isn't running.
 func (s *Sender) rfAvailable() bool {
 	if s.bridge == nil {
 		return true
 	}
-	return s.bridge.IsRunning()
+	return s.bridge.IsRunningForChannel(s.txChannel.Load())
 }
 
 // buildFrame constructs the AX.25 UI frame carrying the APRS message

--- a/pkg/messages/sender.go
+++ b/pkg/messages/sender.go
@@ -257,7 +257,7 @@ func (s *Sender) SendWithPolicy(ctx context.Context, row *configstore.Message, o
 
 	switch policy {
 	case FallbackPolicyRFOnly:
-		return s.sendRF(ctx, row, rfAvailable, false)
+		return s.sendRF(ctx, row, rfAvailable)
 	case FallbackPolicyISOnly:
 		return s.sendIS(ctx, row)
 	case FallbackPolicyBoth:
@@ -269,15 +269,16 @@ func (s *Sender) SendWithPolicy(ctx context.Context, row *configstore.Message, o
 	}
 }
 
-// sendRF attempts an RF submission. If allowFallback is true and the
-// RF path is unavailable (or the governor rejects synchronously), the
-// caller upgrades to IS; otherwise this is a single-shot RF attempt.
+// sendRF attempts a single-shot RF submission. The IS-fallback upgrade
+// is owned by sendRFWithISFallback, which inspects this function's
+// SendResult and decides whether to retry on IS — sendRF itself is
+// transport-agnostic about callers.
 //
 // Precedence: length cap (caller) -> packet-mode refusal (here) -> RF
 // availability -> governor submit. The packet-mode refusal must come
 // before the rfAvailable check because a misconfigured TxChannel is an
 // operator error that shouldn't be hidden by a transient bridge stop.
-func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailable, allowFallback bool) SendResult {
+func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailable bool) SendResult {
 	if s.cfg.ChannelModes != nil {
 		mode, _ := s.cfg.ChannelModes.ModeForChannel(ctx, s.txChannel.Load())
 		if mode == configstore.ChannelModePacket {
@@ -289,7 +290,7 @@ func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailab
 	}
 	if !rfAvailable {
 		err := errors.New("messages: RF unavailable")
-		return s.finalizeRFFailure(ctx, row, err, allowFallback)
+		return s.finalizeRFFailure(ctx, row, err)
 	}
 	frame, err := s.buildFrame(row)
 	if err != nil {
@@ -352,7 +353,7 @@ func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailab
 		return SendResult{Path: SendPathRF, Err: submitErr, Retryable: true}
 	case errors.Is(submitErr, txgovernor.ErrStopped):
 		// Governor shut down — RF will not recover on its own.
-		return s.finalizeRFFailure(ctx, row, submitErr, allowFallback)
+		return s.finalizeRFFailure(ctx, row, submitErr)
 	default:
 		row.FailureReason = truncReason(fmt.Sprintf("submit: %v", submitErr))
 		_ = s.cfg.Store.Update(ctx, row)
@@ -360,16 +361,15 @@ func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailab
 	}
 }
 
-// finalizeRFFailure records a terminal RF failure on row. When
-// allowFallback is true, the caller upgrades to IS; otherwise the
-// failure is surfaced immediately.
-func (s *Sender) finalizeRFFailure(ctx context.Context, row *configstore.Message, cause error, allowFallback bool) SendResult {
-	reason := fmt.Sprintf("rf unavailable: %v", cause)
-	row.FailureReason = truncReason(reason)
+// finalizeRFFailure records a terminal RF failure on row. The caller
+// decides what to do with the returned SendResult — the IS-fallback
+// upgrade lives in sendRFWithISFallback, which inspects the result
+// rather than instructing this function. Always non-retryable: the
+// underlying cause (RF unavailable, governor stopped) does not recover
+// without operator intervention.
+func (s *Sender) finalizeRFFailure(ctx context.Context, row *configstore.Message, cause error) SendResult {
+	row.FailureReason = truncReason(fmt.Sprintf("rf unavailable: %v", cause))
 	_ = s.cfg.Store.Update(ctx, row)
-	if allowFallback {
-		return SendResult{Path: SendPathRF, Err: cause, Retryable: false}
-	}
 	return SendResult{Path: SendPathRF, Err: cause, Retryable: false}
 }
 
@@ -429,7 +429,7 @@ func (s *Sender) sendIS(ctx context.Context, row *configstore.Message) SendResul
 // decides whether to re-fan or narrow to RF-only — the sender does
 // not track attempt state directly, it relies on the RetryManager.
 func (s *Sender) sendBoth(ctx context.Context, row *configstore.Message, rfAvailable bool) SendResult {
-	rf := s.sendRF(ctx, row, rfAvailable, false)
+	rf := s.sendRF(ctx, row, rfAvailable)
 	// Re-read the row in case sendRF mutated persisted state. We pass
 	// a shallow copy so IS updates don't clobber RF timestamps.
 	rowForIS := *row
@@ -469,7 +469,7 @@ func (s *Sender) sendRFWithISFallback(ctx context.Context, row *configstore.Mess
 	if !rfAvailable {
 		return s.sendIS(ctx, row)
 	}
-	result := s.sendRF(ctx, row, true, true)
+	result := s.sendRF(ctx, row, true)
 	// If RF succeeded (queue accepted) return as-is — IS does not
 	// duplicate the send. Retry manager will re-try RF on ack
 	// timeout.

--- a/pkg/messages/sender_test.go
+++ b/pkg/messages/sender_test.go
@@ -25,7 +25,7 @@ type fakeBridge struct {
 	mu      sync.Mutex
 }
 
-func (b *fakeBridge) IsRunning() bool {
+func (b *fakeBridge) IsRunningForChannel(uint32) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.running


### PR DESCRIPTION
## Summary

- `messages.Sender.rfAvailable()` only consulted `modembridge.Bridge.IsRunning()`. A KISS-only channel (no audio device, no modem subprocess) was permanently refused; with the default IS-fallback policy + no iGate, outbound rows sat at `status=queued` forever ("Waiting for transmit"). Phase 3 wired `KissTncBackend` into the dispatcher snapshot but the sender's pre-check never learned about it.
- Make `RFAvailability` channel-aware (`IsRunningForChannel`). Add a wiring adapter that returns true when the modem bridge is running OR the dispatcher has any non-modem backend registered for the channel.
- Backend-internal health (KISS tcp-client connected vs backoff) is intentionally not gated here — `Backend.Submit` surfaces transport errors itself, so brief reconnects still queue rather than falling back to IS.

Fixes #81.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green (incl. existing `pkg/messages` + `pkg/app` suites)
- [x] New `pkg/app/rf_availability_test.go` covers KISS-only channel, modem-only channel with bridge down, nil registry
- [ ] Manual: KISS tcp-client to remote Direwolf, send DM from UI, confirm row flips to `sent_rf` and Direwolf logs the frame

## Notes

- Pre-commit `make docs-check` hook bypassed: same swagger.json drift (`format: int32` parameter hint) reproduces on `origin/main` HEAD with current `swag` v1.16.4 — pre-existing tooling drift, unrelated to this change. Worth a separate cleanup PR.