### PR TITLE
fix(ax25): uppercase callsign in binary address decode

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -352,3 +352,21 @@ Source: [`../../pkg/app/wiring.go`](../../pkg/app/wiring.go)
 [`../../pkg/igate/output.go`](../../pkg/igate/output.go)
 (`IgateOutput.SetIgate`),
 [`../../pkg/app/igate_toggle_test.go`](../../pkg/app/igate_toggle_test.go).
+
+### 29. AX.25 callsigns are uppercased on decode
+
+*Why:* APRS callsigns are uppercase alphanumeric per spec, but
+non-conformant transmitters occasionally ship lowercase shifted bytes
+in the address field. The text parser `ax25.ParseAddress` already
+uppercases, but the binary `decodeAddress` path used for every RF
+frame did not, so lowercase callsigns leaked through `pkt.Source`
+into the station cache and message store. Normalizing at the single
+binary-decode chokepoint keeps every downstream consumer (router,
+station cache, persistInbound, digipeater) working from canonical
+uppercase. Object and Item names are NOT normalized — APRS101 §11
+defines them as case-sensitive free-form names, not callsigns.
+
+Source: [`../../pkg/ax25/address.go`](../../pkg/ax25/address.go)
+(`decodeAddress`),
+[`../../pkg/ax25/frame_test.go`](../../pkg/ax25/frame_test.go)
+(`TestDecodeAddressUppercasesCallsign`).

--- a/pkg/ax25/address.go
+++ b/pkg/ax25/address.go
@@ -130,7 +130,7 @@ func decodeAddress(buf []byte) (Address, bool, error) {
 		}
 		call = append(call, c)
 	}
-	a.Call = string(call)
+	a.Call = strings.ToUpper(string(call))
 	a.SSID = (buf[6] >> 1) & 0x0F
 	a.Repeated = buf[6]&0x80 != 0 // interpretation depends on position; caller reinterprets for dest/src
 	last := buf[6]&0x01 != 0

--- a/pkg/ax25/frame_test.go
+++ b/pkg/ax25/frame_test.go
@@ -45,6 +45,28 @@ func TestAddressString(t *testing.T) {
 	}
 }
 
+// TestDecodeAddressUppercasesCallsign guards against non-conformant
+// transmitters that ship lowercase shifted bytes in AX.25 address
+// fields. We normalize on decode so lowercase callsigns never reach
+// the station cache or message store.
+func TestDecodeAddressUppercasesCallsign(t *testing.T) {
+	// Build a 7-byte address with lowercase 'n0call' shifted left by 1.
+	var buf [addrLen]byte
+	call := "n0call"
+	for i := range 6 {
+		buf[i] = call[i] << 1
+	}
+	buf[6] = 0x60 | 0x01 // RR=1, SSID=0, end-of-address
+
+	got, _, err := decodeAddress(buf[:])
+	if err != nil {
+		t.Fatalf("decodeAddress: %v", err)
+	}
+	if got.Call != "N0CALL" {
+		t.Errorf("Call = %q, want %q", got.Call, "N0CALL")
+	}
+}
+
 func TestUIFrameRoundTrip(t *testing.T) {
 	src, _ := ParseAddress("N0CALL-1")
 	dst, _ := ParseAddress("APRS")


### PR DESCRIPTION
## Problem

Non-conformant transmitters occasionally ship lowercase shifted bytes in the AX.25 address field. The text parser \`ParseAddress\` already uppercased, but the binary \`decodeAddress\` path — used for **every RF frame** — did not. Lowercase callsigns leaked through \`pkt.Source\` into the station cache and message store.

## Fix

Normalize with \`strings.ToUpper\` at the single binary-decode chokepoint (\`decodeAddress\`), so every downstream consumer (router, station cache, persistInbound, digipeater) works from canonical uppercase.

APRS Object/Item names are **not** touched — they are case-sensitive free-form names per APRS101 §11, decoded via a fully disjoint path (\`parseObject\`/\`parseItem\`).

## Verification

- \`TestDecodeAddressUppercasesCallsign\` added — confirmed true regression test (fails without the fix: \`Call = "n0call", want "N0CALL"\`)
- \`GOWORK=off go test ./pkg/ax25/\` passes
- Code review: chokepoint claim and Object/Item carve-out independently verified against code; no Critical/Important issues
- Invariant #29 documented in \`docs/wiki/invariants.md\`