### PR TITLE
fix(map): default Live Map to station position instead of USA

### DIFF
--- a/web/src/lib/map/data-store.svelte.js
+++ b/web/src/lib/map/data-store.svelte.js
@@ -274,10 +274,15 @@ export function createDataStore() {
       document.addEventListener('visibilitychange', visibilityHandler);
     }
 
-    fetchMyPosition();
-    // Fire one immediately so the UI populates without waiting for the timer.
-    fetchOnce().then(() => {
-      if (started) schedule();
+    // Resolve the station's position before the first /api/stations poll
+    // so LiveMapV2's first-load camera logic has a deterministic chance to
+    // recenter on "My Position" before the fit-to-stations fallback fires.
+    // /api/position is an in-memory read; the added latency is negligible.
+    fetchMyPosition().finally(() => {
+      if (!started) return;
+      fetchOnce().then(() => {
+        if (started) schedule();
+      });
     });
   }
 

--- a/web/src/lib/map/map-store.svelte.js
+++ b/web/src/lib/map/map-store.svelte.js
@@ -3,10 +3,15 @@
 // Uses .svelte.js extension so $state runes work. Exported as an object
 // with getter/setter pairs so reactivity crosses module boundaries.
 // localStorage sync for user preferences that persist across sessions.
-// Initial center: localStorage → browser geolocation → US geographic center.
+// Initial center: localStorage → world view. The station's own position
+// (when available from /api/position) is applied by LiveMapV2 as a
+// one-shot recentering after the data store first reports it.
 
-const US_CENTER = [39.8283, -98.5795];
-const GEOLOCATED_ZOOM = 10;
+// Slightly above the equator so the world view shows more land than ocean.
+const WORLD_CENTER = [20, 0];
+const WORLD_ZOOM = 2;
+// Zoom used when LiveMapV2 recenters on the station's "My Position".
+export const MY_POSITION_ZOOM = 10;
 
 function loadFloat(key, fallback) {
   const v = localStorage.getItem(key);
@@ -40,22 +45,10 @@ export const mapState = (() => {
 
   let timerange = $state(loadInt('map-timerange', 3600));
   let mapCenter = $state([
-    loadFloat('map-center-lat', US_CENTER[0]),
-    loadFloat('map-center-lon', US_CENTER[1]),
+    loadFloat('map-center-lat', WORLD_CENTER[0]),
+    loadFloat('map-center-lon', WORLD_CENTER[1]),
   ]);
-  let mapZoom = $state(loadInt('map-zoom', 4));
-
-  // If no saved center, try browser geolocation and update reactively
-  if (!hasSavedCenter && 'geolocation' in navigator) {
-    navigator.geolocation.getCurrentPosition(
-      (pos) => {
-        mapCenter = [pos.coords.latitude, pos.coords.longitude];
-        mapZoom = GEOLOCATED_ZOOM;
-      },
-      () => {}, // denied or unavailable — keep US center
-      { timeout: 5000, maximumAge: 300000 },
-    );
-  }
+  let mapZoom = $state(loadInt('map-zoom', WORLD_ZOOM));
 
   return {
     get selectedStation() { return selectedStation; },

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -17,7 +17,7 @@
   import { mountMyPositionLayer } from '../lib/map/layers/my-position.js';
   import { renderStationPopupHTML } from '../lib/map/popup.js';
   import { unitsState } from '../lib/settings/units-store.svelte.js';
-  import { mapState } from '../lib/map/map-store.svelte.js';
+  import { mapState, MY_POSITION_ZOOM } from '../lib/map/map-store.svelte.js';
   import { toMaidenhead } from '../lib/map/maidenhead.js';
   import { fmtLat, fmtLon, timeAgo } from '../lib/map/popup-helpers.js';
 
@@ -309,8 +309,27 @@
     dataStore.setTimerange(timerangeSec * 1000);
   });
 
-  // One-shot auto-fit: after the first poll completes, frame all stations
-  // currently in the data store. Empty result → leave at planet view.
+  // One-shot recenter on the station's "My Position" as soon as the data
+  // store reports a valid fix. Takes precedence over fit-to-stations: the
+  // operator's own location is the more useful default than a bounding
+  // box of every callsign heard in the last hour. Suppressed when a
+  // persisted view exists — restoring that view is what the operator
+  // wants on reload.
+  $effect(() => {
+    const my = dataStore.myPosition;
+    if (!my || !mapRef || didAutoFit) return;
+    didAutoFit = true;
+    mapRef.easeTo({
+      center: [my.lon, my.lat],
+      zoom: MY_POSITION_ZOOM,
+      duration: 600,
+    });
+  });
+
+  // Fallback auto-fit: after the first poll completes, frame all stations
+  // currently in the data store. Empty result → leave at world view. Only
+  // fires when the My Position recenter above did not — i.e., the station
+  // has no GPS lock and no configured position.
   $effect(() => {
     const t = dataStore.lastFetchAt;
     if (!t || !mapRef || didAutoFit) return;

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -327,18 +327,19 @@
   });
 
   // Fallback auto-fit: after the first poll completes, frame all stations
-  // currently in the data store. Empty result → leave at world view. Only
-  // fires when the My Position recenter above did not — i.e., the station
-  // has no GPS lock and no configured position.
+  // currently in the data store. Only fires when the My Position recenter
+  // above did not — i.e., the station has no GPS lock and no configured
+  // position. If there are also no heard stations, the map stays at the
+  // world view, and didAutoFit stays false so a later myPosition arrival
+  // can still claim the camera.
   $effect(() => {
     const t = dataStore.lastFetchAt;
     if (!t || !mapRef || didAutoFit) return;
-    didAutoFit = true;
-    fitToStations();
+    if (fitToStations()) didAutoFit = true;
   });
 
   function fitToStations() {
-    if (!mapRef) return;
+    if (!mapRef) return false;
     const coords = [];
     for (const s of dataStore.stations.values()) {
       const p = s.positions && s.positions[0];
@@ -346,14 +347,15 @@
         coords.push([p.lon, p.lat]);
       }
     }
-    if (coords.length === 0) return;
+    if (coords.length === 0) return false;
     if (coords.length === 1) {
       mapRef.easeTo({ center: coords[0], zoom: 9, duration: 600 });
-      return;
+      return true;
     }
     const bounds = new maplibregl.LngLatBounds(coords[0], coords[0]);
     for (let i = 1; i < coords.length; i++) bounds.extend(coords[i]);
     mapRef.fitBounds(bounds, { padding: 60, maxZoom: 12, duration: 600 });
+    return true;
   }
 
   // ---- Status bar derivations ----


### PR DESCRIPTION
## Summary

- Live Map opened centered on the geographic center of the United States at zoom 4 on every fresh page load, regardless of where the station actually was. The fallback chain was localStorage → browser geolocation → US center, but the geolocation update fired after MapLibre had already constructed the map with the US center, so the recenter was never visible.
- Replaced the US-center fallback with a world view (lat 20, lon 0, zoom 2). When the data store reports a valid `/api/position` fix, recenter once on "My Position" at zoom 10. Existing fit-to-stations behavior remains as the next fallback when the station has neither a GPS lock nor a configured position.
- A persisted localStorage view still wins over both auto-recenters, so reloads preserve whatever the operator had panned/zoomed to.

## Test plan

- [ ] Clear localStorage (`map-center-lat`, `map-center-lon`, `map-zoom`) and reload `/map` on a station with a valid GPS fix → map opens at world view, then eases to station position at zoom 10.
- [ ] Same flow on a station with no GPS / no configured position → map stays at world view; if any stations are heard in the active timerange, fit-to-stations runs as before.
- [ ] Pan/zoom, reload → persisted view restored, no auto-recenter fires.

## Notes

- `node --test` reports one pre-existing failure in `src/lib/settings/messages-preferences-store.test.js` (imports `vitest`, but the suite runs under `node --test`). Reproduces on `main` without these changes — out of scope here.

Refs #119