### PR TITLE
fix(ptt): rekey channel atomically on edit (#111)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -75,6 +75,13 @@ Source: [`../../pkg/pttdevice/`](../../pkg/pttdevice/);
 [`../../proto/graywolf.proto`](../../proto/graywolf.proto)
 (`ConfigurePtt`).
 
+### 9a. PTT is one-row-per-channel; PUT supports atomic rekey
+
+*Why:* `PttConfig.ChannelID` carries a uniqueIndex, so an operator changing the channel field on an existing PTT means *move*, not copy. `PUT /api/ptt/{channel}` matches the body's `channel_id` against the URL's: same → in-place upsert; different → atomic rekey in a single GORM transaction (`Store.RekeyPttConfig`), with `ErrPttChannelTaken` mapped to HTTP 400 on collision. The bridge reload (`notifyBridgeForChannel` → `ReconfigureAudioDevice`) is global, so a single notify covers both vacated and newly-targeted channels.
+
+Source: [`../../pkg/configstore/store.go`](../../pkg/configstore/store.go) (`RekeyPttConfig`, `ErrPttChannelTaken`);
+[`../../pkg/webapi/ptt.go`](../../pkg/webapi/ptt.go) (`updatePttConfig`).
+
 ### 10. Gitignored output dirs are not canonical
 
 *Why:* `target/`, `bin/`, `dist/`, `rust-bin/`, `rust-artifacts/`, `web/dist/`, `.worktrees/`, `.context/`, `*.db*` regenerate from sources and are gitignored, so never reference them as authoritative.

--- a/pkg/configstore/iface.go
+++ b/pkg/configstore/iface.go
@@ -25,6 +25,8 @@ type ConfigStore interface {
 	// PTT
 	UpsertPttConfig(ctx context.Context, p *PttConfig) error
 	GetPttConfigForChannel(ctx context.Context, channelID uint32) (*PttConfig, error)
+	RekeyPttConfig(ctx context.Context, oldChannelID uint32, p *PttConfig) error
+	DeletePttConfig(ctx context.Context, channelID uint32) error
 
 	// TX timing
 	ListTxTimings(ctx context.Context) ([]TxTiming, error)

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -781,6 +781,39 @@ func (s *Store) DeletePttConfig(ctx context.Context, channelID uint32) error {
 	return s.db.WithContext(ctx).Where("channel_id = ?", channelID).Delete(&PttConfig{}).Error
 }
 
+// ErrPttChannelTaken is returned by RekeyPttConfig when the target
+// channel already has a PttConfig. Callers route this to HTTP 409 /
+// validation error rather than a generic 500.
+var ErrPttChannelTaken = errors.New("ptt config already exists for target channel")
+
+// RekeyPttConfig moves the PttConfig at oldChannelID onto p.ChannelID
+// atomically, applying any other field updates from p in the same
+// transaction. Preserves the row's autoincrement ID. Returns
+// ErrPttChannelTaken when p.ChannelID != oldChannelID and the target
+// already has a config (the unique index on channel_id would otherwise
+// fail with a driver-specific error). Returns gorm.ErrRecordNotFound
+// when no row exists at oldChannelID.
+func (s *Store) RekeyPttConfig(ctx context.Context, oldChannelID uint32, p *PttConfig) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing PttConfig
+		if err := tx.Where("channel_id = ?", oldChannelID).First(&existing).Error; err != nil {
+			return err
+		}
+		if p.ChannelID != oldChannelID {
+			var clash PttConfig
+			err := tx.Where("channel_id = ?", p.ChannelID).First(&clash).Error
+			if err == nil {
+				return ErrPttChannelTaken
+			}
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
+		}
+		p.ID = existing.ID
+		return tx.Save(p).Error
+	})
+}
+
 // ---------------------------------------------------------------------------
 // Channel validation
 // ---------------------------------------------------------------------------

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -782,8 +782,9 @@ func (s *Store) DeletePttConfig(ctx context.Context, channelID uint32) error {
 }
 
 // ErrPttChannelTaken is returned by RekeyPttConfig when the target
