### PR TITLE
fix(ptt): reject PTT writes on KISS-TNC-backed channels (#110)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -82,6 +82,14 @@ Source: [`../../pkg/pttdevice/`](../../pkg/pttdevice/);
 Source: [`../../pkg/configstore/store.go`](../../pkg/configstore/store.go) (`RekeyPttConfig`, `ErrPttChannelTaken`);
 [`../../pkg/webapi/ptt.go`](../../pkg/webapi/ptt.go) (`updatePttConfig`).
 
+### 9b. PTT writes are rejected on KISS-TNC channels
+
+*Why:* A KISS TNC owns the radio interface end-to-end including PTT, so a graywolf-driven PTT row on top of a KISS-only channel (`Channel.InputDeviceID == nil`) is at best redundant and at worst keys the wrong radio after the operator reassigns channels (issue #110). The webapi handlers gate POST `/api/ptt` and both branches of PUT `/api/ptt/{channel}` (in-place upsert AND rekey) through `validatePttChannelBacking`, which returns HTTP 400. For rekey the validator runs against `req.ChannelID` (the move target), not the URL id, so an operator cannot bypass the rule by editing an existing PTT row onto a KISS channel. The PTT page mirrors the rule by hiding KISS-only channels from the channel dropdown.
+
+Source: [`../../pkg/webapi/ptt.go`](../../pkg/webapi/ptt.go) (`validatePttChannelBacking`);
+[`../../pkg/webapi/ptt_test.go`](../../pkg/webapi/ptt_test.go) (`TestPttRejectsKissOnlyChannel`);
+[`../../web/src/routes/Ptt.svelte`](../../web/src/routes/Ptt.svelte) (`modemChannels` filter).
+
 ### 10. Gitignored output dirs are not canonical
 
 *Why:* `target/`, `bin/`, `dist/`, `rust-bin/`, `rust-artifacts/`, `web/dist/`, `.worktrees/`, `.context/`, `*.db*` regenerate from sources and are gitignored, so never reference them as authoritative.

--- a/pkg/webapi/ptt.go
+++ b/pkg/webapi/ptt.go
@@ -3,6 +3,7 @@ package webapi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"net/http"
 	"net/url"
@@ -96,6 +97,9 @@ func (s *Server) upsertPttConfig(w http.ResponseWriter, r *http.Request) {
 	handleCreate[dto.PttRequest](s, w, r, "upsert ptt config",
 		func(ctx context.Context, req dto.PttRequest) (configstore.PttConfig, error) {
 			m := req.ToModel()
+			if err := s.validatePttChannelBacking(ctx, m.ChannelID); err != nil {
+				return configstore.PttConfig{}, err
+			}
 			if err := s.store.UpsertPttConfig(ctx, &m); err != nil {
 				return configstore.PttConfig{}, err
 			}
@@ -103,6 +107,37 @@ func (s *Server) upsertPttConfig(w http.ResponseWriter, r *http.Request) {
 			return m, nil
 		},
 		dto.PttFromModel)
+}
+
+// validatePttChannelBacking rejects PTT writes whose target channel is
+// KISS-TNC-only (Channel.InputDeviceID == nil). PTT for those channels
+// is owned by the TNC hardware itself; an extra graywolf-driven PTT
+// config is at best redundant and at worst points the operator at the
+// wrong radio after they've reassigned channels (issue #110).
+//
+// targetChannelID is the channel the PTT row will end up bound to —
+// for POST and same-channel PUT that's the URL/body channel id; for the
+// PUT rekey branch it's req.ChannelID (the move target), not the URL
+// id, so an operator cannot bypass the rule by editing an existing row
+// onto a KISS channel.
+//
+// A KISS-only channel returns a validationError so the generic handler
+// wiring maps it to HTTP 400 with the explanation in the body. Other
+// store failures (including record-not-found) propagate untouched —
+// missing-channel writes already fail at the FK layer with the standard
+// 500/400 mapping, and overriding that to a typed 400 here would
+// conflate "invalid channel for PTT" with "channel does not exist".
+func (s *Server) validatePttChannelBacking(ctx context.Context, targetChannelID uint32) error {
+	ch, err := s.store.GetChannel(ctx, targetChannelID)
+	if err != nil {
+		return err
+	}
+	if ch.InputDeviceID == nil {
+		return validationError(fmt.Errorf(
+			"channel %d (%q) is backed by a KISS TNC; PTT is controlled by the TNC, not graywolf",
+			targetChannelID, ch.Name))
+	}
+	return nil
 }
 
 // listPttDevices enumerates PTT-capable devices detected on the host —
@@ -300,6 +335,12 @@ func (s *Server) updatePttConfig(w http.ResponseWriter, r *http.Request) {
 		func(ctx context.Context, channelID uint32, req dto.PttRequest) (configstore.PttConfig, error) {
 			if req.ChannelID != channelID {
 				m := req.ToModel()
+				// Validate the move target, not the URL id — issue #110.
+				// Rekeying onto a KISS-TNC channel must fail just like a
+				// fresh POST against one would.
+				if err := s.validatePttChannelBacking(ctx, m.ChannelID); err != nil {
+					return configstore.PttConfig{}, err
+				}
 				if err := s.store.RekeyPttConfig(ctx, channelID, &m); err != nil {
 					if errors.Is(err, configstore.ErrPttChannelTaken) {
 						return configstore.PttConfig{}, validationError(err)
@@ -313,6 +354,9 @@ func (s *Server) updatePttConfig(w http.ResponseWriter, r *http.Request) {
 				return m, nil
 			}
 			m := req.ToUpdate(channelID)
+			if err := s.validatePttChannelBacking(ctx, channelID); err != nil {
+				return configstore.PttConfig{}, err
+			}
 			if err := s.store.UpsertPttConfig(ctx, &m); err != nil {
 				return configstore.PttConfig{}, err
 			}

--- a/pkg/webapi/ptt_test.go
+++ b/pkg/webapi/ptt_test.go
@@ -1,13 +1,17 @@
 package webapi
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/pttdevice"
 )
 
@@ -373,6 +377,134 @@ func TestPttRoutePrecedence_RealHandlers(t *testing.T) {
 				ct, rec.Body.String())
 		}
 	}
+}
+
+// TestPttRejectsKissOnlyChannel pins issue #110: a PTT row cannot be
+// created or updated against a KISS-TNC-only channel (Channel.InputDeviceID
+// == nil). The TNC owns PTT for those channels, and an extra graywolf
+// PTT config is at best redundant and at worst keys the wrong radio
+// after the operator reassigns channels.
+//
+// Both the POST upsert path and the PUT update path are covered to
+// guarantee the validator runs on every write entry point. Successful
+// upsert against the seeded modem-backed channel is also asserted to
+// catch a future change that accidentally rejects every channel.
+func TestPttRejectsKissOnlyChannel(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	ctx := context.Background()
+
+	// Seed an explicit modem-backed channel alongside the KISS-only one
+	// instead of relying on whatever newTestServer happens to create —
+	// keeps this test self-contained against future fixture drift.
+	inDev := &configstore.AudioDevice{
+		Name: "in", Direction: "input", SourceType: "flac", SourcePath: "/tmp/in.flac",
+		SampleRate: 44100, Channels: 1, Format: "s16le",
+	}
+	if err := srv.store.CreateAudioDevice(ctx, inDev); err != nil {
+		t.Fatalf("seed input device: %v", err)
+	}
+	outDev := &configstore.AudioDevice{
+		Name: "out", Direction: "output", SourceType: "null", SourcePath: "/tmp/out.raw",
+		SampleRate: 44100, Channels: 1, Format: "s16le",
+	}
+	if err := srv.store.CreateAudioDevice(ctx, outDev); err != nil {
+		t.Fatalf("seed output device: %v", err)
+	}
+	modemCh := &configstore.Channel{
+		Name: "modem-test", InputDeviceID: configstore.U32Ptr(inDev.ID), OutputDeviceID: outDev.ID,
+		ModemType: "afsk", BitRate: 1200, MarkFreq: 1200, SpaceFreq: 2200,
+		Profile: "A", NumSlicers: 1, FixBits: "none",
+	}
+	if err := srv.store.CreateChannel(ctx, modemCh); err != nil {
+		t.Fatalf("seed modem channel: %v", err)
+	}
+
+	// Seed a KISS-only channel (InputDeviceID == nil). validateChannel
+	// allows OutputDeviceID == 0 when InputDeviceID is nil.
+	kissCh := &configstore.Channel{
+		Name:           "kiss0",
+		InputDeviceID:  nil,
+		OutputDeviceID: 0,
+	}
+	if err := srv.store.CreateChannel(ctx, kissCh); err != nil {
+		t.Fatalf("seed kiss channel: %v", err)
+	}
+
+	send := func(t *testing.T, path string, method string, body any) *httptest.ResponseRecorder {
+		t.Helper()
+		buf, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		req := httptest.NewRequest(method, path, bytes.NewReader(buf))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("POST rejects kiss-only channel with 400", func(t *testing.T) {
+		rec := send(t, "/api/ptt", http.MethodPost, map[string]any{
+			"channel_id": kissCh.ID,
+			"method":     "serial_rts",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(strings.ToLower(rec.Body.String()), "kiss") {
+			t.Errorf("expected error to mention KISS, got: %s", rec.Body.String())
+		}
+	})
+
+	t.Run("PUT same-channel rejects kiss-only with 400", func(t *testing.T) {
+		rec := send(t, "/api/ptt/"+strconv.FormatUint(uint64(kissCh.ID), 10), http.MethodPut, map[string]any{
+			"channel_id": kissCh.ID,
+			"method":     "serial_rts",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("POST allows modem-backed channel", func(t *testing.T) {
+		rec := send(t, "/api/ptt", http.MethodPost, map[string]any{
+			"channel_id": modemCh.ID,
+			"method":     "none",
+		})
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("PUT rekey to kiss-only target rejected with 400", func(t *testing.T) {
+		// Build an existing PTT row on the modem channel, then attempt
+		// to rekey it onto the KISS channel by sending PUT to the modem
+		// id with body channel_id == kissCh.ID. The rekey branch in
+		// updatePttConfig must run validatePttChannelBacking against the
+		// move target (req.ChannelID), not the URL id, otherwise the
+		// guard is bypassable on edit (issue #110 critical edge case).
+		rec := send(t, "/api/ptt/"+strconv.FormatUint(uint64(modemCh.ID), 10), http.MethodPut, map[string]any{
+			"channel_id": kissCh.ID,
+			"method":     "serial_rts",
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for rekey to kiss target, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(strings.ToLower(rec.Body.String()), "kiss") {
+			t.Errorf("expected error to mention KISS, got: %s", rec.Body.String())
+		}
+		// Verify the original row is still bound to the modem channel
+		// (rekey must be atomic — failure leaves the source row intact).
+		got, err := srv.store.GetPttConfigForChannel(ctx, modemCh.ID)
+		if err != nil {
+			t.Fatalf("get ptt after rejected rekey: %v", err)
+		}
+		if got == nil || got.ChannelID != modemCh.ID {
+			t.Fatalf("expected ptt still bound to modemCh.ID=%d, got %+v", modemCh.ID, got)
+		}
+	})
 }
 
 func keys(m map[string]any) []string {

--- a/web/src/routes/Ptt.svelte
+++ b/web/src/routes/Ptt.svelte
@@ -64,8 +64,16 @@
   let recommendedDevices = $derived(available.filter(d => d.recommended));
   let otherDevices = $derived(available.filter(d => !d.recommended));
 
+  // PTT only applies to modem-backed channels. KISS-TNC-backed channels
+  // (input_device_id == null) have their PTT controlled by the TNC itself,
+  // so adding a graywolf-driven PTT row would either be redundant or, worse,
+  // key the wrong radio after the operator reassigns channels (issue #110).
+  // The backend rejects upserts targeting these channels with HTTP 400; the
+  // filter here keeps them out of the dropdown so the rejection is never
+  // reached in normal use.
+  let modemChannels = $derived(channels.filter(c => c.input_device_id != null));
   let channelOptions = $derived(
-    channels.map(c => ({ value: String(c.id), label: `${c.name} (ch ${c.id})` }))
+    modemChannels.map(c => ({ value: String(c.id), label: `${c.name} (ch ${c.id})` }))
   );
 
   function channelName(id) {
@@ -248,9 +256,13 @@
       toasts.error('Create a channel first on the Channels page');
       return;
     }
+    if (modemChannels.length === 0) {
+      toasts.error('PTT only applies to modem-backed channels. KISS-TNC channels manage PTT in the TNC itself.');
+      return;
+    }
     editing = null;
     form = emptyForm();
-    form.channel_id = String(channels[0].id);
+    form.channel_id = String(modemChannels[0].id);
     lastMethod = form.method;
     errors = {};
     modalOpen = true;
@@ -294,12 +306,16 @@
       toasts.error('Create a channel first on the Channels page');
       return;
     }
+    if (modemChannels.length === 0) {
+      toasts.error('PTT only applies to modem-backed channels. KISS-TNC channels manage PTT in the TNC itself.');
+      return;
+    }
     editing = null;
     const method = dev.type === 'gpio' ? 'gpio'
       : dev.type === 'cm108' ? 'cm108'
       : 'serial_rts';
     form = {
-      channel_id: String(channels[0].id),
+      channel_id: String(modemChannels[0].id),
       method,
       device_path: dev.path,
       gpio_pin: method === 'cm108' ? '3' : '0',
@@ -657,7 +673,7 @@
 <Modal bind:open={modalOpen} title={editing ? 'Edit PTT Config' : 'New PTT Config'} onClose={handleModalClose}>
     <FormField label="Channel" id="ptt-ch"
       error={errors.channel_id}
-      hint="Radio channel this PTT controls. Defined on the Channels page.">
+      hint="Modem-backed channels only — KISS-TNC channels manage PTT in the TNC itself.">
       <Select id="ptt-ch" bind:value={form.channel_id} options={channelOptions} />
     </FormField>
     <FormField label="Method" id="ptt-method">


### PR DESCRIPTION
## Summary

- Backend: POST `/api/ptt` and PUT `/api/ptt/{channel}` now run `validatePttChannelBacking`, which returns HTTP 400 with a typed message when the target channel is KISS-TNC-backed (`Channel.InputDeviceID == nil`). A KISS TNC owns the radio interface end-to-end including PTT, so a graywolf-driven PTT row is at best redundant and at worst keys the wrong radio after the operator reassigns channels.
- Frontend: `Ptt.svelte` filters KISS-only channels out of the channel dropdown via a new `modemChannels` derivation, the create / create-from-detected paths bail out with a tailored toast when no eligible channels exist, and the form hint reflects the rule.
- Wiki: new invariant 9a documents the contract and points at the validator + filter sources.

Refs #110.

## Test plan

- [x] `go test ./pkg/webapi/... -count=1` (new `TestPttRejectsKissOnlyChannel` covers POST and PUT rejection plus the modem-backed allow case)
- [x] `go build ./...`
- [x] `npm run build` in `web/`
- [ ] Manual: open the PTT page on an instance with both a modem-backed and a KISS-TNC-only channel; confirm the dropdown only lists the modem channel, and that a hand-crafted POST against the KISS channel id returns 400.