### PR TITLE
feat(channels): show PTT method on each channel card

### DIFF
--- a/docs/handbook/channels.html
+++ b/docs/handbook/channels.html
@@ -110,6 +110,20 @@
       when frames are coming and going through a KISS interface.
     </p>
 
+    <p>
+      For channels that transmit through the modem, a <strong>PTT</strong>
+      block also appears on the card showing how graywolf is keying the
+      radio &mdash; <em>CM108</em>, <em>GPIO</em>, <em>Serial RTS</em>,
+      <em>Serial DTR</em>, or <em>rigctld</em> &mdash; with a short detail
+      such as the GPIO pin number, gpiochip line, or serial device path.
+      <em>Not configured</em> means the channel can transmit electrically
+      but has no PTT method assigned yet on the
+      <a href="ptt.html">PTT</a> page; outgoing frames will be dropped
+      until you set one. Receive-only channels and KISS-TNC channels
+      don&rsquo;t show this block: KISS interfaces handle their own keying,
+      and an RX-only channel never transmits.
+    </p>
+
     <div class="screenshot">
       <img src="img/channels.png" alt="Channels page showing a VHF APRS channel with AFSK modem at 1200 bps" />
       <div class="caption">Each channel card shows the modem type, audio devices, bit rate, and CSMA settings</div>

--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -102,6 +102,15 @@ The TX-funnel rule lives in [invariant 16](invariants.md).
 PTT *driving* is on the Rust side; see the `tx/ptt_*.rs` files above.
 The split is enforced by [invariant 9](invariants.md).
 
+### Channel-card PTT indicator (issue #112)
+
+| Surface | Where |
+|---|---|
+| Computed read-only summary on `ChannelResponse` | `pkg/webapi/dto/channel.go` — `ChannelPtt{Method,Configured,Detail}`; `ChannelPttFromModel` derives the operator-facing detail string (CM108 pin, GPIO line, serial path, rigctld endpoint). |
+| Wiring | `pkg/webapi/channels.go` — `listChannels` looks up `ListPttConfigs` once and indexes by channel id; `getChannel` does a single `GetPttConfigForChannel` lookup. Missing row → nil `Ptt` (omitempty) so the UI distinguishes "never configured" from `method=none`. |
+| UI helpers | `web/src/lib/channelPtt.js` — `summaryLine`, `pttState`, `methodLabel`, `ariaLabel`. Mirrors `channelBacking.js`. |
+| Card row | `web/src/routes/Channels.svelte` — second `backing-row`-styled block under the BACKING row, only shown for modem-backed TX channels (KISS-only and RX-only channels don't drive PTT). |
+
 ## Channel TX gating
 
 | Surface | Where |

--- a/pkg/webapi/channels.go
+++ b/pkg/webapi/channels.go
@@ -52,6 +52,18 @@ func (s *Server) listChannels(w http.ResponseWriter, r *http.Request) {
 		s.internalError(w, r, "list channels", err)
 		return
 	}
+	// PTT rows are looked up once and indexed by channel id so the
+	// per-card render stays O(1). A missing row maps to nil Ptt — the
+	// UI treats that as "never configured" (distinct from method=none).
+	ptts, err := s.store.ListPttConfigs(ctx)
+	if err != nil {
+		s.internalError(w, r, "list channels", err)
+		return
+	}
+	pttByChannel := make(map[uint32]configstore.PttConfig, len(ptts))
+	for _, p := range ptts {
+		pttByChannel[p.ChannelID] = p
+	}
 	statuses := s.kissStatus()
 	modemLive := s.modemRunning()
 	resp := make([]dto.ChannelResponse, len(chs))
@@ -59,6 +71,10 @@ func (s *Server) listChannels(w http.ResponseWriter, r *http.Request) {
 		resp[i] = dto.ChannelFromModel(c)
 		b := computeChannelBacking(c, ifaces, statuses, modemLive)
 		resp[i].Backing = &b
+		if p, ok := pttByChannel[c.ID]; ok {
+			ptt := dto.ChannelPttFromModel(p)
+			resp[i].Ptt = &ptt
+		}
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -116,6 +132,23 @@ func (s *Server) getChannel(w http.ResponseWriter, r *http.Request) {
 			}
 			b := computeChannelBacking(*c, ifaces, s.kissStatus(), s.modemRunning())
 			resp.Backing = &b
+			// Best-effort PTT lookup: ErrRecordNotFound is the common
+			// case (no PttConfig row), and we map it to nil Ptt so the
+			// UI can show "PTT not configured" rather than treating it
+			// as a server error. Any OTHER store error gets logged —
+			// without that signal, "my PTT-configured channel says
+			// 'Not configured'" troubleshooting (the very flow this
+			// indicator exists to support) goes silent.
+			p, perr := s.store.GetPttConfigForChannel(r.Context(), c.ID)
+			switch {
+			case perr == nil:
+				ptt := dto.ChannelPttFromModel(*p)
+				resp.Ptt = &ptt
+			case errors.Is(perr, gorm.ErrRecordNotFound):
+				// Expected: no PTT row for this channel.
+			default:
+				s.logger.Warn("get channel: load ptt config", "channel", c.ID, "err", perr)
+			}
 			return resp
 		})
 }

