### PR TITLE
fix(audio): use IMMDevice id + FriendlyName for Windows disambiguation

### DIFF
--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -419,17 +419,24 @@ pub fn resolve_output_device(pcm_id: &str) -> Result<Device, String> {
     }
 }
 
-/// Find a cpal device whose pcm_id (the driver-level identifier returned by
-/// `DeviceTrait::name()`) matches `id`. This is the unique ALSA device
-/// string like `hw:CARD=AllInOneCable,DEV=0` — not the human-friendly
-/// description.
-#[allow(deprecated)] // DeviceTrait::name() gives the raw pcm_id we need
+/// Find a cpal device whose stable id matches `id`.
+///
+/// On Linux/macOS the stable id is the cpal `name()` value (the ALSA
+/// hw identifier like `hw:CARD=AllInOneCable,DEV=0`). On Windows it is
+/// the IMMDevice endpoint id surfaced via cpal `Device::id()`; cpal's
+/// `name()` there returns only the device class label (`"Speakers"` /
+/// Hungarian `"Hangszórók"`) which is shared by every endpoint of that
+/// class, so matching by `name()` would resolve to the wrong card.
+/// Issue #100.
+#[allow(deprecated)] // DeviceTrait::name() gives the raw pcm_id we need on non-Windows
 pub fn find_device_by_id(devices: impl Iterator<Item = Device>, id: &str) -> Option<Device> {
     for d in devices {
-        if let Ok(pcm_id) = d.name() {
-            if pcm_id == id {
-                return Some(d);
-            }
+        #[cfg(target_os = "windows")]
+        let matches = d.id().ok().map(|did| did.1 == id).unwrap_or(false);
+        #[cfg(not(target_os = "windows"))]
+        let matches = d.name().ok().map(|n| n == id).unwrap_or(false);
+        if matches {
+            return Some(d);
         }
     }
     None
@@ -1069,21 +1076,19 @@ pub mod listing {
             //
             // Windows exception: `description().name()` returns only the
             // device class label (e.g. `"Speakers"` / Hungarian
-            // `"Hangszórók"`), shared by every soundcard of that class,
-            // which would tag every output device as the system default.
-            // The deprecated `name()` on WASAPI returns the friendly
-            // `"Speakers (Realtek(R) Audio)"` form which uniquely
-            // identifies the device — use that on Windows so the
-            // `default_*` source matches what `collect_devices` writes
-            // into `name` below. Issue #100.
+            // `"Hangszórók"`), shared by every soundcard of that class.
+            // Source the default-device match key from `Device::id()`
+            // (the IMMDevice endpoint id, unique per endpoint) and have
+            // `collect_devices` key its `is_default` comparison the
+            // same way. Issue #100.
             #[cfg(target_os = "windows")]
             let default_input = host
                 .default_input_device()
-                .and_then(|d| { #[allow(deprecated)] d.name().ok() });
+                .and_then(|d| d.id().ok().map(|id| id.1));
             #[cfg(target_os = "windows")]
             let default_output = host
                 .default_output_device()
-                .and_then(|d| { #[allow(deprecated)] d.name().ok() });
+                .and_then(|d| d.id().ok().map(|id| id.1));
             #[cfg(not(target_os = "windows"))]
             let default_input = host
                 .default_input_device()
@@ -1154,10 +1159,7 @@ pub mod listing {
             // pcm_id (cpal `name()`) is the ALSA hw identifier on Linux
             // (e.g. `plughw:CARD=Foo,DEV=0`). On macOS / Windows the
             // recommendation heuristic does not apply and `recommended`
-            // stays false. On Windows, pcm_id is the WASAPI friendly
-            // name (e.g. `"Speakers (Realtek(R) Audio)"`) which we also
-            // surface as the device `name` so two cards of the same
-            // class are distinguishable in the flare bundle. Issue #100.
+            // stays false.
             //
             // Skip devices that fail to report a pcm_id, matching the
             // modem-side `collect_devices`: a phantom `<unknown>` row
@@ -1167,14 +1169,58 @@ pub mod listing {
                 Ok(id) => id,
                 Err(_) => continue,
             };
+            // Windows: build a unique display `name` from the WASAPI
+            // FriendlyName (`description().extended()[0]`, e.g.
+            // `"Speakers (Realtek(R) Audio)"`) or the interface friendly
+            // name (`description().driver()`, e.g. `"USB PnP Sound
+            // Device"`). cpal's `description().name()` returns only the
+            // class label (`"Speakers"` / `"Hangszórók"`), shared by
+            // every endpoint of that class — two cards of the same
+            // class would otherwise produce identical rows in the
+            // flare bundle. `is_default` is keyed on the IMMDevice
+            // endpoint id surfaced by `Device::id()`, matching the
+            // `default_input`/`default_output` source above. Issue #100.
             #[cfg(target_os = "windows")]
-            let name = pcm_id.clone();
+            let (name, is_default) = {
+                let desc = dev.description().ok();
+                let class = desc.as_ref().map(|d| d.name().to_string());
+                let friendly = desc
+                    .as_ref()
+                    .and_then(|d| d.extended().first().cloned())
+                    .filter(|s| !s.is_empty())
+                    .or_else(|| {
+                        desc.as_ref()
+                            .and_then(|d| d.driver().map(|s| s.to_string()))
+                            .filter(|s| !s.is_empty())
+                    });
+                let endpoint_id = dev.id().ok().map(|id| id.1);
+                let display = friendly
+                    .or_else(|| {
+                        // Fall back to "ClassName (endpoint id)" so two
+                        // identical class labels still differ.
+                        match (class, endpoint_id.as_ref()) {
+                            (Some(c), Some(id)) => Some(format!("{} ({})", c, id)),
+                            (Some(c), None) => Some(c),
+                            (None, Some(id)) => Some(id.clone()),
+                            (None, None) => None,
+                        }
+                    })
+                    .unwrap_or_else(|| pcm_id.clone());
+                let is_default = match (default_name, endpoint_id.as_deref()) {
+                    (Some(d), Some(id)) => d == id,
+                    _ => false,
+                };
+                (display, is_default)
+            };
             #[cfg(not(target_os = "windows"))]
-            let name = dev
-                .description()
-                .map(|d| d.name().to_string())
-                .unwrap_or_else(|_| pcm_id.clone());
-            let is_default = default_name.map(|d| d == name).unwrap_or(false);
+            let (name, is_default) = {
+                let display = dev
+                    .description()
+                    .map(|d| d.name().to_string())
+                    .unwrap_or_else(|_| pcm_id.clone());
+                let is_default = default_name.map(|d| d == display).unwrap_or(false);
+                (display, is_default)
+            };
             let recommended = super::is_recommended_pcm_id(&pcm_id);
 
             let configs = match direction {

--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -424,10 +424,9 @@ pub fn resolve_output_device(pcm_id: &str) -> Result<Device, String> {
 /// On Linux/macOS the stable id is the cpal `name()` value (the ALSA
 /// hw identifier like `hw:CARD=AllInOneCable,DEV=0`). On Windows it is
 /// the IMMDevice endpoint id surfaced via cpal `Device::id()`; cpal's
-/// `name()` there returns only the device class label (`"Speakers"` /
-/// Hungarian `"Hangszórók"`) which is shared by every endpoint of that
-/// class, so matching by `name()` would resolve to the wrong card.
-/// Issue #100.
+/// `name()` there returns only the device class label (e.g.
+/// `"Speakers"`) which is shared by every endpoint of that class, so
+/// matching by `name()` would resolve to the wrong card. Issue #100.
 #[allow(deprecated)] // DeviceTrait::name() gives the raw pcm_id we need on non-Windows
 pub fn find_device_by_id(devices: impl Iterator<Item = Device>, id: &str) -> Option<Device> {
     for d in devices {
@@ -1075,8 +1074,8 @@ pub mod listing {
             // JSON field stays `name` for the schema contract.
             //
             // Windows exception: `description().name()` returns only the
-            // device class label (e.g. `"Speakers"` / Hungarian
-            // `"Hangszórók"`), shared by every soundcard of that class.
+            // device class label (e.g. `"Speakers"`), shared by every
+            // soundcard of that class.
             // Source the default-device match key from `Device::id()`
             // (the IMMDevice endpoint id, unique per endpoint) and have
             // `collect_devices` key its `is_default` comparison the
@@ -1174,11 +1173,11 @@ pub mod listing {
             // `"Speakers (Realtek(R) Audio)"`) or the interface friendly
             // name (`description().driver()`, e.g. `"USB PnP Sound
             // Device"`). cpal's `description().name()` returns only the
-            // class label (`"Speakers"` / `"Hangszórók"`), shared by
-            // every endpoint of that class — two cards of the same
-            // class would otherwise produce identical rows in the
-            // flare bundle. `is_default` is keyed on the IMMDevice
-            // endpoint id surfaced by `Device::id()`, matching the
+            // class label (e.g. `"Speakers"`), shared by every endpoint
+            // of that class — two cards of the same class would
+            // otherwise produce identical rows in the flare bundle.
+            // `is_default` is keyed on the IMMDevice endpoint id
+            // surfaced by `Device::id()`, matching the
             // `default_input`/`default_output` source above. Issue #100.
             #[cfg(target_os = "windows")]
             let (name, is_default) = {

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -1289,22 +1289,55 @@ fn read_sysfs(path: &std::path::Path) -> String {
         .unwrap_or_default()
 }
 
-/// On Windows, cpal's deprecated `DeviceTrait::name()` returns the WASAPI
-/// friendly name (e.g. `"Speakers (Realtek(R) Audio)"`) which already
-/// disambiguates multiple devices of the same class. The newer
-/// `description().name()` returns only the device class label
-/// (`"Speakers"` / Hungarian `"Hangszórók"`), making two distinct cards
-/// look identical in the UI. Surfacing the WASAPI friendly name as the
-/// description lets the UI render a disambiguated label without changing
-/// the schema. Issue #100.
-#[cfg(target_os = "windows")]
-fn alsa_card_description(cpal_name: &str) -> String {
-    cpal_name.to_string()
-}
-
-#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+#[cfg(not(target_os = "linux"))]
 fn alsa_card_description(_cpal_name: &str) -> String {
     String::new()
+}
+
+/// On Windows, pull a device-specific friendly string out of cpal's
+/// `DeviceDescription`. `description().name()` itself prefers
+/// `DEVPKEY_Device_DeviceDesc` (the device class label `"Speakers"` /
+/// Hungarian `"Hangszórók"`), which is shared by every endpoint of
+/// that class — so it can't disambiguate two soundcards. We try, in
+/// order:
+///
+/// 1. `extended()[0]` — cpal stores `DEVPKEY_Device_FriendlyName`
+///    there when it differs from the class name (see
+///    `cpal/host/wasapi/device.rs:419-423`), e.g.
+///    `"Speakers (Realtek(R) Audio)"`.
+/// 2. `driver()` — `DEVPKEY_DeviceInterface_FriendlyName`, e.g.
+///    `"USB PnP Sound Device"`.
+/// 3. empty string — caller's UI fallback (`description || name`)
+///    will render the class label.
+///
+/// The result is surfaced as the proto `description` field. Issue #100.
+#[cfg(target_os = "windows")]
+fn windows_friendly_name(dev: &cpal::Device) -> String {
+    use cpal::traits::DeviceTrait;
+    let Ok(desc) = dev.description() else {
+        return String::new();
+    };
+    if let Some(s) = desc.extended().first() {
+        if !s.is_empty() {
+            return s.clone();
+        }
+    }
+    if let Some(driver) = desc.driver() {
+        if !driver.is_empty() {
+            return driver.to_string();
+        }
+    }
+    String::new()
+}
+
+/// On Windows, return the IMMDevice endpoint id (a per-endpoint GUID
+/// string like `{0.0.0.00000000}.{...}`) as the device's stable id.
+/// This is what cpal's `Device::id()` exposes; unlike `name()` it is
+/// guaranteed unique across endpoints of the same class. Issue #100.
+#[cfg(target_os = "windows")]
+fn windows_device_id(dev: &cpal::Device) -> Option<String> {
+    use cpal::traits::DeviceTrait;
+    dev.id().ok().map(|id| id.1)
 }
 
 /// dBFS floor representing silence — the theoretical dynamic range of
@@ -1391,25 +1424,37 @@ where
             continue;
         }
 
-        // Default-device match is keyed on the device class label
-        // (`description().name()`) on every platform except Windows. On
-        // Windows that label is the same shared string for every device
-        // of a class (e.g. `"Speakers"`) so the comparison would flag
-        // every output as default; pcm_id is the WASAPI friendly name
-        // and uniquely identifies the device. Issue #100.
+        // On Windows, key both the stable id and the default-device
+        // match on the IMMDevice endpoint id (cpal `Device::id()`).
+        // `pcm_id` (cpal `name()`) is just the device class label there
+        // and would flag every output of the class as default. The
+        // proto `description` carries the WASAPI FriendlyName so the
+        // UI's `description || name` fallback renders a disambiguated
+        // string; `recommended` is always false on Windows (no plughw).
+        // Issue #100.
         #[cfg(target_os = "windows")]
-        let is_default = default_display_name == Some(pcm_id.as_str());
+        let (stable_id, is_default, description, recommended) = {
+            let id = match windows_device_id(&dev) {
+                Some(id) => id,
+                None => continue,
+            };
+            let is_default = default_display_name == Some(id.as_str());
+            (id, is_default, windows_friendly_name(&dev), false)
+        };
         #[cfg(not(target_os = "windows"))]
-        let is_default = default_display_name == Some(display_name.as_str());
-        let description = alsa_card_description(&pcm_id);
-        // Prefer plughw: devices that use a stable card name (CARD=Foo)
-        // rather than a numeric index (CARD=0) which can change across
-        // reboots if USB devices enumerate in a different order.
-        let recommended = crate::audio::soundcard::is_recommended_pcm_id(&pcm_id);
+        let (stable_id, is_default, description, recommended) = (
+            pcm_id.clone(),
+            default_display_name == Some(display_name.as_str()),
+            alsa_card_description(&pcm_id),
+            // Prefer plughw: devices that use a stable card name (CARD=Foo)
+            // rather than a numeric index (CARD=0) which can change across
+            // reboots if USB devices enumerate in a different order.
+            crate::audio::soundcard::is_recommended_pcm_id(&pcm_id),
+        );
 
         out.push(AudioDeviceInfo {
             name: display_name,
-            stable_id: pcm_id,
+            stable_id,
             kind,
             sample_rates,
             channel_counts,
@@ -1430,14 +1475,15 @@ fn enumerate_audio_devices(include_output: bool) -> Vec<AudioDeviceInfo> {
     let host_name = format!("{:?}", host.id());
 
     // Source the default-device identifier the same way `collect_devices`
-    // keys its `is_default` comparison: pcm_id on Windows (uniquely
-    // identifies the device via the WASAPI friendly name), description
-    // name elsewhere. The function-level `#[allow(deprecated)]` covers
-    // the Windows `d.name()` calls below. Issue #100.
+    // keys its `is_default` comparison: IMMDevice endpoint id on
+    // Windows (uniquely identifies the endpoint), `description().name()`
+    // elsewhere. Issue #100.
     #[cfg(target_os = "windows")]
-    let default_input_name = host.default_input_device().and_then(|d| d.name().ok());
+    let default_input_name = host.default_input_device()
+        .and_then(|d| windows_device_id(&d));
     #[cfg(target_os = "windows")]
-    let default_output_name = host.default_output_device().and_then(|d| d.name().ok());
+    let default_output_name = host.default_output_device()
+        .and_then(|d| windows_device_id(&d));
     #[cfg(not(target_os = "windows"))]
     let default_input_name = host.default_input_device()
         .and_then(|d| d.description().ok().map(|desc| desc.name().to_string()));

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -1296,10 +1296,9 @@ fn alsa_card_description(_cpal_name: &str) -> String {
 
 /// On Windows, pull a device-specific friendly string out of cpal's
 /// `DeviceDescription`. `description().name()` itself prefers
-/// `DEVPKEY_Device_DeviceDesc` (the device class label `"Speakers"` /
-/// Hungarian `"Hangszórók"`), which is shared by every endpoint of
-/// that class — so it can't disambiguate two soundcards. We try, in
-/// order:
+/// `DEVPKEY_Device_DeviceDesc` (the device class label, e.g.
+/// `"Speakers"`), which is shared by every endpoint of that class —
+/// so it can't disambiguate two soundcards. We try, in order:
 ///
 /// 1. `extended()[0]` — cpal stores `DEVPKEY_Device_FriendlyName`
 ///    there when it differs from the class name (see


### PR DESCRIPTION
## Summary

Refs #100. Reporter HA2ZB confirmed v0.13.3 still rendered two soundcards as identical \"Hangszórók\" entries and flagged every output as System Default — i.e. the fix in #105 didn't take.

## Why #105 didn't work

#105 surfaced cpal's deprecated `DeviceTrait::name()` as the proto `description` field on Windows, on the assumption that it returned the WASAPI friendly form (`\"Speakers (Realtek(R) Audio)\"`). It does not.

- In cpal 0.17, `DeviceTrait::name()` is a default impl that calls `description().name()` (`cpal/src/traits.rs:110-112`). Both return the same string.
- WASAPI's `description().name()` prefers `DEVPKEY_Device_DeviceDesc` (the class label `\"Speakers\"` / Hungarian `\"Hangszórók\"`) over `DEVPKEY_Device_FriendlyName` (`cpal/src/host/wasapi/device.rs:374-382`).

So `name()` and `description().name()` collapse to the same shared class label across every endpoint of the class — the `description` field rendered the same string in `description || name` and `is_default` matched every output.

## Fix

- **Stable id + `is_default` match key**: switch to cpal `Device::id()` on Windows. The IMMDevice endpoint id is a per-endpoint GUID string, unique across cards of the same class.
- **Display string**: pull the WASAPI FriendlyName out of `description().extended()` (cpal stores `DEVPKEY_Device_FriendlyName` there when it differs from the class label — see `cpal/src/host/wasapi/device.rs:419-423`). Fall back to `description().driver()` (the interface friendly name, e.g. `\"USB PnP Sound Device\"`) when extended is empty. Surfaced as the proto `description` field; UI's existing `description || name` fallback renders the disambiguated string with no schema change.
- `find_device_by_id` matches on `Device::id()` on Windows so the runtime can resolve a saved configuration back to the right endpoint.
- Listing module (`--list-audio` flare CLI) gets the same id-keyed default match plus a unique display `name`.

Linux and macOS code paths unchanged. No proto, Go, or UI edits required.

## Test plan

- [x] `cargo check --all-targets` clean on darwin.
- [x] `cargo test --lib audio::soundcard` 10/10 pass.
- [ ] **Windows verification**: confirm with reporter (HA2ZB) that the Audio Devices panel shows distinguishable strings for two soundcards of the same class and only one is flagged System Default.
- [ ] Re-test on Linux to confirm no regression in ALSA card description or default detection.
- [ ] Verify a flare bundle generated on Windows lists each card with a unique `name` / supported_configs row.