### PR TITLE
fix(map): show RF-heard count vs total when Direct RX filter is on (#86)

### DIFF
--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -339,6 +339,13 @@
 
   // ---- Status bar derivations ----
   let stationCount = $derived(dataStore.stations.size);
+  let rfStationCount = $derived.by(() => {
+    let n = 0;
+    for (const s of dataStore.stations.values()) {
+      if (isDirectRx(s)) n++;
+    }
+    return n;
+  });
   let timerangeLabel = $derived(
     TIMERANGES_S.find((o) => o.value === timerangeSec)?.label || '',
   );
@@ -525,7 +532,11 @@
     <span class="status-dot {pollDotClass}" aria-hidden="true"></span>
     <span>{pollLabel}</span>
     <span class="status-sep">&middot;</span>
-    <span>{stationCount} station{stationCount !== 1 ? 's' : ''}</span>
+    {#if layerToggles.directRxOnly}
+      <span>{rfStationCount} of {stationCount} station{stationCount !== 1 ? 's' : ''} heard direct</span>
+    {:else}
+      <span>{stationCount} station{stationCount !== 1 ? 's' : ''}</span>
+    {/if}
     <span class="status-sep">&middot;</span>
     <span>{timerangeLabel}</span>
     {#if lastFetchAgo}

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -533,7 +533,7 @@
     <span>{pollLabel}</span>
     <span class="status-sep">&middot;</span>
     {#if layerToggles.directRxOnly}
-      <span>{rfStationCount} of {stationCount} station{stationCount !== 1 ? 's' : ''} heard direct</span>
+      <span>{rfStationCount} heard direct / {stationCount} total</span>
     {:else}
       <span>{stationCount} station{stationCount !== 1 ? 's' : ''}</span>
     {/if}


### PR DESCRIPTION
## Summary
- Status bar shows `N heard direct / M total` while the Direct RX filter is on, instead of `M stations`
- N = stations with at least one RX position at zero hops (matches the existing filter predicate)
- Falls back to `M stations` when the filter is off

Closes #86. Replaces #92 (which accidentally carried an unrelated Android docs commit).

## Test plan
- [x] `npm run build` clean
- [ ] Operator verification: load LiveMap with active stations, toggle Direct RX, confirm count switches to `N heard direct / M total`