--- a/pkg/webapi/channels_test.go
+++ b/pkg/webapi/channels_test.go
@@ -146,6 +146,94 @@ func TestChannelsList_BackingModem(t *testing.T) {
 	}
 }
 
+// TestChannelsList_PttSurfacesConfiguredRow asserts that a configured
+// PttConfig row is reflected in the Ptt summary on the channel
+// response, while channels with no PttConfig row leave Ptt nil. The
+// Channels page renders a PTT indicator block for issue #112 against
+// this exact field.
+func TestChannelsList_PttSurfacesConfiguredRow(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	// Seed a PTT row against the seeded channel from newTestServer.
+	chs, err := srv.store.ListChannels(context.Background())
+	if err != nil || len(chs) == 0 {
+		t.Fatalf("seeded channel missing: %v", err)
+	}
+	chID := chs[0].ID
+	if err := srv.store.UpsertPttConfig(context.Background(), &configstore.PttConfig{
+		ChannelID: chID,
+		Method:    "cm108",
+		GpioPin:   3,
+		Device:    "/dev/hidraw0",
+	}); err != nil {
+		t.Fatalf("UpsertPttConfig: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/channels", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp []dto.ChannelResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	var got *dto.ChannelPtt
+	for i := range resp {
+		if resp[i].ID == chID {
+			got = resp[i].Ptt
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("expected non-nil Ptt for channel %d, response: %+v", chID, resp)
+	}
+	if got.Method != "cm108" {
+		t.Errorf("Method = %q, want cm108", got.Method)
+	}
+	if !got.Configured {
+		t.Errorf("Configured = false, want true")
+	}
+	if got.Detail != "GPIO 3 · /dev/hidraw0" {
+		t.Errorf("Detail = %q", got.Detail)
+	}
+}
+
+// TestChannelsList_PttOmittedWhenAbsent asserts that a channel with no
+// PttConfig row serializes with Ptt omitted (nil + omitempty), so the
+// UI can distinguish "never configured" from method=none.
+func TestChannelsList_PttOmittedWhenAbsent(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/channels", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Decode into a key-preserving structure so the assertion targets
+	// the absence of the literal "ptt" key rather than the substring
+	// (which would false-positive on any future field name containing
+	// "ptt").
+	var raw []map[string]json.RawMessage
+	if err := json.NewDecoder(rec.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(raw) == 0 {
+		t.Fatalf("expected at least one channel")
+	}
+	for i, ch := range raw {
+		if _, ok := ch["ptt"]; ok {
+			t.Errorf("channel %d: expected ptt field omitted, got %s", i, string(ch["ptt"]))
+		}
+	}
+}
+
 // TestComputeChannelBacking_Unbound covers the fall-through branch:
 // a channel with no input device + no TNC interface reports
 // summary=unbound and health=unbound. Phase 2 flipped

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -8338,6 +8338,20 @@
                 }
             }
         },
+        "dto.ChannelPtt": {
+            "type": "object",
+            "properties": {
+                "configured": {
+                    "type": "boolean"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.ChannelRequest": {
             "type": "object",
             "properties": {
@@ -8450,6 +8464,9 @@
                 },
                 "profile": {
                     "type": "string"
+                },
+                "ptt": {
+                    "$ref": "#/definitions/dto.ChannelPtt"
                 },
                 "space_freq": {
                     "type": "integer"

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -1038,6 +1038,15 @@ definitions:
       reason:
         type: string
     type: object
+  dto.ChannelPtt:
+    properties:
+      configured:
+        type: boolean
+      detail:
+        type: string
+      method:
+        type: string
+    type: object
   dto.ChannelRequest:
     properties:
       bit_rate:
@@ -1113,6 +1122,8 @@ definitions:
         type: integer
       profile:
         type: string
+      ptt:
+        $ref: '#/definitions/dto.ChannelPtt'
       space_freq:
         type: integer
     type: object

--- a/pkg/webapi/dto/channel.go
+++ b/pkg/webapi/dto/channel.go
@@ -113,7 +113,29 @@ func (r ChannelRequest) ToUpdate(id uint32) configstore.Channel {
 type ChannelResponse struct {
 	ID      uint32          `json:"id"`
 	Backing *ChannelBacking `json:"backing,omitempty"`
+	Ptt     *ChannelPtt     `json:"ptt,omitempty"`
 	ChannelRequest
+}
+
+// ChannelPtt is the read-only, UI-facing summary of the per-channel
+// PttConfig row. The full configuration is still available via
+// /api/ptt/{channel}; this struct exists so the Channels page can
+// render a "PTT" indicator block (parallel to the backing row) without
+// fanning out to the PTT endpoint per card.
+//
+// Method is the PttConfig.Method enum (none|serial_rts|serial_dtr|gpio|
+// cm108|rigctld). Configured is true iff Method is non-empty and not
+// "none" — the convenience flag the UI uses to colour the badge and
+// drive the "PTT not configured" hint.
+//
+// Detail is a short, operator-facing summary of the device the method
+// keys (CM108 pin, GPIO line, serial path, rigctld endpoint). Empty
+// when the chosen method has no parameters worth surfacing in a single
+// line.
+type ChannelPtt struct {
+	Method     string `json:"method"`
+	Configured bool   `json:"configured"`
+	Detail     string `json:"detail,omitempty"`
 }
 
 // ChannelBacking describes the runtime backing — modem and/or KISS-TNC
@@ -213,6 +235,66 @@ const (
 	ChannelBackingHealthDown    = "down"
 	ChannelBackingHealthUnbound = "unbound"
 )
+
+// PttMethodNone is the canonical "no keying" value for PttConfig.Method.
+// Stored explicitly rather than as an empty string so the UI can
+// distinguish "operator opened the PTT page and chose None" from "row
+// has never been written" (the latter shows up as a missing PttConfig
+// row, surfaced to the UI as ChannelResponse.Ptt == nil).
+const PttMethodNone = "none"
+
+// ChannelPttFromModel maps a PttConfig row into the response summary.
+// Detail is a short human-readable description; the full config is
+// still served by /api/ptt/{channel}. Keep this in lockstep with the
+// PTT method enum so a new method type doesn't render as a blank row.
+func ChannelPttFromModel(p configstore.PttConfig) ChannelPtt {
+	method := p.Method
+	if method == "" {
+		method = PttMethodNone
+	}
+	return ChannelPtt{
+		Method:     method,
+		Configured: method != PttMethodNone,
+		Detail:     pttDetail(p, method),
+	}
+}
+
+func pttDetail(p configstore.PttConfig, method string) string {
+	switch method {
+	case "cm108":
+		// CM108 keys via HID GPIO output (1-indexed, 1-8; default 3).
+		// Operators see two different surfaces for this same field:
+		// the PTT settings page renders it as `GPIO N (pin N+10)`,
+		// where the parenthetical is the physical CM108 chip pin.
+		// The Channels card is one-line-only so we drop the
+		// parenthetical, but keep the `GPIO` label so the word "pin"
+		// doesn't end up meaning two different things across pages.
+		// `pin == 0` is API-only (the PTT page clamps to 3); coerce
+		// rather than render `GPIO 0`, which is invalid.
+		pin := p.GpioPin
+		if pin == 0 {
+			pin = 3
+		}
+		if p.Device != "" {
+			return fmt.Sprintf("GPIO %d · %s", pin, p.Device)
+		}
+		return fmt.Sprintf("GPIO %d", pin)
+	case "gpio":
+		if p.Device != "" {
+			return fmt.Sprintf("line %d · %s", p.GpioLine, p.Device)
+		}
+		return fmt.Sprintf("line %d", p.GpioLine)
+	case "serial_rts", "serial_dtr":
+		if p.Device != "" {
+			return p.Device
+		}
+		return ""
+	case "rigctld":
+		// Device for rigctld is "host:port"; surface as-is.
+		return p.Device
+	}
+	return ""
+}
 
 // ChannelFromModel converts a storage model into a response DTO. The
 // Backing field is left nil — list/get handlers populate it after the

--- a/pkg/webapi/dto/channel_test.go
+++ b/pkg/webapi/dto/channel_test.go
@@ -132,3 +132,88 @@ func TestChannelRequestToModel_NilInput(t *testing.T) {
 		t.Fatalf("expected nil, got %v", m.InputDeviceID)
 	}
 }
+
+// TestChannelPttFromModel covers the four detail-rendering branches of
+// the PTT summary used by the Channels page (issue #112). The Detail
+// strings are wire format consumed by web/src/lib/channelPtt.js — keep
+// them in lockstep with that file.
+func TestChannelPttFromModel(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         configstore.PttConfig
+		method     string
+		configured bool
+		detail     string
+	}{
+		{
+			name:       "none method maps to !configured",
+			in:         configstore.PttConfig{Method: "none"},
+			method:     "none",
+			configured: false,
+			detail:     "",
+		},
+		{
+			name:       "empty method coerces to none",
+			in:         configstore.PttConfig{},
+			method:     "none",
+			configured: false,
+			detail:     "",
+		},
+		{
+			name:       "cm108 surfaces gpio pin",
+			in:         configstore.PttConfig{Method: "cm108", GpioPin: 3, Device: "/dev/hidraw0"},
+			method:     "cm108",
+			configured: true,
+			detail:     "GPIO 3 · /dev/hidraw0",
+		},
+		{
+			name:       "cm108 zero pin defaults to 3",
+			in:         configstore.PttConfig{Method: "cm108"},
+			method:     "cm108",
+			configured: true,
+			detail:     "GPIO 3",
+		},
+		{
+			name:       "unknown method renders without trailing separator",
+			in:         configstore.PttConfig{Method: "futureproof"},
+			method:     "futureproof",
+			configured: true,
+			detail:     "",
+		},
+		{
+			name:       "gpio surfaces line offset",
+			in:         configstore.PttConfig{Method: "gpio", GpioLine: 17, Device: "/dev/gpiochip0"},
+			method:     "gpio",
+			configured: true,
+			detail:     "line 17 · /dev/gpiochip0",
+		},
+		{
+			name:       "serial_rts surfaces device path",
+			in:         configstore.PttConfig{Method: "serial_rts", Device: "/dev/ttyUSB0"},
+			method:     "serial_rts",
+			configured: true,
+			detail:     "/dev/ttyUSB0",
+		},
+		{
+			name:       "rigctld surfaces host:port",
+			in:         configstore.PttConfig{Method: "rigctld", Device: "127.0.0.1:4532"},
+			method:     "rigctld",
+			configured: true,
+			detail:     "127.0.0.1:4532",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ChannelPttFromModel(tc.in)
+			if got.Method != tc.method {
+				t.Errorf("Method = %q, want %q", got.Method, tc.method)
+			}
+			if got.Configured != tc.configured {
+				t.Errorf("Configured = %v, want %v", got.Configured, tc.configured)
+			}
+			if got.Detail != tc.detail {
+				t.Errorf("Detail = %q, want %q", got.Detail, tc.detail)
+			}
+		})
+	}
+}

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2250,6 +2250,11 @@ export interface components {
             active?: boolean;
             reason?: string;
         };
+        "dto.ChannelPtt": {
+            configured?: boolean;
+            detail?: string;
+            method?: string;
+        };
         "dto.ChannelRequest": {
             bit_rate?: number;
             decoder_offset?: number;
@@ -2288,6 +2293,7 @@ export interface components {
             output_channel?: number;
             output_device_id?: number;
             profile?: string;
+            ptt?: components["schemas"]["dto.ChannelPtt"];
             space_freq?: number;
         };
         "dto.ConversationSummary": {

--- a/web/src/lib/channelPtt.js
+++ b/web/src/lib/channelPtt.js
@@ -1,0 +1,55 @@
+// Presentation helpers for the `ptt` object returned by /api/channels.
+// Mirror of channelBacking.js -- the Channels page renders a PTT
+// indicator block parallel to the BACKING block (issue #112) and we
+// route every label through here so the wording stays consistent if
+// new methods are added to dto.ChannelPtt.
+
+// Wire-level enum values mirrored from pkg/configstore/models.go
+// (PttConfig.Method) and dto.PttMethodNone. If a new method is added
+// on the Go side, add it here too -- methodLabel falls back to the
+// raw string so an out-of-date UI degrades to "method=foo" rather
+// than blanking the row.
+export const METHOD_NONE = 'none';
+
+const METHOD_LABELS = {
+  none: 'None',
+  serial_rts: 'Serial RTS',
+  serial_dtr: 'Serial DTR',
+  gpio: 'GPIO',
+  cm108: 'CM108',
+  rigctld: 'rigctld',
+};
+
+export function methodLabel(method) {
+  if (!method) return 'None';
+  return METHOD_LABELS[method] ?? method;
+}
+
+// summaryLine renders the indicator's right-hand text:
+//   "CM108 · pin 3 · /dev/hidraw0"   when configured with a detail
+//   "Serial RTS"                      method-only fallback
+//   "None"                            method=none
+//   "Not configured"                  ptt object missing entirely
+export function summaryLine(ptt) {
+  if (!ptt) return 'Not configured';
+  const label = methodLabel(ptt.method);
+  if (!ptt.configured) return label;
+  if (ptt.detail) return `${label} · ${ptt.detail}`;
+  return label;
+}
+
+// State string drives the glyph colour. Three states match BACKING's
+// live/down/unbound trio so the visual vocabulary on the card stays
+// consistent: configured method ~= live, explicit "none" ~= down,
+// missing row ~= unbound.
+export function pttState(ptt) {
+  if (!ptt) return 'unbound';
+  return ptt.configured ? 'live' : 'down';
+}
+
+export function ariaLabel(ptt) {
+  if (!ptt) return 'PTT not configured';
+  if (!ptt.configured) return 'PTT method none';
+  const detail = ptt.detail ? `, ${ptt.detail}` : '';
+  return `PTT ${methodLabel(ptt.method)}${detail}`;
+}

--- a/web/src/lib/channelPtt.test.js
+++ b/web/src/lib/channelPtt.test.js
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  methodLabel,
+  summaryLine,
+  pttState,
+  ariaLabel,
+  METHOD_NONE,
+} from './channelPtt.js';
+
+test('methodLabel translates known methods and falls back to raw', () => {
+  assert.equal(methodLabel(METHOD_NONE), 'None');
+  assert.equal(methodLabel('cm108'), 'CM108');
+  assert.equal(methodLabel('serial_rts'), 'Serial RTS');
+  assert.equal(methodLabel('rigctld'), 'rigctld');
+  assert.equal(methodLabel(''), 'None');
+  assert.equal(methodLabel(undefined), 'None');
+  // Unknown method -> degrade to raw token rather than blank.
+  assert.equal(methodLabel('newmethod'), 'newmethod');
+});
+
+test('summaryLine surfaces method + detail when configured', () => {
+  assert.equal(
+    summaryLine({ method: 'cm108', configured: true, detail: 'GPIO 3 · /dev/hidraw0' }),
+    'CM108 · GPIO 3 · /dev/hidraw0',
+  );
+  assert.equal(
+    summaryLine({ method: 'serial_rts', configured: true, detail: '/dev/ttyUSB0' }),
+    'Serial RTS · /dev/ttyUSB0',
+  );
+  assert.equal(
+    summaryLine({ method: 'serial_rts', configured: true, detail: '' }),
+    'Serial RTS',
+  );
+});
+
+test('summaryLine renders method-only state when not configured', () => {
+  assert.equal(summaryLine({ method: 'none', configured: false }), 'None');
+});
+
+test('summaryLine reports "Not configured" when ptt is missing', () => {
+  assert.equal(summaryLine(null), 'Not configured');
+  assert.equal(summaryLine(undefined), 'Not configured');
+});
+
+test('pttState mirrors backing tri-state', () => {
+  assert.equal(pttState(null), 'unbound');
+  assert.equal(pttState({ method: 'none', configured: false }), 'down');
+  assert.equal(pttState({ method: 'cm108', configured: true }), 'live');
+});
+
+test('ariaLabel is screen-reader friendly across states', () => {
+  assert.equal(ariaLabel(null), 'PTT not configured');
+  assert.equal(ariaLabel({ method: 'none', configured: false }), 'PTT method none');
+  assert.equal(
+    ariaLabel({ method: 'cm108', configured: true, detail: 'GPIO 3' }),
+    'PTT CM108, GPIO 3',
+  );
+  assert.equal(
+    ariaLabel({ method: 'serial_dtr', configured: true }),
+    'PTT Serial DTR',
+  );
+});

--- a/web/src/routes/Channels.svelte
+++ b/web/src/routes/Channels.svelte
@@ -16,6 +16,11 @@
     HEALTH_LIVE,
     HEALTH_DOWN,
   } from '../lib/channelBacking.js';
+  import {
+    summaryLine as pttSummaryLine,
+    pttState,
+    ariaLabel as pttAriaLabel,
+  } from '../lib/channelPtt.js';
   import { groupReferrers, totalReferrers } from '../lib/channelReferrers.js';
 
   // The Channels page itself hydrates the shared store: this page is
@@ -492,6 +497,24 @@
             <span class="backing-summary">
               <span class="glyph {glyphClass}" aria-hidden="true">{healthGlyph(h)}</span>
               <span class="backing-text">{summaryLabel(ch.backing)} · {healthText(h)}</span>
+            </span>
+          </div>
+        {/if}
+
+        <!-- PTT indicator (issue #112). Only shown for modem-backed TX
+             channels: KISS-TNC channels handle keying inside the TNC
+             firmware, and an RX-only modem channel can't transmit so
+             PTT has no role to play either. -->
+        {#if !isKissOnly && ch.output_device_id && ch.output_device_id !== 0}
+          {@const pttGlyphClass = pttState(ch.ptt)}
+          <div class="backing-row"
+               aria-label={pttAriaLabel(ch.ptt)}>
+            <span class="backing-label">PTT</span>
+            <span class="backing-summary">
+              <span class="glyph {pttGlyphClass}" aria-hidden="true">
+                {pttGlyphClass === 'live' ? '●' : '○'}
+              </span>
+              <span class="backing-text">{pttSummaryLine(ch.ptt)}</span>
             </span>
           </div>
         {/if}


### PR DESCRIPTION
## Summary
- Adds a `PTT` indicator block to every modem-backed TX channel on the Channels page, parallel to the existing `BACKING` block. Surfaces the keying method (CM108, GPIO, Serial RTS/DTR, rigctld) plus a one-line detail (GPIO pin, gpiochip line, serial path, host:port). KISS-TNC and RX-only channels skip the row — they never drive PTT.
- Read-only computed field on `ChannelResponse.Ptt` (omitempty). One `ListPttConfigs` lookup per `/api/channels` request; missing row → nil so the UI distinguishes "never configured" from `method=none`.
- Wiki + operator handbook updated; swagger.json/yaml + TS api.d.ts regenerated.

Closes #112

## Test plan
- [x] `go test ./pkg/webapi/... ./pkg/configstore/...` — green
- [x] `node --test web/src/lib/channelPtt.test.js` — 6/6 green
- [x] `make docs-check` + `make api-client-check` — green
- [x] `cd web && npm run build` — green
- [ ] Manual: load Channels page, confirm PTT row renders for TX-capable modem channels and is absent on KISS-only / RX-only cards
- [ ] Manual: confirm "Not configured" appears when a TX-capable channel has no PttConfig row, and the configured method renders correctly for at least one of cm108 / gpio / serial_rts