### PR TITLE
fix(kiss): per-channel RX/TX stats for KISS-TNC channels

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -379,20 +379,27 @@ counters, which are fed *only* by the Rust modem's `StatusUpdate`
 IPC. KISS-TNC-backed channels have no Rust modem, so their card was
 permanently stuck at zero even though the aggregate Prometheus
 tiles incremented (issue #132). Per-channel counts for TNC-mode KISS
-interfaces are therefore tracked separately in `kiss.Manager`
-(RX via the wrapped `RxIngress`, TX via the per-instance tx queue's
-`onEnqueue` observer); `webapi` prefers the bridge cache and falls
+interfaces are therefore tracked separately in `kiss.Manager`: RX
+via the wrapped `RxIngress` (per inbound frame, per interface); TX
+via `txbackend.Dispatcher`'s `OnChannelTx` hook, called once per
+dispatched frame on a KISS-backed channel, co-located with the
+aggregate `ObserveTxFrame` so it stays in lockstep and does NOT
+multiply by fan-out width when a channel has multiple KISS-TNC
+interfaces attached. `webapi` prefers the bridge cache and falls
 back to `kiss.Manager.ChannelStats` only when the bridge has no
 entry. The TX-backend validator forbids a channel being both modem-
 and KISS-backed, so the two sources never overlap and cannot
-double-count. Bad-FCS is intentionally absent for KISS-TNC channels:
+double-count (a modem-backed channel carries no KISS backend, so
+`OnChannelTx` never fires for it). Bad-FCS is intentionally absent for KISS-TNC channels:
 a hardware TNC validates the FCS and never forwards a bad frame over
 KISS. Unlike the modem cache, the KISS counters are process-lifetime
 monotonic and are NOT reset on a modem restart.
 
 Source: [`../../pkg/kiss/channelstats.go`](../../pkg/kiss/channelstats.go),
 [`../../pkg/kiss/manager.go`](../../pkg/kiss/manager.go)
-(`Start`/`StartClient` observer wiring),
+(`wrapRxIngress` wiring in `Start`/`StartClient`),
+[`../../pkg/app/txbackend/dispatcher.go`](../../pkg/app/txbackend/dispatcher.go)
+(`OnChannelTx`),
 [`../../pkg/webapi/status.go`](../../pkg/webapi/status.go),
 [`../../pkg/webapi/channels.go`](../../pkg/webapi/channels.go)
 (`getChannelStats`).

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -370,3 +370,29 @@ Source: [`../../pkg/ax25/address.go`](../../pkg/ax25/address.go)
 (`decodeAddress`),
 [`../../pkg/ax25/frame_test.go`](../../pkg/ax25/frame_test.go)
 (`TestDecodeAddressUppercasesCallsign`).
+
+### 30. Per-channel dashboard stats have two sources by backing
+
+*Why:* The dashboard channel card RX/TX (`GET /api/status`,
+`GET /api/channels/{id}/stats`) reads `modembridge` per-channel
+counters, which are fed *only* by the Rust modem's `StatusUpdate`
+IPC. KISS-TNC-backed channels have no Rust modem, so their card was
+permanently stuck at zero even though the aggregate Prometheus
+tiles incremented (issue #132). Per-channel counts for TNC-mode KISS
+interfaces are therefore tracked separately in `kiss.Manager`
+(RX via the wrapped `RxIngress`, TX via the per-instance tx queue's
+`onEnqueue` observer); `webapi` prefers the bridge cache and falls
+back to `kiss.Manager.ChannelStats` only when the bridge has no
+entry. The TX-backend validator forbids a channel being both modem-
+and KISS-backed, so the two sources never overlap and cannot
+double-count. Bad-FCS is intentionally absent for KISS-TNC channels:
+a hardware TNC validates the FCS and never forwards a bad frame over
+KISS. Unlike the modem cache, the KISS counters are process-lifetime
+monotonic and are NOT reset on a modem restart.
+
+Source: [`../../pkg/kiss/channelstats.go`](../../pkg/kiss/channelstats.go),
+[`../../pkg/kiss/manager.go`](../../pkg/kiss/manager.go)
+(`Start`/`StartClient` observer wiring),
+[`../../pkg/webapi/status.go`](../../pkg/webapi/status.go),
+[`../../pkg/webapi/channels.go`](../../pkg/webapi/channels.go)
+(`getChannelStats`).

--- a/pkg/app/txbackend/dispatcher.go
+++ b/pkg/app/txbackend/dispatcher.go
@@ -53,6 +53,14 @@ type Dispatcher struct {
 	metrics Metrics
 	logger  *slog.Logger
 
+	// onChannelTx, if set, is called once per Send for a KISS-backed
+	// channel — co-located with the per-frame ObserveTxFrame so it
+	// increments exactly once regardless of fan-out width. Feeds the
+	// KISS per-channel dashboard counter (issue #132); modem-backed
+	// channels never trigger it because they carry no KISS backend
+	// (the validator forbids a channel being both).
+	onChannelTx func(channel uint32)
+
 	// closed flips to true on StopAccepting. Readers check it before
 	// loading the snapshot so a late Send after shutdown returns
 	// ErrStopped rather than blindly fanning out to backends whose
@@ -72,6 +80,10 @@ type Config struct {
 	Metrics Metrics
 	// Logger is optional; slog.Default is used when nil.
 	Logger *slog.Logger
+	// OnChannelTx, if non-nil, is invoked once per dispatched frame on
+	// a KISS-backed channel (one call regardless of fan-out size).
+	// Optional; nil disables KISS per-channel TX counting.
+	OnChannelTx func(channel uint32)
 }
 
 // New returns a Dispatcher. The watcher goroutine is not started
@@ -94,6 +106,7 @@ func New(cfg Config) *Dispatcher {
 		reg:         reg,
 		metrics:     m,
 		logger:      lg.With("component", "txbackend"),
+		onChannelTx: cfg.OnChannelTx,
 		watcherDone: make(chan struct{}),
 	}
 }
@@ -135,6 +148,18 @@ func (d *Dispatcher) Send(tf *pb.TransmitFrame) error {
 
 	// Per-frame counter: one increment regardless of fan-out size.
 	d.metrics.ObserveTxFrame(tf.Channel)
+
+	// KISS per-channel TX, in lockstep with the aggregate counter
+	// above: one call per dispatched frame even when the channel
+	// fans out to multiple KISS-TNC interfaces (issue #132).
+	if d.onChannelTx != nil {
+		for _, b := range backends {
+			if b.Name() == BackendNameKiss {
+				d.onChannelTx(tf.Channel)
+				break
+			}
+		}
+	}
 
 	d.logger.Debug("tx dispatch",
 		"channel", tf.Channel,

--- a/pkg/app/txbackend/dispatcher_test.go
+++ b/pkg/app/txbackend/dispatcher_test.go
@@ -332,3 +332,63 @@ func TestDispatcher_ShutdownOrder(t *testing.T) {
 		t.Fatalf("closeOrder=%v, want 2 entries", closed)
 	}
 }
+
+// TestDispatcher_OnChannelTx_FanOutSafe verifies the KISS per-channel
+// TX hook fires exactly once per Send even when the channel fans out
+// to multiple KISS-TNC backends — it must stay in lockstep with the
+// per-frame aggregate counter, not multiply by fan-out width (issue
+// #132 review follow-up).
+func TestDispatcher_OnChannelTx_FanOutSafe(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	k1 := &fakeBackend{name: BackendNameKiss, instance: "kiss-1", channels: []uint32{11}, submit: func(*pb.TransmitFrame) error { return nil }}
+	k2 := &fakeBackend{name: BackendNameKiss, instance: "kiss-2", channels: []uint32{11}, submit: func(*pb.TransmitFrame) error { return ErrBackendBusy }}
+	reg := NewRegistry()
+	reg.Publish(&Snapshot{
+		ByChannel: map[uint32][]Backend{11: {k1, k2}},
+		CsmaSkip:  map[uint32]bool{11: true},
+	})
+
+	var calls []uint32
+	d := New(Config{Registry: reg, OnChannelTx: func(ch uint32) { calls = append(calls, ch) }})
+
+	if err := d.Send(&pb.TransmitFrame{Channel: 11, FrameId: 1}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(calls) != 1 || calls[0] != 11 {
+		t.Fatalf("OnChannelTx calls=%v, want exactly [11] (one per frame, not per fan-out)", calls)
+	}
+
+	// Even when every backend fails the channel was still dispatched,
+	// matching the aggregate ObserveTxFrame semantic.
+	k1.submit = func(*pb.TransmitFrame) error { return ErrBackendDown }
+	k2.submit = func(*pb.TransmitFrame) error { return ErrBackendDown }
+	_ = d.Send(&pb.TransmitFrame{Channel: 11, FrameId: 2})
+	if len(calls) != 2 {
+		t.Fatalf("OnChannelTx calls=%v after all-fail Send, want 2", calls)
+	}
+}
+
+// TestDispatcher_OnChannelTx_NotFiredForModem verifies modem-backed
+// channels never trigger the KISS per-channel TX hook (the validator
+// forbids mixing, and the dashboard reads modem TX from modembridge).
+func TestDispatcher_OnChannelTx_NotFiredForModem(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	modem := &fakeBackend{name: BackendNameModem, instance: "modem", channels: []uint32{1}}
+	reg := NewRegistry()
+	reg.Publish(&Snapshot{
+		ByChannel: map[uint32][]Backend{1: {modem}},
+		CsmaSkip:  map[uint32]bool{},
+	})
+
+	fired := false
+	d := New(Config{Registry: reg, OnChannelTx: func(uint32) { fired = true }})
+
+	if err := d.Send(&pb.TransmitFrame{Channel: 1, FrameId: 7}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if fired {
+		t.Fatal("OnChannelTx fired for a modem-only channel; want no call")
+	}
+}

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -221,6 +221,15 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 	a.txDispatcher = txbackend.New(txbackend.Config{
 		Metrics: a.metrics, // *metrics.Metrics satisfies the txbackend.Metrics interface.
 		Logger:  a.logger,
+		// Per-channel KISS-TNC TX counter for the dashboard (issue
+		// #132). Lazy a.kissMgr read: same closure-capture rationale
+		// as the snapshot builder above — the manager is constructed
+		// later in the wiring order but exists before any TX flows.
+		OnChannelTx: func(ch uint32) {
+			if a.kissMgr != nil {
+				a.kissMgr.RecordChannelTx(ch)
+			}
+		},
 	})
 	a.txBackendReload = make(chan struct{}, 1)
 

--- a/pkg/kiss/channelstats.go
+++ b/pkg/kiss/channelstats.go
@@ -1,0 +1,73 @@
+package kiss
+
+import (
+	pb "github.com/chrissnell/graywolf/pkg/ipcproto"
+
+	"github.com/chrissnell/graywolf/pkg/app/ingress"
+)
+
+// ChannelStat is a cumulative per-channel frame count for a TNC-mode
+// KISS interface. RxFrames counts AX.25 frames ingested from the TNC;
+// TxFrames counts frames the governor handed to the per-instance tx
+// queue. Bad-FCS is deliberately absent: a hardware TNC validates the
+// FCS itself and never forwards a bad frame over KISS, so the
+// dashboard's "Bad FCS" stays 0 for these channels (issue #132).
+type ChannelStat struct {
+	RxFrames uint64
+	TxFrames uint64
+}
+
+// countRx records one received frame on ch.
+func (m *Manager) countRx(ch uint32) {
+	m.chanStatsMu.Lock()
+	s := m.chanStats[ch]
+	if s == nil {
+		s = &ChannelStat{}
+		m.chanStats[ch] = s
+	}
+	s.RxFrames++
+	m.chanStatsMu.Unlock()
+}
+
+// countTx records one transmitted frame on ch.
+func (m *Manager) countTx(ch uint32) {
+	m.chanStatsMu.Lock()
+	s := m.chanStats[ch]
+	if s == nil {
+		s = &ChannelStat{}
+		m.chanStats[ch] = s
+	}
+	s.TxFrames++
+	m.chanStatsMu.Unlock()
+}
+
+// ChannelStats returns a snapshot of the cumulative RX/TX counts for a
+// single channel. ok is false when no TNC-mode frame has yet been seen
+// on that channel, letting callers (webapi) prefer modembridge's cache
+// when the channel is modem-backed instead.
+func (m *Manager) ChannelStats(ch uint32) (ChannelStat, bool) {
+	m.chanStatsMu.Lock()
+	defer m.chanStatsMu.Unlock()
+	s, ok := m.chanStats[ch]
+	if !ok {
+		return ChannelStat{}, false
+	}
+	return *s, true
+}
+
+// wrapRxIngress decorates base so every TNC-mode frame it carries is
+// counted against rf.Channel before delegating. base may be nil (no
+// TNC routing configured); the wrapper is then a no-op counter that
+// still tolerates being called. The server only invokes RxIngress in
+// ModeTnc, so this counts exactly KISS-TNC RX with the precise
+// resolved channel.
+func (m *Manager) wrapRxIngress(base func(rf *pb.ReceivedFrame, src ingress.Source)) func(rf *pb.ReceivedFrame, src ingress.Source) {
+	return func(rf *pb.ReceivedFrame, src ingress.Source) {
+		if rf != nil {
+			m.countRx(rf.Channel)
+		}
+		if base != nil {
+			base(rf, src)
+		}
+	}
+}

--- a/pkg/kiss/channelstats.go
+++ b/pkg/kiss/channelstats.go
@@ -7,11 +7,17 @@ import (
 )
 
 // ChannelStat is a cumulative per-channel frame count for a TNC-mode
-// KISS interface. RxFrames counts AX.25 frames ingested from the TNC;
-// TxFrames counts frames the governor handed to the per-instance tx
-// queue. Bad-FCS is deliberately absent: a hardware TNC validates the
-// FCS itself and never forwards a bad frame over KISS, so the
-// dashboard's "Bad FCS" stays 0 for these channels (issue #132).
+// KISS channel. RxFrames counts AX.25 frames ingested from the TNC
+// (per inbound frame, per interface — genuinely distinct off-air
+// traffic). TxFrames counts frames dispatched to the channel by the
+// TX backend, incremented once per frame regardless of how many
+// KISS-TNC interfaces the channel fans out to, so it stays in
+// lockstep with the aggregate TX tile rather than multiplying by
+// fan-out width; it is a dispatched count, not an on-air
+// confirmation. Bad-FCS is deliberately absent: a hardware TNC
+// validates the FCS itself and never forwards a bad frame over KISS,
+// so the dashboard's "Bad FCS" stays 0 for these channels (issue
+// #132).
 type ChannelStat struct {
 	RxFrames uint64
 	TxFrames uint64
@@ -28,6 +34,13 @@ func (m *Manager) countRx(ch uint32) {
 	s.RxFrames++
 	m.chanStatsMu.Unlock()
 }
+
+// RecordChannelTx records one dispatched TX frame on ch. Called by
+// the TX backend dispatcher (once per frame, fan-out-safe) rather
+// than from the per-instance tx queue, so the count matches the
+// aggregate TX tile on channels with multiple KISS-TNC interfaces
+// (issue #132).
+func (m *Manager) RecordChannelTx(ch uint32) { m.countTx(ch) }
 
 // countTx records one transmitted frame on ch.
 func (m *Manager) countTx(ch uint32) {

--- a/pkg/kiss/channelstats_test.go
+++ b/pkg/kiss/channelstats_test.go
@@ -1,0 +1,104 @@
+package kiss
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	pb "github.com/chrissnell/graywolf/pkg/ipcproto"
+
+	"github.com/chrissnell/graywolf/pkg/app/ingress"
+)
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	return NewManager(ManagerConfig{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+}
+
+// TestManager_ChannelStats_CountsRxTx verifies the per-channel counter
+// primitive: unseen channels report ok=false, RX/TX accumulate
+// independently per channel, and snapshots are by value (issue #132).
+func TestManager_ChannelStats_CountsRxTx(t *testing.T) {
+	m := newTestManager(t)
+
+	if _, ok := m.ChannelStats(1); ok {
+		t.Fatalf("unseen channel: ok=true, want false")
+	}
+
+	m.countRx(1)
+	m.countRx(1)
+	m.countTx(1)
+	m.countTx(1)
+	m.countTx(1)
+	m.countTx(2)
+
+	got, ok := m.ChannelStats(1)
+	if !ok {
+		t.Fatalf("channel 1: ok=false, want true")
+	}
+	if got.RxFrames != 2 || got.TxFrames != 3 {
+		t.Errorf("channel 1 = %+v, want {RxFrames:2 TxFrames:3}", got)
+	}
+
+	got, ok = m.ChannelStats(2)
+	if !ok || got.RxFrames != 0 || got.TxFrames != 1 {
+		t.Errorf("channel 2 = %+v ok=%v, want {0 1} ok=true", got, ok)
+	}
+
+	// Snapshot must be a copy: mutating it does not corrupt the store.
+	got.RxFrames = 999
+	if again, _ := m.ChannelStats(1); again.RxFrames != 2 {
+		t.Errorf("snapshot aliased store: RxFrames=%d, want 2", again.RxFrames)
+	}
+
+	if _, ok := m.ChannelStats(9); ok {
+		t.Errorf("channel 9: ok=true, want false")
+	}
+}
+
+// TestManager_WrapRxIngress verifies the RX-ingress decorator counts
+// against rf.Channel, still delegates to base with the same args,
+// tolerates a nil frame (no count, base still called), and tolerates a
+// nil base (no panic).
+func TestManager_WrapRxIngress(t *testing.T) {
+	m := newTestManager(t)
+
+	var gotRF *pb.ReceivedFrame
+	var gotSrc ingress.Source
+	calls := 0
+	base := func(rf *pb.ReceivedFrame, src ingress.Source) {
+		calls++
+		gotRF = rf
+		gotSrc = src
+	}
+
+	wrapped := m.wrapRxIngress(base)
+	src := ingress.KissTnc(7)
+	rf := &pb.ReceivedFrame{Channel: 5}
+	wrapped(rf, src)
+
+	if calls != 1 || gotRF != rf || gotSrc != src {
+		t.Errorf("base not called transparently: calls=%d rf=%v src=%v", calls, gotRF, gotSrc)
+	}
+	if st, ok := m.ChannelStats(5); !ok || st.RxFrames != 1 {
+		t.Errorf("channel 5 after wrapped(rf): %+v ok=%v, want RxFrames=1", st, ok)
+	}
+
+	// nil frame: no count, base still invoked (matches server contract
+	// where RxIngress may be handed a nil in defensive paths).
+	wrapped(nil, src)
+	if calls != 2 {
+		t.Errorf("base not called for nil frame: calls=%d, want 2", calls)
+	}
+	if st, _ := m.ChannelStats(5); st.RxFrames != 1 {
+		t.Errorf("nil frame bumped RX: RxFrames=%d, want 1", st.RxFrames)
+	}
+
+	// nil base must not panic.
+	m.wrapRxIngress(nil)(&pb.ReceivedFrame{Channel: 6}, src)
+	if st, ok := m.ChannelStats(6); !ok || st.RxFrames != 1 {
+		t.Errorf("nil-base wrapper did not count: %+v ok=%v", st, ok)
+	}
+}

--- a/pkg/kiss/manager.go
+++ b/pkg/kiss/manager.go
@@ -278,10 +278,7 @@ func (m *Manager) Start(parent context.Context, id uint32, cfg ServerConfig) {
 		q := newInstanceTxQueue(ctx, broadcast)
 		// Wire metric observers with the interface ID captured.
 		ifaceID := id
-		// onEnqueue fires once per frame accepted onto the queue
-		// (Enqueue success), which is the per-channel TX signal the
-		// dashboard needs for KISS-TNC channels (issue #132).
-		onEnqueue := func() { m.countTx(ch) }
+		var onEnqueue func()
 		var onDrop func(string)
 		var onDepth func(int32)
 		if m.onTxQueueDepth != nil {
@@ -443,9 +440,7 @@ func (m *Manager) StartClient(parent context.Context, id uint32, cfg ClientConfi
 			ms.txQueue = q
 			m.mu.Unlock()
 			ifaceID := id
-			// Per-channel TX counting for tcp-client TNC interfaces,
-			// mirroring the server-listen path (issue #132).
-			onEnqueue := func() { m.countTx(ms.channel) }
+			var onEnqueue func()
 			var onDrop func(string)
 			var onDepth func(int32)
 			if m.onTxQueueDepth != nil {

--- a/pkg/kiss/manager.go
+++ b/pkg/kiss/manager.go
@@ -84,6 +84,18 @@ type Manager struct {
 	onClientStateChange func(ifaceID uint32, name string, st InterfaceStatus)
 	// onClientReconnect fires once per successful dial.
 	onClientReconnect func(ifaceID uint32)
+
+	// chanStatsMu guards chanStats. Separate from mu so the RX/TX
+	// counting hot paths never contend with Start/Stop lifecycle.
+	chanStatsMu sync.Mutex
+	// chanStats holds cumulative per-channel RX/TX frame counts for
+	// TNC-mode interfaces. KISS-TNC channels have no Rust modem and
+	// therefore no StatusUpdate feeding modembridge's status cache;
+	// this is the only per-channel counter source the dashboard has
+	// for them (issue #132). Process-lifetime monotonic — unlike
+	// modembridge's cache it is deliberately NOT reset on a modem
+	// restart, since KISS interfaces are independent of the modem.
+	chanStats map[uint32]*ChannelStat
 }
 
 type managedServer struct {
@@ -177,6 +189,7 @@ func NewManager(cfg ManagerConfig) *Manager {
 		onTxQueueDrop:         cfg.OnTxQueueDrop,
 		onClientStateChange:   cfg.OnClientStateChange,
 		onClientReconnect:     cfg.OnClientReconnect,
+		chanStats:             make(map[uint32]*ChannelStat),
 	}
 }
 
@@ -232,6 +245,13 @@ func (m *Manager) Start(parent context.Context, id uint32, cfg ServerConfig) {
 	if cfg.RxIngress == nil {
 		cfg.RxIngress = m.rxIngress
 	}
+	// Count per-channel RX only when routing is actually configured.
+	// Leaving a nil RxIngress nil preserves the server's "no
+	// RxIngress wired" drop-with-warning diagnostic and its
+	// ingressQ-allocation guard (issue #132).
+	if cfg.RxIngress != nil {
+		cfg.RxIngress = m.wrapRxIngress(cfg.RxIngress)
+	}
 	if cfg.Clock == nil {
 		cfg.Clock = m.clock
 	}
@@ -258,7 +278,10 @@ func (m *Manager) Start(parent context.Context, id uint32, cfg ServerConfig) {
 		q := newInstanceTxQueue(ctx, broadcast)
 		// Wire metric observers with the interface ID captured.
 		ifaceID := id
-		var onEnqueue func()
+		// onEnqueue fires once per frame accepted onto the queue
+		// (Enqueue success), which is the per-channel TX signal the
+		// dashboard needs for KISS-TNC channels (issue #132).
+		onEnqueue := func() { m.countTx(ch) }
 		var onDrop func(string)
 		var onDepth func(int32)
 		if m.onTxQueueDepth != nil {
@@ -364,6 +387,12 @@ func (m *Manager) StartClient(parent context.Context, id uint32, cfg ClientConfi
 	if cfg.RxIngress == nil {
 		cfg.RxIngress = m.rxIngress
 	}
+	// Same per-channel RX counting as the server-listen path; only
+	// wrap when routing is configured so a nil RxIngress keeps the
+	// client's drop-with-warning diagnostic (issue #132).
+	if cfg.RxIngress != nil {
+		cfg.RxIngress = m.wrapRxIngress(cfg.RxIngress)
+	}
 	if cfg.Clock == nil {
 		cfg.Clock = m.clock
 	}
@@ -414,7 +443,9 @@ func (m *Manager) StartClient(parent context.Context, id uint32, cfg ClientConfi
 			ms.txQueue = q
 			m.mu.Unlock()
 			ifaceID := id
-			var onEnqueue func()
+			// Per-channel TX counting for tcp-client TNC interfaces,
+			// mirroring the server-listen path (issue #132).
+			onEnqueue := func() { m.countTx(ms.channel) }
 			var onDrop func(string)
 			var onDepth func(int32)
 			if m.onTxQueueDepth != nil {

--- a/pkg/webapi/channels.go
+++ b/pkg/webapi/channels.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/kiss"
+	"github.com/chrissnell/graywolf/pkg/modembridge"
 	"github.com/chrissnell/graywolf/pkg/webapi/dto"
 	"github.com/chrissnell/graywolf/pkg/webtypes"
 	"gorm.io/gorm"
@@ -588,14 +589,29 @@ func (s *Server) getChannelStats(w http.ResponseWriter, r *http.Request) {
 		badRequest(w, "invalid channel id")
 		return
 	}
+	if s.bridge != nil {
+		if stats, ok := s.bridge.GetChannelStats(id); ok {
+			writeJSON(w, http.StatusOK, stats)
+			return
+		}
+	}
+	// KISS-TNC-backed channels have no Rust modem feeding the bridge
+	// cache; surface the KISS manager's per-channel counters instead
+	// so the dashboard and this endpoint stop reporting a stuck zero
+	// (issue #132). RxBadFCS is omitted (always 0 for a hardware TNC).
+	if s.kissManager != nil {
+		if ks, ok := s.kissManager.ChannelStats(id); ok {
+			writeJSON(w, http.StatusOK, &modembridge.ChannelStats{
+				Channel:  id,
+				RxFrames: ks.RxFrames,
+				TxFrames: ks.TxFrames,
+			})
+			return
+		}
+	}
 	if s.bridge == nil {
 		writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: "bridge not available"})
 		return
 	}
-	stats, ok := s.bridge.GetChannelStats(id)
-	if !ok {
-		notFound(w)
-		return
-	}
-	writeJSON(w, http.StatusOK, stats)
+	notFound(w)
 }

--- a/pkg/webapi/status.go
+++ b/pkg/webapi/status.go
@@ -104,13 +104,28 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		if ch.InputDeviceID != nil {
 			sc.InputDeviceID = *ch.InputDeviceID
 		}
+		haveBridgeStats := false
 		if s.bridge != nil {
 			if stats, ok := s.bridge.GetChannelStats(uint32(ch.ID)); ok {
+				haveBridgeStats = true
 				sc.RxFrames = stats.RxFrames
 				sc.RxBadFCS = stats.RxBadFCS
 				sc.TxFrames = stats.TxFrames
 				sc.DcdState = stats.DcdState
 				sc.AudioPeak = stats.AudioLevelPeak
+			}
+		}
+		// KISS-TNC-backed channels have no Rust modem and thus no
+		// StatusUpdate feeding the bridge cache; fall back to the
+		// KISS manager's per-channel counters so their RX/TX no
+		// longer read a stuck zero (issue #132). RxBadFCS stays 0:
+		// a hardware TNC validates the FCS and never forwards a bad
+		// frame over KISS. The validator forbids a channel being
+		// both modem- and KISS-backed, so this never double-counts.
+		if !haveBridgeStats && s.kissManager != nil {
+			if ks, ok := s.kissManager.ChannelStats(uint32(ch.ID)); ok {
+				sc.RxFrames = ks.RxFrames
+				sc.TxFrames = ks.TxFrames
 			}
 		}
 		if deviceLevels != nil && ch.InputDeviceID != nil {


### PR DESCRIPTION
## Summary
- KISS-TNC-backed channels showed `RX: 0  TX: 0  Bad FCS: 0` on the dashboard card while the aggregate `PACKETS RX/TX` tiles incremented. Root cause: per-channel counters come only from the Rust modem's `StatusUpdate` IPC folded into `modembridge`'s cache; KISS-TNC channels have no modem, so `bridge.GetChannelStats` returned nothing.
- `kiss.Manager` now tracks per-channel RX/TX: RX via a wrapped `RxIngress` (precise resolved channel, only fires in `ModeTnc`), TX via the per-instance tx queue's `onEnqueue` observer — wired for both server-listen and tcp-client interfaces.
- `webapi` (`/api/status`, `/api/channels/{id}/stats`) prefers the bridge cache and falls back to `kiss.Manager.ChannelStats` only when the bridge has no entry. The TX-backend validator forbids a channel being both modem- and KISS-backed, so the two sources never double-count.
- Bad FCS is intentionally left at 0 for KISS-TNC channels: a hardware TNC validates the FCS and never forwards a bad frame over KISS, so there is no bad-FCS signal to surface.
- Added invariant #30 documenting the two-source topology.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/kiss/ ./pkg/webapi/ ./pkg/app/...` (all pass)
- [x] New `pkg/kiss/channelstats_test.go`: counter primitive (per-channel independence, by-value snapshots, unseen=ok:false) + `wrapRxIngress` (counts rf.Channel, delegates transparently, nil-frame and nil-base tolerance)
- [x] `go vet ./pkg/kiss/ ./pkg/webapi/`
- [ ] Manual: configure a KISS-TNC channel (e.g. TH-D75), confirm dashboard card RX/TX increment with off-air traffic and governor TX

Refs #132