### PR TITLE
fix(igate): make enable/disable toggle hot-reloadable (#84)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -293,9 +293,11 @@ flag. `App.reloadIgate` then handles three transitions on every signal
 from `signalIgateReload`:
 
 1. **disabled → enabled**: build a fresh `*igate.Igate` via
-   `App.buildIgateInstance`, `Start` it, store the pointer into `a.ig`,
-   propagate to `a.igateOut.SetIgate` and `beaconSched.SetISSink`, and
-   seed `lastAppliedIgateFilter`.
+   `App.buildIgateInstance`, store the pointer + propagate to
+   `a.igateOut.SetIgate` and `beaconSched.SetISSink` BEFORE calling
+   `Start`, then seed `lastAppliedIgateFilter`. A `Start` failure rolls
+   all of those back to nil so a subsequent toggle gets a fresh build
+   instead of trying to re-Start the dead instance.
 2. **enabled → disabled**: `Stop` the current iGate, clear `a.ig` /
    `a.igateOut` / beacon ISSink, reset `lastAppliedIgateFilter`.
 3. **enabled → enabled**: re-read filters/rules and call `Reconfigure`
@@ -309,6 +311,21 @@ forbidden because they freeze a stale instance across toggles. The
 status / simulation REST routes at `/api/igate*` and the
 `SetIgateStatusFn` callback are registered unconditionally with
 closures that re-load `a.ig` on every call.
+
+The disabled-state HTTP contract is **503 "igate not available"**, not
+200 with a Connected=false snapshot. `GET /api/igate` and the
+`/api/status` aggregate's `igate` field both omit the body when the
+status callback returns nil, and the simulation toggle returns
+`igate.ErrNotEnabled` which `setIgateSimulation` maps to 503. The Svelte
+"Disabled" badge logic in `web/src/routes/Igate.svelte` keys off a
+non-2xx response — a 200 with `connected:false` would render a red
+"Disconnected" badge for an iGate the operator deliberately turned off.
+
+Repeated enable cycles must not orphan Prometheus collectors. On a
+second-and-later `igate.New`, `initMetrics` rebinds `ig.m*` to the
+already-registered collector via `prometheus.AlreadyRegisteredError.ExistingCollector`
+so `/metrics` keeps reflecting live counter increments instead of
+freezing at the first instance's values.
 
 *Why:* graywolf issue #84 — toggling the Enable iGate switch on the
 iGate page used to require a daemon restart. The reload signal

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -281,3 +281,42 @@ Source: [`../../pkg/messages/preflight.go`](../../pkg/messages/preflight.go),
 [`../../pkg/messages/service.go`](../../pkg/messages/service.go)
 (`(*Service).Preflight()`),
 [`actions.md`](actions.md) ("Preflight: shared auto-ACK + dedup").
+
+### 28. iGate enable/disable is hot-reloadable; reload plumbing is unconditional
+
+The iGate's reload signal channel (`a.igateReload`), the reload-drainer
+goroutine, the RF→IS fanout adapter (`a.igateOut`, an `*igate.IgateOutput`
+holding an `atomic.Pointer[Igate]`), and the live `IGateLineSender`
+adapter passed to `messages.Service` (`a.igateLineSender`) are ALL
+allocated at boot regardless of the persisted `IGateConfig.Enabled`
+flag. `App.reloadIgate` then handles three transitions on every signal
+from `signalIgateReload`:
+
+1. **disabled → enabled**: build a fresh `*igate.Igate` via
+   `App.buildIgateInstance`, `Start` it, store the pointer into `a.ig`,
+   propagate to `a.igateOut.SetIgate` and `beaconSched.SetISSink`, and
+   seed `lastAppliedIgateFilter`.
+2. **enabled → disabled**: `Stop` the current iGate, clear `a.ig` /
+   `a.igateOut` / beacon ISSink, reset `lastAppliedIgateFilter`.
+3. **enabled → enabled**: re-read filters/rules and call `Reconfigure`
+   on the running iGate (skipping the reconnect when the composed
+   filter is unchanged).
+
+Consequence: `a.ig` is `atomic.Pointer[igate.Igate]`. Code paths that
+read it MUST go through `a.ig.Load()` and tolerate a nil result —
+captured method values (`a.ig.Status`, `a.ig.SetSimulationMode`) are
+forbidden because they freeze a stale instance across toggles. The
+status / simulation REST routes at `/api/igate*` and the
+`SetIgateStatusFn` callback are registered unconditionally with
+closures that re-load `a.ig` on every call.
+
+*Why:* graywolf issue #84 — toggling the Enable iGate switch on the
+iGate page used to require a daemon restart. The reload signal
+silently no-op'd (channel was nil when boot-time config was disabled)
+and the reload path only ever ran `Reconfigure`, never `Stop` or build.
+
+Source: [`../../pkg/app/wiring.go`](../../pkg/app/wiring.go)
+(`wireIGate`, `buildIgateInstance`, `igateComponent`, `reloadIgate`),
+[`../../pkg/igate/output.go`](../../pkg/igate/output.go)
+(`IgateOutput.SetIgate`),
+[`../../pkg/app/igate_toggle_test.go`](../../pkg/app/igate_toggle_test.go).

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -107,7 +107,20 @@ type App struct {
 	stationPos  *gps.StationPos
 	gpsMgr      *gpsManager
 	beaconSched *beacon.Scheduler
-	ig          *igate.Igate // nil if iGate is disabled in config
+	// ig is the live *igate.Igate; nil while the iGate is disabled.
+	// Held in an atomic pointer so the runtime enable/disable toggle
+	// (reloadIgate) can swap it without coordinating with consumers
+	// (RF->IS fanout adapter, status fn closures, beacon ISSink).
+	ig          atomic.Pointer[igate.Igate]
+	// igateOut is the always-allocated aprs.PacketOutput adapter for the
+	// RF->IS fanout. Its inner *igate.Igate is set/cleared by reloadIgate
+	// so the bridge fanout doesn't need to be torn down on toggle.
+	igateOut    *igate.IgateOutput
+	// igateLineSender is the always-allocated IGateLineSender adapter
+	// passed to messages.Service. It loads a.ig on every SendLine call
+	// so a runtime enable lights up the IS path without rebuilding the
+	// Service.
+	igateLineSender *liveIGateLineSender
 	apiSrv      *webapi.Server
 	httpSrv     *http.Server
 	// updatesChecker polls GitHub once a day for a newer release tag and

--- a/pkg/app/igate_filter_integration_test.go
+++ b/pkg/app/igate_filter_integration_test.go
@@ -268,10 +268,10 @@ func tfSetup(t *testing.T, baseFilter string, preseed []configstore.TacticalCall
 		logger:                 logger,
 		store:                  store,
 		metrics:                m,
-		ig:                     ig,
 		igateReload:            make(chan struct{}, 1),
 		lastAppliedIgateFilter: composed,
 	}
+	a.ig.Store(ig)
 
 	// Start the igate supervisor so the first connection (and any
 	// subsequent reconnects triggered by Reconfigure) actually reach

--- a/pkg/app/igate_toggle_test.go
+++ b/pkg/app/igate_toggle_test.go
@@ -1,0 +1,257 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/metrics"
+)
+
+// Regression coverage for graywolf issue #84: enable/disable toggling
+// the iGate at runtime had no effect until the daemon was restarted.
+// The fix wires the reload signal channel and reload-drainer goroutine
+// unconditionally, and rewrites reloadIgate to handle the
+// disabled<->enabled transitions instead of only the enabled-enabled
+// reconfigure path.
+
+// toggleHarness boots an App with the iGate disabled at config time,
+// matching the production wireIGate path: a.ig stays nil but the reload
+// channel + adapters are still allocated. The harness drives reload
+// signals through the production App.reloadIgate.
+type toggleHarness struct {
+	ctx        context.Context
+	cancel     context.CancelFunc
+	mock       *tfMockAprsIsServer
+	app        *App
+	reloadDone sync.WaitGroup
+}
+
+func (h *toggleHarness) close() {
+	h.cancel()
+	h.reloadDone.Wait()
+	if ig := h.app.ig.Load(); ig != nil {
+		ig.Stop()
+	}
+	h.mock.close()
+	if h.app.store != nil {
+		_ = h.app.store.Close()
+	}
+}
+
+func newToggleHarness(t *testing.T) *toggleHarness {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	store, err := configstore.OpenMemory()
+	if err != nil {
+		cancel()
+		t.Fatalf("OpenMemory: %v", err)
+	}
+
+	if err := store.UpsertStationConfig(ctx, configstore.StationConfig{Callsign: "KE7XYZ"}); err != nil {
+		cancel()
+		t.Fatalf("UpsertStationConfig: %v", err)
+	}
+
+	mock := newTFMockAprsIsServer(t, "# logresp KE7XYZ verified, server TFMOCK")
+	mock.start()
+
+	host, portStr, _ := net.SplitHostPort(mock.addr())
+	var port int
+	_, _ = fmt.Sscanf(portStr, "%d", &port)
+
+	// Seed a disabled iGate config pointed at the mock so a subsequent
+	// enable toggle has somewhere real to connect.
+	if err := store.UpsertIGateConfig(ctx, &configstore.IGateConfig{
+		Enabled:         false,
+		Server:          host,
+		Port:            uint32(port),
+		TxChannel:       1,
+		RfChannel:       1,
+		MaxMsgHops:      2,
+		ServerFilter:    "",
+		SoftwareName:    "graywolf-test",
+		SoftwareVersion: "toggle",
+	}); err != nil {
+		cancel()
+		t.Fatalf("UpsertIGateConfig: %v", err)
+	}
+
+	a := &App{
+		cfg:     DefaultConfig(),
+		logger:  logger,
+		store:   store,
+		metrics: metrics.New(),
+	}
+
+	// Production wireIGate behavior for a disabled-at-boot config:
+	// allocate the reload channel, the RF->IS fanout adapter, and the
+	// live IGateLineSender so subsequent reload signals have somewhere
+	// to land. We replicate that here without spinning up the rest of
+	// wireServices.
+	if err := a.wireIGate(ctx); err != nil {
+		cancel()
+		t.Fatalf("wireIGate: %v", err)
+	}
+	if got := a.ig.Load(); got != nil {
+		cancel()
+		t.Fatalf("disabled-at-boot harness should leave a.ig nil, got %v", got)
+	}
+	if a.igateReload == nil {
+		cancel()
+		t.Fatalf("wireIGate must allocate igateReload even when disabled")
+	}
+	if a.igateOut == nil {
+		cancel()
+		t.Fatalf("wireIGate must allocate igateOut even when disabled")
+	}
+	if a.igateLineSender == nil {
+		cancel()
+		t.Fatalf("wireIGate must allocate igateLineSender even when disabled")
+	}
+
+	h := &toggleHarness{
+		ctx:    ctx,
+		cancel: cancel,
+		mock:   mock,
+		app:    a,
+	}
+
+	// Reload-drainer goroutine — same shape as igateComponent.start.
+	h.reloadDone.Add(1)
+	go func() {
+		defer h.reloadDone.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-a.igateReload:
+				if !ok {
+					return
+				}
+				a.reloadIgate(ctx)
+			}
+		}
+	}()
+
+	return h
+}
+
+func (h *toggleHarness) signalReload(t *testing.T) {
+	t.Helper()
+	select {
+	case h.app.igateReload <- struct{}{}:
+	case <-time.After(time.Second):
+		t.Fatalf("timeout pushing reload signal")
+	}
+}
+
+func (h *toggleHarness) waitForIgate(t *testing.T, want bool, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		got := h.app.ig.Load() != nil
+		if got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for a.ig non-nil=%v after %v", want, timeout)
+}
+
+// TestIgateToggle_DisabledThenEnabled is the direct regression for
+// issue #84's primary scenario: graywolf boots with the iGate off, the
+// operator flips Enable on through the UI, and the iGate must connect
+// without a daemon restart.
+func TestIgateToggle_DisabledThenEnabled(t *testing.T) {
+	h := newToggleHarness(t)
+	defer h.close()
+
+	// Flip Enabled=true in the configstore (mirrors what the webapi
+	// PUT /api/igate/config handler does before signalIgateReload).
+	cfg, err := h.app.store.GetIGateConfig(h.ctx)
+	if err != nil {
+		t.Fatalf("GetIGateConfig: %v", err)
+	}
+	cfg.Enabled = true
+	if err := h.app.store.UpsertIGateConfig(h.ctx, cfg); err != nil {
+		t.Fatalf("UpsertIGateConfig: %v", err)
+	}
+	h.signalReload(t)
+
+	// Mock APRS-IS server must see a fresh login arrive — proves the
+	// iGate was constructed AND Started by reloadIgate, not just
+	// stored.
+	h.mock.waitForLogin(t, 5*time.Second)
+	h.waitForIgate(t, true, 2*time.Second)
+}
+
+// TestIgateToggle_EnabledThenDisabled covers the inverse: the operator
+// turns the iGate off through the UI and the existing connection must
+// be torn down without a restart.
+func TestIgateToggle_EnabledThenDisabled(t *testing.T) {
+	h := newToggleHarness(t)
+	defer h.close()
+
+	// Bring it up first.
+	cfg, err := h.app.store.GetIGateConfig(h.ctx)
+	if err != nil {
+		t.Fatalf("GetIGateConfig: %v", err)
+	}
+	cfg.Enabled = true
+	if err := h.app.store.UpsertIGateConfig(h.ctx, cfg); err != nil {
+		t.Fatalf("UpsertIGateConfig (enable): %v", err)
+	}
+	h.signalReload(t)
+	h.mock.waitForLogin(t, 5*time.Second)
+	h.waitForIgate(t, true, 2*time.Second)
+
+	// Now flip Enabled=false and signal again.
+	cfg.Enabled = false
+	if err := h.app.store.UpsertIGateConfig(h.ctx, cfg); err != nil {
+		t.Fatalf("UpsertIGateConfig (disable): %v", err)
+	}
+	h.signalReload(t)
+
+	h.waitForIgate(t, false, 2*time.Second)
+}
+
+// TestIgateToggle_DisableEnableCycle confirms the fix supports
+// repeated transitions in a single session (each enable rebuilds a
+// fresh *igate.Igate; each disable tears it down).
+func TestIgateToggle_DisableEnableCycle(t *testing.T) {
+	h := newToggleHarness(t)
+	defer h.close()
+
+	cfg, err := h.app.store.GetIGateConfig(h.ctx)
+	if err != nil {
+		t.Fatalf("GetIGateConfig: %v", err)
+	}
+
+	flip := func(enabled bool, want bool) {
+		t.Helper()
+		cfg.Enabled = enabled
+		if err := h.app.store.UpsertIGateConfig(h.ctx, cfg); err != nil {
+			t.Fatalf("UpsertIGateConfig: %v", err)
+		}
+		h.signalReload(t)
+		if enabled {
+			h.mock.waitForLogin(t, 5*time.Second)
+		}
+		h.waitForIgate(t, want, 2*time.Second)
+	}
+
+	flip(true, true)
+	flip(false, false)
+	flip(true, true)
+	flip(false, false)
+}

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -682,18 +682,19 @@ func (a *App) buildIgateInstance(ctx context.Context, igCfg *configstore.IGateCo
 // liveIGateLineSender is the always-allocated adapter passed to
 // messages.Service so the IGate ref captured into Sender / Router /
 // Preflight stays live across runtime enable/disable toggles. SendLine
-// loads a.ig on every call; when the iGate is disabled the call returns
-// an explicit error which the messages.Sender already handles by
-// marking the row failed.
+// loads a.ig on every call; when the iGate is disabled it returns
+// igate.ErrNotEnabled, which messages.Sender handles by marking the
+// row failed. The l == nil / l.a == nil guards are wiring-bug
+// defenses — wireIGate always allocates this adapter on a.
 type liveIGateLineSender struct{ a *App }
 
 func (l *liveIGateLineSender) SendLine(line string) error {
 	if l == nil || l.a == nil {
-		return errors.New("igate not enabled")
+		return igate.ErrNotEnabled
 	}
 	ig := l.a.ig.Load()
 	if ig == nil {
-		return errors.New("igate not enabled")
+		return igate.ErrNotEnabled
 	}
 	return ig.SendLine(line)
 }
@@ -1069,15 +1070,16 @@ func (a *App) wireHTTP(ctx context.Context) error {
 
 	// Status fn loads a.ig on each call so an iGate constructed at
 	// runtime (via the enable toggle) becomes visible to /api/status
-	// without rewiring. Returns a zero-value Status (Connected=false)
-	// while disabled, matching the disabled-at-boot behavior the UI
-	// expects.
-	apiSrv.SetIgateStatusFn(func() igate.Status {
+	// without rewiring. Returns nil while disabled so the UI's
+	// "Disabled" badge logic (which treats a non-2xx /api/igate as
+	// "off") and the /api/status field-omission both work.
+	apiSrv.SetIgateStatusFn(func() *igate.Status {
 		ig := a.ig.Load()
 		if ig == nil {
-			return igate.Status{}
+			return nil
 		}
-		return ig.Status()
+		st := ig.Status()
+		return &st
 	})
 	// Reload signal channel is allocated unconditionally in wireIGate
 	// so the operator's enable toggle is delivered even when the iGate
@@ -1183,23 +1185,26 @@ func (a *App) wireHTTP(ctx context.Context) error {
 	webapi.RegisterPosition(apiSrv, apiMux, a.stationPos)
 	// Always register /api/igate routes; the closures below load a.ig
 	// on each request so the operator's runtime enable toggle lights
-	// the endpoints up without rewiring. While disabled, the simulation
-	// toggle returns 503 (igate not available) and status reports
-	// Connected=false.
+	// the endpoints up without rewiring. While disabled, the status
+	// closure returns nil so the handler responds 503 (preserving the
+	// pre-fix wire contract the UI's "Disabled" badge depends on);
+	// the simulation closure returns igate.ErrNotEnabled, which the
+	// handler maps to 503 instead of a generic 500.
 	webapi.RegisterIgate(apiSrv, apiMux,
 		func(b bool) error {
 			ig := a.ig.Load()
 			if ig == nil {
-				return errors.New("igate not enabled")
+				return igate.ErrNotEnabled
 			}
 			return ig.SetSimulationMode(b)
 		},
-		func() igate.Status {
+		func() *igate.Status {
 			ig := a.ig.Load()
 			if ig == nil {
-				return igate.Status{}
+				return nil
 			}
-			return ig.Status()
+			st := ig.Status()
+			return &st
 		},
 	)
 	// Stations autocomplete is an out-of-band registrar (matches the
@@ -2286,16 +2291,28 @@ func (a *App) reloadIgate(ctx context.Context) {
 			// logged. Leave a.ig nil; the next save retries.
 			return
 		}
-		if err := ig.Start(ctx); err != nil {
-			a.logger.Error("igate reload: start", "err", err)
-			return
-		}
+		// Install the live pointer + adapters BEFORE Start so a
+		// status fetch / RX packet that races against the supervise
+		// goroutine's first connect cannot observe a.ig as nil while
+		// the iGate is already wiring up.
 		a.ig.Store(ig)
 		a.igateOut.SetIgate(ig)
 		if a.beaconSched != nil {
 			a.beaconSched.SetISSink(ig)
 		}
 		a.lastAppliedIgateFilter = composed
+		if err := ig.Start(ctx); err != nil {
+			a.logger.Error("igate reload: start", "err", err)
+			// Roll back so a subsequent toggle gets a fresh build
+			// instead of trying to re-Start the dead instance.
+			a.ig.Store(nil)
+			a.igateOut.SetIgate(nil)
+			if a.beaconSched != nil {
+				a.beaconSched.SetISSink(nil)
+			}
+			a.lastAppliedIgateFilter = ""
+			return
+		}
 		a.logger.Info("igate enabled at runtime")
 		return
 	}

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -408,8 +408,8 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 	if err := a.wireIGate(ctx); err != nil {
 		return err
 	}
-	if a.ig != nil {
-		a.beaconSched.SetISSink(a.ig)
+	if ig := a.ig.Load(); ig != nil {
+		a.beaconSched.SetISSink(ig)
 	}
 
 	// --- Messages service ---------------------------------------------
@@ -552,27 +552,56 @@ func (a *App) applyFlacOverride(ctx context.Context) error {
 	return nil
 }
 
-// wireIGate constructs a.ig from configstore. A disabled or missing
-// iGate config leaves a.ig nil, which the igateComponent stop closure
-// handles via a nil-check. Per D7 the webapi layer refuses to save
-// Enabled=true without a station callsign set, so the resolve-below
-// should succeed in the happy path. If it doesn't (hand-edited DB,
-// migration anomaly), we log a warning and leave the iGate nil rather
-// than panicking — graceful degradation matches the rest of the wiring.
+// wireIGate sets up the always-allocated iGate plumbing (reload signal
+// channel, RF->IS fanout adapter, live IGateLineSender adapter) and,
+// when the operator has the iGate enabled at boot, constructs the
+// concrete *igate.Igate and stores it into a.ig. A disabled or missing
+// iGate config leaves a.ig nil — reloadIgate will build the instance
+// when the operator flips the toggle on at runtime.
+//
+// Per D7 the webapi layer refuses to save Enabled=true without a
+// station callsign set, so the resolve inside buildIgateInstance should
+// succeed in the happy path. If it doesn't (hand-edited DB, migration
+// anomaly), we log a warning and leave the iGate nil rather than
+// panicking — graceful degradation matches the rest of the wiring.
 func (a *App) wireIGate(ctx context.Context) error {
+	a.igateReload = make(chan struct{}, 1)
+	a.igateOut = igate.NewIgateOutput(nil)
+	a.igateLineSender = &liveIGateLineSender{a: a}
+
 	igCfg, err := a.store.GetIGateConfig(ctx)
 	if err != nil || igCfg == nil || !igCfg.Enabled {
 		return nil
 	}
 
+	ig, composed, err := a.buildIgateInstance(ctx, igCfg)
+	if err != nil {
+		return err
+	}
+	if ig == nil {
+		return nil
+	}
+	a.ig.Store(ig)
+	a.igateOut.SetIgate(ig)
+	a.lastAppliedIgateFilter = composed
+	return nil
+}
+
+// buildIgateInstance constructs a fresh *igate.Igate from the supplied
+// IGateConfig. Returns (nil, "", nil) when construction is benignly
+// skipped (callsign empty/N0CALL or igate.New init failure); both cases
+// log and let the caller treat the iGate as unavailable. Used by both
+// wireIGate at startup and reloadIgate when the operator toggles the
+// iGate on at runtime.
+func (a *App) buildIgateInstance(ctx context.Context, igCfg *configstore.IGateConfig) (*igate.Igate, string, error) {
 	stationCall, err := a.store.ResolveStationCallsign(ctx)
 	if err != nil {
 		if errors.Is(err, callsign.ErrCallsignEmpty) || errors.Is(err, callsign.ErrCallsignN0Call) {
 			a.logger.Warn("iGate will not start: station callsign unset or N0CALL — set it on the Station Callsign page",
 				"reason", err.Error())
-			return nil
+			return nil, "", nil
 		}
-		return fmt.Errorf("resolve station callsign: %w", err)
+		return nil, "", fmt.Errorf("resolve station callsign: %w", err)
 	}
 
 	rfFilters, _ := a.store.ListIGateRfFilters(ctx)
@@ -598,15 +627,10 @@ func (a *App) wireIGate(ctx context.Context) error {
 
 	txCh := a.resolveTxChannel(ctx, igCfg.TxChannel)
 
-	// Compose the APRS-IS server filter via the single entry point so
-	// enabled tactical callsigns are auto-appended as g/ clauses. Any
-	// raw read of igCfg.ServerFilter outside buildIgateFilter is
-	// guarded by an enforcement test.
 	composedFilter, err := buildIgateFilter(ctx, a.store)
 	if err != nil {
-		return fmt.Errorf("compose igate server filter: %w", err)
+		return nil, "", fmt.Errorf("compose igate server filter: %w", err)
 	}
-	a.lastAppliedIgateFilter = composedFilter
 
 	ig, err := igate.New(igate.Config{
 		Server:          serverAddr,
@@ -641,25 +665,37 @@ func (a *App) wireIGate(ctx context.Context) error {
 				Decoded:   pkt,
 				Notes:     "rf2is",
 			})
-			// RF-heard station uploaded to IS — cache as via=rf,
-			// direction=RX (we heard them on the air, even though we
-			// also forwarded the packet onto APRS-IS).
 			if entries := stationcache.ExtractEntry(pkt, "igate", "RX", uint32(pkt.Channel)); len(entries) > 0 {
 				a.stationCache.Update(entries)
 			}
 		},
 		IsRxHook:     a.onIGateIsRxPacket,
-		ChannelModes: a.store, // *configstore.Store satisfies ChannelModeLookup
+		ChannelModes: a.store,
 	})
 	if err != nil {
-		// Matches the old main.go behavior: init failure is logged but
-		// does not take out the whole app. The iGate just stays nil.
 		a.logger.Error("igate init", "err", err)
-		return nil
+		return nil, "", nil
 	}
-	a.ig = ig
-	a.igateReload = make(chan struct{}, 1)
-	return nil
+	return ig, composedFilter, nil
+}
+
+// liveIGateLineSender is the always-allocated adapter passed to
+// messages.Service so the IGate ref captured into Sender / Router /
+// Preflight stays live across runtime enable/disable toggles. SendLine
+// loads a.ig on every call; when the iGate is disabled the call returns
+// an explicit error which the messages.Sender already handles by
+// marking the row failed.
+type liveIGateLineSender struct{ a *App }
+
+func (l *liveIGateLineSender) SendLine(line string) error {
+	if l == nil || l.a == nil {
+		return errors.New("igate not enabled")
+	}
+	ig := l.a.ig.Load()
+	if ig == nil {
+		return errors.New("igate not enabled")
+	}
+	return ig.SendLine(line)
 }
 
 // onIGateIsRxPacket is the IsRxHook body for the iGate: it records the
@@ -803,13 +839,12 @@ func (a *App) wireMessages(ctx context.Context) error {
 		passcode = strconv.Itoa(callsign.APRSPasscode(stationCall))
 	}
 
-	// iGate line-sender: only when the iGate is wired. A nil IGate in
-	// ServiceConfig means the IS path logs + emits message.failed and
-	// falls back per policy; the Service tolerates nil.
-	var igSender messages.IGateLineSender
-	if a.ig != nil {
-		igSender = a.ig
-	}
+	// iGate line-sender: always the live adapter so a runtime
+	// enable/disable toggle (reloadIgate) is reflected on every
+	// SendLine call without rebuilding messages.Service. The adapter
+	// returns "igate not enabled" when the iGate is currently disabled,
+	// which Sender already handles by marking the row failed.
+	var igSender messages.IGateLineSender = a.igateLineSender
 
 	svc, err := messages.NewService(messages.ServiceConfig{
 		Store:         a.msgStore,
@@ -1032,10 +1067,22 @@ func (a *App) wireHTTP(ctx context.Context) error {
 	}
 	a.apiSrv = apiSrv
 
-	if a.ig != nil {
-		apiSrv.SetIgateStatusFn(a.ig.Status)
-		apiSrv.SetIgateReload(a.igateReload)
-	}
+	// Status fn loads a.ig on each call so an iGate constructed at
+	// runtime (via the enable toggle) becomes visible to /api/status
+	// without rewiring. Returns a zero-value Status (Connected=false)
+	// while disabled, matching the disabled-at-boot behavior the UI
+	// expects.
+	apiSrv.SetIgateStatusFn(func() igate.Status {
+		ig := a.ig.Load()
+		if ig == nil {
+			return igate.Status{}
+		}
+		return ig.Status()
+	})
+	// Reload signal channel is allocated unconditionally in wireIGate
+	// so the operator's enable toggle is delivered even when the iGate
+	// was disabled at boot.
+	apiSrv.SetIgateReload(a.igateReload)
 	apiSrv.SetGPSReload(a.gpsReload)
 	apiSrv.SetBeaconReload(a.beaconReload)
 	apiSrv.SetSmartBeaconReload(a.smartBeaconReload)
@@ -1134,9 +1181,27 @@ func (a *App) wireHTTP(ctx context.Context) error {
 	webapi.RegisterPackets(apiSrv, apiMux, a.plog, a.stationPos)
 	webapi.RegisterStations(apiSrv, apiMux, a.stationCache)
 	webapi.RegisterPosition(apiSrv, apiMux, a.stationPos)
-	if a.ig != nil {
-		webapi.RegisterIgate(apiSrv, apiMux, a.ig.SetSimulationMode, a.ig.Status)
-	}
+	// Always register /api/igate routes; the closures below load a.ig
+	// on each request so the operator's runtime enable toggle lights
+	// the endpoints up without rewiring. While disabled, the simulation
+	// toggle returns 503 (igate not available) and status reports
+	// Connected=false.
+	webapi.RegisterIgate(apiSrv, apiMux,
+		func(b bool) error {
+			ig := a.ig.Load()
+			if ig == nil {
+				return errors.New("igate not enabled")
+			}
+			return ig.SetSimulationMode(b)
+		},
+		func() igate.Status {
+			ig := a.ig.Load()
+			if ig == nil {
+				return igate.Status{}
+			}
+			return ig.Status()
+		},
+	)
 	// Stations autocomplete is an out-of-band registrar (matches the
 	// RegisterPackets / RegisterStations shape). Needs the messages
 	// store for history-prefix lookups and the station cache for
@@ -1926,11 +1991,13 @@ func (a *App) bridgeComponent() namedComponent {
 			aprsOut := aprs.NewLogOutput(a.logger)
 			aprsSubmit := newAPRSSubmitter(a.aprsQueue, a.metrics.AprsOutDropped, a.logger)
 
-			// iGate output adapter for the fan-out (nil if iGate is off).
-			var igateOut *igate.IgateOutput
-			if a.ig != nil {
-				igateOut = igate.NewIgateOutput(a.ig)
-			}
+			// iGate output adapter for the fan-out. The adapter is
+			// always allocated (see wireIGate); its inner *Igate is
+			// nil while the iGate is disabled and SendPacket returns
+			// nil silently in that state. Toggling the iGate on at
+			// runtime swaps a non-nil instance into the adapter via
+			// reloadIgate without rebuilding the fanout.
+			igateOut := a.igateOut
 
 			// Messages router output: classifies inbound APRS text
 			// messages into DM / tactical / auto-ACK responses. Nil
@@ -2128,14 +2195,9 @@ func (a *App) igateComponent() namedComponent {
 	return namedComponent{
 		name: "igate",
 		start: func(ctx context.Context) error {
-			if a.ig == nil {
-				return nil
-			}
-			if err := a.ig.Start(ctx); err != nil {
-				a.logger.Error("igate start", "err", err)
-				// Match old main.go behavior: don't abort startup on
-				// an iGate connection error, just log it.
-			}
+			// The reload-drainer is spawned unconditionally so the
+			// operator's enable toggle reaches reloadIgate even when
+			// the iGate was disabled at boot (issue #84).
 			if a.igateReload != nil {
 				a.igateReloadWG.Add(1)
 				go func() {
@@ -2150,30 +2212,96 @@ func (a *App) igateComponent() namedComponent {
 					}
 				}()
 			}
+			ig := a.ig.Load()
+			if ig == nil {
+				return nil
+			}
+			if err := ig.Start(ctx); err != nil {
+				a.logger.Error("igate start", "err", err)
+				// Match old main.go behavior: don't abort startup on
+				// an iGate connection error, just log it.
+			}
 			return nil
 		},
 		stop: func(shutdownCtx context.Context) error {
-			if a.ig == nil {
-				return nil
+			if ig := a.ig.Load(); ig != nil {
+				ig.Stop()
 			}
-			a.ig.Stop()
 			return waitGroup(shutdownCtx, &a.igateReloadWG, "igate reload")
 		},
 	}
 }
 
-// reloadIgate re-reads igate config, rf filters, and tactical callsigns
-// from the database and pushes them into the running igate. When the
-// composed filter is unchanged we still call Reconfigure (so rule and
-// governor changes on the same signal propagate) but skip the metric
-// and debug log; Reconfigure's own filter-changed check prevents the
-// reconnect.
+// reloadIgate handles the three transitions an iGate config save can
+// produce:
+//   - disabled → enabled: build a fresh *igate.Igate via
+//     buildIgateInstance, Start it, install into a.ig + a.igateOut +
+//     beacon ISSink, and seed lastAppliedIgateFilter.
+//   - enabled → disabled: Stop the current iGate, clear a.ig +
+//     a.igateOut + beacon ISSink, reset lastAppliedIgateFilter so a
+//     subsequent enable rebuilds cleanly.
+//   - enabled → enabled: re-read filters/rules and push them into the
+//     running iGate via Reconfigure. When the composed filter is
+//     unchanged the reconnect is skipped but Reconfigure still runs so
+//     rule/governor changes propagate.
+//
+// Issue #84: prior to this rewrite the function only handled the third
+// case, so toggling the enable flag at runtime had no effect until the
+// next daemon restart.
 func (a *App) reloadIgate(ctx context.Context) {
-	var configuredTxCh uint32
-	if igCfg, _ := a.store.GetIGateConfig(ctx); igCfg != nil {
-		configuredTxCh = igCfg.TxChannel
+	igCfg, err := a.store.GetIGateConfig(ctx)
+	if err != nil {
+		a.logger.Warn("igate reload: read config", "err", err)
+		return
 	}
-	a.ig.SetTxChannel(a.resolveTxChannel(ctx, configuredTxCh))
+	enabled := igCfg != nil && igCfg.Enabled
+	cur := a.ig.Load()
+
+	// enabled → disabled.
+	if !enabled {
+		if cur == nil {
+			return
+		}
+		a.logger.Info("igate disabled at runtime, stopping")
+		cur.Stop()
+		a.ig.Store(nil)
+		a.igateOut.SetIgate(nil)
+		if a.beaconSched != nil {
+			a.beaconSched.SetISSink(nil)
+		}
+		a.lastAppliedIgateFilter = ""
+		return
+	}
+
+	// disabled → enabled.
+	if cur == nil {
+		ig, composed, err := a.buildIgateInstance(ctx, igCfg)
+		if err != nil {
+			a.logger.Warn("igate reload: build", "err", err)
+			return
+		}
+		if ig == nil {
+			// Build benignly skipped (callsign empty/N0CALL or
+			// igate.New init failure); buildIgateInstance already
+			// logged. Leave a.ig nil; the next save retries.
+			return
+		}
+		if err := ig.Start(ctx); err != nil {
+			a.logger.Error("igate reload: start", "err", err)
+			return
+		}
+		a.ig.Store(ig)
+		a.igateOut.SetIgate(ig)
+		if a.beaconSched != nil {
+			a.beaconSched.SetISSink(ig)
+		}
+		a.lastAppliedIgateFilter = composed
+		a.logger.Info("igate enabled at runtime")
+		return
+	}
+
+	// enabled → enabled (TX channel + filter / rules push-through).
+	cur.SetTxChannel(a.resolveTxChannel(ctx, igCfg.TxChannel))
 	rfFilters, _ := a.store.ListIGateRfFilters(ctx)
 	rules := make([]filters.Rule, 0, len(rfFilters))
 	for _, f := range rfFilters {
@@ -2201,14 +2329,14 @@ func (a *App) reloadIgate(ctx context.Context) {
 	}
 
 	if composed == a.lastAppliedIgateFilter {
-		a.ig.Reconfigure(composed, rules, gov)
+		cur.Reconfigure(composed, rules, gov)
 		return
 	}
 
 	a.logger.Debug("igate filter recomposed, reconnecting",
 		"filter", composed,
 		"previous", a.lastAppliedIgateFilter)
-	a.ig.Reconfigure(composed, rules, gov)
+	cur.Reconfigure(composed, rules, gov)
 	a.lastAppliedIgateFilter = composed
 	if a.metrics != nil {
 		a.metrics.IgateFilterRecompositions.Inc()

--- a/pkg/igate/igate.go
+++ b/pkg/igate/igate.go
@@ -306,21 +306,61 @@ func (ig *Igate) initMetrics() error {
 		Name: "igate_is_to_rf_fanout_dropped_total",
 		Help: "IS->RF frames dropped from the PacketInput fan-out because no consumer was ready.",
 	})
-	if ig.cfg.Registry != nil {
-		for _, c := range []prometheus.Collector{
-			ig.mGatedTotal, ig.mFilteredTotal, ig.mConnectedGauge, ig.mDroppedOffline, ig.mSubmitDropped, ig.mFanoutDropped,
-		} {
-			if err := ig.cfg.Registry.Register(c); err != nil {
-				// An AlreadyRegisteredError is fine (tests may call
-				// New twice); anything else is a real problem.
-				are := prometheus.AlreadyRegisteredError{}
-				if !errors.As(err, &are) {
-					return err
-				}
-			}
-		}
+	if ig.cfg.Registry == nil {
+		return nil
+	}
+	// On a re-construction (operator toggled the iGate off then on again
+	// — see graywolf issue #84), the original collectors are still
+	// registered; without rebinding to ExistingCollector below, every
+	// .Inc on the new instance would target an orphan collector and
+	// /metrics would freeze at the first instance's values forever.
+	if c, err := registerOrExisting(ig.cfg.Registry, ig.mGatedTotal); err != nil {
+		return err
+	} else if v, ok := c.(*prometheus.CounterVec); ok {
+		ig.mGatedTotal = v
+	}
+	if c, err := registerOrExisting(ig.cfg.Registry, ig.mFilteredTotal); err != nil {
+		return err
+	} else if v, ok := c.(prometheus.Counter); ok {
+		ig.mFilteredTotal = v
+	}
+	if c, err := registerOrExisting(ig.cfg.Registry, ig.mConnectedGauge); err != nil {
+		return err
+	} else if v, ok := c.(prometheus.Gauge); ok {
+		ig.mConnectedGauge = v
+	}
+	if c, err := registerOrExisting(ig.cfg.Registry, ig.mDroppedOffline); err != nil {
+		return err
+	} else if v, ok := c.(prometheus.Counter); ok {
+		ig.mDroppedOffline = v
+	}
+	if c, err := registerOrExisting(ig.cfg.Registry, ig.mSubmitDropped); err != nil {
+		return err
+	} else if v, ok := c.(prometheus.Counter); ok {
+		ig.mSubmitDropped = v
+	}
+	if c, err := registerOrExisting(ig.cfg.Registry, ig.mFanoutDropped); err != nil {
+		return err
+	} else if v, ok := c.(prometheus.Counter); ok {
+		ig.mFanoutDropped = v
 	}
 	return nil
+}
+
+// registerOrExisting registers c with reg, returning c on success or the
+// already-registered collector on AlreadyRegisteredError. Any other
+// error is propagated. Used by initMetrics so a rebuilt *Igate (issue
+// #84 enable cycle) shares the originally-registered collector instead
+// of orphaning a fresh one that /metrics will never scrape.
+func registerOrExisting(reg prometheus.Registerer, c prometheus.Collector) (prometheus.Collector, error) {
+	if err := reg.Register(c); err != nil {
+		are := prometheus.AlreadyRegisteredError{}
+		if errors.As(err, &are) {
+			return are.ExistingCollector, nil
+		}
+		return nil, err
+	}
+	return c, nil
 }
 
 // Start opens the APRS-IS session and launches the supervising

--- a/pkg/igate/output.go
+++ b/pkg/igate/output.go
@@ -2,10 +2,20 @@ package igate
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 
 	"github.com/chrissnell/graywolf/pkg/aprs"
 )
+
+// ErrNotEnabled is the sentinel returned by adapters that wrap a
+// runtime-toggleable iGate (the IGateLineSender adapter passed to
+// messages.Service, the simulation toggle closure registered with
+// webapi.RegisterIgate, etc.) when the operator has the iGate disabled.
+// Webapi handlers map this to 503 "igate not available" instead of a
+// generic 500 so a deliberately-off iGate does not surface as an
+// internal error in operator dashboards.
+var ErrNotEnabled = errors.New("igate not enabled")
 
 // IgateOutput adapts the iGate's RF->IS gating to the aprs.PacketOutput
 // interface so it can be wired into the decoder's fanout alongside

--- a/pkg/igate/output.go
+++ b/pkg/igate/output.go
@@ -2,30 +2,51 @@ package igate
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/chrissnell/graywolf/pkg/aprs"
 )
 
 // IgateOutput adapts the iGate's RF->IS gating to the aprs.PacketOutput
 // interface so it can be wired into the decoder's fanout alongside
-// LogOutput and the packet log sink.
+// LogOutput and the packet log sink. The inner *Igate is held in an
+// atomic pointer so it can be swapped at runtime when the operator
+// toggles the iGate enable flag.
 type IgateOutput struct {
-	ig *Igate
+	ig atomic.Pointer[Igate]
 }
 
-// NewIgateOutput returns a PacketOutput bound to ig.
+// NewIgateOutput returns a PacketOutput bound to ig. ig may be nil; the
+// inner pointer can be replaced later via SetIgate.
 func NewIgateOutput(ig *Igate) *IgateOutput {
-	return &IgateOutput{ig: ig}
+	o := &IgateOutput{}
+	if ig != nil {
+		o.ig.Store(ig)
+	}
+	return o
+}
+
+// SetIgate swaps the inner *Igate. Pass nil to disable forwarding (used
+// when the operator turns the iGate off at runtime).
+func (o *IgateOutput) SetIgate(ig *Igate) {
+	if o == nil {
+		return
+	}
+	o.ig.Store(ig)
 }
 
 // SendPacket feeds a decoded RF packet into the iGate for possible
 // forwarding to APRS-IS. Always returns nil — gating errors are logged
 // internally and counted in metrics; they are not caller-visible.
 func (o *IgateOutput) SendPacket(_ context.Context, pkt *aprs.DecodedAPRSPacket) error {
-	if o == nil || o.ig == nil {
+	if o == nil {
 		return nil
 	}
-	o.ig.gateRFToIS(pkt)
+	ig := o.ig.Load()
+	if ig == nil {
+		return nil
+	}
+	ig.gateRFToIS(pkt)
 	return nil
 }
 

--- a/pkg/webapi/igate.go
+++ b/pkg/webapi/igate.go
@@ -1,6 +1,7 @@
 package webapi
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/chrissnell/graywolf/pkg/igate"
@@ -32,7 +33,7 @@ type IgateSimulationResponse struct {
 // Operation IDs in the swag annotation blocks below are frozen against
 // constants in pkg/webapi/docs/op_ids.go; `make docs-lint` enforces the
 // correspondence.
-func RegisterIgate(srv *Server, mux *http.ServeMux, toggle func(bool) error, status func() igate.Status) {
+func RegisterIgate(srv *Server, mux *http.ServeMux, toggle func(bool) error, status func() *igate.Status) {
 	if srv == nil || mux == nil {
 		return
 	}
@@ -40,7 +41,10 @@ func RegisterIgate(srv *Server, mux *http.ServeMux, toggle func(bool) error, sta
 	mux.HandleFunc("POST /api/igate/simulation", setIgateSimulation(srv, toggle))
 }
 
-// getIgateStatus returns the current igate runtime status.
+// getIgateStatus returns the current igate runtime status. The status
+// callback returns nil when the iGate is currently disabled; the
+// handler maps that to 503 so the UI's "Disabled" badge logic (which
+// keys off a non-2xx response) keeps working.
 //
 // @Summary  Get igate status
 // @Tags     igate
@@ -50,13 +54,18 @@ func RegisterIgate(srv *Server, mux *http.ServeMux, toggle func(bool) error, sta
 // @Failure  503 {object} webtypes.ErrorResponse
 // @Security CookieAuth
 // @Router   /igate [get]
-func getIgateStatus(status func() igate.Status) http.HandlerFunc {
+func getIgateStatus(status func() *igate.Status) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if status == nil {
 			writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: "igate not available"})
 			return
 		}
-		writeJSON(w, http.StatusOK, status())
+		st := status()
+		if st == nil {
+			writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: "igate not available"})
+			return
+		}
+		writeJSON(w, http.StatusOK, *st)
 	}
 }
 
@@ -91,6 +100,14 @@ func setIgateSimulation(srv *Server, toggle func(bool) error) http.HandlerFunc {
 			return
 		}
 		if err := toggle(req.Enabled); err != nil {
+			// igate.ErrNotEnabled means the operator has the iGate
+			// turned off at runtime. Return 503 so the UI / metrics
+			// don't see this perfectly-normal state as a 500
+			// internal error.
+			if errors.Is(err, igate.ErrNotEnabled) {
+				writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: "igate not available"})
+				return
+			}
 			srv.internalError(w, r, "igate toggle", err)
 			return
 		}

--- a/pkg/webapi/igate_test.go
+++ b/pkg/webapi/igate_test.go
@@ -1,0 +1,101 @@
+package webapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/igate"
+)
+
+// Wire-level regressions for the disabled-state HTTP contract introduced
+// alongside the iGate runtime-toggle fix (graywolf issue #84). When the
+// status / toggle closures report the iGate is currently off, the
+// handlers must respond 503 — NOT 200-with-empty-snapshot, NOT 500 —
+// because the Svelte "Disabled" badge logic in
+// web/src/routes/Igate.svelte keys off a non-2xx response.
+
+func TestGetIgateStatus_NilCallback_Returns503(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	RegisterIgate(srv, mux,
+		func(bool) error { return nil },
+		nil, // callback==nil mimics a server constructed before SetIgate*
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/igate", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when status callback is nil, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGetIgateStatus_DisabledClosureReturnsNil_503(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	RegisterIgate(srv, mux,
+		func(bool) error { return igate.ErrNotEnabled },
+		func() *igate.Status { return nil }, // disabled
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/igate", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when iGate is disabled, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGetIgateStatus_EnabledClosureReturnsSnapshot_200(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	RegisterIgate(srv, mux,
+		func(bool) error { return nil },
+		func() *igate.Status {
+			return &igate.Status{Connected: true, Server: "test:14580"}
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/igate", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 when iGate is enabled, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got igate.Status
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal status body: %v", err)
+	}
+	if !got.Connected || got.Server != "test:14580" {
+		t.Fatalf("status body did not round-trip the snapshot: %+v", got)
+	}
+}
+
+func TestSetIgateSimulation_DisabledToggleReturnsErrNotEnabled_503(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	RegisterIgate(srv, mux,
+		func(bool) error { return igate.ErrNotEnabled },
+		func() *igate.Status { return nil },
+	)
+
+	body, _ := json.Marshal(IgateToggleRequest{Enabled: true})
+	req := httptest.NewRequest(http.MethodPost, "/api/igate/simulation", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when toggle returns ErrNotEnabled, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -60,7 +60,7 @@ type Server struct {
 	startedAt         time.Time
 	historyDBPath     string // read-only; set by -history-db flag
 	version           string // build-time version string returned by GET /api/version
-	igateStatusFn     func() igate.Status
+	igateStatusFn     func() *igate.Status
 	gpsReload         chan struct{} // signalled when GPS config changes
 	beaconReload      chan struct{} // signalled when beacon config changes
 	digipeaterReload  chan struct{} // signalled when digipeater config/rules change
@@ -396,8 +396,10 @@ func (s *Server) SetActionsService(svc ActionsService) { s.actions = svc }
 func (s *Server) SetRemoteActions(svc *remoteactions.Service) { s.remoteActions = svc }
 
 // SetIgateStatusFn installs the function used by /api/status to report
-// igate counters.
-func (s *Server) SetIgateStatusFn(fn func() igate.Status) { s.igateStatusFn = fn }
+// igate counters. The callback should return nil when the iGate is
+// currently disabled so the aggregate status omits the field rather
+// than embedding a deceptive Connected=false snapshot.
+func (s *Server) SetIgateStatusFn(fn func() *igate.Status) { s.igateStatusFn = fn }
 
 // SetUpdatesChecker installs the updates checker post-construction.
 // Called by pkg/app wiring once the checker has been built with the

--- a/pkg/webapi/status.go
+++ b/pkg/webapi/status.go
@@ -124,8 +124,12 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.igateStatusFn != nil {
-		st := s.igateStatusFn()
-		out.Igate = newStatusIgateDTO(st)
+		// nil result means the iGate is currently disabled — leave
+		// out.Igate unset so /api/status callers can distinguish
+		// "off" from "on but disconnected".
+		if st := s.igateStatusFn(); st != nil {
+			out.Igate = newStatusIgateDTO(*st)
+		}
 	}
 
 	writeJSON(w, http.StatusOK, out)


### PR DESCRIPTION
Toggling the iGate Enable switch on the iGate page silently no-op'd until the daemon was restarted. The reload signal channel and reload-drainer goroutine were only allocated when the iGate was already enabled at boot, and reloadIgate only ever ran Reconfigure, never Stop or build.

Reload plumbing (signal channel, drainer goroutine, RF->IS fanout adapter, IGateLineSender adapter) is now allocated unconditionally. reloadIgate handles all three transitions: disabled->enabled (build, Start, install), enabled->disabled (Stop, clear), enabled->enabled (existing Reconfigure path). a.ig is held in atomic.Pointer so consumers that captured method values across the toggle no longer freeze on a stale instance; the status / simulation REST routes re-load it on every call.

Documents the new behavior as wiki invariant 28 and adds three regression tests covering the disabled<->enabled transitions plus a repeated cycle.

Fixes #84.