-// channel already has a PttConfig. Callers route this to HTTP 409 /
-// validation error rather than a generic 500.
+// channel already has a PttConfig. Callers route this through the
+// webapi validationError wrapper so it lands as HTTP 400 with a real
+// message rather than a generic 500.
 var ErrPttChannelTaken = errors.New("ptt config already exists for target channel")
 
 // RekeyPttConfig moves the PttConfig at oldChannelID onto p.ChannelID

--- a/pkg/configstore/store_test.go
+++ b/pkg/configstore/store_test.go
@@ -146,9 +146,10 @@ func TestRekeyPttConfig(t *testing.T) {
 		}
 		return c
 	}
-	chA := mkChan("rxA")
-	chB := mkChan("rxB")
-	chC := mkChan("rxC")
+	// Channel name is irrelevant to rekey (which keys by ChannelID).
+	chA := mkChan("chA")
+	chB := mkChan("chB")
+	chC := mkChan("chC")
 
 	pttA := &PttConfig{ChannelID: chA.ID, Method: "gpio", Device: "/dev/gpiochip0", GpioPin: 17}
 	if err := s.UpsertPttConfig(ctx, pttA); err != nil {
@@ -212,7 +213,7 @@ func TestRekeyPttConfig(t *testing.T) {
 	}
 
 	// Missing source row → ErrRecordNotFound.
-	chD := mkChan("rxD")
+	chD := mkChan("chD")
 	miss := &PttConfig{ChannelID: chD.ID, Method: "none"}
 	if err := s.RekeyPttConfig(ctx, chD.ID, miss); !errors.Is(err, gorm.ErrRecordNotFound) {
 		t.Fatalf("expected ErrRecordNotFound for missing source, got %v", err)

--- a/pkg/configstore/store_test.go
+++ b/pkg/configstore/store_test.go
@@ -2,8 +2,11 @@ package configstore
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 func newTestStore(t *testing.T) *Store {
@@ -118,6 +121,101 @@ func TestChannelAndPtt(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected 1 ptt row, got %d", count)
+	}
+}
+
+func TestRekeyPttConfig(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	dev := &AudioDevice{Name: "a", Direction: "input", SourceType: "flac", SourcePath: "x.flac", SampleRate: 44100, Channels: 1, Format: "s16le"}
+	if err := s.CreateAudioDevice(ctx, dev); err != nil {
+		t.Fatal(err)
+	}
+	mkChan := func(name string) *Channel {
+		c := &Channel{
+			Name: name, InputDeviceID: U32Ptr(dev.ID),
+			ModemType: "afsk", BitRate: 1200, MarkFreq: 1200, SpaceFreq: 2200,
+			Profile: "A", NumSlicers: 1, FixBits: "none",
+		}
+		if err := s.CreateChannel(ctx, c); err != nil {
+			t.Fatalf("CreateChannel %s: %v", name, err)
+		}
+		return c
+	}
+	chA := mkChan("rxA")
+	chB := mkChan("rxB")
+	chC := mkChan("rxC")
+
+	pttA := &PttConfig{ChannelID: chA.ID, Method: "gpio", Device: "/dev/gpiochip0", GpioPin: 17}
+	if err := s.UpsertPttConfig(ctx, pttA); err != nil {
+		t.Fatalf("UpsertPttConfig A: %v", err)
+	}
+	originalID := pttA.ID
+
+	// Move A→B with field changes; row id preserved, A vacated, B populated.
+	moved := *pttA
+	moved.ChannelID = chB.ID
+	moved.GpioPin = 22
+	if err := s.RekeyPttConfig(ctx, chA.ID, &moved); err != nil {
+		t.Fatalf("RekeyPttConfig A→B: %v", err)
+	}
+	if moved.ID != originalID {
+		t.Fatalf("rekey changed row id: was %d, now %d", originalID, moved.ID)
+	}
+	if _, err := s.GetPttConfigForChannel(ctx, chA.ID); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected A to have no PTT after rekey, got err=%v", err)
+	}
+	gotB, err := s.GetPttConfigForChannel(ctx, chB.ID)
+	if err != nil {
+		t.Fatalf("GetPttConfigForChannel B: %v", err)
+	}
+	if gotB.Method != "gpio" || gotB.GpioPin != 22 || gotB.ID != originalID {
+		t.Fatalf("expected B to carry rekeyed config, got %+v", gotB)
+	}
+
+	// Collision: C already has a PTT, so rekey B→C must fail without
+	// touching either row.
+	pttC := &PttConfig{ChannelID: chC.ID, Method: "cm108", Device: "hidraw0", GpioPin: 3}
+	if err := s.UpsertPttConfig(ctx, pttC); err != nil {
+		t.Fatalf("UpsertPttConfig C: %v", err)
+	}
+	clash := *gotB
+	clash.ChannelID = chC.ID
+	if err := s.RekeyPttConfig(ctx, chB.ID, &clash); !errors.Is(err, ErrPttChannelTaken) {
+		t.Fatalf("expected ErrPttChannelTaken, got %v", err)
+	}
+	stillB, err := s.GetPttConfigForChannel(ctx, chB.ID)
+	if err != nil || stillB.GpioPin != 22 {
+		t.Fatalf("expected B unchanged after collision, got=%+v err=%v", stillB, err)
+	}
+	stillC, err := s.GetPttConfigForChannel(ctx, chC.ID)
+	if err != nil || stillC.Method != "cm108" {
+		t.Fatalf("expected C unchanged after collision, got=%+v err=%v", stillC, err)
+	}
+
+	// Same-channel rekey is permitted (acts as in-place save).
+	same := *stillB
+	same.GpioPin = 27
+	if err := s.RekeyPttConfig(ctx, chB.ID, &same); err != nil {
+		t.Fatalf("RekeyPttConfig same-channel: %v", err)
+	}
+	gotB2, err := s.GetPttConfigForChannel(ctx, chB.ID)
+	if err != nil {
+		t.Fatalf("GetPttConfigForChannel B (post-same): %v", err)
+	}
+	if gotB2.GpioPin != 27 {
+		t.Fatalf("expected GpioPin=27 after same-channel rekey, got %+v", gotB2)
+	}
+
+	// Missing source row → ErrRecordNotFound.
+	chD := mkChan("rxD")
+	miss := &PttConfig{ChannelID: chD.ID, Method: "none"}
+	if err := s.RekeyPttConfig(ctx, chD.ID, miss); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("expected ErrRecordNotFound for missing source, got %v", err)
 	}
 }
 

