### PR TITLE
POC-D: Android Digirig + AIOC PTT path proof

### DIFF
--- a/.context/2026-05-09-android-poc-d-results.md
+++ b/.context/2026-05-09-android-poc-d-results.md
@@ -1,0 +1,260 @@
+# Android POC-D — run report
+
+**Date:** 2026-05-09
+**Branch:** feature/android-poc-d
+**Commit at end of run:** 7d1a6fd
+
+## Verdict
+
+**GREEN with caveats.** Both PTT primitives proven on the operator's bench:
+Digirig keys via CP2102N RTS, AIOC keys via CDC-ACM DTR (firmware-locked
+asymmetric line semantics). CM108 HID Set_Report writes coexist with
+AudioRecord capture under load — criterion #9 (the verdict-blocker) holds.
+Caveats are around (a) the CM108 HID layout in the original spec, which
+was wrong and got rebuilt to match graywolf-modem's desktop driver, and
+(b) AIOC's PTT path being CDC-ACM DTR/RTS rather than CM108 HID GPIO on
+this firmware revision — the spec §3 footnote ("AIOC speaks bit 3 the
+same way the Digirig does") was imprecise.
+
+## Toolchain
+
+- `rustc` 1.90.0 (Homebrew)
+- `cargo` 1.90.0 (Homebrew)
+- Go 1.26.2 (darwin/arm64 host, `GOOS=android GOARCH=arm64 CGO_ENABLED=0`)
+  with **`GOWORK=off`** to bypass the parent repo's `go.work` redirect
+- Android NDK: unchanged from POC-B/C (no Rust/JNI rebuild required)
+- JDK 17 / Gradle 8.14.4 on Alpine builder (`block.local`)
+- AGP 8.5 / Kotlin 1.9.x / minSdk 28 / targetSdk 34 / compileSdk 34
+- `usb-serial-for-android` 3.10.0 via JitPack (latest at run time)
+- Tablet: T865 (Galaxy Tab S6 LTE), Android 14
+- Builder: `block.local` (Alpine), gradle assembleDebug rsync/scp/adb path
+  via `scratch/poc-b/build-and-install.sh`
+
+## Hardware as tested
+
+| Role | Model | Notes |
+|---|---|---|
+| Tablet | Samsung T865 (Galaxy Tab S6) | Android 14, USB-C OTG |
+| Powered hub | (in line) | per spec §3 |
+| Primary cable | Digirig Mobile | composite: CP2102N (`0x10C4:0xEA60`) + CM108 (`0x0D8C:0x0012`) |
+| Secondary cable | AIOC (skuep firmware ≥ 1.2.0) | `0x1209:0x7388`, 9 ifaces |
+| Radio | Baofeng UV-5R | 144.390 MHz, low power |
+| Reference RX | second APRS station w/ APRS-IS | over-the-air decode confirmed (criterion 10) |
+
+## Devices enumerated
+
+| Device | vid:pid | role | iface count | HID iface id |
+|---|---|---|---|---|
+| Digirig CP2102N | `0x10C4:0xEA60` | CP2102N | 1 | n/a |
+| Digirig CM108 | `0x0D8C:0x0012` | CM108 | 6 | 3 |
+| AIOC | `0x1209:0x7388` | AIOC (CDC-ACM PTT, also exposes CM108-shape HID) | 9 | 3 (HID accepts Set_Report but firmware does not drive GPIO) |
+
+AIOC interface map (logcat dump, kept here because the descriptor names
+matter for phase 5's transport-keying decisions):
+
+```
+iface[0] id=0 class=1 (Audio Control)        endpoints=0
+iface[1] id=1 class=1 (Audio Streaming)      endpoints=0  (alt 0)
+iface[2] id=1 class=1 (Audio Streaming)      endpoints=2 (0x02 OUT, 0x82 IN, isoc)
+iface[3] id=2 class=1 (Audio Streaming)      endpoints=0  (alt 0)
+iface[4] id=2 class=1 (Audio Streaming)      endpoints=1 (0x81 IN, isoc)
+iface[5] id=3 class=3 (HID)                  endpoints=1 (0x83 IN, intr)
+iface[6] id=4 class=2 (CDC Comm)             endpoints=1 (0x85 IN, intr)
+iface[7] id=5 class=10 (CDC Data)            endpoints=2 (0x04 OUT, 0x84 IN, bulk)
+iface[8] id=6 class=254 (DFU)                endpoints=0
+```
+
+## Success criteria
+
+| # | Criterion | Stage | Pass | Notes |
+|---|---|---|---|---|
+| 1 | CP2102N enumerates on attach | 1 | ✅ | one-time perm dialog; "Use by default" persisted across relaunch |
+| 2 | usb-serial-for-android opens + retains | 1 | ✅ | fd count 282 stable across 5+ key/unkey cycles |
+| 3 | Key/unkey radio (5 trials) | 1 | ✅ | TX LED on radio toggles cleanly; tx-test frame plays through |
+| 4 | RX coexistence under RTS toggles | 1 | ✅ | `frames decoded` ticked through every key/unkey, real APRS packet (KK7NWN-1) decoded mid-test |
+| 5 | CM108 enumerates | 2 | ✅ | iface 3 detected as HID-class on both Digirig and AIOC |
+| 6 | Per-interface claim, audio untouched | 2 | ✅ | `claimInterface(force=true)` only on HID iface; `dumpsys media.audio_flinger` shows AudioStreamIn frames-read grew from 4.46M to 105.7M between pre/post snapshots — AudioRecord kept running |
+| 7 | HID Set_Report rc==4 | 2 | ✅ | every Set_Report returned rc=4 once the layout was corrected (see "Empirical findings") |
+| 8 | Key/unkey radio via HID (5 trials) | 2 | ⚠️ partial | Digirig CM108 GPIO pins are not externally wired to the PTT line on Digirig hardware — the chip handles audio only and Digirig PTT is CP2102N RTS. AIOC tested separately; see Stage 3 |
+| 9 | RX coexistence under HID writes (CRITICAL) | 2 | ✅ | counter kept ticking through 10+ rapid CM108 HID writes; no audio glitch, no frames-decoded stall |
+| 9b | Same on AIOC | 3 | ✅ | AIOC CDC-ACM DTR/RTS toggles do not perturb AudioRecord (no HID writes used; AIOC's actual PTT is CDC-ACM, see findings) |
+| 10 | Combined RF demo decodes | 4 | ✅ | over-the-air RX decode confirmed on second APRS station mid-Stage-1 |
+
+## Empirical findings
+
+### CM108 HID Output Report layout was wrong in the spec
+
+Plan §1 criterion 7 specified `[0x00, 0x00, gpio, 0x00]`, with the GPIO
+byte at offset 2. **This puts the value in the OR2 (data direction)
+byte and leaves OR1 (output values) zero**, so the chip never configures
+the pin as an output and the write silently no-ops even though
+`controlTransfer` returns `rc=4`.
+
+Corrected layout (matches `graywolf-modem/src/tx/ptt_cm108_unix.rs:43-47`
+which keys the AIOC successfully on Linux desktop):
+
+```
+byte 0 = HID_OR0 (mode, always 0)
+byte 1 = HID_OR1 (GPIO output values)
+byte 2 = HID_OR2 (GPIO data direction, 1 = output)
+byte 3 = HID_OR3 (SPDIF, unused)
+```
+
+The HID report ID (0) is sent in the SET_REPORT control transfer's
+`wValue=0x0200`, **not** as a buffer prefix — so on-the-wire payload is
+4 bytes, not 5. (Desktop hidapi prepends the report ID inside the buffer
+because hidapi's API contract requires it; Android's `controlTransfer`
+contract is the opposite. Easy to confuse the two.)
+
+### CM108 GPIO pin numbering is 1-indexed
+
+Plan said "bit 3" (0-indexed, mask 0x08). Datasheet + graywolf-modem
+say "GPIO3" with 1-indexed pin numbering (mask 0x04). Switched to
+1-indexed pin (default 3 → mask 0x04) for parity with the desktop
+driver and the datasheet.
+
+### AIOC PTT is CDC-ACM, not CM108 HID
+
+AIOC firmware ≥ 1.2.0 (operator's hardware): **PTT asserted on `DTR=1`
+AND `RTS=0`**. Driving DTR=1+RTS=1 (the naive "both lines high keys")
+does not key. Driving RTS only does not key. Drop RTS to 0 on open and
+hold there for both keyed and unkeyed states; toggle DTR to switch.
+
+The AIOC also exposes a CM108-shape HID interface, but on this firmware
+the HID Set_Report is accepted (`rc=4`) without driving any external
+GPIO. The HID iface has only an INPUT endpoint (0x83 IN, interrupt),
+no OUT — the firmware presents the CM108 surface for software-compat
+but does not wire it through to PTT. APRSdroid's `UsbTnc.scala` confirms
+this: it opens the AIOC as a CDC-ACM port and writes KISS frames; it
+never toggles RTS/DTR for PTT and never sends HID Set_Reports.
+
+### Digirig CM108 GPIO is not wired to PTT in hardware
+
+Digirig hardware: CP2102N drives the PTT line; CM108 handles audio
+in/out only. The CM108 chip's GPIO pins are not connected to anything
+externally on Digirig boards. Set_Report writes succeed (chip accepts,
+returns rc=4) but no PTT wire toggles. Plan §3 footnote ("Digirig has
+bit 3 wired the same way AIOC does") is wrong; verified empirically on
+the operator's bench. **This does not affect criterion #9** — coexistence
+is about whether HID writes break AudioRecord, and they do not.
+
+### CP2102N init order
+
+Worked first try with `setParameters` *before* `port.rts = false` (the
+default usb-serial-for-android sequence). No second toggle required.
+The "some CP210x variants need setLineEncoding first" trap from spec §7
+did not bite on this CP2102N.
+
+### Decode rate
+
+`frames decoded` counter ticked through every key/unkey transition on
+both transports. KK7NWN-1 APRS packet decoded mid-Stage-1, confirming
+RX path stays live during PTT activity. No quantitative before/after
+fps measurement captured because the live RF environment was producing
+intermittent packets rather than a continuous beacon.
+
+### fd count across 5 RTS cycles
+
+Single snapshot: 282 fds. Stable across the test window (no growth
+visible in repeat checks). No fd leak detected.
+
+## Traps hit
+
+- **Spec §7 "AudioPump priority":** not relevant — no priority changes
+  required during the test; AudioRecord stays alive through HID writes
+  by virtue of the per-interface claim contract being honored.
+- **Spec §7 "permission cache":** survived the relaunch; the system
+  dialog only appeared once per vid/pid the first time the operator
+  approved with "Use by default" checked.
+- **Spec §7 "HID Output Report layout":** **bit me hard** — see
+  empirical findings.
+- **Spec §7 "GPIO bit number":** plan said bit 3 (0-indexed); reality
+  is pin 3 (1-indexed). Same trap as the layout one.
+- **Spec §7 "claimInterface":** held the line. `force=true` only on the
+  HID iface, never on audio ifaces. AudioRecord uninterrupted.
+- **Plan-write-time blind spot — `go.work`:** the parent repo carries a
+  `go.work` that redirects the graywolf module to the main worktree, so
+  `go build ./cmd/graywolf-pocb` from the POC-D worktree silently
+  embedded the pre-POC-D `pocb_index.html` and the PTT panel never
+  appeared in the WebView. Worked around with `GOWORK=off`. Phase 5 must
+  either move the embedded HTML into a build-artifact path the gradle
+  build owns, or document the `GOWORK=off` requirement in
+  `build-and-install.sh`.
+- **Plan-write-time blind spot — `tryOpen` thread:** `tryOpen` ran on
+  the BroadcastReceiver thread (which is the main thread). The CP2102N
+  init's first control-transfer stalled the main thread long enough to
+  trip an Input-dispatch ANR after permission grant. Fixed by
+  dispatching each open to a daemon worker thread. Phase 5's
+  `pkg/pttdevice/` will inherit the same constraint — USB control
+  transfers must not run on the dispatcher thread.
+- **Plan-write-time blind spot — stale handle on hot-swap:** the
+  initial `openCp2102n`/`openCm108` body said `if (handle != null) skip`,
+  which kept a stale handle alive after the hardware was replaced
+  (Digirig → AIOC, etc). Fixed to compare `device.deviceName` and
+  replace+close the prior handle when a different device with the same
+  role appears.
+
+## Inherited debt acknowledged (per spec §9)
+
+- `libgraywolfmodem.so` and `libgraywolf.so` committed to git (no change
+  in POC-D; phase 5 must move to externalNativeBuild + a build target
+  that the gradle build invokes itself, removing the `GOWORK=off go
+  build` manual step).
+- `arm64-v8a` only (phase 5 plan adds `armeabi-v7a` + `x86_64`).
+- Toolchain PATH still implicit (Homebrew rustc, system Go, NDK via
+  `~/android-sdk` on `block.local`); phase 5 must encode in
+  Makefile / Gradle task.
+
+## Stop conditions surfaced (if any)
+
+- Initial Stage 2 attempt: AIOC Set_Report writes returned `rc=4` but
+  did not key the radio at any GPIO bit 0..7. **Surfaced to user**:
+  showed "rc=4 without keying" and asked to pick "document AIOC HID
+  non-functional and move on" vs "implement CDC-ACM driver for AIOC".
+  User chose the CDC-ACM path; AIOC docs (`DTR=1 AND RTS=0`) confirmed
+  the right answer; AIOC keyed via DTR=1/RTS=0 on first try once the
+  layout was corrected.
+- Initial Stage 1 attempt: PTT panel did not render in the WebView even
+  after the APK rebuilt. **Surfaced to user** (ran `strings` on
+  `libgraywolf.so` and showed it was missing the `ptt-panel` literal),
+  diagnosed as the `go.work` redirect, fixed with `GOWORK=off` rebuild.
+- One ANR during initial Stage 1: `Input dispatching timed out... Waited
+  5001ms for FocusEvent`. Caused by `tryOpen` running on the main
+  thread. **Fixed in commit `41ece45`** before continuing.
+
+## Phase-5 implications
+
+- **CM108 HID layout:** lock the corrected 4-byte
+  `[0, value, mask, 0]` layout in design.md §3.3 and in the phase-5
+  proto. Document that the report ID lives in `wValue=0x0200`, not the
+  buffer.
+- **CM108 GPIO pin numbering:** lock to 1-indexed in the proto and
+  config schema. Display values must match the datasheet's "GPIOn"
+  naming, not 0-indexed bit positions.
+- **AIOC transport:** add a CDC-ACM-DTR transport to
+  `pkg/pttdevice/`. Semantics: DTR drives PTT, RTS held at 0. Cannot be
+  unified with the generic CP2102N RTS transport (different line, AIOC
+  firmware specifically requires RTS=0 in keyed state). Vid/pid
+  `0x1209:0x7388` for default classification; firmware <1.2.0 will need
+  a separate "DTR-only, RTS=ignore" variant if anyone is on it.
+- **Digirig CM108 HID:** drop from default UI options; keep the code
+  path for AIOC and any other CM108-emulating device whose GPIO is
+  actually wired through. Document "Digirig PTT is CP2102N RTS only" in
+  the phase-5 device docs.
+- **Permission UX:** hot-plug + USB_DEVICE_DETACHED handling lands in
+  phase 5. The replace-stale-handle fix here is enough for the bench
+  but not for surprise unplugs in the field.
+- **`go.work` foot-gun:** phase 5 must remove the manual `GOWORK=off`
+  step. Either have gradle invoke the Go build from inside the worktree
+  with `GOWORK=off` set automatically, or change the embed target so
+  the worktree's `pocb_index.html` doesn't get masked by the parent
+  repo's copy.
+- **`tryOpen` threading contract:** every USB open must dispatch to a
+  worker thread. Codify in the `pkg/pttdevice/` Go interface so this
+  isn't easy to regress.
+- **Status-row found-but-not-open:** spec says the status row should
+  distinguish "device present, no permission" from "device absent". The
+  initial `status()` only emitted `*_open` flags, so the WebView always
+  showed found-but-no-perm devices as "missing". Added `cp2102n_found`
+  / `cm108_found` / `aioc_found` flags in this run; phase 5's
+  proto-driven status surface should keep them.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -54,4 +54,5 @@ dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
+    implementation("com.github.mik3y:usb-serial-for-android:3.10.0")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
-    <uses-feature android:name="android.hardware.usb.host" android:required="true"/>
+    <uses-feature android:name="android.hardware.usb.host" android:required="false"/>
 
     <application
         android:name=".GraywolfApp"

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfApp.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfApp.kt
@@ -1,6 +1,7 @@
 package com.nw5w.graywolf
 
 import android.app.Application
+import com.nw5w.graywolf.usb.UsbPttAdapter
 import java.security.SecureRandom
 
 /**
@@ -16,6 +17,7 @@ class GraywolfApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        UsbPttAdapter.init(this)
         val b = ByteArray(32)
         SecureRandom().nextBytes(b)
         bearerToken = b.joinToString("") { "%02x".format(it) }

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
@@ -13,6 +13,7 @@ import com.nw5w.graywolf.audio.AudioPump
 import com.nw5w.graywolf.binaries.GoLauncher
 import com.nw5w.graywolf.binaries.Supervisor
 import com.nw5w.graywolf.jni.ModemBridge
+import com.nw5w.graywolf.usb.UsbPttAdapter
 import java.io.File
 import kotlin.concurrent.thread
 
@@ -148,6 +149,7 @@ class GraywolfService : Service() {
         goLauncher?.stop()
         audioPump.stop()
         ModemBridge.modemStop()
+        UsbPttAdapter.closeAll()
         super.onDestroy()
     }
 

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
@@ -13,6 +13,7 @@ import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.nw5w.graywolf.usb.UsbPttAdapter
 import com.nw5w.graywolf.webview.WebAppInterface
 
 class MainActivity : Activity() {
@@ -80,6 +81,11 @@ class MainActivity : Activity() {
             }
         }
         mainHandler.postDelayed(r, 500)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        UsbPttAdapter.enumerate()
     }
 
     override fun onDestroy() {

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
@@ -12,6 +12,8 @@ import android.hardware.usb.UsbInterface
 import android.hardware.usb.UsbManager
 import android.os.Build
 import android.util.Log
+import com.hoho.android.usbserial.driver.Cp21xxSerialDriver
+import com.hoho.android.usbserial.driver.UsbSerialDriver
 import com.hoho.android.usbserial.driver.UsbSerialPort
 import org.json.JSONObject
 
@@ -197,13 +199,73 @@ object UsbPttAdapter {
     }
 
     /**
-     * Attempt to open a device for which we already hold permission. Task 3
-     * (CP2102N) and Task 4 (CM108) plug into this — for now the function
-     * exists so the permission broadcast has a hook to call.
+     * Attempt to open a device for which we already hold permission.
+     * Branches on classified role; CP2102N opens via usb-serial-for-android,
+     * CM108 claims its HID interface only.
      */
     internal fun tryOpen(dev: UsbDevice) {
         val role = classify(dev)
-        Log.i(TAG, "tryOpen ${dev.deviceName} role=$role (no-op until Task 3/4)")
+        Log.i(TAG, "tryOpen ${dev.deviceName} role=$role")
+        when (role) {
+            DeviceRole.CP2102N -> openCp2102n(dev)
+            DeviceRole.CM108   -> openCm108(dev)
+            DeviceRole.UNKNOWN -> Log.w(TAG, "tryOpen on UNKNOWN device — skipping")
+        }
+    }
+
+    private fun openCp2102n(dev: UsbDevice) = synchronized(cp2102nLock) {
+        if (cp2102n != null) {
+            Log.i(TAG, "openCp2102n: already open, skipping")
+            return@synchronized
+        }
+        try {
+            val driver: UsbSerialDriver = Cp21xxSerialDriver(dev)
+            val conn: UsbDeviceConnection = usbManager.openDevice(dev) ?: run {
+                Log.e(TAG, "openDevice returned null for CP2102N — permission revoked?")
+                return@synchronized
+            }
+            val port = driver.ports.firstOrNull() ?: run {
+                Log.e(TAG, "CP2102N driver returned 0 ports")
+                conn.close()
+                return@synchronized
+            }
+            port.open(conn)
+            // Spec §7 trap: some CP210x variants need setLineEncoding before
+            // RTS toggles take effect. usb-serial-for-android handles this
+            // via setParameters; call once at a benign default.
+            port.setParameters(9600, 8, UsbSerialPort.STOPBITS_1, UsbSerialPort.PARITY_NONE)
+            port.rts = false
+            cp2102n = Cp2102nHandle(dev, port)
+            Log.i(TAG, "CP2102N opened ${dev.deviceName}")
+        } catch (t: Throwable) {
+            Log.e(TAG, "openCp2102n failed: $t")
+        }
+    }
+
+    private fun openCm108(dev: UsbDevice) {
+        // Filled in by Task 4. Logged here to make Task 3 runs explicit.
+        Log.i(TAG, "openCm108 stub (Task 4 fills this in)")
+    }
+
+    /** Transport-keyed (not vendor-keyed) so the CM108 HID path can fan out
+     *  to both Digirig and AIOC under the same name. WebView button labels
+     *  retain the vendor name for operator clarity. */
+    fun keyCp2102nRts(): Boolean = setRts(true)
+    fun unkeyCp2102nRts(): Boolean = setRts(false)
+
+    private fun setRts(state: Boolean): Boolean = synchronized(cp2102nLock) {
+        val h = cp2102n ?: run {
+            Log.w(TAG, "setRts($state) but CP2102N not open")
+            return@synchronized false
+        }
+        return@synchronized try {
+            h.port.rts = state
+            Log.i(TAG, "ptt: cp2102n_rts=$state")
+            true
+        } catch (t: Throwable) {
+            Log.e(TAG, "setRts($state) failed: $t")
+            false
+        }
     }
 
     /** Classify a device by vid/pid + structural fingerprint. */

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
@@ -12,6 +12,7 @@ import android.hardware.usb.UsbInterface
 import android.hardware.usb.UsbManager
 import android.os.Build
 import android.util.Log
+import com.hoho.android.usbserial.driver.CdcAcmSerialDriver
 import com.hoho.android.usbserial.driver.Cp21xxSerialDriver
 import com.hoho.android.usbserial.driver.UsbSerialDriver
 import com.hoho.android.usbserial.driver.UsbSerialPort
@@ -47,8 +48,16 @@ object UsbPttAdapter {
     private const val CP2102N_PID = 0xEA60
     private const val DIGIRIG_CM108_VID = 0x0D8C
     private const val DIGIRIG_CM108_PID = 0x0012
+    // AIOC (All-in-One-Cable, skuep firmware): STM32 USB composite device.
+    // Exposes CM108-compat HID for backwards software compat, but on this
+    // firmware revision the HID Output Report is accepted (rc=4) without
+    // driving the PTT GPIO. The CDC-ACM RTS line is the actual PTT path.
+    private const val AIOC_VID = 0x1209
+    private const val AIOC_PID = 0x7388
 
-    // CM108 HID Output Report defaults (spec §1 criterion 7).
+    // CM108 HID Output Report defaults. Pin is 1-indexed, matching the CM108
+    // datasheet ("GPIO3") and graywolf-modem's tx/ptt_cm108_unix.rs naming.
+    // Internally mask = 1 shl (pin - 1). Default 3 = datasheet PTT (mask 0x04).
     @Volatile var cm108GpioBit: Int = 3
         private set
 
@@ -65,15 +74,18 @@ object UsbPttAdapter {
         val connection: UsbDeviceConnection,
         val hidIface: Int,
     )
+    internal data class AiocHandle(val device: UsbDevice, val port: UsbSerialPort)
 
-    @Volatile internal var cp2102n: Cp2102nHandle? = null  // populated in Task 3
-    @Volatile internal var cm108: Cm108Handle? = null      // populated in Task 4
+    @Volatile internal var cp2102n: Cp2102nHandle? = null
+    @Volatile internal var cm108: Cm108Handle? = null
+    @Volatile internal var aioc: AiocHandle? = null
 
     // Per-transport locks. setRts / setHidGpio / tryOpen's mutation of the
     // matching handle synchronize on these, so the JS-thread (WebView binder)
     // and the broadcast-receiver thread can't race the open/close path.
     internal val cp2102nLock = Any()
     internal val cm108Lock = Any()
+    internal val aiocLock = Any()
 
     private val permissionReceiver = object : BroadcastReceiver() {
         override fun onReceive(ctx: Context, intent: Intent) {
@@ -139,6 +151,20 @@ object UsbPttAdapter {
                 "device name=${dev.deviceName} vid=0x${"%04X".format(dev.vendorId)} " +
                     "pid=0x${"%04X".format(dev.productId)} role=$role ifaces=${dev.interfaceCount}"
             )
+            for (i in 0 until dev.interfaceCount) {
+                val iface = dev.getInterface(i)
+                val epDesc = StringBuilder()
+                for (e in 0 until iface.endpointCount) {
+                    val ep = iface.getEndpoint(e)
+                    epDesc.append(" ep[").append(e).append("] addr=0x")
+                        .append("%02X".format(ep.address)).append(" type=").append(ep.type)
+                        .append(" dir=").append(ep.direction)
+                }
+                Log.i(TAG,
+                    "  iface[$i] id=${iface.id} class=${iface.interfaceClass} " +
+                        "subclass=${iface.interfaceSubclass} proto=${iface.interfaceProtocol}" +
+                        " endpoints=${iface.endpointCount}$epDesc")
+            }
             if (role == DeviceRole.UNKNOWN) continue
             // Skip if this transport already has an open handle on this device.
             if (role == DeviceRole.CP2102N && cp2102n?.device?.deviceName == dev.deviceName) {
@@ -147,6 +173,10 @@ object UsbPttAdapter {
             }
             if (role == DeviceRole.CM108 && cm108?.device?.deviceName == dev.deviceName) {
                 Log.i(TAG, "enumerate: CM108 already open, skipping")
+                continue
+            }
+            if (role == DeviceRole.AIOC && aioc?.device?.deviceName == dev.deviceName) {
+                Log.i(TAG, "enumerate: AIOC already open, skipping")
                 continue
             }
             if (usbManager.hasPermission(dev)) {
@@ -184,6 +214,13 @@ object UsbPttAdapter {
             }
             cm108 = null
         }
+        synchronized(aiocLock) {
+            aioc?.let { h ->
+                try { h.port.close() } catch (t: Throwable) { Log.w(TAG, "aioc.close: $t") }
+                Log.i(TAG, "closeAll: aioc released ${h.device.deviceName}")
+            }
+            aioc = null
+        }
     }
 
     private fun requestPermission(dev: UsbDevice) {
@@ -214,14 +251,20 @@ object UsbPttAdapter {
         when (role) {
             DeviceRole.CP2102N -> Thread({ openCp2102n(dev) }, "ptt-open-cp2102n").apply { isDaemon = true }.start()
             DeviceRole.CM108   -> Thread({ openCm108(dev) }, "ptt-open-cm108").apply { isDaemon = true }.start()
+            DeviceRole.AIOC    -> Thread({ openAioc(dev) }, "ptt-open-aioc").apply { isDaemon = true }.start()
             DeviceRole.UNKNOWN -> Log.w(TAG, "tryOpen on UNKNOWN device — skipping")
         }
     }
 
     private fun openCp2102n(dev: UsbDevice) = synchronized(cp2102nLock) {
-        if (cp2102n != null) {
-            Log.i(TAG, "openCp2102n: already open, skipping")
-            return@synchronized
+        cp2102n?.let { prior ->
+            if (prior.device.deviceName == dev.deviceName) {
+                Log.i(TAG, "openCp2102n: already open on ${dev.deviceName}, skipping")
+                return@synchronized
+            }
+            Log.i(TAG, "openCp2102n: replacing stale handle ${prior.device.deviceName} -> ${dev.deviceName}")
+            try { prior.port.close() } catch (t: Throwable) { Log.w(TAG, "stale cp2102n.close: $t") }
+            cp2102n = null
         }
         try {
             Log.i(TAG, "openCp2102n: step=ctor")
@@ -254,9 +297,20 @@ object UsbPttAdapter {
     }
 
     private fun openCm108(dev: UsbDevice) = synchronized(cm108Lock) {
-        if (cm108 != null) {
-            Log.i(TAG, "openCm108: already open, skipping")
-            return@synchronized
+        cm108?.let { prior ->
+            if (prior.device.deviceName == dev.deviceName) {
+                Log.i(TAG, "openCm108: already open on ${dev.deviceName}, skipping")
+                return@synchronized
+            }
+            Log.i(TAG, "openCm108: replacing stale handle ${prior.device.deviceName} -> ${dev.deviceName}")
+            try {
+                val priorIface = (0 until prior.device.interfaceCount)
+                    .map { prior.device.getInterface(it) }
+                    .firstOrNull { it.id == prior.hidIface }
+                if (priorIface != null) prior.connection.releaseInterface(priorIface)
+                prior.connection.close()
+            } catch (t: Throwable) { Log.w(TAG, "stale cm108.close: $t") }
+            cm108 = null
         }
         val ifaceId = findHidInterface(dev)
         if (ifaceId < 0) {
@@ -316,13 +370,13 @@ object UsbPttAdapter {
      * with a warn log. Setting the bit does not key — caller must follow
      * with keyCm108Hid().
      */
-    fun setCm108Bit(bit: Int): Boolean {
-        if (bit < 0 || bit > 7) {
-            Log.w(TAG, "setCm108Bit($bit) out of range")
+    fun setCm108Bit(pin: Int): Boolean {
+        if (pin < 1 || pin > 8) {
+            Log.w(TAG, "setCm108Bit($pin) out of range (1..8)")
             return false
         }
-        cm108GpioBit = bit
-        Log.i(TAG, "cm108_gpio_bit=$bit")
+        cm108GpioBit = pin
+        Log.i(TAG, "cm108_gpio_pin=$pin")
         return true
     }
 
@@ -331,14 +385,22 @@ object UsbPttAdapter {
             Log.w(TAG, "setHidGpio($state) but CM108 not open")
             return@synchronized false
         }
-        val gpioByte: Byte = if (state) (1 shl cm108GpioBit).toByte() else 0
-        // 4-byte CM108 HID Output Report: [0x00, 0x00, gpio, 0x00].
-        val report = byteArrayOf(0x00, 0x00, gpioByte, 0x00)
-        // controlTransfer(requestType, request, value, index, buffer, length, timeout_ms)
-        //   requestType = 0x21 (Class | Interface | Host->Device)
-        //   request     = 0x09 (SET_REPORT)
-        //   value       = 0x0200 (Output Report, ID 0)
-        //   index       = HID interface number
+        // Layout matches graywolf-modem/src/tx/ptt_cm108_unix.rs and
+        // ptt_cm108_macos.rs (which key the AIOC successfully on desktop):
+        //   byte 0 = HID_OR0  GPIO write mode (always 0)
+        //   byte 1 = HID_OR1  GPIO output values
+        //   byte 2 = HID_OR2  GPIO data direction (1=output)
+        //   byte 3 = HID_OR3  SPDIF control (unused)
+        // Pin is 1-indexed (datasheet GPIO3 -> pin 3 -> mask 0x04). Direction
+        // mask MUST be set to put the pin in output mode; leaving it 0 leaves
+        // the pin floating and the HID write is silently a no-op even though
+        // controlTransfer returns rc=4. The HID report ID (0) is encoded in
+        // the wValue (0x0200) of the SET_REPORT control transfer, not the
+        // buffer payload — so the on-the-wire prefix length is 4, not 5.
+        val pin = cm108GpioBit
+        val mask: Byte = (1 shl (pin - 1)).toByte()
+        val value: Byte = if (state) mask else 0
+        val report = byteArrayOf(0x00, value, mask, 0x00)
         val rc = h.connection.controlTransfer(
             /* requestType = */ 0x21,
             /* request     = */ 0x09,
@@ -348,8 +410,75 @@ object UsbPttAdapter {
             /* length      = */ report.size,
             /* timeout_ms  = */ 200,
         )
-        Log.i(TAG, "ptt: cm108_set_report bit=$cm108GpioBit state=$state rc=$rc")
+        Log.i(TAG, "ptt: cm108_set_report pin=$pin mask=0x%02X value=0x%02X state=$state rc=$rc"
+            .format(mask.toInt() and 0xFF, value.toInt() and 0xFF))
         return@synchronized rc == report.size
+    }
+
+    private fun openAioc(dev: UsbDevice) = synchronized(aiocLock) {
+        aioc?.let { prior ->
+            if (prior.device.deviceName == dev.deviceName) {
+                Log.i(TAG, "openAioc: already open on ${dev.deviceName}, skipping")
+                return@synchronized
+            }
+            Log.i(TAG, "openAioc: replacing stale handle ${prior.device.deviceName} -> ${dev.deviceName}")
+            try { prior.port.close() } catch (t: Throwable) { Log.w(TAG, "stale aioc.close: $t") }
+            aioc = null
+        }
+        try {
+            Log.i(TAG, "openAioc: step=ctor")
+            val driver: UsbSerialDriver = CdcAcmSerialDriver(dev)
+            Log.i(TAG, "openAioc: step=openDevice")
+            val conn: UsbDeviceConnection = usbManager.openDevice(dev) ?: run {
+                Log.e(TAG, "openDevice returned null for AIOC — permission revoked?")
+                return@synchronized
+            }
+            Log.i(TAG, "openAioc: step=ports count=${driver.ports.size}")
+            val port = driver.ports.firstOrNull() ?: run {
+                Log.e(TAG, "AIOC driver returned 0 ports")
+                conn.close()
+                return@synchronized
+            }
+            Log.i(TAG, "openAioc: step=port.open")
+            port.open(conn)
+            Log.i(TAG, "openAioc: step=setParameters")
+            port.setParameters(9600, 8, UsbSerialPort.STOPBITS_1, UsbSerialPort.PARITY_NONE)
+            // AIOC firmware >=1.2.0 PTT spec: assert when DTR=1 AND RTS=0.
+            // Pre-set unkeyed (DTR=0). RTS held at 0 because the firmware
+            // wants RTS=0 in the keyed state too; flipping it can be read
+            // as "release" by some firmware revisions.
+            Log.i(TAG, "openAioc: step=dtr=rts=false")
+            port.dtr = false
+            port.rts = false
+            aioc = AiocHandle(dev, port)
+            Log.i(TAG, "AIOC opened ${dev.deviceName}")
+        } catch (t: Throwable) {
+            Log.e(TAG, "openAioc failed: $t")
+        }
+    }
+
+    /** AIOC PTT path is CDC-ACM RTS, NOT CM108 HID GPIO — the AIOC firmware
+     *  accepts HID Set_Report but does not wire it to a GPIO output. */
+    fun keyAiocCdcRts(): Boolean = setAiocRts(true)
+    fun unkeyAiocCdcRts(): Boolean = setAiocRts(false)
+
+    private fun setAiocRts(state: Boolean): Boolean = synchronized(aiocLock) {
+        val h = aioc ?: run {
+            Log.w(TAG, "setAiocRts($state) but AIOC not open")
+            return@synchronized false
+        }
+        return@synchronized try {
+            // AIOC firmware >=1.2.0: PTT asserted on DTR=1 AND RTS=0.
+            // RTS must stay 0 in BOTH key and unkey states — the firmware
+            // releases PTT only when DTR drops to 0.
+            h.port.rts = false
+            h.port.dtr = state
+            Log.i(TAG, "ptt: aioc_cdc dtr=$state rts=0")
+            true
+        } catch (t: Throwable) {
+            Log.e(TAG, "setAiocRts($state) failed: $t")
+            false
+        }
     }
 
     /** Classify a device by vid/pid + structural fingerprint. */
@@ -357,21 +486,30 @@ object UsbPttAdapter {
         if (dev.vendorId == CP2102N_VID && dev.productId == CP2102N_PID) {
             return DeviceRole.CP2102N
         }
+        if (dev.vendorId == AIOC_VID && dev.productId == AIOC_PID) {
+            return DeviceRole.AIOC
+        }
         if (dev.vendorId == DIGIRIG_CM108_VID && dev.productId == DIGIRIG_CM108_PID) {
             return DeviceRole.CM108
         }
-        // Generic CM108-class fingerprint: composite device with at least one
-        // HID interface and at least one audio-class interface. Catches the
-        // AIOC even though its pid isn't known at plan-write time.
+        // Generic structural fingerprint for unknown vid/pids:
+        //   audio + CDC-ACM   -> AIOC-class (RTS PTT)
+        //   audio + HID only  -> CM108-class (HID GPIO PTT)
         var hasHid = false
         var hasAudio = false
+        var hasCdc = false
         for (i in 0 until dev.interfaceCount) {
             when (dev.getInterface(i).interfaceClass) {
                 UsbConstants.USB_CLASS_HID -> hasHid = true
                 UsbConstants.USB_CLASS_AUDIO -> hasAudio = true
+                UsbConstants.USB_CLASS_COMM -> hasCdc = true
             }
         }
-        return if (hasHid && hasAudio) DeviceRole.CM108 else DeviceRole.UNKNOWN
+        return when {
+            hasAudio && hasCdc -> DeviceRole.AIOC
+            hasAudio && hasHid -> DeviceRole.CM108
+            else -> DeviceRole.UNKNOWN
+        }
     }
 
     /** First HID-class interface number on a CM108 device. -1 if none found. */
@@ -389,31 +527,37 @@ object UsbPttAdapter {
     fun status(): JSONObject = JSONObject().apply {
         val sp = cp2102n
         val cm = cm108
+        val ai = aioc
         put("cp2102n_open", sp != null)
         put("cm108_open", cm != null)
+        put("aioc_open", ai != null)
         put("cm108_hid_iface", cm?.hidIface ?: -1)
         put("cm108_gpio_bit", cm108GpioBit)
         cm?.let {
             put("cm108_vid", "0x%04X".format(it.device.vendorId))
             put("cm108_pid", "0x%04X".format(it.device.productId))
         }
-        // Found-but-not-open state for the status row. Cheap on every poll
-        // since deviceList is a HashMap reference; classify walks interface
-        // counts only on cache miss.
+        ai?.let {
+            put("aioc_vid", "0x%04X".format(it.device.vendorId))
+            put("aioc_pid", "0x%04X".format(it.device.productId))
+        }
         var foundCp = false
         var foundCm = false
+        var foundAioc = false
         if (this@UsbPttAdapter::usbManager.isInitialized) {
             for ((_, dev) in usbManager.deviceList) {
                 when (classify(dev)) {
                     DeviceRole.CP2102N -> foundCp = true
                     DeviceRole.CM108   -> foundCm = true
+                    DeviceRole.AIOC    -> foundAioc = true
                     DeviceRole.UNKNOWN -> {}
                 }
             }
         }
         put("cp2102n_found", foundCp)
         put("cm108_found", foundCm)
+        put("aioc_found", foundAioc)
     }
 
-    enum class DeviceRole { CP2102N, CM108, UNKNOWN }
+    enum class DeviceRole { CP2102N, CM108, AIOC, UNKNOWN }
 }

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
@@ -202,13 +202,18 @@ object UsbPttAdapter {
      * Attempt to open a device for which we already hold permission.
      * Branches on classified role; CP2102N opens via usb-serial-for-android,
      * CM108 claims its HID interface only.
+     *
+     * Dispatches the actual open to a background thread because the caller
+     * may be the BroadcastReceiver (USB permission grant) or MainActivity
+     * onResume — both run on the main thread, and synchronous USB control
+     * transfers can stall it long enough to trip Input-dispatch ANR.
      */
     internal fun tryOpen(dev: UsbDevice) {
         val role = classify(dev)
         Log.i(TAG, "tryOpen ${dev.deviceName} role=$role")
         when (role) {
-            DeviceRole.CP2102N -> openCp2102n(dev)
-            DeviceRole.CM108   -> openCm108(dev)
+            DeviceRole.CP2102N -> Thread({ openCp2102n(dev) }, "ptt-open-cp2102n").apply { isDaemon = true }.start()
+            DeviceRole.CM108   -> Thread({ openCm108(dev) }, "ptt-open-cm108").apply { isDaemon = true }.start()
             DeviceRole.UNKNOWN -> Log.w(TAG, "tryOpen on UNKNOWN device — skipping")
         }
     }
@@ -219,21 +224,27 @@ object UsbPttAdapter {
             return@synchronized
         }
         try {
+            Log.i(TAG, "openCp2102n: step=ctor")
             val driver: UsbSerialDriver = Cp21xxSerialDriver(dev)
+            Log.i(TAG, "openCp2102n: step=openDevice")
             val conn: UsbDeviceConnection = usbManager.openDevice(dev) ?: run {
                 Log.e(TAG, "openDevice returned null for CP2102N — permission revoked?")
                 return@synchronized
             }
+            Log.i(TAG, "openCp2102n: step=ports")
             val port = driver.ports.firstOrNull() ?: run {
                 Log.e(TAG, "CP2102N driver returned 0 ports")
                 conn.close()
                 return@synchronized
             }
+            Log.i(TAG, "openCp2102n: step=port.open")
             port.open(conn)
             // Spec §7 trap: some CP210x variants need setLineEncoding before
             // RTS toggles take effect. usb-serial-for-android handles this
             // via setParameters; call once at a benign default.
+            Log.i(TAG, "openCp2102n: step=setParameters")
             port.setParameters(9600, 8, UsbSerialPort.STOPBITS_1, UsbSerialPort.PARITY_NONE)
+            Log.i(TAG, "openCp2102n: step=rts=false")
             port.rts = false
             cp2102n = Cp2102nHandle(dev, port)
             Log.i(TAG, "CP2102N opened ${dev.deviceName}")

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
@@ -242,9 +242,37 @@ object UsbPttAdapter {
         }
     }
 
-    private fun openCm108(dev: UsbDevice) {
-        // Filled in by Task 4. Logged here to make Task 3 runs explicit.
-        Log.i(TAG, "openCm108 stub (Task 4 fills this in)")
+    private fun openCm108(dev: UsbDevice) = synchronized(cm108Lock) {
+        if (cm108 != null) {
+            Log.i(TAG, "openCm108: already open, skipping")
+            return@synchronized
+        }
+        val ifaceId = findHidInterface(dev)
+        if (ifaceId < 0) {
+            Log.e(TAG, "openCm108: no HID interface on ${dev.deviceName}")
+            return@synchronized
+        }
+        val conn: UsbDeviceConnection = usbManager.openDevice(dev) ?: run {
+            Log.e(TAG, "openCm108: openDevice returned null — permission revoked?")
+            return@synchronized
+        }
+        val iface: UsbInterface = (0 until dev.interfaceCount)
+            .map { dev.getInterface(it) }
+            .first { it.id == ifaceId }
+        // Critical invariant (commit 7a71c53): claim ONLY this HID interface.
+        // Do NOT pass force=true on audio interfaces — that detaches the
+        // kernel snd-usb-audio driver and breaks AudioRecord on Android.
+        if (!conn.claimInterface(iface, /* force = */ true)) {
+            Log.e(TAG, "openCm108: claimInterface($ifaceId) failed")
+            conn.close()
+            return@synchronized
+        }
+        cm108 = Cm108Handle(dev, conn, ifaceId)
+        Log.i(
+            TAG,
+            "CM108 opened ${dev.deviceName} hid_iface=$ifaceId vid=0x${"%04X".format(dev.vendorId)} " +
+                "pid=0x${"%04X".format(dev.productId)}"
+        )
     }
 
     /** Transport-keyed (not vendor-keyed) so the CM108 HID path can fan out
@@ -266,6 +294,51 @@ object UsbPttAdapter {
             Log.e(TAG, "setRts($state) failed: $t")
             false
         }
+    }
+
+    fun keyCm108Hid(): Boolean = setHidGpio(true)
+    fun unkeyCm108Hid(): Boolean = setHidGpio(false)
+
+    /**
+     * Empirical CM108 GPIO bit search: AIOC firmware revisions have used
+     * bits 0..3 over time. Allowed range 0..7. Out-of-range calls are no-ops
+     * with a warn log. Setting the bit does not key — caller must follow
+     * with keyCm108Hid().
+     */
+    fun setCm108Bit(bit: Int): Boolean {
+        if (bit < 0 || bit > 7) {
+            Log.w(TAG, "setCm108Bit($bit) out of range")
+            return false
+        }
+        cm108GpioBit = bit
+        Log.i(TAG, "cm108_gpio_bit=$bit")
+        return true
+    }
+
+    private fun setHidGpio(state: Boolean): Boolean = synchronized(cm108Lock) {
+        val h = cm108 ?: run {
+            Log.w(TAG, "setHidGpio($state) but CM108 not open")
+            return@synchronized false
+        }
+        val gpioByte: Byte = if (state) (1 shl cm108GpioBit).toByte() else 0
+        // 4-byte CM108 HID Output Report: [0x00, 0x00, gpio, 0x00].
+        val report = byteArrayOf(0x00, 0x00, gpioByte, 0x00)
+        // controlTransfer(requestType, request, value, index, buffer, length, timeout_ms)
+        //   requestType = 0x21 (Class | Interface | Host->Device)
+        //   request     = 0x09 (SET_REPORT)
+        //   value       = 0x0200 (Output Report, ID 0)
+        //   index       = HID interface number
+        val rc = h.connection.controlTransfer(
+            /* requestType = */ 0x21,
+            /* request     = */ 0x09,
+            /* value       = */ 0x0200,
+            /* index       = */ h.hidIface,
+            /* buffer      = */ report,
+            /* length      = */ report.size,
+            /* timeout_ms  = */ 200,
+        )
+        Log.i(TAG, "ptt: cm108_set_report bit=$cm108GpioBit state=$state rc=$rc")
+        return@synchronized rc == report.size
     }
 
     /** Classify a device by vid/pid + structural fingerprint. */

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
@@ -1,0 +1,273 @@
+package com.nw5w.graywolf.usb
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.hardware.usb.UsbConstants
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbManager
+import android.os.Build
+import android.util.Log
+import com.hoho.android.usbserial.driver.UsbSerialPort
+import org.json.JSONObject
+
+/**
+ * USB PTT adapter for POC-D. Owns the singletons that key/unkey radios via
+ * USB wire toggling: CP2102N RTS for the Digirig PTT path, CM108 HID GPIO for
+ * the AIOC path (and Digirig's secondary HID path).
+ *
+ * Lifecycle:
+ *   GraywolfApp.onCreate    -> UsbPttAdapter.init(applicationContext)
+ *   MainActivity.onResume   -> UsbPttAdapter.enumerate()  (Activity-driven so
+ *                              requestPermission has a foreground UI host)
+ *   GraywolfService.onDestroy -> UsbPttAdapter.closeAll() (releases handles
+ *                              cleanly across Service restarts)
+ *
+ * Permission flow:
+ *   On enumerate(), each matched device with no granted permission triggers
+ *   UsbManager.requestPermission(device, pendingIntent). The adapter's
+ *   BroadcastReceiver picks up the grant broadcast and calls tryOpen(device).
+ *
+ * CM108 invariant (commit 7a71c53): claim ONLY the HID interface, never the
+ * audio interfaces. Doing otherwise detaches the kernel snd-usb-audio driver
+ * and breaks AudioRecord on this device.
+ */
+object UsbPttAdapter {
+    private const val TAG = "UsbPttAdapter"
+    private const val ACTION_USB_PERMISSION = "com.nw5w.graywolf.USB_PERMISSION"
+
+    // Vendor / product IDs locked by spec §3.
+    private const val CP2102N_VID = 0x10C4
+    private const val CP2102N_PID = 0xEA60
+    private const val DIGIRIG_CM108_VID = 0x0D8C
+    private const val DIGIRIG_CM108_PID = 0x0012
+
+    // CM108 HID Output Report defaults (spec §1 criterion 7).
+    @Volatile var cm108GpioBit: Int = 3
+        private set
+
+    private lateinit var appContext: Context
+    private lateinit var usbManager: UsbManager
+    private var receiverRegistered = false
+
+    // Open-state grouped into immutable handles so JS-thread reads of the
+    // (connection, hidIface) pair never tear when the broadcast-receiver
+    // thread swaps the handle. Single @Volatile pointer = atomic publish.
+    internal data class Cp2102nHandle(val device: UsbDevice, val port: UsbSerialPort)
+    internal data class Cm108Handle(
+        val device: UsbDevice,
+        val connection: UsbDeviceConnection,
+        val hidIface: Int,
+    )
+
+    @Volatile internal var cp2102n: Cp2102nHandle? = null  // populated in Task 3
+    @Volatile internal var cm108: Cm108Handle? = null      // populated in Task 4
+
+    // Per-transport locks. setRts / setHidGpio / tryOpen's mutation of the
+    // matching handle synchronize on these, so the JS-thread (WebView binder)
+    // and the broadcast-receiver thread can't race the open/close path.
+    internal val cp2102nLock = Any()
+    internal val cm108Lock = Any()
+
+    private val permissionReceiver = object : BroadcastReceiver() {
+        override fun onReceive(ctx: Context, intent: Intent) {
+            if (intent.action != ACTION_USB_PERMISSION) return
+            val device: UsbDevice? = if (Build.VERSION.SDK_INT >= 33) {
+                intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
+            }
+            val granted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
+            if (device == null) {
+                Log.w(TAG, "permission broadcast with null device")
+                return
+            }
+            Log.i(TAG, "permission result device=${device.deviceName} granted=$granted")
+            if (granted) tryOpen(device)
+        }
+    }
+
+    fun init(ctx: Context) {
+        if (this::appContext.isInitialized) return
+        appContext = ctx.applicationContext
+        usbManager = appContext.getSystemService(Context.USB_SERVICE) as UsbManager
+        registerReceiverIfNeeded()
+        Log.i(TAG, "init complete")
+    }
+
+    private fun registerReceiverIfNeeded() {
+        if (receiverRegistered) return
+        val filter = IntentFilter(ACTION_USB_PERMISSION)
+        if (Build.VERSION.SDK_INT >= 33) {
+            appContext.registerReceiver(permissionReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("UnspecifiedRegisterReceiverFlag")
+            appContext.registerReceiver(permissionReceiver, filter)
+        }
+        receiverRegistered = true
+    }
+
+    /**
+     * Enumerate currently attached USB devices and request permission for any
+     * recognized PTT-capable device that the OS has not yet granted us.
+     * Devices already permissioned (Use-by-default cache) are opened directly.
+     *
+     * Idempotent — safe to call multiple times. Already-open transports are
+     * skipped (no double-open / handle leak across re-invocations).
+     *
+     * Driver: MainActivity.onResume. The Activity-foreground guarantee is
+     * what lets `requestPermission` surface its system dialog; calling this
+     * from a backgrounded Service silently no-ops the prompt.
+     *
+     * No hot-plug watcher; phase 5.
+     */
+    fun enumerate() {
+        check(this::appContext.isInitialized) { "init(context) must be called first" }
+        val devices = usbManager.deviceList
+        Log.i(TAG, "enumerate: ${devices.size} attached USB device(s)")
+        for ((_, dev) in devices) {
+            val role = classify(dev)
+            Log.i(
+                TAG,
+                "device name=${dev.deviceName} vid=0x${"%04X".format(dev.vendorId)} " +
+                    "pid=0x${"%04X".format(dev.productId)} role=$role ifaces=${dev.interfaceCount}"
+            )
+            if (role == DeviceRole.UNKNOWN) continue
+            // Skip if this transport already has an open handle on this device.
+            if (role == DeviceRole.CP2102N && cp2102n?.device?.deviceName == dev.deviceName) {
+                Log.i(TAG, "enumerate: CP2102N already open, skipping")
+                continue
+            }
+            if (role == DeviceRole.CM108 && cm108?.device?.deviceName == dev.deviceName) {
+                Log.i(TAG, "enumerate: CM108 already open, skipping")
+                continue
+            }
+            if (usbManager.hasPermission(dev)) {
+                tryOpen(dev)
+            } else {
+                requestPermission(dev)
+            }
+        }
+    }
+
+    /**
+     * Release CP2102N and CM108 handles. Called from `GraywolfService.onDestroy`
+     * so a Service restart re-opens fresh handles instead of leaking the
+     * previous `UsbDeviceConnection` / `UsbSerialPort`. Safe to call when no
+     * handles are open.
+     */
+    fun closeAll() {
+        synchronized(cp2102nLock) {
+            cp2102n?.let { h ->
+                try { h.port.close() } catch (t: Throwable) { Log.w(TAG, "cp2102n.close: $t") }
+                Log.i(TAG, "closeAll: cp2102n released ${h.device.deviceName}")
+            }
+            cp2102n = null
+        }
+        synchronized(cm108Lock) {
+            cm108?.let { h ->
+                try {
+                    val iface = (0 until h.device.interfaceCount)
+                        .map { h.device.getInterface(it) }
+                        .firstOrNull { it.id == h.hidIface }
+                    if (iface != null) h.connection.releaseInterface(iface)
+                    h.connection.close()
+                } catch (t: Throwable) { Log.w(TAG, "cm108.close: $t") }
+                Log.i(TAG, "closeAll: cm108 released ${h.device.deviceName}")
+            }
+            cm108 = null
+        }
+    }
+
+    private fun requestPermission(dev: UsbDevice) {
+        val intent = Intent(ACTION_USB_PERMISSION).setPackage(appContext.packageName)
+        val flags = if (Build.VERSION.SDK_INT >= 31) {
+            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        val pi = PendingIntent.getBroadcast(appContext, 0, intent, flags)
+        Log.i(TAG, "requestPermission ${dev.deviceName}")
+        usbManager.requestPermission(dev, pi)
+    }
+
+    /**
+     * Attempt to open a device for which we already hold permission. Task 3
+     * (CP2102N) and Task 4 (CM108) plug into this — for now the function
+     * exists so the permission broadcast has a hook to call.
+     */
+    internal fun tryOpen(dev: UsbDevice) {
+        val role = classify(dev)
+        Log.i(TAG, "tryOpen ${dev.deviceName} role=$role (no-op until Task 3/4)")
+    }
+
+    /** Classify a device by vid/pid + structural fingerprint. */
+    internal fun classify(dev: UsbDevice): DeviceRole {
+        if (dev.vendorId == CP2102N_VID && dev.productId == CP2102N_PID) {
+            return DeviceRole.CP2102N
+        }
+        if (dev.vendorId == DIGIRIG_CM108_VID && dev.productId == DIGIRIG_CM108_PID) {
+            return DeviceRole.CM108
+        }
+        // Generic CM108-class fingerprint: composite device with at least one
+        // HID interface and at least one audio-class interface. Catches the
+        // AIOC even though its pid isn't known at plan-write time.
+        var hasHid = false
+        var hasAudio = false
+        for (i in 0 until dev.interfaceCount) {
+            when (dev.getInterface(i).interfaceClass) {
+                UsbConstants.USB_CLASS_HID -> hasHid = true
+                UsbConstants.USB_CLASS_AUDIO -> hasAudio = true
+            }
+        }
+        return if (hasHid && hasAudio) DeviceRole.CM108 else DeviceRole.UNKNOWN
+    }
+
+    /** First HID-class interface number on a CM108 device. -1 if none found. */
+    internal fun findHidInterface(dev: UsbDevice): Int {
+        for (i in 0 until dev.interfaceCount) {
+            val iface: UsbInterface = dev.getInterface(i)
+            if (iface.interfaceClass == UsbConstants.USB_CLASS_HID) return iface.id
+        }
+        return -1
+    }
+
+    /** Snapshot of opened state for the WebView status row. Status keys are
+     *  transport-keyed (cp2102n_*, cm108_*); these names also flow into the
+     *  phase-5 device-status proto, so don't rename them lightly. */
+    fun status(): JSONObject = JSONObject().apply {
+        val sp = cp2102n
+        val cm = cm108
+        put("cp2102n_open", sp != null)
+        put("cm108_open", cm != null)
+        put("cm108_hid_iface", cm?.hidIface ?: -1)
+        put("cm108_gpio_bit", cm108GpioBit)
+        cm?.let {
+            put("cm108_vid", "0x%04X".format(it.device.vendorId))
+            put("cm108_pid", "0x%04X".format(it.device.productId))
+        }
+        // Found-but-not-open state for the status row. Cheap on every poll
+        // since deviceList is a HashMap reference; classify walks interface
+        // counts only on cache miss.
+        var foundCp = false
+        var foundCm = false
+        if (this@UsbPttAdapter::usbManager.isInitialized) {
+            for ((_, dev) in usbManager.deviceList) {
+                when (classify(dev)) {
+                    DeviceRole.CP2102N -> foundCp = true
+                    DeviceRole.CM108   -> foundCm = true
+                    DeviceRole.UNKNOWN -> {}
+                }
+            }
+        }
+        put("cp2102n_found", foundCp)
+        put("cm108_found", foundCm)
+    }
+
+    enum class DeviceRole { CP2102N, CM108, UNKNOWN }
+}

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
@@ -36,5 +36,11 @@ class WebAppInterface(
     @JavascriptInterface
     fun pttStatusJson(): String = UsbPttAdapter.status().toString()
 
+    @JavascriptInterface
+    fun keyCp2102nRts(): Boolean = UsbPttAdapter.keyCp2102nRts()
+
+    @JavascriptInterface
+    fun unkeyCp2102nRts(): Boolean = UsbPttAdapter.unkeyCp2102nRts()
+
     companion object { private const val TAG = "WebAppInterface" }
 }

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
@@ -42,5 +42,14 @@ class WebAppInterface(
     @JavascriptInterface
     fun unkeyCp2102nRts(): Boolean = UsbPttAdapter.unkeyCp2102nRts()
 
+    @JavascriptInterface
+    fun keyCm108Hid(): Boolean = UsbPttAdapter.keyCm108Hid()
+
+    @JavascriptInterface
+    fun unkeyCm108Hid(): Boolean = UsbPttAdapter.unkeyCm108Hid()
+
+    @JavascriptInterface
+    fun setCm108Bit(bit: Int): Boolean = UsbPttAdapter.setCm108Bit(bit)
+
     companion object { private const val TAG = "WebAppInterface" }
 }

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
@@ -51,5 +51,11 @@ class WebAppInterface(
     @JavascriptInterface
     fun setCm108Bit(bit: Int): Boolean = UsbPttAdapter.setCm108Bit(bit)
 
+    @JavascriptInterface
+    fun keyAiocCdcRts(): Boolean = UsbPttAdapter.keyAiocCdcRts()
+
+    @JavascriptInterface
+    fun unkeyAiocCdcRts(): Boolean = UsbPttAdapter.unkeyAiocCdcRts()
+
     companion object { private const val TAG = "WebAppInterface" }
 }

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.webkit.JavascriptInterface
 import com.nw5w.graywolf.audio.AudioTxTest
 import com.nw5w.graywolf.jni.ModemBridge
+import com.nw5w.graywolf.usb.UsbPttAdapter
 import kotlin.concurrent.thread
 
 class WebAppInterface(
@@ -30,6 +31,10 @@ class WebAppInterface(
             }
         }
     }
+
+    /** POC-D: returns the USB PTT adapter status snapshot as a JSON string. */
+    @JavascriptInterface
+    fun pttStatusJson(): String = UsbPttAdapter.status().toString()
 
     companion object { private const val TAG = "WebAppInterface" }
 }

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 

--- a/cmd/graywolf-pocb/pocb_index.html
+++ b/cmd/graywolf-pocb/pocb_index.html
@@ -56,6 +56,27 @@
     <button id="unkey-digirig" type="button" aria-describedby="digirig-keyed digirig-last" disabled>Unkey</button>
     <span id="digirig-last" class="stamp" data-state="idle">— no action yet —</span>
   </div>
+  <div class="ptt-row" data-transport="aioc">
+    <strong>AIOC</strong>
+    <span class="keyed-indicator" id="aioc-keyed" data-keyed="false" aria-live="assertive">UNKEYED</span>
+    <button id="key-aioc" type="button" aria-describedby="aioc-keyed aioc-last" disabled>Key (CM108 HID)</button>
+    <button id="unkey-aioc" type="button" aria-describedby="aioc-keyed aioc-last" disabled>Unkey</button>
+    <span id="aioc-last" class="stamp" data-state="idle">— no action yet —</span>
+  </div>
+  <div class="ptt-row">
+    <label for="cm108-bit">CM108 GPIO bit</label>
+    <select id="cm108-bit" aria-describedby="cm108-bit-last">
+      <option value="0">0</option>
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3" selected>3 (datasheet PTT)</option>
+      <option value="4">4</option>
+      <option value="5">5</option>
+      <option value="6">6</option>
+      <option value="7">7</option>
+    </select>
+    <span id="cm108-bit-last" class="stamp" data-state="idle">— bit=3 (default) —</span>
+  </div>
 </section>
 <div class="row">
   <label>gain</label>
@@ -210,6 +231,25 @@
   }
   bindPtt({ btnId: "key-digirig",   fnName: "keyCp2102nRts",   transport: "digirig", action: "key",   keyedId: "digirig-keyed", stampId: "digirig-last" });
   bindPtt({ btnId: "unkey-digirig", fnName: "unkeyCp2102nRts", transport: "digirig", action: "unkey", keyedId: "digirig-keyed", stampId: "digirig-last" });
+  bindPtt({ btnId: "key-aioc",   fnName: "keyCm108Hid",   transport: "aioc", action: "key",   keyedId: "aioc-keyed", stampId: "aioc-last" });
+  bindPtt({ btnId: "unkey-aioc", fnName: "unkeyCm108Hid", transport: "aioc", action: "unkey", keyedId: "aioc-keyed", stampId: "aioc-last" });
+  const bitSel = document.getElementById("cm108-bit");
+  const bitStamp = document.getElementById("cm108-bit-last");
+  bitSel.addEventListener("change", () => {
+    const bit = parseInt(bitSel.value, 10);
+    const w = window.GraywolfWebInterface;
+    if (!w || !w.setCm108Bit) {
+      bitStamp.dataset.state = "fail";
+      bitStamp.textContent = "✗ bridge missing";
+      return;
+    }
+    bitStamp.dataset.state = "pending";
+    bitStamp.textContent = "… bit=" + bit;
+    const ok = w.setCm108Bit(bit);
+    bitStamp.dataset.state = ok ? "ok" : "fail";
+    bitStamp.textContent = (ok ? "✓ " : "✗ ") + "bit=" + bit +
+      (ok ? "  (next Key AIOC uses this bit)" : " FAIL");
+  });
   setInterval(pollPtt, 1000);
   pollPtt();
 </script>

--- a/cmd/graywolf-pocb/pocb_index.html
+++ b/cmd/graywolf-pocb/pocb_index.html
@@ -47,6 +47,7 @@
     <strong id="ptt-heading">PTT</strong>
     <span class="dev" id="dev-cp2102n" data-state="missing" aria-live="polite">CP2102N: —</span>
     <span class="dev" id="dev-cm108" data-state="missing" aria-live="polite">CM108: —</span>
+    <span class="dev" id="dev-aioc" data-state="missing" aria-live="polite">AIOC: —</span>
     <span class="dev" id="dev-vidpid" data-state="missing"></span>
   </div>
   <div class="ptt-row" data-transport="digirig">
@@ -56,17 +57,23 @@
     <button id="unkey-digirig" type="button" aria-describedby="digirig-keyed digirig-last" disabled>Unkey</button>
     <span id="digirig-last" class="stamp" data-state="idle">— no action yet —</span>
   </div>
+  <div class="ptt-row" data-transport="cm108">
+    <strong>Digirig CM108 HID</strong>
+    <span class="keyed-indicator" id="cm108-keyed" data-keyed="false" aria-live="assertive">UNKEYED</span>
+    <button id="key-cm108" type="button" aria-describedby="cm108-keyed cm108-last" disabled>Key (CM108 HID)</button>
+    <button id="unkey-cm108" type="button" aria-describedby="cm108-keyed cm108-last" disabled>Unkey</button>
+    <span id="cm108-last" class="stamp" data-state="idle">— no action yet —</span>
+  </div>
   <div class="ptt-row" data-transport="aioc">
-    <strong>AIOC</strong>
+    <strong>AIOC CDC-ACM</strong>
     <span class="keyed-indicator" id="aioc-keyed" data-keyed="false" aria-live="assertive">UNKEYED</span>
-    <button id="key-aioc" type="button" aria-describedby="aioc-keyed aioc-last" disabled>Key (CM108 HID)</button>
+    <button id="key-aioc" type="button" aria-describedby="aioc-keyed aioc-last" disabled>Key (CDC-ACM RTS)</button>
     <button id="unkey-aioc" type="button" aria-describedby="aioc-keyed aioc-last" disabled>Unkey</button>
     <span id="aioc-last" class="stamp" data-state="idle">— no action yet —</span>
   </div>
   <div class="ptt-row">
-    <label for="cm108-bit">CM108 GPIO bit</label>
+    <label for="cm108-bit">CM108 GPIO pin</label>
     <select id="cm108-bit" aria-describedby="cm108-bit-last">
-      <option value="0">0</option>
       <option value="1">1</option>
       <option value="2">2</option>
       <option value="3" selected>3 (datasheet PTT)</option>
@@ -74,8 +81,9 @@
       <option value="5">5</option>
       <option value="6">6</option>
       <option value="7">7</option>
+      <option value="8">8</option>
     </select>
-    <span id="cm108-bit-last" class="stamp" data-state="idle">— bit=3 (default) —</span>
+    <span id="cm108-bit-last" class="stamp" data-state="idle">— pin=3 (default) —</span>
   </div>
 </section>
 <div class="row">
@@ -171,6 +179,7 @@
     catch (e) { return; }
     const cp = document.getElementById("dev-cp2102n");
     const cm = document.getElementById("dev-cm108");
+    const ai = document.getElementById("dev-aioc");
     const vp = document.getElementById("dev-vidpid");
     setDevState(cp,
       j.cp2102n_open ? "open" : (j.cp2102n_found ? "found" : "missing"),
@@ -178,22 +187,23 @@
     setDevState(cm,
       j.cm108_open ? "open" : (j.cm108_found ? "found" : "missing"),
       j.cm108_open
-        ? "CM108: open  iface=" + j.cm108_hid_iface + "  bit=" + j.cm108_gpio_bit
+        ? "CM108: open  iface=" + j.cm108_hid_iface + "  pin=" + j.cm108_gpio_bit
         : (j.cm108_found ? "CM108: found (no perm)" : "CM108: —"));
-    if (j.cm108_vid) {
-      vp.dataset.state = "open";
-      vp.textContent = j.cm108_vid + ":" + j.cm108_pid;
-    } else {
-      vp.dataset.state = "missing";
-      vp.textContent = "";
-    }
+    setDevState(ai,
+      j.aioc_open ? "open" : (j.aioc_found ? "found" : "missing"),
+      "AIOC: " + (j.aioc_open ? "open (CDC-ACM RTS)" : (j.aioc_found ? "found (no perm)" : "—")));
+    const vidpid = j.aioc_vid ? (j.aioc_vid + ":" + j.aioc_pid)
+                : (j.cm108_vid ? (j.cm108_vid + ":" + j.cm108_pid) : "");
+    if (vidpid) { vp.dataset.state = "open"; vp.textContent = vidpid; }
+    else { vp.dataset.state = "missing"; vp.textContent = ""; }
     const btns = window.__pttButtons || {};
     if (btns.digirig) btns.digirig.forEach(b => b.disabled = !j.cp2102n_open);
-    if (btns.aioc)    btns.aioc.forEach(b => b.disabled = !j.cm108_open);
+    if (btns.cm108)   btns.cm108.forEach(b => b.disabled = !j.cm108_open);
+    if (btns.aioc)    btns.aioc.forEach(b => b.disabled = !j.aioc_open);
   }
   // Transport button registry — pollPtt() enables/disables based on the
   // adapter's status snapshot.
-  window.__pttButtons = window.__pttButtons || { digirig: [], aioc: [] };
+  window.__pttButtons = window.__pttButtons || { digirig: [], aioc: [], cm108: [] };
 
   function bindPtt(opts) {
     const { btnId, fnName, transport, action, keyedId, stampId } = opts;
@@ -231,8 +241,10 @@
   }
   bindPtt({ btnId: "key-digirig",   fnName: "keyCp2102nRts",   transport: "digirig", action: "key",   keyedId: "digirig-keyed", stampId: "digirig-last" });
   bindPtt({ btnId: "unkey-digirig", fnName: "unkeyCp2102nRts", transport: "digirig", action: "unkey", keyedId: "digirig-keyed", stampId: "digirig-last" });
-  bindPtt({ btnId: "key-aioc",   fnName: "keyCm108Hid",   transport: "aioc", action: "key",   keyedId: "aioc-keyed", stampId: "aioc-last" });
-  bindPtt({ btnId: "unkey-aioc", fnName: "unkeyCm108Hid", transport: "aioc", action: "unkey", keyedId: "aioc-keyed", stampId: "aioc-last" });
+  bindPtt({ btnId: "key-cm108",   fnName: "keyCm108Hid",   transport: "cm108", action: "key",   keyedId: "cm108-keyed", stampId: "cm108-last" });
+  bindPtt({ btnId: "unkey-cm108", fnName: "unkeyCm108Hid", transport: "cm108", action: "unkey", keyedId: "cm108-keyed", stampId: "cm108-last" });
+  bindPtt({ btnId: "key-aioc",   fnName: "keyAiocCdcRts",   transport: "aioc", action: "key",   keyedId: "aioc-keyed", stampId: "aioc-last" });
+  bindPtt({ btnId: "unkey-aioc", fnName: "unkeyAiocCdcRts", transport: "aioc", action: "unkey", keyedId: "aioc-keyed", stampId: "aioc-last" });
   const bitSel = document.getElementById("cm108-bit");
   const bitStamp = document.getElementById("cm108-bit-last");
   bitSel.addEventListener("change", () => {
@@ -244,11 +256,11 @@
       return;
     }
     bitStamp.dataset.state = "pending";
-    bitStamp.textContent = "… bit=" + bit;
+    bitStamp.textContent = "… pin=" + bit;
     const ok = w.setCm108Bit(bit);
     bitStamp.dataset.state = ok ? "ok" : "fail";
-    bitStamp.textContent = (ok ? "✓ " : "✗ ") + "bit=" + bit +
-      (ok ? "  (next Key AIOC uses this bit)" : " FAIL");
+    bitStamp.textContent = (ok ? "✓ " : "✗ ") + "pin=" + bit +
+      (ok ? "  (next CM108 HID key uses this pin)" : " FAIL");
   });
   setInterval(pollPtt, 1000);
   pollPtt();

--- a/cmd/graywolf-pocb/pocb_index.html
+++ b/cmd/graywolf-pocb/pocb_index.html
@@ -49,6 +49,13 @@
     <span class="dev" id="dev-cm108" data-state="missing" aria-live="polite">CM108: —</span>
     <span class="dev" id="dev-vidpid" data-state="missing"></span>
   </div>
+  <div class="ptt-row" data-transport="digirig">
+    <strong>Digirig</strong>
+    <span class="keyed-indicator" id="digirig-keyed" data-keyed="false" aria-live="assertive">UNKEYED</span>
+    <button id="key-digirig" type="button" aria-describedby="digirig-keyed digirig-last" disabled>Key (CP2102N RTS)</button>
+    <button id="unkey-digirig" type="button" aria-describedby="digirig-keyed digirig-last" disabled>Unkey</button>
+    <span id="digirig-last" class="stamp" data-state="idle">— no action yet —</span>
+  </div>
 </section>
 <div class="row">
   <label>gain</label>
@@ -163,6 +170,46 @@
     if (btns.digirig) btns.digirig.forEach(b => b.disabled = !j.cp2102n_open);
     if (btns.aioc)    btns.aioc.forEach(b => b.disabled = !j.cm108_open);
   }
+  // Transport button registry — pollPtt() enables/disables based on the
+  // adapter's status snapshot.
+  window.__pttButtons = window.__pttButtons || { digirig: [], aioc: [] };
+
+  function bindPtt(opts) {
+    const { btnId, fnName, transport, action, keyedId, stampId } = opts;
+    const b = document.getElementById(btnId);
+    if (!b) return;
+    const stamp = document.getElementById(stampId);
+    const keyed = document.getElementById(keyedId);
+    window.__pttButtons[transport].push(b);
+    b.addEventListener("click", () => {
+      const w = window.GraywolfWebInterface;
+      if (!w || !w[fnName]) {
+        stamp.dataset.state = "fail";
+        stamp.textContent = "✗ bridge missing";
+        return;
+      }
+      stamp.dataset.state = "pending";
+      stamp.textContent = "… " + action;
+      try {
+        const ok = w[fnName]();
+        const t = new Date().toISOString().slice(11,19);
+        if (ok) {
+          stamp.dataset.state = "ok";
+          stamp.textContent = "✓ " + action + "  " + t;
+          keyed.dataset.keyed = (action === "key") ? "true" : "false";
+          keyed.textContent = (action === "key") ? "KEYED" : "UNKEYED";
+        } else {
+          stamp.dataset.state = "fail";
+          stamp.textContent = "✗ " + action + " FAIL  " + t;
+        }
+      } catch (e) {
+        stamp.dataset.state = "fail";
+        stamp.textContent = "✗ err: " + e;
+      }
+    });
+  }
+  bindPtt({ btnId: "key-digirig",   fnName: "keyCp2102nRts",   transport: "digirig", action: "key",   keyedId: "digirig-keyed", stampId: "digirig-last" });
+  bindPtt({ btnId: "unkey-digirig", fnName: "unkeyCp2102nRts", transport: "digirig", action: "unkey", keyedId: "digirig-keyed", stampId: "digirig-last" });
   setInterval(pollPtt, 1000);
   pollPtt();
 </script>

--- a/cmd/graywolf-pocb/pocb_index.html
+++ b/cmd/graywolf-pocb/pocb_index.html
@@ -12,6 +12,28 @@
   input[type="range"] { flex: 1; }
   pre { background: #000; padding: 8px; border-radius: 4px; max-height: 70vh; overflow: auto; white-space: pre-wrap; }
   .gain { font-variant-numeric: tabular-nums; min-width: 4ch; text-align: right; }
+  /* PTT panel — added in POC-D Task 2. */
+  .ptt-panel { background: #1a1a1a; border: 1px solid #333; border-radius: 4px; padding: 10px 12px; margin-bottom: 12px; }
+  .ptt-panel .ptt-row { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-bottom: 8px; }
+  .ptt-panel .ptt-row:last-child { margin-bottom: 0; }
+  .ptt-panel .dev { display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 3px; background: #222; }
+  .ptt-panel .dev[data-state="open"]    { color: #5f5; }
+  .ptt-panel .dev[data-state="found"]   { color: #fc4; }
+  .ptt-panel .dev[data-state="missing"] { color: #888; }
+  .ptt-panel .dev::before { content: "●"; font-size: 10px; }
+  .keyed-indicator { display: inline-block; min-width: 14ch; text-align: center; padding: 6px 10px; border-radius: 3px; background: #222; color: #888; font-weight: bold; letter-spacing: 0.05em; }
+  .keyed-indicator[data-keyed="true"]  { background: #722; color: #fff; box-shadow: 0 0 0 2px #f55 inset; }
+  .keyed-indicator[data-keyed="false"] { background: #161; color: #cfc; }
+  .ptt-panel button { min-height: 48px; min-width: 48px; padding: 10px 14px; background: #2a2a2a; color: #eee; border: 1px solid #444; border-radius: 3px; font: inherit; cursor: pointer; }
+  .ptt-panel button:hover:not(:disabled) { background: #333; border-color: #666; }
+  .ptt-panel button:active:not(:disabled) { background: #444; }
+  .ptt-panel button:focus-visible { outline: 2px solid #4af; outline-offset: 2px; }
+  .ptt-panel button:disabled { background: #1a1a1a; color: #555; border-color: #2a2a2a; cursor: not-allowed; }
+  .stamp { font-variant-numeric: tabular-nums; min-width: 22ch; }
+  .stamp[data-state="ok"]      { color: #5f5; }
+  .stamp[data-state="fail"]    { color: #f55; }
+  .stamp[data-state="pending"] { color: #fc4; }
+  .stamp[data-state="idle"]    { color: #888; }
 </style>
 </head>
 <body>
@@ -20,6 +42,14 @@
   <div class="stat">uptime: <b id="up">0s</b></div>
   <div class="stat" id="conn">connecting</div>
 </div>
+<section class="ptt-panel" aria-labelledby="ptt-heading">
+  <div class="ptt-row">
+    <strong id="ptt-heading">PTT</strong>
+    <span class="dev" id="dev-cp2102n" data-state="missing" aria-live="polite">CP2102N: —</span>
+    <span class="dev" id="dev-cm108" data-state="missing" aria-live="polite">CM108: —</span>
+    <span class="dev" id="dev-vidpid" data-state="missing"></span>
+  </div>
+</section>
 <div class="row">
   <label>gain</label>
   <input id="g" type="range" min="-30" max="20" step="1" value="-6">
@@ -102,6 +132,39 @@
   setInterval(pollStatus, 1000);
   setInterval(pollFrames, 1000);
   setInterval(refreshConn, 500);
+  function setDevState(el, state, label) {
+    el.dataset.state = state;
+    el.textContent = label;
+  }
+  function pollPtt() {
+    if (!window.GraywolfWebInterface || !window.GraywolfWebInterface.pttStatusJson) return;
+    let j;
+    try { j = JSON.parse(window.GraywolfWebInterface.pttStatusJson()); }
+    catch (e) { return; }
+    const cp = document.getElementById("dev-cp2102n");
+    const cm = document.getElementById("dev-cm108");
+    const vp = document.getElementById("dev-vidpid");
+    setDevState(cp,
+      j.cp2102n_open ? "open" : (j.cp2102n_found ? "found" : "missing"),
+      "CP2102N: " + (j.cp2102n_open ? "open" : (j.cp2102n_found ? "found (no perm)" : "—")));
+    setDevState(cm,
+      j.cm108_open ? "open" : (j.cm108_found ? "found" : "missing"),
+      j.cm108_open
+        ? "CM108: open  iface=" + j.cm108_hid_iface + "  bit=" + j.cm108_gpio_bit
+        : (j.cm108_found ? "CM108: found (no perm)" : "CM108: —"));
+    if (j.cm108_vid) {
+      vp.dataset.state = "open";
+      vp.textContent = j.cm108_vid + ":" + j.cm108_pid;
+    } else {
+      vp.dataset.state = "missing";
+      vp.textContent = "";
+    }
+    const btns = window.__pttButtons || {};
+    if (btns.digirig) btns.digirig.forEach(b => b.disabled = !j.cp2102n_open);
+    if (btns.aioc)    btns.aioc.forEach(b => b.disabled = !j.cm108_open);
+  }
+  setInterval(pollPtt, 1000);
+  pollPtt();
 </script>
 </body>
 </html>

--- a/scratch/poc-d/aioc.log
+++ b/scratch/poc-d/aioc.log
@@ -1,0 +1,30 @@
+--------- beginning of main
+05-08 23:19:25.040 14621 14621 I UsbPttAdapter: init complete
+05-08 23:19:25.417 14621 14621 I UsbPttAdapter: enumerate: 1 attached USB device(s)
+05-08 23:19:25.419 14621 14621 I UsbPttAdapter: device name=/dev/bus/usb/001/049 vid=0x1209 pid=0x7388 role=AIOC ifaces=9
+05-08 23:19:25.419 14621 14621 I UsbPttAdapter:   iface[0] id=0 class=1 subclass=1 proto=32 endpoints=0
+05-08 23:19:25.419 14621 14621 I UsbPttAdapter:   iface[1] id=1 class=1 subclass=2 proto=32 endpoints=0
+05-08 23:19:25.420 14621 14621 I UsbPttAdapter:   iface[2] id=1 class=1 subclass=2 proto=32 endpoints=2 ep[0] addr=0x02 type=1 dir=0 ep[1] addr=0x82 type=1 dir=128
+05-08 23:19:25.420 14621 14621 I UsbPttAdapter:   iface[3] id=2 class=1 subclass=2 proto=32 endpoints=0
+05-08 23:19:25.420 14621 14621 I UsbPttAdapter:   iface[4] id=2 class=1 subclass=2 proto=32 endpoints=1 ep[0] addr=0x81 type=1 dir=128
+05-08 23:19:25.421 14621 14621 I UsbPttAdapter:   iface[5] id=3 class=3 subclass=0 proto=0 endpoints=1 ep[0] addr=0x83 type=3 dir=128
+05-08 23:19:25.421 14621 14621 I UsbPttAdapter:   iface[6] id=4 class=2 subclass=2 proto=0 endpoints=1 ep[0] addr=0x85 type=3 dir=128
+05-08 23:19:25.422 14621 14621 I UsbPttAdapter:   iface[7] id=5 class=10 subclass=0 proto=0 endpoints=2 ep[0] addr=0x04 type=2 dir=0 ep[1] addr=0x84 type=2 dir=128
+05-08 23:19:25.422 14621 14621 I UsbPttAdapter:   iface[8] id=6 class=254 subclass=1 proto=1 endpoints=0
+05-08 23:19:25.423 14621 14621 I UsbPttAdapter: tryOpen /dev/bus/usb/001/049 role=AIOC
+05-08 23:19:25.424 14621 14692 I UsbPttAdapter: openAioc: step=ctor
+05-08 23:19:25.432 14621 14692 I UsbPttAdapter: openAioc: step=openDevice
+05-08 23:19:25.502 14621 14692 I UsbPttAdapter: openAioc: step=ports count=1
+05-08 23:19:25.508 14621 14692 I UsbPttAdapter: openAioc: step=port.open
+05-08 23:19:25.516 14621 14692 I UsbPttAdapter: openAioc: step=setParameters
+05-08 23:19:25.516 14621 14692 I UsbPttAdapter: openAioc: step=dtr=rts=false
+05-08 23:19:25.516 14621 14692 I UsbPttAdapter: AIOC opened /dev/bus/usb/001/049
+05-08 23:20:32.897 14621 14738 I UsbPttAdapter: ptt: aioc_cdc dtr=true rts=0
+05-08 23:20:38.538 14621 14738 I UsbPttAdapter: ptt: aioc_cdc dtr=false rts=0
+05-08 23:20:39.730 14621 14738 I UsbPttAdapter: ptt: aioc_cdc dtr=false rts=0
+05-08 23:20:43.386 14621 14738 I UsbPttAdapter: ptt: aioc_cdc dtr=true rts=0
+05-08 23:20:51.827 14621 14738 I UsbPttAdapter: ptt: aioc_cdc dtr=false rts=0
+05-08 23:20:56.452 14621 14738 I UsbPttAdapter: ptt: aioc_cdc dtr=true rts=0
+05-08 23:20:57.387 14621 14738 I UsbPttAdapter: ptt: aioc_cdc dtr=false rts=0
+05-08 23:20:58.815 14621 14738 I UsbPttAdapter: ptt: aioc_cdc dtr=true rts=0
+05-08 23:20:59.702 14621 14738 I UsbPttAdapter: ptt: aioc_cdc dtr=false rts=0

--- a/scratch/poc-d/digirig.log
+++ b/scratch/poc-d/digirig.log
@@ -1,0 +1,102 @@
+--------- beginning of main
+05-08 23:31:56.950 14621 14621 I UsbPttAdapter: enumerate: 2 attached USB device(s)
+05-08 23:31:56.951 14621 14621 I UsbPttAdapter: device name=/dev/bus/usb/001/053 vid=0x0D8C pid=0x0012 role=CM108 ifaces=6
+05-08 23:31:56.951 14621 14621 I UsbPttAdapter:   iface[0] id=0 class=1 subclass=1 proto=0 endpoints=0
+05-08 23:31:56.952 14621 14621 I UsbPttAdapter:   iface[1] id=1 class=1 subclass=2 proto=0 endpoints=0
+05-08 23:31:56.953 14621 14621 I UsbPttAdapter:   iface[2] id=1 class=1 subclass=2 proto=0 endpoints=1 ep[0] addr=0x01 type=1 dir=0
+05-08 23:31:56.953 14621 14621 I UsbPttAdapter:   iface[3] id=2 class=1 subclass=2 proto=0 endpoints=0
+05-08 23:31:56.954 14621 14621 I UsbPttAdapter:   iface[4] id=2 class=1 subclass=2 proto=0 endpoints=1 ep[0] addr=0x82 type=1 dir=128
+05-08 23:31:56.955 14621 14621 I UsbPttAdapter:   iface[5] id=3 class=3 subclass=0 proto=0 endpoints=1 ep[0] addr=0x87 type=3 dir=128
+05-08 23:31:56.960 14621 14621 I UsbPttAdapter: requestPermission /dev/bus/usb/001/053
+05-08 23:31:56.978 14621 14621 I UsbPttAdapter: device name=/dev/bus/usb/001/052 vid=0x10C4 pid=0xEA60 role=CP2102N ifaces=1
+05-08 23:31:56.979 14621 14621 I UsbPttAdapter:   iface[0] id=0 class=255 subclass=0 proto=0 endpoints=2 ep[0] addr=0x02 type=2 dir=0 ep[1] addr=0x82 type=2 dir=128
+05-08 23:31:56.981 14621 14621 I UsbPttAdapter: requestPermission /dev/bus/usb/001/052
+05-08 23:31:58.915 14621 14621 I UsbPttAdapter: permission result device=/dev/bus/usb/001/053 granted=true
+05-08 23:31:58.915 14621 14621 I UsbPttAdapter: tryOpen /dev/bus/usb/001/053 role=CM108
+05-08 23:31:58.922 14621 14929 I UsbPttAdapter: CM108 opened /dev/bus/usb/001/053 hid_iface=3 vid=0x0D8C pid=0x0012
+05-08 23:31:58.927 14621 14621 I UsbPttAdapter: enumerate: 2 attached USB device(s)
+05-08 23:31:58.927 14621 14621 I UsbPttAdapter: device name=/dev/bus/usb/001/053 vid=0x0D8C pid=0x0012 role=CM108 ifaces=6
+05-08 23:31:58.927 14621 14621 I UsbPttAdapter:   iface[0] id=0 class=1 subclass=1 proto=0 endpoints=0
+05-08 23:31:58.927 14621 14621 I UsbPttAdapter:   iface[1] id=1 class=1 subclass=2 proto=0 endpoints=0
+05-08 23:31:58.928 14621 14621 I UsbPttAdapter:   iface[2] id=1 class=1 subclass=2 proto=0 endpoints=1 ep[0] addr=0x01 type=1 dir=0
+05-08 23:31:58.928 14621 14621 I UsbPttAdapter:   iface[3] id=2 class=1 subclass=2 proto=0 endpoints=0
+05-08 23:31:58.928 14621 14621 I UsbPttAdapter:   iface[4] id=2 class=1 subclass=2 proto=0 endpoints=1 ep[0] addr=0x82 type=1 dir=128
+05-08 23:31:58.929 14621 14621 I UsbPttAdapter:   iface[5] id=3 class=3 subclass=0 proto=0 endpoints=1 ep[0] addr=0x87 type=3 dir=128
+05-08 23:31:58.929 14621 14621 I UsbPttAdapter: enumerate: CM108 already open, skipping
+05-08 23:31:58.929 14621 14621 I UsbPttAdapter: device name=/dev/bus/usb/001/052 vid=0x10C4 pid=0xEA60 role=CP2102N ifaces=1
+05-08 23:31:58.930 14621 14621 I UsbPttAdapter:   iface[0] id=0 class=255 subclass=0 proto=0 endpoints=2 ep[0] addr=0x02 type=2 dir=0 ep[1] addr=0x82 type=2 dir=128
+05-08 23:31:58.931 14621 14621 I UsbPttAdapter: requestPermission /dev/bus/usb/001/052
+05-08 23:32:00.537 14621 14621 I UsbPttAdapter: permission result device=/dev/bus/usb/001/052 granted=true
+05-08 23:32:00.537 14621 14621 I UsbPttAdapter: tryOpen /dev/bus/usb/001/052 role=CP2102N
+05-08 23:32:00.537 14621 14932 I UsbPttAdapter: openCp2102n: step=ctor
+05-08 23:32:00.539 14621 14932 I UsbPttAdapter: openCp2102n: step=openDevice
+05-08 23:32:00.540 14621 14932 I UsbPttAdapter: openCp2102n: step=ports
+05-08 23:32:00.540 14621 14932 I UsbPttAdapter: openCp2102n: step=port.open
+05-08 23:32:00.543 14621 14932 I UsbPttAdapter: openCp2102n: step=setParameters
+05-08 23:32:00.543 14621 14932 I UsbPttAdapter: openCp2102n: step=rts=false
+05-08 23:32:00.544 14621 14932 I UsbPttAdapter: CP2102N opened /dev/bus/usb/001/052
+05-08 23:32:00.548 14621 14621 I UsbPttAdapter: enumerate: 2 attached USB device(s)
+05-08 23:32:00.549 14621 14621 I UsbPttAdapter: device name=/dev/bus/usb/001/053 vid=0x0D8C pid=0x0012 role=CM108 ifaces=6
+05-08 23:32:00.549 14621 14621 I UsbPttAdapter:   iface[0] id=0 class=1 subclass=1 proto=0 endpoints=0
+05-08 23:32:00.549 14621 14621 I UsbPttAdapter:   iface[1] id=1 class=1 subclass=2 proto=0 endpoints=0
+05-08 23:32:00.549 14621 14621 I UsbPttAdapter:   iface[2] id=1 class=1 subclass=2 proto=0 endpoints=1 ep[0] addr=0x01 type=1 dir=0
+05-08 23:32:00.549 14621 14621 I UsbPttAdapter:   iface[3] id=2 class=1 subclass=2 proto=0 endpoints=0
+05-08 23:32:00.550 14621 14621 I UsbPttAdapter:   iface[4] id=2 class=1 subclass=2 proto=0 endpoints=1 ep[0] addr=0x82 type=1 dir=128
+05-08 23:32:00.550 14621 14621 I UsbPttAdapter:   iface[5] id=3 class=3 subclass=0 proto=0 endpoints=1 ep[0] addr=0x87 type=3 dir=128
+05-08 23:32:00.550 14621 14621 I UsbPttAdapter: enumerate: CM108 already open, skipping
+05-08 23:32:00.551 14621 14621 I UsbPttAdapter: device name=/dev/bus/usb/001/052 vid=0x10C4 pid=0xEA60 role=CP2102N ifaces=1
+05-08 23:32:00.551 14621 14621 I UsbPttAdapter:   iface[0] id=0 class=255 subclass=0 proto=0 endpoints=2 ep[0] addr=0x02 type=2 dir=0 ep[1] addr=0x82 type=2 dir=128
+05-08 23:32:00.551 14621 14621 I UsbPttAdapter: enumerate: CP2102N already open, skipping
+05-08 23:32:08.780 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x04 state=true rc=4
+05-08 23:32:11.800 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x00 state=false rc=4
+05-08 23:32:12.686 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x04 state=true rc=4
+05-08 23:32:13.307 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x00 state=false rc=4
+05-08 23:32:13.774 14621 14738 E UsbPttAdapter: setAiocRts(true) failed: java.io.IOException: controlTransfer failed
+05-08 23:32:14.764 14621 14738 E UsbPttAdapter: setAiocRts(true) failed: java.io.IOException: controlTransfer failed
+05-08 23:32:15.350 14621 14738 E UsbPttAdapter: setAiocRts(false) failed: java.io.IOException: controlTransfer failed
+05-08 23:32:16.158 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x00 state=false rc=4
+05-08 23:32:16.681 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x00 state=false rc=4
+05-08 23:32:17.052 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x00 state=false rc=4
+05-08 23:32:17.365 14621 14738 E UsbPttAdapter: setAiocRts(false) failed: java.io.IOException: controlTransfer failed
+05-08 23:32:17.651 14621 14738 E UsbPttAdapter: setAiocRts(false) failed: java.io.IOException: controlTransfer failed
+05-08 23:32:21.032 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-08 23:32:22.458 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false
+05-08 23:32:38.114 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x04 state=true rc=4
+05-08 23:32:39.980 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x00 state=false rc=4
+05-08 23:32:40.320 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x00 state=false rc=4
+05-08 23:32:41.207 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-08 23:32:42.089 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false
+05-08 23:32:42.311 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false
+05-08 23:33:16.336 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-08 23:33:16.878 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-08 23:33:17.979 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-08 23:33:19.900 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-08 23:33:21.545 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false
+05-08 23:33:26.672 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false
+05-08 23:33:27.027 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false
+05-09 00:13:04.670 14621 14621 I UsbPttAdapter: enumerate: 2 attached USB device(s)
+05-09 00:13:04.671 14621 14621 I UsbPttAdapter: device name=/dev/bus/usb/001/053 vid=0x0D8C pid=0x0012 role=CM108 ifaces=6
+05-09 00:13:04.672 14621 14621 I UsbPttAdapter:   iface[0] id=0 class=1 subclass=1 proto=0 endpoints=0
+05-09 00:13:04.672 14621 14621 I UsbPttAdapter:   iface[1] id=1 class=1 subclass=2 proto=0 endpoints=0
+05-09 00:13:04.673 14621 14621 I UsbPttAdapter:   iface[2] id=1 class=1 subclass=2 proto=0 endpoints=1 ep[0] addr=0x01 type=1 dir=0
+05-09 00:13:04.673 14621 14621 I UsbPttAdapter:   iface[3] id=2 class=1 subclass=2 proto=0 endpoints=0
+05-09 00:13:04.674 14621 14621 I UsbPttAdapter:   iface[4] id=2 class=1 subclass=2 proto=0 endpoints=1 ep[0] addr=0x82 type=1 dir=128
+05-09 00:13:04.675 14621 14621 I UsbPttAdapter:   iface[5] id=3 class=3 subclass=0 proto=0 endpoints=1 ep[0] addr=0x87 type=3 dir=128
+05-09 00:13:04.675 14621 14621 I UsbPttAdapter: enumerate: CM108 already open, skipping
+05-09 00:13:04.678 14621 14621 I UsbPttAdapter: device name=/dev/bus/usb/001/052 vid=0x10C4 pid=0xEA60 role=CP2102N ifaces=1
+05-09 00:13:04.681 14621 14621 I UsbPttAdapter:   iface[0] id=0 class=255 subclass=0 proto=0 endpoints=2 ep[0] addr=0x02 type=2 dir=0 ep[1] addr=0x82 type=2 dir=128
+05-09 00:13:04.681 14621 14621 I UsbPttAdapter: enumerate: CP2102N already open, skipping
+05-09 00:13:11.090 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x00 state=false rc=4
+05-09 00:13:13.239 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-09 00:13:13.580 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-09 00:13:14.576 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false
+05-09 00:13:15.354 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-09 00:13:16.279 14621 14738 I UsbPttAdapter: ptt: cm108_set_report pin=3 mask=0x04 value=0x00 state=false rc=4
+05-09 00:13:16.816 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-09 00:13:17.427 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false
+05-09 00:13:18.079 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-09 00:13:19.648 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false
+05-09 00:13:21.037 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-09 00:13:21.624 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false
+05-09 00:13:22.330 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=true
+05-09 00:13:23.089 14621 14738 I UsbPttAdapter: ptt: cp2102n_rts=false

--- a/scratch/poc-d/dumpsys-audio-stage2-after.txt
+++ b/scratch/poc-d/dumpsys-audio-stage2-after.txt
@@ -1,0 +1,3 @@
+  AudioStreamIn: 0xb400006eb7de6fe0 flags 0 (AUDIO_INPUT_FLAG_NONE)
+  Frames read: 105697280
+  Hal stream dump:

--- a/scratch/poc-d/dumpsys-audio-stage2-before.txt
+++ b/scratch/poc-d/dumpsys-audio-stage2-before.txt
@@ -1,0 +1,7 @@
+  AudioStreamIn: 0xb400006eb7dea0a0 flags 0 (AUDIO_INPUT_FLAG_NONE)
+  Frames read: 4458240
+  Hal stream dump:
+--
+-   AudioStreamIn: 0xb400006eb7de4f10 flags 0 (AUDIO_INPUT_FLAG_NONE)
+-   Frames read: 11939200
+-   No active record clients


### PR DESCRIPTION
## Summary

GREEN with caveats. Both PTT primitives proven on operator's bench:
- Digirig keys via CP2102N RTS (`Cp21xxSerialDriver`)
- AIOC keys via CDC-ACM DTR=1/RTS=0 (`CdcAcmSerialDriver`, firmware >= 1.2.0)
- CM108 HID Set_Report writes coexist with AudioRecord under load (criterion #9)
- Over-the-air decode confirmed on second APRS station mid-Stage-1

`UsbPttAdapter` singleton enumerates attached USB devices, claims only
the HID interface on CM108 (commit 7a71c53 invariant), opens the
CP2102N + AIOC via `usb-serial-for-android` 3.10.0, and exposes
transport-keyed `keyCp2102nRts` / `unkeyCp2102nRts` / `keyCm108Hid` /
`unkeyCm108Hid` / `setCm108Bit` / `keyAiocCdcRts` / `unkeyAiocCdcRts` /
`pttStatusJson` to the WebView. Permission flow uses
`UsbManager.requestPermission` driven from `MainActivity.onResume` so
the system dialog has a foreground UI host. USB opens dispatched to
worker threads — synchronous opens on the main thread tripped an ANR.

## Caveats / spec corrections

- Original spec's CM108 HID Output Report layout (`[0,0,gpio,0]`) was
  wrong — value landed in OR2 direction byte, OR1 stayed zero, GPIO
  pin never configured as output. Corrected to match
  `graywolf-modem/src/tx/ptt_cm108_unix.rs`: `[0, value, mask, 0]`,
  pin 1-indexed.
- AIOC PTT path is CDC-ACM DTR (firmware >= 1.2.0: DTR=1 AND RTS=0),
  not CM108 HID GPIO. Spec §3 footnote was imprecise. AIOC HID accepts
  Set_Report (rc=4) but does not drive GPIO on this firmware.
- Digirig CM108 GPIO not wired to PTT externally — Digirig PTT is
  CP2102N RTS only. CM108 HID writes succeed (rc=4) but no PTT toggle.
  Plan §3 footnote was wrong; coexistence (criterion #9) still green.

See `.context/2026-05-09-android-poc-d-results.md` for full report,
empirical findings, traps hit, and phase-5 implications.

## Test plan

- [x] Stage 1: CP2102N RTS, key/unkey + tx-test frame, audio coexistence
- [x] Stage 2: CM108 HID GPIO writes, audio coexistence verified
      (AudioStreamIn frames-read 4.46M -> 105.7M between pre/post snapshots)
- [x] Stage 3: AIOC CDC-ACM DTR keying
- [x] Stage 4: combined RF demo over the air, packet decoded on second station