### PR TITLE
fix(audio): disambiguate Windows audio devices

### DIFF
--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -1066,10 +1066,30 @@ pub mod listing {
             // which returns a structured DeviceDescription. We carry
             // its `.name()` field (an owned String) on the wire — the
             // JSON field stays `name` for the schema contract.
+            //
+            // Windows exception: `description().name()` returns only the
+            // device class label (e.g. `"Speakers"` / Hungarian
+            // `"Hangszórók"`), shared by every soundcard of that class,
+            // which would tag every output device as the system default.
+            // The deprecated `name()` on WASAPI returns the friendly
+            // `"Speakers (Realtek(R) Audio)"` form which uniquely
+            // identifies the device — use that on Windows so the
+            // `default_*` source matches what `collect_devices` writes
+            // into `name` below. Issue #100.
+            #[cfg(target_os = "windows")]
+            let default_input = host
+                .default_input_device()
+                .and_then(|d| { #[allow(deprecated)] d.name().ok() });
+            #[cfg(target_os = "windows")]
+            let default_output = host
+                .default_output_device()
+                .and_then(|d| { #[allow(deprecated)] d.name().ok() });
+            #[cfg(not(target_os = "windows"))]
             let default_input = host
                 .default_input_device()
                 .and_then(|d| d.description().ok())
                 .map(|desc| desc.name().to_string());
+            #[cfg(not(target_os = "windows"))]
             let default_output = host
                 .default_output_device()
                 .and_then(|d| d.description().ok())
@@ -1131,16 +1151,30 @@ pub mod listing {
         };
 
         for dev in iter {
-            let name = dev
-                .description()
-                .map(|d| d.name().to_string())
-                .unwrap_or_else(|_| "<unknown>".to_string());
-            let is_default = default_name.map(|d| d == name).unwrap_or(false);
             // pcm_id (cpal `name()`) is the ALSA hw identifier on Linux
             // (e.g. `plughw:CARD=Foo,DEV=0`). On macOS / Windows the
             // recommendation heuristic does not apply and `recommended`
-            // stays false.
-            let pcm_id = dev.name().unwrap_or_default();
+            // stays false. On Windows, pcm_id is the WASAPI friendly
+            // name (e.g. `"Speakers (Realtek(R) Audio)"`) which we also
+            // surface as the device `name` so two cards of the same
+            // class are distinguishable in the flare bundle. Issue #100.
+            //
+            // Skip devices that fail to report a pcm_id, matching the
+            // modem-side `collect_devices`: a phantom `<unknown>` row
+            // confuses operator triage when comparing the live UI to
+            // the flare bundle.
+            let pcm_id = match dev.name() {
+                Ok(id) => id,
+                Err(_) => continue,
+            };
+            #[cfg(target_os = "windows")]
+            let name = pcm_id.clone();
+            #[cfg(not(target_os = "windows"))]
+            let name = dev
+                .description()
+                .map(|d| d.name().to_string())
+                .unwrap_or_else(|_| pcm_id.clone());
+            let is_default = default_name.map(|d| d == name).unwrap_or(false);
             let recommended = super::is_recommended_pcm_id(&pcm_id);
 
             let configs = match direction {

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -1289,7 +1289,20 @@ fn read_sysfs(path: &std::path::Path) -> String {
         .unwrap_or_default()
 }
 
-#[cfg(not(target_os = "linux"))]
+/// On Windows, cpal's deprecated `DeviceTrait::name()` returns the WASAPI
+/// friendly name (e.g. `"Speakers (Realtek(R) Audio)"`) which already
+/// disambiguates multiple devices of the same class. The newer
+/// `description().name()` returns only the device class label
+/// (`"Speakers"` / Hungarian `"Hangszórók"`), making two distinct cards
+/// look identical in the UI. Surfacing the WASAPI friendly name as the
+/// description lets the UI render a disambiguated label without changing
+/// the schema. Issue #100.
+#[cfg(target_os = "windows")]
+fn alsa_card_description(cpal_name: &str) -> String {
+    cpal_name.to_string()
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 fn alsa_card_description(_cpal_name: &str) -> String {
     String::new()
 }
@@ -1378,6 +1391,15 @@ where
             continue;
         }
 
+        // Default-device match is keyed on the device class label
+        // (`description().name()`) on every platform except Windows. On
+        // Windows that label is the same shared string for every device
+        // of a class (e.g. `"Speakers"`) so the comparison would flag
+        // every output as default; pcm_id is the WASAPI friendly name
+        // and uniquely identifies the device. Issue #100.
+        #[cfg(target_os = "windows")]
+        let is_default = default_display_name == Some(pcm_id.as_str());
+        #[cfg(not(target_os = "windows"))]
         let is_default = default_display_name == Some(display_name.as_str());
         let description = alsa_card_description(&pcm_id);
         // Prefer plughw: devices that use a stable card name (CARD=Foo)
@@ -1407,8 +1429,19 @@ fn enumerate_audio_devices(include_output: bool) -> Vec<AudioDeviceInfo> {
     let host = cpal::default_host();
     let host_name = format!("{:?}", host.id());
 
+    // Source the default-device identifier the same way `collect_devices`
+    // keys its `is_default` comparison: pcm_id on Windows (uniquely
+    // identifies the device via the WASAPI friendly name), description
+    // name elsewhere. The function-level `#[allow(deprecated)]` covers
+    // the Windows `d.name()` calls below. Issue #100.
+    #[cfg(target_os = "windows")]
+    let default_input_name = host.default_input_device().and_then(|d| d.name().ok());
+    #[cfg(target_os = "windows")]
+    let default_output_name = host.default_output_device().and_then(|d| d.name().ok());
+    #[cfg(not(target_os = "windows"))]
     let default_input_name = host.default_input_device()
         .and_then(|d| d.description().ok().map(|desc| desc.name().to_string()));
+    #[cfg(not(target_os = "windows"))]
     let default_output_name = host.default_output_device()
         .and_then(|d| d.description().ok().map(|desc| desc.name().to_string()));
 


### PR DESCRIPTION
## Summary

Fixes #100. On Windows, two physically distinct soundcards rendered as identical entries in the Audio Devices UI (e.g. both labeled "Speakers" / Hungarian "Hangszórók"), and every output device of the same class was flagged "System Default".

Root cause: cpal's `Device::description().name()` on the WASAPI host returns only the device class label, which is shared by every device of that class. The deprecated `DeviceTrait::name()` returns the WASAPI friendly name ("Speakers (Realtek(R) Audio)" vs "Speakers (USB PnP Sound Device)") which uniquely identifies the device. The fix surfaces the friendly name as the proto `description` field on Windows and switches `is_default` keying to match.

- `graywolf-modem/src/modem/mod.rs` — runtime `/api/audio-devices/available` path. Windows `alsa_card_description` now returns pcm_id; `collect_devices` keys `is_default` on pcm_id on Windows; `enumerate_audio_devices` sources the default-device key the same way.
- `graywolf-modem/src/audio/soundcard.rs` — `listing` module used by `--list-audio` flare CLI. `name` field set from pcm_id on Windows; default-name source switches to pcm_id; the existing `default_name == name` equality check then works.
- Drive-by: listing module now skips devices whose `name()` errors instead of emitting a phantom `<unknown>` row, matching modem-side behavior.

Linux and macOS code paths unchanged. No proto, Go, or UI edits — the existing `description || name` fallback in `web/src/routes/AudioDevices.svelte` already renders whichever field is populated.

## Test plan

- [x] `cargo check --all-targets` clean on darwin host.
- [x] `cargo test --lib audio::soundcard` 10/10 pass.
- [x] `GOWORK=off go test ./pkg/modembridge/... ./pkg/webapi/...` clean.
- [ ] **Windows verification:** confirm with reporter (HA2ZB or other Windows operator) that the Audio Devices panel shows distinguishable strings for two soundcards of the same class and only one is flagged System Default.
- [ ] Re-test on Linux to confirm no regression in ALSA card description or default detection.
- [ ] Verify a flare bundle generated on Windows lists each card with a unique `name`.