--- a/pkg/webapi/dto/ptt.go
+++ b/pkg/webapi/dto/ptt.go
@@ -46,9 +46,11 @@ func (r PttRequest) ToModel() configstore.PttConfig {
 	}
 }
 
-// ToUpdate maps an update request to a storage model, pinning the
-// channel id from the URL instead of the body so path-wins semantics
-// match the current handler.
+// ToUpdate maps an update request to a storage model with the URL's
+// channel id forced into the result. Used on the same-channel branch
+// of updatePttConfig (where body.channel_id == URL channel_id, or the
+// body omitted channel_id and the URL fills it in). The cross-channel
+// rekey branch calls ToModel directly so the body's channel_id wins.
 func (r PttRequest) ToUpdate(channelID uint32) configstore.PttConfig {
 	m := r.ToModel()
 	m.ChannelID = channelID

--- a/pkg/webapi/dto/ptt.go
+++ b/pkg/webapi/dto/ptt.go
@@ -29,6 +29,13 @@ func (r PttRequest) Validate() error {
 	if r.Method == "" {
 		return fmt.Errorf("method is required")
 	}
+	// channel_id is the upsert key; 0 has no corresponding Channel row
+	// (FK would fail anyway). Reject up front so the rekey branch can't
+	// be tricked into a same-channel coalesce by a missing/zero body
+	// field.
+	if r.ChannelID == 0 {
+		return fmt.Errorf("channel_id is required")
+	}
 	return nil
 }
 

--- a/pkg/webapi/ptt.go
+++ b/pkg/webapi/ptt.go
@@ -269,8 +269,14 @@ func (s *Server) getPttConfig(w http.ResponseWriter, r *http.Request) {
 		})
 }
 
