### PR TITLE
fix(themes): define --color-text-inverse for graywolf/grayscale themes

### DIFF
--- a/web/themes/grayscale-night.css
+++ b/web/themes/grayscale-night.css
@@ -17,6 +17,7 @@
   --color-text: #e0e0e0;
   --color-text-muted: #888888;
   --color-text-dim: #555555;
+  --color-text-inverse: #000000;
   --color-accent: #cccccc;
   --color-primary: #cccccc;
   --color-primary-hover: #ffffff;

--- a/web/themes/grayscale.css
+++ b/web/themes/grayscale.css
@@ -18,6 +18,7 @@
   --color-text: #111111;
   --color-text-muted: #555555;
   --color-text-dim: #888888;
+  --color-text-inverse: #ffffff;
   --color-accent: #333333;
   --color-primary: #333333;
   --color-primary-hover: #111111;

--- a/web/themes/graywolf-night.css
+++ b/web/themes/graywolf-night.css
@@ -19,6 +19,7 @@
   --color-text: #e0e0e0;
   --color-text-muted: #888888;
   --color-text-dim: #5a5a5a;
+  --color-text-inverse: #0a0a0a;
   --color-accent: #4fa74f;
   --color-primary: #ffaa00;
   --color-primary-hover: #ffbb33;

--- a/web/themes/graywolf.css
+++ b/web/themes/graywolf.css
@@ -23,6 +23,7 @@
   --color-text: #111111;
   --color-text-muted: #666666;
   --color-text-dim: #999999;
+  --color-text-inverse: #ffffff;
   --color-accent: #215e21;
   --color-primary: #ffaa00;
   --color-primary-hover: #ffbb33;


### PR DESCRIPTION
The chonky-ui tooltip ([data-tooltip-content]) renders with background: var(--color-text) and color: var(--color-text-inverse). Our theme files declared --color-text but omitted --color-text-inverse, so the inverse token leaked through chonky-ui's
@media (prefers-color-scheme: dark) :root:not([data-theme="light"]) fallback. Users running an OS dark preference with the light graywolf or grayscale theme selected got tooltip text at #0a0a0a on a #111 background -- black on black.

Declare --color-text-inverse in all four themes so the tooltip (and any other consumer of the inverse token) renders correctly regardless of OS color-scheme preference.

Fixes #101