### PR TITLE
android: phase 4a code-review follow-up

### DIFF
--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -237,13 +237,19 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 			// the system default speaker regardless of any DB rows;
 			// the seed pair just gives the SPA's UI something to
 			// show + something to bind a channel to.
+			// Sample rate matches AudioPump's default (22050) and the Rust
+			// modem's Android JNI canned-frame rate (22050). The DB value
+			// is informational on Android — the modem reads samples from
+			// the JNI bridge at the bridge's rate, not from the
+			// configstore-driven CPAL device-open path — but matching the
+			// real rate keeps the UI honest.
 			for _, seed := range []configstore.AudioDevice{
 				{
 					Name:       "Default Input",
 					Direction:  "input",
 					SourceType: "soundcard",
 					SourcePath: "android-default",
-					SampleRate: 48000,
+					SampleRate: 22050,
 					Channels:   1,
 					Format:     "s16le",
 				},
@@ -252,7 +258,7 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 					Direction:  "output",
 					SourceType: "soundcard",
 					SourcePath: "android-default",
-					SampleRate: 48000,
+					SampleRate: 22050,
 					Channels:   1,
 					Format:     "s16le",
 				},

--- a/pkg/webauth/auth_test.go
+++ b/pkg/webauth/auth_test.go
@@ -210,6 +210,74 @@ func TestMiddleware(t *testing.T) {
 	}
 }
 
+// TestBearerThenRequireAuthBypassLoadsStationUser asserts the Android
+// auth path: BearerAuthMiddleware stamps the bypass marker, RequireAuth
+// honors it, loads the first user (single-station model), and the
+// handler sees AuthenticatedUser(r) populated.
+func TestBearerThenRequireAuthBypassLoadsStationUser(t *testing.T) {
+	s := testAuthStore(t)
+	ctx := context.Background()
+	if _, err := s.CreateUser(ctx, "admin", "hash", ""); err != nil {
+		t.Fatalf("CreateUser admin: %v", err)
+	}
+	if _, err := s.CreateUser(ctx, "second", "hash", ""); err != nil {
+		t.Fatalf("CreateUser second: %v", err)
+	}
+
+	var seen *WebUser
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = AuthenticatedUser(r)
+		w.WriteHeader(http.StatusOK)
+	})
+	stack := BearerAuthMiddleware("tok")(RequireAuth(s)(inner))
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	stack.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if seen == nil {
+		t.Fatal("expected AuthenticatedUser non-nil after bearer bypass")
+	}
+	// ListUsers orders by username ascending, so "admin" sorts before "second".
+	if seen.Username != "admin" {
+		t.Fatalf("expected admin user, got %q", seen.Username)
+	}
+}
+
+// TestBearerBypassWithEmptyStorePassesNilUser asserts the fresh-install
+// path: bearer accepted, no users yet, handler runs with nil user.
+// Downstream handlers that require a user must surface their own 401.
+func TestBearerBypassWithEmptyStorePassesNilUser(t *testing.T) {
+	s := testAuthStore(t)
+	var seen *WebUser
+	var ran bool
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ran = true
+		seen = AuthenticatedUser(r)
+		w.WriteHeader(http.StatusOK)
+	})
+	stack := BearerAuthMiddleware("tok")(RequireAuth(s)(inner))
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	stack.ServeHTTP(rec, req)
+
+	if !ran {
+		t.Fatal("expected handler to run on empty-store bearer bypass")
+	}
+	if seen != nil {
+		t.Fatalf("expected nil user on empty store, got %+v", seen)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
 func TestFirstRunSetup(t *testing.T) {
 	s := testAuthStore(t)
 	h := &Handlers{Auth: s}

--- a/pkg/webauth/bearer.go
+++ b/pkg/webauth/bearer.go
@@ -22,11 +22,11 @@ func BearerAuthMiddleware(token string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if matchHeader(r, want) {
-				next.ServeHTTP(w, r.WithContext(WithBearerAuthed(r.Context())))
+				next.ServeHTTP(w, r.WithContext(withBearerAuthed(r.Context())))
 				return
 			}
 			if isWebSocketUpgrade(r) && matchQueryToken(r, want) {
-				next.ServeHTTP(w, r.WithContext(WithBearerAuthed(r.Context())))
+				next.ServeHTTP(w, r.WithContext(withBearerAuthed(r.Context())))
 				return
 			}
 			jsonError(w, http.StatusUnauthorized, "authentication required")

--- a/pkg/webauth/middleware.go
+++ b/pkg/webauth/middleware.go
@@ -25,10 +25,10 @@ func AuthenticatedUser(r *http.Request) *WebUser {
 	return u
 }
 
-// WithBearerAuthed marks ctx as already authenticated via Bearer token
-// (set by BearerAuthMiddleware). RequireAuth uses this to short-circuit
-// the cookie check.
-func WithBearerAuthed(ctx context.Context) context.Context {
+// withBearerAuthed marks ctx as already authenticated via Bearer token.
+// Unexported so only BearerAuthMiddleware can stamp the marker —
+// downstream code cannot synthesize the bypass.
+func withBearerAuthed(ctx context.Context) context.Context {
 	return context.WithValue(ctx, bearerAuthedContextKey, true)
 }
 

--- a/web/src/routes/AudioDevices.svelte
+++ b/web/src/routes/AudioDevices.svelte
@@ -480,7 +480,12 @@
   </FormField>
   <FormField label="Device Path" error={errors.device_path} id="ad-path">
     {#if Platform.kind === 'android'}
-      <Input id="ad-path" value="android-default" readonly />
+      <!-- Read-only on Android, but still bound to form.device_path so the
+           displayed value reflects what will be saved. If the row was
+           loaded with a non-default path (manual DB edit, migration), the
+           field shows that path rather than silently overriding with
+           "android-default" only in the UI. -->
+      <Input id="ad-path" bind:value={form.device_path} readonly />
     {:else}
       <Input id="ad-path" bind:value={form.device_path} placeholder="hw:0,0" />
     {/if}


### PR DESCRIPTION
Post-merge code-review fixes for phase 4a (PR #125).

## Fixes
- **Critical**: seed Android default audio rows at `SampleRate=22050` (matches `AudioPump`'s capture rate). The 48000 value was cosmetic (Android JNI path bypasses configstore-driven device-open) but misrepresented reality in the UI.
- **Important**: unexport `WithBearerAuthed → withBearerAuthed`. Only `BearerAuthMiddleware` should stamp the bypass marker; package-private now.
- **Important**: add bearer-auth bypass tests (`pkg/webauth/auth_test.go`) — populated store loads `ListUsers()[0]` into context; fresh install passes through with nil user.
- **Important**: `AudioDevices.svelte` Android Device Path Input binds to `form.device_path` (readonly) rather than rendering a hardcoded literal. Honest display if a row carries a non-default path.

## Skipped (deferred for future cleanup)
- `cfg.Platform` vs `platform.Kind` dual sources of truth — established repo pattern, broader cleanup.
- `Platform.kind` coupled to bearer-token presence — would need a new bridge method.
- `GpsAndroid.svelte` freshness derived from poll wall-clock instead of `fix.time_unix_ms` — minor UI accuracy.
- Lat/Lon `omitempty` on the equator — theoretical, not hit in practice.
- Adaptive icon as raster bitmap — placeholder; vector path is a separate art task.

## Test plan
- [x] `GOWORK=off go test ./pkg/webauth/... ./pkg/app/... ./pkg/webapi/...` — green
- [x] Two new tests in `pkg/webauth/auth_test.go` pass

Stacked on `docs/android-phase-3-plan` (the branch phase 4a merged into).