-// updatePttConfig upserts the PTT config for a channel, pinning the
-// channel id from the URL over anything the body carries.
+// updatePttConfig updates the PTT config for the URL-specified channel.
+// When the body's channel_id matches the URL, the existing row is
+// upserted in place. When it differs (and is non-zero), the row is
+// atomically rekeyed onto the new channel — PTT is one-row-per-channel
+// (uniqueIndex on channel_id), so the old channel loses its PTT
+// configuration and the new channel gains it. The rekey runs in a
+// single transaction; a target-channel collision is reported as 400
+// rather than silently clobbering an existing config.
 //
 // @Summary  Update PTT config
 // @Tags     ptt
@@ -292,6 +298,20 @@ func (s *Server) updatePttConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	handleUpdate[dto.PttRequest](s, w, r, "upsert ptt config", id,
 		func(ctx context.Context, channelID uint32, req dto.PttRequest) (configstore.PttConfig, error) {
+			if req.ChannelID != 0 && req.ChannelID != channelID {
+				m := req.ToModel()
+				if err := s.store.RekeyPttConfig(ctx, channelID, &m); err != nil {
+					if errors.Is(err, configstore.ErrPttChannelTaken) {
+						return configstore.PttConfig{}, validationError(err)
+					}
+					return configstore.PttConfig{}, err
+				}
+				// Bridge reload is global (StopAudio → re-push config
+				// → StartAudio), so a single notify refreshes both the
+				// vacated and the newly-targeted channels.
+				s.notifyBridgeForChannel(ctx, m.ChannelID)
+				return m, nil
+			}
 			m := req.ToUpdate(channelID)
 			if err := s.store.UpsertPttConfig(ctx, &m); err != nil {
 				return configstore.PttConfig{}, err

--- a/pkg/webapi/ptt.go
+++ b/pkg/webapi/ptt.go
@@ -298,7 +298,7 @@ func (s *Server) updatePttConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	handleUpdate[dto.PttRequest](s, w, r, "upsert ptt config", id,
 		func(ctx context.Context, channelID uint32, req dto.PttRequest) (configstore.PttConfig, error) {
-			if req.ChannelID != 0 && req.ChannelID != channelID {
+			if req.ChannelID != channelID {
 				m := req.ToModel()
 				if err := s.store.RekeyPttConfig(ctx, channelID, &m); err != nil {
 					if errors.Is(err, configstore.ErrPttChannelTaken) {

--- a/web/src/routes/Ptt.svelte
+++ b/web/src/routes/Ptt.svelte
@@ -324,6 +324,16 @@
 
   function validate() {
     const e = {};
+    // PTT is keyed by channel_id (one config per channel). When editing
+    // and the user picks a different channel, the save flow rekeys the
+    // row. Refuse here if the target channel already has a config —
+    // upsert would silently clobber it.
+    if (editing && String(form.channel_id) !== String(editing.channel_id)) {
+      const target = parseInt(form.channel_id, 10);
+      if (items.some(p => p.channel_id === target)) {
+        e.channel_id = `${channelName(target) || 'That channel'} already has a PTT configuration. Delete it first.`;
+      }
+    }
     if (form.method === 'rigctld') {
       const host = (form.rigctld_host || '').trim();
       if (!host) {
@@ -371,6 +381,10 @@
     delete data.rigctld_port;
     try {
       if (editing) {
+        // PUT addresses the original channel_id (the row's current
+        // key); the body carries the chosen channel_id. When the two
+        // differ, the server atomically rekeys the row in a single
+        // transaction — old channel loses PTT, new channel gains it.
         await api.put(`/ptt/${editing.channel_id}`, data);
         toasts.success('PTT config updated');
       } else {
@@ -642,6 +656,7 @@
 <!-- Add/Edit modal -->
 <Modal bind:open={modalOpen} title={editing ? 'Edit PTT Config' : 'New PTT Config'} onClose={handleModalClose}>
     <FormField label="Channel" id="ptt-ch"
+      error={errors.channel_id}
       hint="Radio channel this PTT controls. Defined on the Channels page.">
       <Select id="ptt-ch" bind:value={form.channel_id} options={channelOptions} />
     </FormField>

--- a/web/src/routes/Ptt.svelte
+++ b/web/src/routes/Ptt.svelte
@@ -331,7 +331,7 @@
     if (editing && String(form.channel_id) !== String(editing.channel_id)) {
       const target = parseInt(form.channel_id, 10);
       if (items.some(p => p.channel_id === target)) {
-        e.channel_id = `${channelName(target) || 'That channel'} already has a PTT configuration. Delete it first.`;
+        e.channel_id = `${channelName(target) || 'That channel'} already has a PTT configuration. Edit that one instead, or delete it first.`;
       }
     }
     if (form.method === 'rigctld') {


### PR DESCRIPTION
## Summary
- Editing an existing PTT and changing the channel now actually moves the config to the new channel. Previously the UI PUT to the original channel id and the handler pinned channel_id from the URL via `ToUpdate`, discarding the body's new id, so the change was silently dropped.
- PTT is one-row-per-channel (uniqueIndex on `channel_id`), so the change-channel UX is a **move**: old channel loses PTT, new channel gains it (with any other field edits applied in the same transaction). If both channels need PTT, the operator adds a second config — same as before.
- Collision on the target channel surfaces as a clear 400 instead of silently clobbering an existing config; the UI also pre-checks for nicer UX.

## Implementation
- `pkg/configstore/store.go`: new `RekeyPttConfig(ctx, oldChannelID, *PttConfig)` runs in a single GORM transaction — load the source row by old channel id, collision-check the target channel, save with new channel id and field edits while preserving the row's auto-increment ID. New sentinel `ErrPttChannelTaken`.
- `pkg/configstore/iface.go`: surface `RekeyPttConfig` and the previously-implicit `DeletePttConfig` on `ConfigStore`.
- `pkg/webapi/ptt.go`: `PUT /api/ptt/{channel}` branches — body channel id matches URL → existing upsert; differs → atomic rekey, collision routed through `validationError` → 400.
- `web/src/routes/Ptt.svelte`: PUT keeps the original channel id in the URL with the new id in the body; pre-validates collisions in `validate()` so the user gets immediate feedback.
- `pkg/configstore/store_test.go`: `TestRekeyPttConfig` covers move, collision (no-mutation guarantee), same-channel rekey, and missing-source.

## Side-effect notes (from review)
- Bridge does a global reload on every PTT change (`StopAudio → re-push config from DB → StartAudio`, ~200 ms blip), so a single notify covers both the vacated and newly-targeted channels.
- Old channel keeps RX, drops TX (no PTT row → modem can't key) — equivalent to setting method=none on it.
- No external FK references `PttConfig.ID`, so the row's id stays stable across rekey and nothing dangles.

## Test plan
- [x] `go test ./...` (all packages green; new test exercises the rekey paths)
- [x] `npm run build` in `web/`
- [ ] Manual UI: edit existing PTT, change channel to a free channel, save → old channel shows no PTT, new channel shows the config
- [ ] Manual UI: edit existing PTT, change channel to a channel that already has PTT, save → blocked with clear message, both rows untouched
- [ ] Manual UI: edit existing PTT, change a non-channel field (method/device), save → in-place update still works

Fixes #111.