### PR TITLE
fix(beacons): surface SendNow errors to UI (#99)

### DIFF
--- a/pkg/beacon/scheduler.go
+++ b/pkg/beacon/scheduler.go
@@ -163,8 +163,7 @@ func (s *Scheduler) SendNow(ctx context.Context, id uint32) error {
 	if found == nil {
 		return fmt.Errorf("beacon: id %d not found", id)
 	}
-	s.sendBeaconImmediate(ctx, *found)
-	return nil
+	return s.sendBeaconImmediate(ctx, *found)
 }
 
 // Run drives the scheduler's single heap-based run loop until ctx is
@@ -346,18 +345,25 @@ func (s *Scheduler) fireAsync(ctx context.Context, p *beaconPlan) {
 // sendBeaconImmediate builds and submits one beacon frame, bypassing
 // the txgovernor's dedup window. Used by SendNow where the operator
 // explicitly requests transmission regardless of recent duplicates.
-func (s *Scheduler) sendBeaconImmediate(ctx context.Context, b Config) {
-	s.sendBeaconWith(ctx, b, true)
+// Returns a *SendNowError on any failure so the operator-driven
+// caller can surface a meaningful reason; nil on success.
+func (s *Scheduler) sendBeaconImmediate(ctx context.Context, b Config) error {
+	return s.sendBeaconWith(ctx, b, true)
 }
 
-// sendBeacon builds and submits one beacon frame.
+// sendBeacon builds and submits one beacon frame. Errors are logged
+// inside sendBeaconWith and dropped here: the scheduled fire path has
+// no upstream caller to surface them to.
 func (s *Scheduler) sendBeacon(ctx context.Context, b Config) {
-	s.sendBeaconWith(ctx, b, false)
+	_ = s.sendBeaconWith(ctx, b, false)
 }
 
 // sendBeaconWith is the shared implementation for sendBeacon and
-// sendBeaconImmediate.
-func (s *Scheduler) sendBeaconWith(ctx context.Context, b Config, skipDedup bool) {
+// sendBeaconImmediate. It always logs failures and notifies observers
+// (preserving existing scheduled-path behavior); additionally it
+// returns a *SendNowError on failure so SendNow can surface the
+// reason to the operator. nil on success.
+func (s *Scheduler) sendBeaconWith(ctx context.Context, b Config, skipDedup bool) error {
 	name := beaconName(b)
 	if s.channelModes != nil {
 		mode, _ := s.channelModes.ModeForChannel(ctx, b.Channel)
@@ -367,7 +373,10 @@ func (s *Scheduler) sendBeaconWith(ctx context.Context, b Config, skipDedup bool
 			if so, ok := s.observer.(SkipObserver); ok && so != nil {
 				so.OnBeaconSkipped(name, "packet_mode")
 			}
-			return
+			return &SendNowError{
+				Kind: SendNowErrorChannelMode,
+				Err:  fmt.Errorf("channel %d is in packet mode and cannot transmit APRS beacons", b.Channel),
+			}
 		}
 	}
 	info, err := s.buildInfo(ctx, b)
@@ -377,7 +386,7 @@ func (s *Scheduler) sendBeaconWith(ctx context.Context, b Config, skipDedup bool
 		// "encode" errors in the AX.25 sense, so they do not feed the
 		// encode counter. The root cause is usually configuration.
 		s.logger.Warn("beacon build", "id", b.ID, "type", b.Type, "err", err)
-		return
+		return &SendNowError{Kind: SendNowErrorBuild, Err: err}
 	}
 	frame, err := ax25.NewUIFrame(b.Source, b.Dest, b.Path, []byte(info))
 	if err != nil {
@@ -389,7 +398,7 @@ func (s *Scheduler) sendBeaconWith(ctx context.Context, b Config, skipDedup bool
 		if eo, ok := s.observer.(ErrorObserver); ok && eo != nil {
 			eo.OnEncodeError(name)
 		}
-		return
+		return &SendNowError{Kind: SendNowErrorEncode, Err: err}
 	}
 	src := txgovernor.SubmitSource{
 		Kind:      "beacon",
@@ -403,14 +412,16 @@ func (s *Scheduler) sendBeaconWith(ctx context.Context, b Config, skipDedup bool
 		if eo, ok := s.observer.(ErrorObserver); ok && eo != nil {
 			eo.OnSubmitError(name, reason)
 		}
-		return
+		return &SendNowError{Kind: SendNowErrorSubmit, Err: err}
 	}
 	s.logger.Info("beacon sent", "id", b.ID, "type", b.Type, "channel", b.Channel, "info", info)
 	if s.observer != nil {
 		s.observer.OnBeaconSent(b.Type)
 	}
 
-	// Optionally duplicate the beacon to APRS-IS.
+	// Optionally duplicate the beacon to APRS-IS. APRS-IS leg failures
+	// do not cause SendNow to report failure: the RF leg already
+	// succeeded, and an offline IS path is normal.
 	if b.SendToAPRSIS && s.isSink != nil {
 		line := formatTNC2(b.Source, b.Dest, b.Path, info)
 		if err := s.isSink.SendLine(line); err != nil {
@@ -419,6 +430,7 @@ func (s *Scheduler) sendBeaconWith(ctx context.Context, b Config, skipDedup bool
 			s.logger.Info("beacon sent to aprs-is", "id", b.ID, "line", line)
 		}
 	}
+	return nil
 }
 
 // formatTNC2 renders a beacon as a TNC-2 monitor line for APRS-IS.

--- a/pkg/beacon/sendnow_error.go
+++ b/pkg/beacon/sendnow_error.go
@@ -1,0 +1,58 @@
+package beacon
+
+// SendNowErrorKind classifies a SendNow failure so callers (notably the
+// REST API handler) can map it to an appropriate HTTP status without
+// string-matching the wrapped error.
+type SendNowErrorKind int
+
+const (
+	// SendNowErrorBuild is a beacon-build failure: the operator's
+	// configuration is internally consistent but cannot produce a frame
+	// right now (no GPS fix, fixed coords 0/0, missing PHG, etc.).
+	SendNowErrorBuild SendNowErrorKind = iota
+	// SendNowErrorEncode is an AX.25 frame-encode failure, almost
+	// always a malformed callsign.
+	SendNowErrorEncode
+	// SendNowErrorChannelMode means the target channel is in
+	// packet-only mode and cannot transmit APRS beacons. The scheduled
+	// fire path skips silently; SendNow surfaces this as an error so
+	// the operator's explicit click does not appear to succeed.
+	SendNowErrorChannelMode
+	// SendNowErrorSubmit means the TX governor refused the frame
+	// (queue full, deadline, etc.). The wrapped Err preserves the
+	// original sentinel so callers can errors.Is against
+	// txgovernor.ErrQueueFull, context.DeadlineExceeded, etc.
+	SendNowErrorSubmit
+)
+
+func (k SendNowErrorKind) String() string {
+	switch k {
+	case SendNowErrorBuild:
+		return "build"
+	case SendNowErrorEncode:
+		return "encode"
+	case SendNowErrorChannelMode:
+		return "channel_mode"
+	case SendNowErrorSubmit:
+		return "submit"
+	default:
+		return "unknown"
+	}
+}
+
+// SendNowError is the typed error returned by Scheduler.SendNow when
+// an explicit operator-driven send fails. Kind selects the failure
+// category; Err preserves the underlying cause for unwrap/errors.Is.
+type SendNowError struct {
+	Kind SendNowErrorKind
+	Err  error
+}
+
+func (e *SendNowError) Error() string {
+	if e.Err == nil {
+		return e.Kind.String()
+	}
+	return e.Err.Error()
+}
+
+func (e *SendNowError) Unwrap() error { return e.Err }

--- a/pkg/beacon/sendnow_error_test.go
+++ b/pkg/beacon/sendnow_error_test.go
@@ -1,0 +1,183 @@
+package beacon
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/gps"
+	"github.com/chrissnell/graywolf/pkg/txgovernor"
+)
+
+// TestSendNow_BuildError_NoGPSCache verifies that SendNow on a position
+// beacon with UseGps set but no GPS cache wired returns a *SendNowError
+// of kind SendNowErrorBuild with the underlying build error preserved.
+// This is the primary issue-99 path: the operator clicks "Beacon Now"
+// on a position beacon configured to use GPS but the station has no
+// GPS hardware. Today SendNow returns nil and the UI shows "Beacon
+// sent" — wrong.
+func TestSendNow_BuildError_NoGPSCache(t *testing.T) {
+	sink := newMockSink(0)
+	logger := slog.New(slog.NewTextHandler(logSink{}, nil))
+	s, _ := New(Options{Sink: sink, Logger: logger}) // no Cache
+
+	s.SetBeacons([]Config{{
+		ID:          1,
+		Type:        TypePosition,
+		Channel:     0,
+		Source:      mustAddr(t, "N0CALL-9"),
+		Dest:        mustAddr(t, "APGRWO"),
+		Slot:        -1,
+		UseGps:      true,
+		SymbolTable: '/', SymbolCode: '-',
+	}})
+
+	err := s.SendNow(context.Background(), 1)
+	if err == nil {
+		t.Fatal("SendNow returned nil; want *SendNowError")
+	}
+	var sne *SendNowError
+	if !errors.As(err, &sne) {
+		t.Fatalf("err = %v; want *SendNowError", err)
+	}
+	if sne.Kind != SendNowErrorBuild {
+		t.Errorf("kind = %v; want SendNowErrorBuild", sne.Kind)
+	}
+	if sink.Recorder.Len() != 0 {
+		t.Errorf("frames submitted = %d; want 0", sink.Recorder.Len())
+	}
+}
+
+// TestSendNow_BuildError_NoGPSFix exercises the issue-99 log line
+// verbatim: cache present, no fix yet. SendNow must surface the
+// "no GPS fix available" reason.
+func TestSendNow_BuildError_NoGPSFix(t *testing.T) {
+	sink := newMockSink(0)
+	cache := gps.NewMemCache() // empty, no Update call
+	logger := slog.New(slog.NewTextHandler(logSink{}, nil))
+	s, _ := New(Options{Sink: sink, Cache: cache, Logger: logger})
+
+	s.SetBeacons([]Config{{
+		ID:          2,
+		Type:        TypePosition,
+		Channel:     0,
+		Source:      mustAddr(t, "N0CALL-9"),
+		Dest:        mustAddr(t, "APGRWO"),
+		Slot:        -1,
+		UseGps:      true,
+		SymbolTable: '/', SymbolCode: '-',
+	}})
+
+	err := s.SendNow(context.Background(), 2)
+	var sne *SendNowError
+	if !errors.As(err, &sne) {
+		t.Fatalf("err = %v; want *SendNowError", err)
+	}
+	if sne.Kind != SendNowErrorBuild {
+		t.Errorf("kind = %v; want SendNowErrorBuild", sne.Kind)
+	}
+	// Verify the operator-visible message names the GPS fix problem.
+	if msg := sne.Error(); msg == "" {
+		t.Error("Error() returned empty string")
+	}
+}
+
+// TestSendNow_ChannelModePacket verifies that sending a beacon to a
+// packet-mode channel surfaces a SendNowErrorChannelMode rather than
+// silently succeeding. The scheduler's silent skip is fine for the
+// scheduled fire path (it is policy, not failure), but for an
+// operator-driven send-now it is misleading to report success.
+func TestSendNow_ChannelModePacket(t *testing.T) {
+	sink := newMockSink(0)
+	logger := slog.New(slog.NewTextHandler(logSink{}, nil))
+	s, _ := New(Options{
+		Sink:   sink,
+		Logger: logger,
+		ChannelModes: &fakeChannelModeLookup{modes: map[uint32]string{
+			3: configstore.ChannelModePacket,
+		}},
+	})
+
+	s.SetBeacons([]Config{{
+		ID:      3,
+		Type:    TypePosition,
+		Channel: 3,
+		Source:  mustAddr(t, "N0CALL-9"),
+		Dest:    mustAddr(t, "APGRWO"),
+		Slot:    -1,
+		Lat:     37.0, Lon: -122.0,
+		SymbolTable: '/', SymbolCode: '-',
+	}})
+
+	err := s.SendNow(context.Background(), 3)
+	var sne *SendNowError
+	if !errors.As(err, &sne) {
+		t.Fatalf("err = %v; want *SendNowError", err)
+	}
+	if sne.Kind != SendNowErrorChannelMode {
+		t.Errorf("kind = %v; want SendNowErrorChannelMode", sne.Kind)
+	}
+	if sink.Recorder.Len() != 0 {
+		t.Errorf("frames submitted = %d; want 0", sink.Recorder.Len())
+	}
+}
+
+// TestSendNow_SubmitError verifies that a Submit failure (TX governor
+// refusing the frame) is surfaced as SendNowErrorSubmit with the
+// underlying error preserved for upstream classification.
+func TestSendNow_SubmitError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(logSink{}, nil))
+	s, _ := New(Options{
+		Sink:   &erroringSink{err: txgovernor.ErrQueueFull},
+		Logger: logger,
+	})
+
+	s.SetBeacons([]Config{{
+		ID:      4,
+		Type:    TypePosition,
+		Channel: 1,
+		Source:  mustAddr(t, "N0CALL-9"),
+		Dest:    mustAddr(t, "APGRWO"),
+		Slot:    -1,
+		Lat:     37.0, Lon: -122.0,
+		SymbolTable: '/', SymbolCode: '-',
+	}})
+
+	err := s.SendNow(context.Background(), 4)
+	var sne *SendNowError
+	if !errors.As(err, &sne) {
+		t.Fatalf("err = %v; want *SendNowError", err)
+	}
+	if sne.Kind != SendNowErrorSubmit {
+		t.Errorf("kind = %v; want SendNowErrorSubmit", sne.Kind)
+	}
+	if !errors.Is(err, txgovernor.ErrQueueFull) {
+		t.Errorf("errors.Is(err, ErrQueueFull) = false; want true")
+	}
+}
+
+// TestSendNow_SuccessReturnsNil guards against regressing the success
+// path: a properly configured beacon with a working sink must still
+// return nil from SendNow.
+func TestSendNow_SuccessReturnsNil(t *testing.T) {
+	sink := newMockSink(1)
+	logger := slog.New(slog.NewTextHandler(logSink{}, nil))
+	s, _ := New(Options{Sink: sink, Logger: logger})
+
+	s.SetBeacons([]Config{{
+		ID:      5,
+		Type:    TypePosition,
+		Channel: 0,
+		Source:  mustAddr(t, "N0CALL-9"),
+		Dest:    mustAddr(t, "APGRWO"),
+		Slot:    -1,
+		Lat:     37.0, Lon: -122.0,
+		SymbolTable: '/', SymbolCode: '-',
+	}})
+
+	if err := s.SendNow(context.Background(), 5); err != nil {
+		t.Fatalf("SendNow on valid beacon returned err: %v", err)
+	}
+}

--- a/pkg/webapi/beacons.go
+++ b/pkg/webapi/beacons.go
@@ -2,9 +2,11 @@ package webapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
+	"github.com/chrissnell/graywolf/pkg/beacon"
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/webapi/dto"
 	"github.com/chrissnell/graywolf/pkg/webtypes"
@@ -185,6 +187,8 @@ func (s *Server) deleteBeacon(w http.ResponseWriter, r *http.Request) {
 // @Success  200 {object} dto.BeaconSendResponse
 // @Failure  400 {object} webtypes.ErrorResponse
 // @Failure  404 {object} webtypes.ErrorResponse
+// @Failure  409 {object} webtypes.ErrorResponse
+// @Failure  422 {object} webtypes.ErrorResponse
 // @Failure  500 {object} webtypes.ErrorResponse
 // @Failure  503 {object} webtypes.ErrorResponse
 // @Security CookieAuth
@@ -204,6 +208,24 @@ func (s *Server) sendBeacon(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.beaconSendNow(r.Context(), id); err != nil {
+		// Map beacon SendNow failure kinds to HTTP statuses so the UI
+		// can surface a useful reason instead of a misleading "sent"
+		// toast (issue #99). Build/encode are operator-config issues;
+		// channel-mode is a config conflict; submit is transient.
+		var sne *beacon.SendNowError
+		if errors.As(err, &sne) {
+			switch sne.Kind {
+			case beacon.SendNowErrorBuild, beacon.SendNowErrorEncode:
+				writeJSON(w, http.StatusUnprocessableEntity, webtypes.ErrorResponse{Error: sne.Error()})
+				return
+			case beacon.SendNowErrorChannelMode:
+				writeJSON(w, http.StatusConflict, webtypes.ErrorResponse{Error: sne.Error()})
+				return
+			case beacon.SendNowErrorSubmit:
+				writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: sne.Error()})
+				return
+			}
+		}
 		s.internalError(w, r, "beacon send now", err)
 		return
 	}

--- a/pkg/webapi/beacons_send_test.go
+++ b/pkg/webapi/beacons_send_test.go
@@ -1,0 +1,177 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/beacon"
+	"github.com/chrissnell/graywolf/pkg/txgovernor"
+	"github.com/chrissnell/graywolf/pkg/webtypes"
+)
+
+// seedBeaconForSend creates a minimal beacon row through the API so the
+// /send route's existence check (s.store.GetBeacon) finds it.
+func seedBeaconForSend(t *testing.T, mux *http.ServeMux) uint32 {
+	t.Helper()
+	body := `{
+		"type":"position",
+		"channel":1,
+		"callsign":"N0CAL",
+		"destination":"APGRWO",
+		"path":"WIDE1-1",
+		"latitude":37.5,
+		"longitude":-122.0,
+		"symbol_table":"/",
+		"symbol":">",
+		"interval":1800,
+		"enabled":true
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/beacons", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("seed: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		ID uint32 `json:"id"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp.ID
+}
+
+// TestBeaconSend_BuildErrorReturns422 verifies that when the beacon
+// scheduler reports a build failure (e.g. issue-99: use_gps without a
+// fix), the /send handler returns 422 Unprocessable Entity with the
+// underlying reason in the JSON error body. Today this returns 200
+// "sent" — the UI then toasts a misleading success.
+func TestBeaconSend_BuildErrorReturns422(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	id := seedBeaconForSend(t, mux)
+
+	srv.SetBeaconSendNow(func(context.Context, uint32) error {
+		return &beacon.SendNowError{
+			Kind: beacon.SendNowErrorBuild,
+			Err:  errors.New("position beacon: use_gps set but no GPS fix available"),
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/beacons/"+strconv.FormatUint(uint64(id), 10)+"/send", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var er webtypes.ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&er); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(er.Error, "GPS fix") {
+		t.Errorf("error body = %q; want substring %q", er.Error, "GPS fix")
+	}
+}
+
+// TestBeaconSend_EncodeErrorReturns422 verifies that an AX.25 encode
+// failure (malformed callsign) is also 422 — the operator's
+// configuration is the cause and they need to see the reason.
+func TestBeaconSend_EncodeErrorReturns422(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	id := seedBeaconForSend(t, mux)
+
+	srv.SetBeaconSendNow(func(context.Context, uint32) error {
+		return &beacon.SendNowError{
+			Kind: beacon.SendNowErrorEncode,
+			Err:  errors.New("ax25: invalid callsign \"BAD!\""),
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/beacons/"+strconv.FormatUint(uint64(id), 10)+"/send", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBeaconSend_ChannelModeReturns409 verifies that attempting to
+// beacon on a packet-mode channel returns 409 Conflict with a clear
+// reason — channel state conflicts with the request.
+func TestBeaconSend_ChannelModeReturns409(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	id := seedBeaconForSend(t, mux)
+
+	srv.SetBeaconSendNow(func(context.Context, uint32) error {
+		return &beacon.SendNowError{
+			Kind: beacon.SendNowErrorChannelMode,
+			Err:  errors.New("channel 1 is in packet mode and cannot transmit APRS beacons"),
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/beacons/"+strconv.FormatUint(uint64(id), 10)+"/send", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var er webtypes.ErrorResponse
+	_ = json.NewDecoder(rec.Body).Decode(&er)
+	if !strings.Contains(er.Error, "packet mode") {
+		t.Errorf("error body = %q; want substring %q", er.Error, "packet mode")
+	}
+}
+
+// TestBeaconSend_SubmitErrorReturns503 verifies that a TX governor
+// failure (queue full, etc.) is 503 — the failure is transient and
+// retrying may succeed once the queue drains.
+func TestBeaconSend_SubmitErrorReturns503(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	id := seedBeaconForSend(t, mux)
+
+	srv.SetBeaconSendNow(func(context.Context, uint32) error {
+		return &beacon.SendNowError{
+			Kind: beacon.SendNowErrorSubmit,
+			Err:  txgovernor.ErrQueueFull,
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/beacons/"+strconv.FormatUint(uint64(id), 10)+"/send", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestBeaconSend_SuccessReturns200 guards the happy path.
+func TestBeaconSend_SuccessReturns200(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	id := seedBeaconForSend(t, mux)
+
+	srv.SetBeaconSendNow(func(context.Context, uint32) error { return nil })
+
+	req := httptest.NewRequest(http.MethodPost, "/api/beacons/"+strconv.FormatUint(uint64(id), 10)+"/send", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -2132,6 +2132,18 @@
                             "$ref": "#/definitions/webtypes.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -4062,6 +4062,14 @@ paths:
           description: Not Found
           schema:
             $ref: '#/definitions/webtypes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -5139,6 +5139,24 @@ export interface operations {
                     "application/json": components["schemas"]["webtypes.ErrorResponse"];
                 };
             };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
             /** @description Internal Server Error */
             500: {
                 headers: {


### PR DESCRIPTION
## Summary
- Fixes #99: beacon "Send Now" reported success even when transmit failed (no GPS fix, packet-mode channel, TX governor refusal, bad callsign)
- New typed `SendNowError` in `pkg/beacon` with kinds Build/Encode/ChannelMode/Submit; `Unwrap` preserves underlying sentinels for `errors.Is`
- `Scheduler.sendBeaconWith` now returns the typed error; `SendNow` propagates; the scheduled fire path still discards (`sendBeacon` calls `_ = sendBeaconWith(...)`) so observer/log behavior is unchanged
- `POST /api/beacons/{id}/send` maps `SendNowError.Kind` to HTTP: Build/Encode → 422, ChannelMode → 409, Submit → 503; underlying reason goes in `error` body field
- UI required no change: `ApiError.message` already pulls `body.error`, and `Beacons.svelte::handleSendNow` already toasts `err.message` on catch

## Test plan
- [x] `GOWORK=off go test ./pkg/beacon/...` (5 new SendNow kind tests + existing scheduler/errors tests)
- [x] `GOWORK=off go test ./pkg/webapi/...` (5 new send-handler status tests + existing auth-gate tests)
- [x] `GOWORK=off go test ./...` (full repo, all green)
- [x] `GOWORK=off go vet ./...` clean
- [x] `GOWORK=off go build ./...` clean
- [ ] Manual: configure a position beacon with `use_gps=true` on a station with no GPS fix, click "Beacon Now", confirm the toast surfaces the GPS-fix reason instead of "Beacon sent"
- [ ] Manual: confirm a normal valid beacon still toasts success