### PR TITLE
fix(audio): probe-verify capture device recommendation, dedup ALSA cards

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -28,6 +28,7 @@ Crate name: `graywolf-demod`. Binary: `graywolf-modem`. Source:
 | Constants, enums, modem types | `types.rs` |
 | Audio source enum | `audio/mod.rs` |
 | CPAL live audio I/O | `audio/soundcard.rs` |
+| ALSA card canonicalize + capture probe | `audio/soundcard.rs` (`parse_proc_asound_cards`, `group_alsa_cards`, `probe_capture`), `modem/mod.rs` (`collect_input_devices_linux`) |
 | FLAC test vector playback | `audio/flac.rs` |
 | Stdin raw i16 PCM | `audio/stdin_raw.rs` |
 | SDR UDP audio bridge | `sdr/mod.rs` |

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -66,6 +66,21 @@ Source: [`../../graywolf-modem/src/audio/`](../../graywolf-modem/src/audio/);
 no CPAL dep in `pkg/`; control surface is the proto messages
 `ConfigureAudio` / `StartAudio` / `StopAudio` / `EnumerateAudioDevices`.
 
+**8a. Capture-device enumeration never probes in-use hardware.**
+On Linux, `EnumerateAudioDevices` (`collect_input_devices_linux`
+in `modem/mod.rs`) collapses cpal's numeric/symbolic ALSA aliases to one
+entry per physical card (via `/proc/asound/cards`) and *probes* each
+**idle** card — briefly opening it — to badge "Recommended" the PCM form
+that actually streams. A card currently held open by a live capture
+stream is **never** probed (opening a second stream on in-use hardware
+can disrupt the running radio) and is surfaced from the in-use snapshot
+the handler passes in, so a rescan keeps showing it. The
+string-only `is_recommended_pcm_id` heuristic is now used **only** by the
+flare `--list-audio` path and the Linux *output* path; flare
+`recommended` and the live capture picker intentionally diverge (the
+separate `--list-audio` process can't probe safely). The live picker is
+authoritative.
+
 ### 9. PTT enumeration vs. driving split
 
 *Why:* Go enumerates PTT hardware and Rust drives it, so both sides must agree on the identifier scheme passed via `ConfigurePtt.method` and `ConfigurePtt.device`.

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -81,6 +81,13 @@ flare `--list-audio` path and the Linux *output* path; flare
 separate `--list-audio` process can't probe safely). The live picker is
 authoritative.
 
+Output side: idle outputs enumerate unchanged (`collect_devices`), but a
+configured/in-use output card (e.g. the AIOC's shared in/out PCM, whose
+`supported_output_configs()` fails once RX holds the card) is re-appended
+from the in-use-output snapshot, one entry per physical card, without
+opening the device — so a configured output never vanishes from
+detection while audio is running.
+
 ### 9. PTT enumeration vs. driving split
 
 *Why:* Go enumerates PTT hardware and Rust drives it, so both sides must agree on the identifier scheme passed via `ConfigurePtt.method` and `ConfigurePtt.device`.

--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -5,6 +5,7 @@
 //! `AudioSource` (input) or `AudioSink` (output) keeps the stream alive;
 //! dropping it releases the device.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
@@ -381,11 +382,23 @@ pub struct SoundcardOutputConfig {
     pub audio_channel: u32,
 }
 
-/// True for cpal pcm_ids that should carry the "Recommended" badge in
-/// any user-facing surface (the runtime audio-device picker, the flare
-/// `--list-audio` enumeration). Source of truth for both call sites:
-/// see modem/mod.rs (live device-info builder) and listing::collect_devices
-/// (the `--list-audio` JSON emitter).
+/// String-only heuristic for the "Recommended" badge.
+///
+/// **Scope:** this is the *flare* heuristic only — used by
+/// the `--list-audio` JSON emitter (`listing::collect_devices`) and the
+/// Linux *output* path in `modem/mod.rs::collect_devices`. The runtime
+/// *input/capture* picker no longer uses it: `collect_input_devices_linux`
+/// verifies Recommended by actually probing the device
+/// (`probe_capture`), because this heuristic recommends the
+/// `plughw:CARD=<name>` form even on cheap USB chips where that PCM
+/// fails to stream while only the raw `hw:` form works.
+///
+/// The split is deliberate. `--list-audio` runs as a separate
+/// short-lived process with no knowledge of what a running modem holds
+/// open, so it cannot probe safely; its `recommended` stays a cheap
+/// hint and the live picker is authoritative. Keep this in sync with
+/// the doc in `pkg/flareschema/audio.go` and the note in
+/// `pkg/flareschema/convergence_test.go`.
 ///
 /// The heuristic is "device targets a stable card name": ALSA's
 /// `plughw:CARD=<name>` form, where `<name>` starts with an alphabetic
@@ -403,6 +416,288 @@ pub fn is_recommended_pcm_id(pcm_id: &str) -> bool {
     } else {
         false
     }
+}
+
+// ---------------------------------------------------------------------------
+// ALSA physical-card canonicalization.
+//
+// cpal's ALSA backend reports the same physical card under several pcm_ids:
+// numeric (`hw:CARD=1`, `plughw:CARD=1`) and symbolic (`hw:CARD=Device`,
+// `plughw:CARD=Device`). Showing all of them produces a redundant picker and
+// hides which form actually streams. These helpers collapse the aliases to
+// one physical card so the runtime picker can probe candidates in order and
+// surface a single, verified-working entry. All pure + platform-independent
+// (Linux is the only caller, but the logic is unit-tested everywhere).
+// ---------------------------------------------------------------------------
+
+/// Parse Linux `/proc/asound/cards` into `(card_index, card_name)` rows.
+///
+/// The file lists one card per stanza, e.g.
+///
+/// ```text
+///  1 [Device         ]: USB-Audio - USB Audio Device
+///                       GeneralPlus USB Audio Device at usb-...
+/// ```
+///
+/// Only the header line (leading integer + `[name]`) is significant; the
+/// indented continuation line is ignored.
+pub fn parse_proc_asound_cards(contents: &str) -> Vec<(u32, String)> {
+    let mut out = Vec::new();
+    for line in contents.lines() {
+        let t = line.trim_start();
+        let digit_end = t.find(|c: char| !c.is_ascii_digit()).unwrap_or(t.len());
+        if digit_end == 0 {
+            continue; // continuation / non-header line
+        }
+        let idx: u32 = match t[..digit_end].parse() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        let lb = match t.find('[') {
+            Some(i) => i,
+            None => continue,
+        };
+        let rb = match t[lb + 1..].find(']') {
+            Some(i) => lb + 1 + i,
+            None => continue,
+        };
+        let name = t[lb + 1..rb].trim().to_string();
+        if name.is_empty() {
+            continue;
+        }
+        out.push((idx, name));
+    }
+    out
+}
+
+/// Extract the ALSA `CARD=` token from a cpal pcm_id: the slice between
+/// `CARD=` and the next `,` (or end). `hw:CARD=Device,DEV=0` -> `Device`,
+/// `plughw:CARD=1` -> `1`. `None` for ids with no card token (`default`,
+/// non-ALSA platforms).
+pub fn alsa_card_token(pcm_id: &str) -> Option<&str> {
+    let start = pcm_id.find("CARD=")? + "CARD=".len();
+    let rest = &pcm_id[start..];
+    let end = rest.find(',').unwrap_or(rest.len());
+    let tok = &rest[..end];
+    if tok.is_empty() {
+        None
+    } else {
+        Some(tok)
+    }
+}
+
+/// Map a `CARD=` token (kernel card name *or* numeric index string) to its
+/// canonical card index, built from parsed `/proc/asound/cards` rows.
+pub fn build_card_resolver(cards: &[(u32, String)]) -> HashMap<String, u32> {
+    let mut m = HashMap::new();
+    for (idx, name) in cards {
+        m.insert(name.clone(), *idx);
+        m.insert(idx.to_string(), *idx);
+    }
+    m
+}
+
+/// Probe-order rank within one physical card. Lower = tried first:
+/// `plughw:` (ALSA software conversion, tolerant of cheap USB chips)
+/// before raw `hw:`; stable alphabetic card name before volatile numeric
+/// index. This keeps the historically-recommended `plughw:CARD=<name>`
+/// first (AIOC / DigiRig stay unchanged) while still allowing fallthrough
+/// to a raw `hw:` form for hardware whose plughw path fails to stream.
+fn alsa_candidate_rank(pcm_id: &str) -> (u8, u8) {
+    let prefix = if pcm_id.starts_with("plughw:") {
+        0
+    } else if pcm_id.starts_with("hw:") {
+        1
+    } else {
+        2
+    };
+    let name_form = match alsa_card_token(pcm_id) {
+        Some(t) if t.starts_with(|c: char| c.is_ascii_alphabetic()) => 0,
+        Some(_) => 1,
+        None => 2,
+    };
+    (prefix, name_form)
+}
+
+/// One physical ALSA card with its candidate PCM ids ordered best-first.
+#[derive(Debug, PartialEq, Eq)]
+pub struct AlsaCardGroup {
+    /// Canonical key: `"card:<idx>"` for resolvable cards, else the raw
+    /// pcm_id (so `default` and unknown ids stay as singleton entries).
+    pub key: String,
+    /// PCM ids for this card, ordered by probe preference.
+    pub candidates: Vec<String>,
+}
+
+/// Collapse cpal-reported ALSA pcm_ids to one entry per physical card.
+///
+/// `resolve` maps a `CARD=` token to the canonical card index; pcm_ids
+/// whose token does not resolve (or have none) become singleton groups
+/// keyed by the pcm_id itself. Within a group, candidates are ordered
+/// best-first via [`alsa_candidate_rank`]. First-seen card order is
+/// preserved so the picker ordering stays stable.
+pub fn group_alsa_cards(
+    pcm_ids: &[String],
+    resolve: impl Fn(&str) -> Option<u32>,
+) -> Vec<AlsaCardGroup> {
+    let mut order: Vec<String> = Vec::new();
+    let mut groups: HashMap<String, Vec<String>> = HashMap::new();
+    for id in pcm_ids {
+        let key = match alsa_card_token(id).and_then(&resolve) {
+            Some(idx) => format!("card:{}", idx),
+            None => id.clone(),
+        };
+        if !groups.contains_key(&key) {
+            order.push(key.clone());
+        }
+        groups.entry(key).or_default().push(id.clone());
+    }
+    order
+        .into_iter()
+        .map(|key| {
+            let mut candidates = groups.remove(&key).unwrap();
+            // slice::sort_by_key is stable: equal-rank pcm_ids keep their
+            // cpal enumeration order.
+            candidates.sort_by_key(|p| alsa_candidate_rank(p));
+            AlsaCardGroup { key, candidates }
+        })
+        .collect()
+}
+
+/// Pick the best input stream config for a brief probe / level scan:
+/// fewest channels (mono > stereo) and most-native sample format
+/// (I16 > F32 > U16), at a preferred scan rate the range supports.
+///
+/// Shared by the device-detection probe ([`probe_capture`])
+/// and the input-level scanner so both negotiate identically.
+/// `default_input_config()` is deliberately not used — it can hand back
+/// parameters a raw `hw:` ALSA device rejects with EINVAL.
+pub fn pick_input_probe_config(dev: &Device) -> Result<(SampleFormat, StreamConfig), String> {
+    let configs = dev.supported_input_configs().map_err(|e| format!("{}", e))?;
+    let mut best: Option<cpal::SupportedStreamConfigRange> = None;
+    for cfg in configs {
+        let dominated_by_best = best.as_ref().is_some_and(|b| {
+            if cfg.channels() > b.channels() {
+                return true;
+            }
+            if cfg.channels() < b.channels() {
+                return false;
+            }
+            let rank = |f: SampleFormat| match f {
+                SampleFormat::I16 => 0,
+                SampleFormat::F32 => 1,
+                _ => 2,
+            };
+            rank(cfg.sample_format()) >= rank(b.sample_format())
+        });
+        if !dominated_by_best {
+            best = Some(cfg);
+        }
+    }
+    let range = best.ok_or_else(|| "no supported input configurations".to_string())?;
+    let rate = super::PREFERRED_SCAN_RATES
+        .iter()
+        .copied()
+        .find(|&r| r >= range.min_sample_rate() && r <= range.max_sample_rate())
+        .unwrap_or(range.max_sample_rate());
+    Ok((
+        range.sample_format(),
+        StreamConfig {
+            channels: range.channels(),
+            sample_rate: rate,
+            buffer_size: cpal::BufferSize::Default,
+        },
+    ))
+}
+
+/// Briefly open `dev` for capture and report whether it actually streams.
+///
+/// Returns `true` only if a stream builds, `play()`s, and delivers at
+/// least one callback within `timeout` without the cpal error callback
+/// firing — the `alsa::poll() returned POLLERR` path that breaks cheap
+/// USB audio chips routed through `plughw:`/named PCMs.
+/// The stream is always dropped before returning, releasing the device.
+///
+/// MUST NOT be called on hardware already held by a live capture stream:
+/// opening a second stream on an in-use device can disrupt the running
+/// radio and, on cheap chips, fail spuriously. Callers gate this through
+/// the in-use snapshot in `enumerate_audio_devices`.
+pub fn probe_capture(dev: &Device, timeout: Duration) -> bool {
+    let (fmt, cfg) = match pick_input_probe_config(dev) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let failed = Arc::new(AtomicBool::new(false));
+    let got_data = Arc::new(AtomicBool::new(false));
+
+    let build: Result<cpal::Stream, cpal::BuildStreamError> = match fmt {
+        SampleFormat::F32 => {
+            let gd = got_data.clone();
+            let ef = failed.clone();
+            dev.build_input_stream(
+                &cfg,
+                move |_d: &[f32], _| gd.store(true, Ordering::Relaxed),
+                move |e| {
+                    eprintln!("probe_capture stream error: {}", e);
+                    ef.store(true, Ordering::Relaxed);
+                },
+                None,
+            )
+        }
+        SampleFormat::I16 => {
+            let gd = got_data.clone();
+            let ef = failed.clone();
+            dev.build_input_stream(
+                &cfg,
+                move |_d: &[i16], _| gd.store(true, Ordering::Relaxed),
+                move |e| {
+                    eprintln!("probe_capture stream error: {}", e);
+                    ef.store(true, Ordering::Relaxed);
+                },
+                None,
+            )
+        }
+        SampleFormat::U16 => {
+            let gd = got_data.clone();
+            let ef = failed.clone();
+            dev.build_input_stream(
+                &cfg,
+                move |_d: &[u16], _| gd.store(true, Ordering::Relaxed),
+                move |e| {
+                    eprintln!("probe_capture stream error: {}", e);
+                    ef.store(true, Ordering::Relaxed);
+                },
+                None,
+            )
+        }
+        _ => return false,
+    };
+
+    let stream = match build {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    if stream.play().is_err() {
+        return false;
+    }
+
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if failed.load(Ordering::Relaxed) {
+            return false;
+        }
+        if got_data.load(Ordering::Relaxed) {
+            // Real audio flowed. Give POLLERR a short grace window to
+            // surface (the cheap-chip failure can lag the first period),
+            // then accept if still clean.
+            thread::sleep(Duration::from_millis(40));
+            return !failed.load(Ordering::Relaxed);
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    // Timed out: a usable device delivers a callback quickly and stays
+    // error-free; one that never produced data or errored is not usable.
+    got_data.load(Ordering::Relaxed) && !failed.load(Ordering::Relaxed)
 }
 
 /// Resolve a cpal output [`Device`] by its pcm_id (e.g. `plughw:CARD=Foo,DEV=0`).
@@ -983,6 +1278,106 @@ mod tests {
             Ok(_) => panic!("expected out-of-range rejection"),
         }
     }
+
+    // --- ALSA physical-card canonicalization --------------------------
+
+    /// Verbatim `/proc/asound/cards` from the field report (Pi 3B,
+    /// Trixie, GeneralPlus USB dongle), including the indented
+    /// continuation lines that must be ignored.
+    const ISSUE_129_PROC_CARDS: &str = "\
+ 0 [Headphones     ]: bcm2835_headpho - bcm2835 Headphones
+                      bcm2835 Headphones
+ 1 [Device         ]: USB-Audio - USB Audio Device
+                      GeneralPlus USB Audio Device at usb-3f980000.usb-1.5, full speed
+ 2 [vc4hdmi        ]: vc4-hdmi - vc4-hdmi
+                      vc4-hdmi
+";
+
+    #[test]
+    fn parse_proc_asound_cards_ignores_continuation_lines() {
+        let got = parse_proc_asound_cards(ISSUE_129_PROC_CARDS);
+        assert_eq!(
+            got,
+            vec![
+                (0, "Headphones".to_string()),
+                (1, "Device".to_string()),
+                (2, "vc4hdmi".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_proc_asound_cards_handles_empty_and_garbage() {
+        assert!(parse_proc_asound_cards("").is_empty());
+        assert!(parse_proc_asound_cards("no leading digit here\n   indented\n").is_empty());
+    }
+
+    #[test]
+    fn alsa_card_token_extracts_name_and_index_forms() {
+        assert_eq!(alsa_card_token("hw:CARD=Device,DEV=0"), Some("Device"));
+        assert_eq!(alsa_card_token("plughw:CARD=1,DEV=0"), Some("1"));
+        assert_eq!(alsa_card_token("plughw:CARD=AIOC"), Some("AIOC"));
+        assert_eq!(alsa_card_token("default"), None);
+        assert_eq!(alsa_card_token("hw:CARD="), None);
+        assert_eq!(alsa_card_token("sysdefault:CARD=Device,DEV=0"), Some("Device"));
+    }
+
+    #[test]
+    fn build_card_resolver_maps_name_and_index_to_same_card() {
+        let cards = parse_proc_asound_cards(ISSUE_129_PROC_CARDS);
+        let r = build_card_resolver(&cards);
+        assert_eq!(r.get("Device").copied(), Some(1));
+        assert_eq!(r.get("1").copied(), Some(1));
+        assert_eq!(r.get("Headphones").copied(), Some(0));
+        assert_eq!(r.get("0").copied(), Some(0));
+        assert_eq!(r.get("nonexistent").copied(), None);
+    }
+
+    #[test]
+    fn group_alsa_cards_collapses_aliases_and_orders_candidates() {
+        let cards = parse_proc_asound_cards(ISSUE_129_PROC_CARDS);
+        let resolver = build_card_resolver(&cards);
+        // The mix cpal's ALSA backend reports for this Pi: numeric and
+        // symbolic forms of both physical capture cards, plus `default`.
+        let pcm_ids: Vec<String> = [
+            "hw:CARD=Headphones,DEV=0",
+            "plughw:CARD=Headphones,DEV=0",
+            "hw:CARD=0,DEV=0",
+            "plughw:CARD=0,DEV=0",
+            "hw:CARD=Device,DEV=0",
+            "plughw:CARD=Device,DEV=0",
+            "hw:CARD=1,DEV=0",
+            "plughw:CARD=1,DEV=0",
+            "default",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let groups = group_alsa_cards(&pcm_ids, |t| resolver.get(t).copied());
+
+        // Two physical cards + the `default` singleton, first-seen order.
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0].key, "card:0");
+        assert_eq!(groups[1].key, "card:1");
+        assert_eq!(groups[2].key, "default");
+
+        // The GeneralPlus USB card: every alias collapsed, ordered
+        // plughw-name > plughw-index > hw-name > hw-index. The broken
+        // `plughw:CARD=Device` is tried first (AIOC/DigiRig succeed there,
+        // unchanged); a probe failure falls through to `hw:CARD=1`, the
+        // only form that streams on this hardware.
+        assert_eq!(
+            groups[1].candidates,
+            vec![
+                "plughw:CARD=Device,DEV=0".to_string(),
+                "plughw:CARD=1,DEV=0".to_string(),
+                "hw:CARD=Device,DEV=0".to_string(),
+                "hw:CARD=1,DEV=0".to_string(),
+            ]
+        );
+        assert_eq!(groups[2].candidates, vec!["default".to_string()]);
+    }
 }
 
 /// Read-only enumeration of every cpal host's input + output devices.
@@ -1018,11 +1413,14 @@ pub mod listing {
         pub name: String,
         pub direction: String,
         pub is_default: bool,
-        // Mirrors graywolf-modem's runtime-API "Recommended" badge
-        // (see web/src/routes/AudioDevices.svelte). Set when the
-        // cpal-reported PCM id is `plughw:CARD=<name>` with a stable
-        // alphabetic card name (not a numeric index that changes
-        // across reboots when USB enumeration reorders).
+        // Flare-side "Recommended" *hint*. Set from the string-only
+        // `is_recommended_pcm_id` heuristic (`plughw:CARD=<name>` with a
+        // stable alphabetic card name). This intentionally does NOT
+        // match the live web picker for capture devices — the
+        // runtime path probes the device and recommends the form that
+        // actually streams, which `--list-audio` cannot do safely from
+        // a separate process. The live picker is authoritative; this
+        // stays a cheap triage hint.
         #[serde(skip_serializing_if = "is_false")]
         pub recommended: bool,
         #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -529,6 +529,18 @@ pub struct AlsaCardGroup {
     pub candidates: Vec<String>,
 }
 
+/// Canonical physical-card key for a pcm_id: `"card:<idx>"` when its
+/// `CARD=` token resolves, else the pcm_id itself (so `default` and
+/// unknown ids stay distinct). The single source of truth for "do two
+/// pcm_ids name the same physical card" — used by grouping and by the
+/// in-use output reconciliation.
+pub fn alsa_canonical_key(pcm_id: &str, resolve: impl Fn(&str) -> Option<u32>) -> String {
+    match alsa_card_token(pcm_id).and_then(resolve) {
+        Some(idx) => format!("card:{}", idx),
+        None => pcm_id.to_string(),
+    }
+}
+
 /// Collapse cpal-reported ALSA pcm_ids to one entry per physical card.
 ///
 /// `resolve` maps a `CARD=` token to the canonical card index; pcm_ids
@@ -543,10 +555,7 @@ pub fn group_alsa_cards(
     let mut order: Vec<String> = Vec::new();
     let mut groups: HashMap<String, Vec<String>> = HashMap::new();
     for id in pcm_ids {
-        let key = match alsa_card_token(id).and_then(&resolve) {
-            Some(idx) => format!("card:{}", idx),
-            None => id.clone(),
-        };
+        let key = alsa_canonical_key(id, &resolve);
         if !groups.contains_key(&key) {
             order.push(key.clone());
         }
@@ -1331,6 +1340,23 @@ mod tests {
         assert_eq!(r.get("Headphones").copied(), Some(0));
         assert_eq!(r.get("0").copied(), Some(0));
         assert_eq!(r.get("nonexistent").copied(), None);
+    }
+
+    #[test]
+    fn alsa_canonical_key_unifies_name_and_index_and_passes_through_default() {
+        let cards = parse_proc_asound_cards(ISSUE_129_PROC_CARDS);
+        let r = build_card_resolver(&cards);
+        let key = |p: &str| alsa_canonical_key(p, |t| r.get(t).copied());
+        // Numeric and symbolic forms of the same card collapse equal.
+        assert_eq!(key("plughw:CARD=Device,DEV=0"), key("hw:CARD=Device,DEV=0"));
+        assert_eq!(key("hw:CARD=Device,DEV=0"), key("plughw:CARD=1,DEV=0"));
+        assert_eq!(key("hw:CARD=Device,DEV=0"), "card:1");
+        assert_eq!(key("plughw:CARD=Headphones,DEV=0"), "card:0");
+        // No card token -> passes through unchanged.
+        assert_eq!(key("default"), "default");
+        // Unknown card (not in /proc/asound/cards) stays distinct by
+        // pcm_id rather than collapsing with anything else.
+        assert_eq!(key("hw:CARD=Unknown,DEV=0"), "hw:CARD=Unknown,DEV=0");
     }
 
     #[test]

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -672,16 +672,43 @@ impl Modem {
     }
 
     fn handle_enumerate_devices(&self, req: EnumerateAudioDevices) {
-        let devices = enumerate_audio_devices(req.include_output);
-        let msg = IpcMessage {
-            payload: Some(Payload::AudioDeviceList(AudioDeviceList {
-                request_id: req.request_id,
-                devices,
-            })),
-        };
-        if let Err(e) = self.handle.send(&msg) {
-            eprintln!("graywolf-modem: send AudioDeviceList failed: {}", e);
+        // Snapshot the pcm_ids currently held open by live capture
+        // streams, with the rate/channels they are running at. The
+        // enumerator surfaces these from cache rather than probing
+        // in-use hardware — probing a device a running radio holds can
+        // disrupt it, and cpal stops listing a held raw hw: device so a
+        // naive rescan loses it entirely.
+        let mut in_use: HashMap<String, (u32, u32)> = HashMap::new();
+        for id in self.active_devices.keys() {
+            if let Some(acfg) = self.audio_configs.get(id) {
+                if acfg.source_type == "soundcard" && !acfg.device_name.is_empty() {
+                    in_use.insert(
+                        acfg.device_name.clone(),
+                        (acfg.sample_rate, acfg.channels),
+                    );
+                }
+            }
         }
+
+        // Probing candidate PCMs takes up to a few hundred ms per idle
+        // card; run off the IPC thread so control messages keep flowing
+        // (mirrors handle_scan_input_levels).
+        let handle = self.handle.clone();
+        std::thread::Builder::new()
+            .name("enumerate-devices".into())
+            .spawn(move || {
+                let devices = enumerate_audio_devices(req.include_output, &in_use);
+                let msg = IpcMessage {
+                    payload: Some(Payload::AudioDeviceList(AudioDeviceList {
+                        request_id: req.request_id,
+                        devices,
+                    })),
+                };
+                if let Err(e) = handle.send(&msg) {
+                    eprintln!("graywolf-modem: send AudioDeviceList failed: {}", e);
+                }
+            })
+            .ok();
     }
 
     fn handle_scan_input_levels(&self, req: ScanInputLevels) {
@@ -1466,8 +1493,190 @@ where
     out
 }
 
+/// Linux capture-device collection. Three behaviors:
+///
+/// 1. **Dedup** — cpal's ALSA backend reports the same physical card
+///    under numeric (`hw:CARD=1`) and symbolic (`hw:CARD=Device`)
+///    aliases. We canonicalize via `/proc/asound/cards` and emit one
+///    entry per physical card.
+/// 2. **Verified Recommended** — for an idle card we probe candidate
+///    PCM forms in preference order (`plughw:` name > `plughw:` index >
+///    `hw:` name > `hw:` index) and surface the first that actually
+///    streams without POLLERR, badged Recommended. AIOC / DigiRig still
+///    win on `plughw:CARD=<name>` exactly as before; cheap chips whose
+///    plughw path fails fall through to the raw `hw:` form that works.
+/// 3. **In-use stays visible** — a card held open by a live capture
+///    stream is never probed (would disrupt the running radio) and
+///    surfaced from `in_use` cache, so a rescan no longer loses it.
+#[cfg(target_os = "linux")]
+#[allow(deprecated)] // DeviceTrait::name() gives the raw pcm_id we need
+fn collect_input_devices_linux(
+    inputs: impl Iterator<Item = cpal::Device>,
+    in_use: &HashMap<String, (u32, u32)>,
+    host_api: &str,
+    default_input_name: Option<&str>,
+) -> Vec<AudioDeviceInfo> {
+    use crate::audio::soundcard::{
+        alsa_card_token, build_card_resolver, group_alsa_cards, parse_proc_asound_cards,
+        pick_input_probe_config, probe_capture,
+    };
+    use cpal::traits::DeviceTrait;
+
+    // (pcm_id, Device) for every useful ALSA capture node cpal reports.
+    let mut devs: Vec<(String, cpal::Device)> = Vec::new();
+    for dev in inputs {
+        let pcm_id = match dev.name() {
+            Ok(id) => id,
+            Err(_) => continue,
+        };
+        if pcm_id == "null" || !is_useful_alsa_device(&pcm_id) {
+            continue;
+        }
+        devs.push((pcm_id, dev));
+    }
+
+    let cards = std::fs::read_to_string("/proc/asound/cards")
+        .map(|c| parse_proc_asound_cards(&c))
+        .unwrap_or_default();
+    let resolver = build_card_resolver(&cards);
+    let canon = |pcm: &str| -> String {
+        match alsa_card_token(pcm).and_then(|t| resolver.get(t).copied()) {
+            Some(idx) => format!("card:{}", idx),
+            None => pcm.to_string(),
+        }
+    };
+
+    // Seed grouping with in-use pcm_ids too: once a raw hw: stream
+    // holds a card, cpal stops listing it, so it must still group.
+    let mut all_pcms: Vec<String> = devs.iter().map(|(p, _)| p.clone()).collect();
+    for pcm in in_use.keys() {
+        if !all_pcms.contains(pcm) {
+            all_pcms.push(pcm.clone());
+        }
+    }
+    let groups = group_alsa_cards(&all_pcms, |t| resolver.get(t).copied());
+
+    // canonical card key -> (in-use pcm_id, running sample_rate, channels)
+    let mut in_use_by_card: HashMap<String, (String, u32, u32)> = HashMap::new();
+    for (pcm, (sr, ch)) in in_use {
+        in_use_by_card
+            .entry(canon(pcm))
+            .or_insert_with(|| (pcm.clone(), *sr, *ch));
+    }
+
+    let find_dev = |pcm: &str| devs.iter().find(|(p, _)| p == pcm).map(|(_, d)| d);
+    let configs_for = |dev: &cpal::Device| -> (Vec<u32>, Vec<u32>) {
+        let mut sample_rates = Vec::new();
+        let mut channel_counts = Vec::new();
+        if let Ok(configs) = dev.supported_input_configs() {
+            for cfg in configs {
+                let (min_rate, max_rate) = (cfg.min_sample_rate(), cfg.max_sample_rate());
+                for &rate in audio::STANDARD_SAMPLE_RATES {
+                    if rate >= min_rate && rate <= max_rate && !sample_rates.contains(&rate) {
+                        sample_rates.push(rate);
+                    }
+                }
+                let c = cfg.channels() as u32;
+                if !channel_counts.contains(&c) {
+                    channel_counts.push(c);
+                }
+            }
+        }
+        (sample_rates, channel_counts)
+    };
+
+    let probe_timeout = std::time::Duration::from_millis(250);
+    let mut out = Vec::new();
+    for group in groups {
+        // Card held open by a live capture stream: never probe it.
+        if let Some((pcm, sr, ch)) = in_use_by_card.get(&group.key) {
+            out.push(AudioDeviceInfo {
+                name: alsa_card_description(pcm),
+                stable_id: pcm.clone(),
+                kind: AudioDeviceKind::Input.into(),
+                sample_rates: vec![*sr],
+                channel_counts: vec![*ch],
+                host_api: host_api.to_string(),
+                is_default: false,
+                description: alsa_card_description(pcm),
+                recommended: true,
+            });
+            continue;
+        }
+
+        // Idle card: first candidate that actually streams wins the
+        // Recommended badge. Falls back to the top-ranked candidate
+        // (unbadged) so a card that fails every probe still appears.
+        let mut chosen: Option<String> = None;
+        for cand in &group.candidates {
+            if let Some(dev) = find_dev(cand) {
+                if probe_capture(dev, probe_timeout) {
+                    chosen = Some(cand.clone());
+                    break;
+                }
+            }
+        }
+        let (pcm, recommended) = match chosen {
+            Some(c) => (c, true),
+            None => match group.candidates.first() {
+                Some(c) => (c.clone(), false),
+                None => continue,
+            },
+        };
+
+        let dev = find_dev(&pcm);
+        let (mut sample_rates, mut channel_counts) =
+            dev.map(&configs_for).unwrap_or_default();
+        if sample_rates.is_empty() || channel_counts.is_empty() {
+            if recommended {
+                // Streamed fine but cpal won't report ranges: fall back
+                // to the negotiated probe config so the row survives the
+                // empty-array drop below.
+                if let Some((_, cfg)) = dev.and_then(|d| pick_input_probe_config(d).ok()) {
+                    sample_rates = vec![cfg.sample_rate];
+                    channel_counts = vec![cfg.channels as u32];
+                } else {
+                    sample_rates = vec![48_000];
+                    channel_counts = vec![1];
+                }
+            } else {
+                // Never streamed and no config ranges: dead node (e.g.
+                // headless HDMI). Match prior behavior — drop it.
+                continue;
+            }
+        }
+
+        let display_name = dev
+            .and_then(|d| d.description().ok())
+            .map(|d| d.name().to_string())
+            .unwrap_or_else(|| alsa_card_description(&pcm));
+        let is_default = default_input_name == Some(display_name.as_str());
+
+        out.push(AudioDeviceInfo {
+            name: display_name,
+            stable_id: pcm.clone(),
+            kind: AudioDeviceKind::Input.into(),
+            sample_rates,
+            channel_counts,
+            host_api: host_api.to_string(),
+            is_default,
+            description: alsa_card_description(&pcm),
+            recommended,
+        });
+    }
+    out
+}
+
+/// `in_use` maps each pcm_id currently held open by a live capture
+/// stream to its running `(sample_rate, channels)`. Linux uses it to
+/// surface in-use cards from cache instead of probing them; other
+/// platforms ignore it.
 #[allow(deprecated)]
-fn enumerate_audio_devices(include_output: bool) -> Vec<AudioDeviceInfo> {
+#[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+fn enumerate_audio_devices(
+    include_output: bool,
+    in_use: &HashMap<String, (u32, u32)>,
+) -> Vec<AudioDeviceInfo> {
     use cpal::traits::{DeviceTrait, HostTrait};
 
     let host = cpal::default_host();
@@ -1493,13 +1702,25 @@ fn enumerate_audio_devices(include_output: bool) -> Vec<AudioDeviceInfo> {
     let mut devices = Vec::new();
 
     if let Ok(inputs) = host.input_devices() {
-        devices.extend(collect_devices(
-            inputs,
-            AudioDeviceKind::Input.into(),
-            default_input_name.as_deref(),
-            &host_name,
-            |d| d.supported_input_configs(),
-        ));
+        #[cfg(target_os = "linux")]
+        {
+            devices.extend(collect_input_devices_linux(
+                inputs,
+                in_use,
+                &host_name,
+                default_input_name.as_deref(),
+            ));
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            devices.extend(collect_devices(
+                inputs,
+                AudioDeviceKind::Input.into(),
+                default_input_name.as_deref(),
+                &host_name,
+                |d| d.supported_input_configs(),
+            ));
+        }
     }
 
     if include_output {
@@ -1544,64 +1765,23 @@ fn scan_input_levels(duration_ms: u32) -> Vec<InputDeviceLevel> {
         if !is_useful_alsa_device(&pcm_id) {
             continue;
         }
-        // Pick the best supported config by querying the device's actual
-        // capabilities.  default_input_config() can return parameters the
-        // hardware rejects (especially on raw hw: ALSA devices), causing
-        // snd_pcm_hw_params to fail with EINVAL.
-        let (sample_format, stream_cfg) = match dev.supported_input_configs() {
-            Ok(configs) => {
-                // Prefer mono > stereo, I16 > F32 > U16 (I16 is native
-                // for most USB audio interfaces).
-                let mut best: Option<cpal::SupportedStreamConfigRange> = None;
-                for cfg in configs {
-                    let dominated_by_best = best.as_ref().is_some_and(|b| {
-                        if cfg.channels() > b.channels() { return true; }
-                        if cfg.channels() < b.channels() { return false; }
-                        let format_rank = |f: SampleFormat| match f {
-                            SampleFormat::I16 => 0,
-                            SampleFormat::F32 => 1,
-                            _ => 2,
-                        };
-                        format_rank(cfg.sample_format()) >= format_rank(b.sample_format())
+        // Negotiate the probe config the same way device detection
+        // does — shared so the scanner and the detector can't drift
+        // apart. default_input_config() is avoided: it can return
+        // parameters a raw hw: ALSA device rejects with EINVAL.
+        let (sample_format, stream_cfg) =
+            match audio::soundcard::pick_input_probe_config(&dev) {
+                Ok(v) => v,
+                Err(e) => {
+                    results.push(InputDeviceLevel {
+                        name: pcm_id,
+                        peak_dbfs: NOISE_FLOOR_DBFS,
+                        has_signal: false,
+                        error: e,
                     });
-                    if !dominated_by_best { best = Some(cfg); }
+                    continue;
                 }
-                match best {
-                    Some(range) => {
-                        let rate = audio::PREFERRED_SCAN_RATES
-                            .iter()
-                            .copied()
-                            .find(|&r| r >= range.min_sample_rate() && r <= range.max_sample_rate())
-                            .unwrap_or(range.max_sample_rate());
-                        let fmt = range.sample_format();
-                        let cfg = cpal::StreamConfig {
-                            channels: range.channels(),
-                            sample_rate: rate,
-                            buffer_size: cpal::BufferSize::Default,
-                        };
-                        (fmt, cfg)
-                    }
-                    None => {
-                        results.push(InputDeviceLevel {
-                            name: pcm_id,
-                            peak_dbfs: NOISE_FLOOR_DBFS,
-                            has_signal: false,
-                            error: "no supported input configurations".into(),
-                        });
-                        continue;
-                    }
-                }
-            }
-            Err(e) => {
-                results.push(InputDeviceLevel {
-                    name: pcm_id,
-                    peak_dbfs: NOISE_FLOOR_DBFS,
-                    has_signal: false,
-                    error: format!("{}", e),
-                });
-                continue;
-            }
-        };
+            };
 
         let peak = Arc::new(AtomicU32::new(0f32.to_bits()));
 

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -1789,7 +1789,7 @@ fn collect_output_devices_linux(
             None => continue,
         };
         let dev = find_dev(&pcm);
-        let (sample_rates, channel_counts) = dev.map(|d| configs_for(d)).unwrap_or_default();
+        let (sample_rates, channel_counts) = dev.map(&configs_for).unwrap_or_default();
         if sample_rates.is_empty() || channel_counts.is_empty() {
             continue;
         }

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -1414,6 +1414,11 @@ fn is_useful_alsa_device(_pcm_id: &str) -> bool {
 /// Shared between input and output enumeration — the only difference is
 /// which config query method (`supported_input_configs` vs
 /// `supported_output_configs`) the caller passes via `get_configs`.
+///
+/// Non-Linux only: Linux input/output go through
+/// `collect_input_devices_linux` / `collect_output_devices_linux`, which
+/// add physical-card dedup, capture probing, and the in-use cache.
+#[cfg(not(target_os = "linux"))]
 #[allow(deprecated)] // DeviceTrait::name() gives the raw pcm_id we need
 fn collect_devices<I>(
     devices: impl Iterator<Item = cpal::Device>,
@@ -1682,6 +1687,133 @@ fn collect_input_devices_linux(
     out
 }
 
+/// Linux playback-device collection. Same physical-card dedup as the
+/// capture path, but **no probe** (output is not stream-tested; cheap
+/// chips don't exhibit the capture POLLERR and probing would make
+/// noise). One entry per physical card: the in-use card is surfaced
+/// from the cache snapshot (never opened — the AIOC's shared in/out PCM
+/// fails `supported_output_configs()` while RX holds it), and an idle
+/// card surfaces its top-ranked alias (`plughw:CARD=<name>` first).
+/// `recommended` stays the string heuristic for outputs.
+#[cfg(target_os = "linux")]
+#[allow(deprecated)] // DeviceTrait::name() gives the raw pcm_id we need
+fn collect_output_devices_linux(
+    outputs: impl Iterator<Item = cpal::Device>,
+    in_use: &HashMap<String, (u32, u32)>,
+    host_api: &str,
+    default_output_name: Option<&str>,
+) -> Vec<AudioDeviceInfo> {
+    use crate::audio::soundcard::{
+        alsa_canonical_key, build_card_resolver, group_alsa_cards, is_recommended_pcm_id,
+        parse_proc_asound_cards,
+    };
+    use cpal::traits::DeviceTrait;
+
+    let mut devs: Vec<(String, cpal::Device)> = Vec::new();
+    for dev in outputs {
+        let pcm_id = match dev.name() {
+            Ok(id) => id,
+            Err(_) => continue,
+        };
+        if pcm_id == "null" || !is_useful_alsa_device(&pcm_id) {
+            continue;
+        }
+        devs.push((pcm_id, dev));
+    }
+
+    let cards = std::fs::read_to_string("/proc/asound/cards")
+        .map(|c| parse_proc_asound_cards(&c))
+        .unwrap_or_default();
+    let resolver = build_card_resolver(&cards);
+    let canon = |pcm: &str| alsa_canonical_key(pcm, |t| resolver.get(t).copied());
+
+    let mut all_pcms: Vec<String> = devs.iter().map(|(p, _)| p.clone()).collect();
+    for pcm in in_use.keys() {
+        if !all_pcms.contains(pcm) {
+            all_pcms.push(pcm.clone());
+        }
+    }
+    let groups = group_alsa_cards(&all_pcms, |t| resolver.get(t).copied());
+
+    let mut in_use_by_card: HashMap<String, (String, u32, u32)> = HashMap::new();
+    for (pcm, (sr, ch)) in in_use {
+        in_use_by_card
+            .entry(canon(pcm))
+            .or_insert_with(|| (pcm.clone(), *sr, *ch));
+    }
+
+    let find_dev = |pcm: &str| devs.iter().find(|(p, _)| p == pcm).map(|(_, d)| d);
+    let configs_for = |dev: &cpal::Device| -> (Vec<u32>, Vec<u32>) {
+        let mut sample_rates = Vec::new();
+        let mut channel_counts = Vec::new();
+        if let Ok(configs) = dev.supported_output_configs() {
+            for cfg in configs {
+                let (min_rate, max_rate) = (cfg.min_sample_rate(), cfg.max_sample_rate());
+                for &rate in audio::STANDARD_SAMPLE_RATES {
+                    if rate >= min_rate && rate <= max_rate && !sample_rates.contains(&rate) {
+                        sample_rates.push(rate);
+                    }
+                }
+                let c = cfg.channels() as u32;
+                if !channel_counts.contains(&c) {
+                    channel_counts.push(c);
+                }
+            }
+        }
+        (sample_rates, channel_counts)
+    };
+
+    let kind: i32 = AudioDeviceKind::Output.into();
+    let mut out = Vec::new();
+    for group in groups {
+        if let Some((pcm, sr, ch)) = in_use_by_card.get(&group.key) {
+            out.push(AudioDeviceInfo {
+                name: alsa_card_description(pcm),
+                stable_id: pcm.clone(),
+                kind,
+                sample_rates: vec![*sr],
+                channel_counts: vec![*ch],
+                host_api: host_api.to_string(),
+                is_default: false,
+                description: alsa_card_description(pcm),
+                recommended: is_recommended_pcm_id(pcm),
+            });
+            continue;
+        }
+
+        // Idle card: no probing for outputs — take the top-ranked
+        // alias (plughw:<name> first). Drop a card with no usable
+        // config ranges (matches prior behavior for dead nodes).
+        let pcm = match group.candidates.first() {
+            Some(c) => c.clone(),
+            None => continue,
+        };
+        let dev = find_dev(&pcm);
+        let (sample_rates, channel_counts) = dev.map(|d| configs_for(d)).unwrap_or_default();
+        if sample_rates.is_empty() || channel_counts.is_empty() {
+            continue;
+        }
+        let display_name = dev
+            .and_then(|d| d.description().ok())
+            .map(|d| d.name().to_string())
+            .unwrap_or_else(|| alsa_card_description(&pcm));
+        let is_default = default_output_name == Some(display_name.as_str());
+
+        out.push(AudioDeviceInfo {
+            name: display_name,
+            stable_id: pcm.clone(),
+            kind,
+            sample_rates,
+            channel_counts,
+            host_api: host_api.to_string(),
+            is_default,
+            description: alsa_card_description(&pcm),
+            recommended: is_recommended_pcm_id(&pcm),
+        });
+    }
+    out
+}
+
 /// `in_use_input` / `in_use_output` map each pcm_id currently held open
 /// by a live capture / playback stream to its running `(sample_rate,
 /// channels)`. Linux uses them to surface in-use cards from cache
@@ -1743,52 +1875,24 @@ fn enumerate_audio_devices(
 
     if include_output {
         if let Ok(outputs) = host.output_devices() {
-            devices.extend(collect_devices(
-                outputs,
-                AudioDeviceKind::Output.into(),
-                default_output_name.as_deref(),
-                &host_name,
-                |d| d.supported_output_configs(),
-            ));
-        }
-
-        // Linux: an output card held open (e.g. AIOC's shared in/out PCM
-        // while RX captures) makes supported_output_configs() fail, so
-        // collect_devices drops it above. Re-append configured/in-use
-        // outputs from cache — one per physical card, never opening the
-        // device — so a configured output never vanishes from detection.
-        #[cfg(target_os = "linux")]
-        {
-            use crate::audio::soundcard::{
-                alsa_canonical_key, build_card_resolver, is_recommended_pcm_id,
-                parse_proc_asound_cards,
-            };
-            let cards = std::fs::read_to_string("/proc/asound/cards")
-                .map(|c| parse_proc_asound_cards(&c))
-                .unwrap_or_default();
-            let resolver = build_card_resolver(&cards);
-            let out_kind: i32 = AudioDeviceKind::Output.into();
-            let mut seen_out_cards: std::collections::HashSet<String> = devices
-                .iter()
-                .filter(|d| d.kind == out_kind)
-                .map(|d| alsa_canonical_key(&d.stable_id, |t| resolver.get(t).copied()))
-                .collect();
-            for (pcm, (sr, ch)) in in_use_output {
-                let key = alsa_canonical_key(pcm, |t| resolver.get(t).copied());
-                if !seen_out_cards.insert(key) {
-                    continue; // card already present from collect_devices
-                }
-                devices.push(AudioDeviceInfo {
-                    name: alsa_card_description(pcm),
-                    stable_id: pcm.clone(),
-                    kind: out_kind,
-                    sample_rates: vec![*sr],
-                    channel_counts: vec![*ch],
-                    host_api: host_name.clone(),
-                    is_default: false,
-                    description: alsa_card_description(pcm),
-                    recommended: is_recommended_pcm_id(pcm),
-                });
+            #[cfg(target_os = "linux")]
+            {
+                devices.extend(collect_output_devices_linux(
+                    outputs,
+                    in_use_output,
+                    &host_name,
+                    default_output_name.as_deref(),
+                ));
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                devices.extend(collect_devices(
+                    outputs,
+                    AudioDeviceKind::Output.into(),
+                    default_output_name.as_deref(),
+                    &host_name,
+                    |d| d.supported_output_configs(),
+                ));
             }
         }
     }

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -730,12 +730,25 @@ impl Modem {
     }
 
     fn handle_scan_input_levels(&self, req: ScanInputLevels) {
+        // pcm_ids held open by a running channel — the scanner reports
+        // these as "in use" instead of failing to open a busy device.
+        let mut in_use_input: HashMap<String, (u32, u32)> = HashMap::new();
+        for id in self.active_devices.keys() {
+            if let Some(acfg) = self.audio_configs.get(id) {
+                if acfg.source_type == "soundcard" && !acfg.device_name.is_empty() {
+                    in_use_input.insert(
+                        acfg.device_name.clone(),
+                        (acfg.sample_rate, acfg.channels),
+                    );
+                }
+            }
+        }
         let handle = self.handle.clone();
         std::thread::Builder::new()
             .name("scan-input-levels".into())
             .spawn(move || {
                 let duration_ms = if req.duration_ms == 0 { 500 } else { req.duration_ms };
-                let results = scan_input_levels(duration_ms);
+                let results = scan_input_levels(duration_ms, &in_use_input);
                 let msg = IpcMessage::input_level_scan_result(InputLevelScanResult {
                     request_id: req.request_id,
                     devices: results,
@@ -1900,23 +1913,106 @@ fn enumerate_audio_devices(
     devices
 }
 
-/// Briefly open each available input device and measure peak level.
+/// Open one input device, capture for `duration`, return its peak level.
+/// Errors (busy device, bad config, unsupported format) come back inside
+/// the `error` field rather than as a panic — the scanner reports them.
 #[allow(deprecated)] // DeviceTrait::name() returns the raw pcm_id we need
-fn scan_input_levels(duration_ms: u32) -> Vec<InputDeviceLevel> {
-    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+fn measure_input_level(
+    dev: &cpal::Device,
+    pcm_id: &str,
+    duration: std::time::Duration,
+) -> InputDeviceLevel {
+    use cpal::traits::{DeviceTrait, StreamTrait};
     use cpal::SampleFormat;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
+
+    let err = |e: String| InputDeviceLevel {
+        name: pcm_id.to_string(),
+        peak_dbfs: NOISE_FLOOR_DBFS,
+        has_signal: false,
+        error: e,
+    };
+
+    // Negotiate the probe config the same way device detection does —
+    // shared so the scanner and the detector can't drift apart.
+    // default_input_config() is avoided: it can return parameters a raw
+    // hw: ALSA device rejects with EINVAL.
+    let (sample_format, stream_cfg) = match audio::soundcard::pick_input_probe_config(dev) {
+        Ok(v) => v,
+        Err(e) => return err(e),
+    };
+
+    let peak = Arc::new(AtomicU32::new(0f32.to_bits()));
+    let stream = match sample_format {
+        SampleFormat::F32 => {
+            let pw = peak.clone();
+            dev.build_input_stream(&stream_cfg,
+                move |data: &[f32], _| update_peak_f32(&pw, data),
+                |e| eprintln!("scan level error: {}", e), None)
+        }
+        SampleFormat::I16 => {
+            let pw = peak.clone();
+            dev.build_input_stream(&stream_cfg,
+                move |data: &[i16], _| update_peak_i16(&pw, data),
+                |e| eprintln!("scan level error: {}", e), None)
+        }
+        SampleFormat::U16 => {
+            let pw = peak.clone();
+            dev.build_input_stream(&stream_cfg,
+                move |data: &[u16], _| update_peak_u16(&pw, data),
+                |e| eprintln!("scan level error: {}", e), None)
+        }
+        other => return err(format!("unsupported format: {:?}", other)),
+    };
+
+    match stream {
+        Ok(s) => {
+            if s.play().is_ok() {
+                std::thread::sleep(duration);
+            }
+            drop(s);
+            let peak_lin = f32::from_bits(peak.load(Ordering::Relaxed));
+            let peak_db = if peak_lin > 0.0 {
+                20.0 * peak_lin.log10()
+            } else {
+                NOISE_FLOOR_DBFS
+            };
+            InputDeviceLevel {
+                name: pcm_id.to_string(),
+                peak_dbfs: peak_db,
+                has_signal: peak_db > SIGNAL_THRESHOLD_DBFS,
+                error: String::new(),
+            }
+        }
+        Err(e) => err(format!("{}", e)),
+    }
+}
+
+/// Measure peak input level on each capture device.
+///
+/// `in_use` lists pcm_ids held open by a running channel. On Linux the
+/// list is collapsed to one row per physical card (same canonicalization
+/// as device detection), and an in-use card reports a clear "busy"
+/// status instead of cpal's misleading "device no longer available" —
+/// you cannot independently scan a device a running channel holds; its
+/// live level shows on the device card.
+#[allow(deprecated)] // DeviceTrait::name() returns the raw pcm_id we need
+#[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+fn scan_input_levels(
+    duration_ms: u32,
+    in_use: &HashMap<String, (u32, u32)>,
+) -> Vec<InputDeviceLevel> {
+    use cpal::traits::{DeviceTrait, HostTrait};
 
     let host = cpal::default_host();
     let inputs = match host.input_devices() {
         Ok(i) => i.collect::<Vec<_>>(),
         Err(_) => return Vec::new(),
     };
-
     let duration = std::time::Duration::from_millis(duration_ms as u64);
-    let mut results = Vec::new();
 
+    let mut devs: Vec<(String, cpal::Device)> = Vec::new();
     for dev in inputs {
         let pcm_id = match dev.name() {
             Ok(id) => id,
@@ -1924,89 +2020,74 @@ fn scan_input_levels(duration_ms: u32) -> Vec<InputDeviceLevel> {
         };
         // Skip virtual/plugin ALSA devices that can poison the ALSA
         // backend when their PCM open fails.
-        if !is_useful_alsa_device(&pcm_id) {
+        if pcm_id == "null" || !is_useful_alsa_device(&pcm_id) {
             continue;
         }
-        // Negotiate the probe config the same way device detection
-        // does — shared so the scanner and the detector can't drift
-        // apart. default_input_config() is avoided: it can return
-        // parameters a raw hw: ALSA device rejects with EINVAL.
-        let (sample_format, stream_cfg) =
-            match audio::soundcard::pick_input_probe_config(&dev) {
-                Ok(v) => v,
-                Err(e) => {
-                    results.push(InputDeviceLevel {
-                        name: pcm_id,
-                        peak_dbfs: NOISE_FLOOR_DBFS,
-                        has_signal: false,
-                        error: e,
-                    });
-                    continue;
-                }
-            };
+        devs.push((pcm_id, dev));
+    }
 
-        let peak = Arc::new(AtomicU32::new(0f32.to_bits()));
+    let mut results: Vec<InputDeviceLevel> = Vec::new();
 
-        // Build stream using the device's native sample format.
-        let stream = match sample_format {
-            SampleFormat::F32 => {
-                let pw = peak.clone();
-                dev.build_input_stream(&stream_cfg,
-                    move |data: &[f32], _| update_peak_f32(&pw, data),
-                    |e| eprintln!("scan level error: {}", e), None)
+    #[cfg(target_os = "linux")]
+    {
+        use crate::audio::soundcard::{
+            alsa_canonical_key, build_card_resolver, group_alsa_cards, parse_proc_asound_cards,
+        };
+        let cards = std::fs::read_to_string("/proc/asound/cards")
+            .map(|c| parse_proc_asound_cards(&c))
+            .unwrap_or_default();
+        let resolver = build_card_resolver(&cards);
+        let canon = |pcm: &str| alsa_canonical_key(pcm, |t| resolver.get(t).copied());
+
+        let mut all_pcms: Vec<String> = devs.iter().map(|(p, _)| p.clone()).collect();
+        for pcm in in_use.keys() {
+            if !all_pcms.contains(pcm) {
+                all_pcms.push(pcm.clone());
             }
-            SampleFormat::I16 => {
-                let pw = peak.clone();
-                dev.build_input_stream(&stream_cfg,
-                    move |data: &[i16], _| update_peak_i16(&pw, data),
-                    |e| eprintln!("scan level error: {}", e), None)
-            }
-            SampleFormat::U16 => {
-                let pw = peak.clone();
-                dev.build_input_stream(&stream_cfg,
-                    move |data: &[u16], _| update_peak_u16(&pw, data),
-                    |e| eprintln!("scan level error: {}", e), None)
-            }
-            _ => {
+        }
+        let groups = group_alsa_cards(&all_pcms, |t| resolver.get(t).copied());
+
+        // canonical card key -> the in-use pcm_id on that card
+        let mut in_use_by_card: HashMap<String, String> = HashMap::new();
+        for pcm in in_use.keys() {
+            in_use_by_card.entry(canon(pcm)).or_insert_with(|| pcm.clone());
+        }
+        let find_dev = |pcm: &str| devs.iter().find(|(p, _)| p == pcm).map(|(_, d)| d);
+
+        for group in groups {
+            if let Some(pcm) = in_use_by_card.get(&group.key) {
                 results.push(InputDeviceLevel {
-                    name: pcm_id,
+                    name: pcm.clone(),
                     peak_dbfs: NOISE_FLOOR_DBFS,
                     has_signal: false,
-                    error: format!("unsupported format: {:?}", sample_format),
+                    error: "in use by a running channel — live level is shown on the device card"
+                        .to_string(),
                 });
                 continue;
             }
-        };
-
-        match stream {
-            Ok(s) => {
-                if s.play().is_ok() {
-                    std::thread::sleep(duration);
+            // Idle card: measure its top-ranked alias once (one row per
+            // physical card, not per hw:/plughw: alias).
+            let mut chosen: Option<String> = None;
+            for cand in &group.candidates {
+                if find_dev(cand).is_some() {
+                    chosen = Some(cand.clone());
+                    break;
                 }
-                drop(s);
-
-                let peak_lin = f32::from_bits(peak.load(Ordering::Relaxed));
-                let peak_db = if peak_lin > 0.0 {
-                    20.0 * peak_lin.log10()
-                } else {
-                    NOISE_FLOOR_DBFS
-                };
-
-                results.push(InputDeviceLevel {
-                    name: pcm_id,
-                    peak_dbfs: peak_db,
-                    has_signal: peak_db > SIGNAL_THRESHOLD_DBFS,
-                    error: String::new(),
-                });
             }
-            Err(e) => {
-                results.push(InputDeviceLevel {
-                    name: pcm_id,
-                    peak_dbfs: NOISE_FLOOR_DBFS,
-                    has_signal: false,
-                    error: format!("{}", e),
-                });
+            let pcm = match chosen {
+                Some(c) => c,
+                None => continue,
+            };
+            if let Some(dev) = find_dev(&pcm) {
+                results.push(measure_input_level(dev, &pcm, duration));
             }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        for (pcm_id, dev) in &devs {
+            results.push(measure_input_level(dev, pcm_id, duration));
         }
     }
 

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -678,15 +678,29 @@ impl Modem {
         // in-use hardware — probing a device a running radio holds can
         // disrupt it, and cpal stops listing a held raw hw: device so a
         // naive rescan loses it entirely.
-        let mut in_use: HashMap<String, (u32, u32)> = HashMap::new();
-        for id in self.active_devices.keys() {
-            if let Some(acfg) = self.audio_configs.get(id) {
+        let cfg_for = |id: &u32| -> Option<(String, u32, u32)> {
+            self.audio_configs.get(id).and_then(|acfg| {
                 if acfg.source_type == "soundcard" && !acfg.device_name.is_empty() {
-                    in_use.insert(
-                        acfg.device_name.clone(),
-                        (acfg.sample_rate, acfg.channels),
-                    );
+                    Some((acfg.device_name.clone(), acfg.sample_rate, acfg.channels))
+                } else {
+                    None
                 }
+            })
+        };
+        let mut in_use_input: HashMap<String, (u32, u32)> = HashMap::new();
+        for id in self.active_devices.keys() {
+            if let Some((name, sr, ch)) = cfg_for(id) {
+                in_use_input.insert(name, (sr, ch));
+            }
+        }
+        // Output devices held by the TX worker. The AIOC shares one PCM
+        // for capture + playback, so once RX holds it the output path's
+        // supported_output_configs() fails and the old enumeration drops
+        // the device. Surface configured/in-use outputs from cache too.
+        let mut in_use_output: HashMap<String, (u32, u32)> = HashMap::new();
+        for id in self.output_devices.keys() {
+            if let Some((name, sr, ch)) = cfg_for(id) {
+                in_use_output.insert(name, (sr, ch));
             }
         }
 
@@ -697,7 +711,11 @@ impl Modem {
         std::thread::Builder::new()
             .name("enumerate-devices".into())
             .spawn(move || {
-                let devices = enumerate_audio_devices(req.include_output, &in_use);
+                let devices = enumerate_audio_devices(
+                    req.include_output,
+                    &in_use_input,
+                    &in_use_output,
+                );
                 let msg = IpcMessage {
                     payload: Some(Payload::AudioDeviceList(AudioDeviceList {
                         request_id: req.request_id,
@@ -1517,7 +1535,7 @@ fn collect_input_devices_linux(
     default_input_name: Option<&str>,
 ) -> Vec<AudioDeviceInfo> {
     use crate::audio::soundcard::{
-        alsa_card_token, build_card_resolver, group_alsa_cards, parse_proc_asound_cards,
+        alsa_canonical_key, build_card_resolver, group_alsa_cards, parse_proc_asound_cards,
         pick_input_probe_config, probe_capture,
     };
     use cpal::traits::DeviceTrait;
@@ -1540,10 +1558,7 @@ fn collect_input_devices_linux(
         .unwrap_or_default();
     let resolver = build_card_resolver(&cards);
     let canon = |pcm: &str| -> String {
-        match alsa_card_token(pcm).and_then(|t| resolver.get(t).copied()) {
-            Some(idx) => format!("card:{}", idx),
-            None => pcm.to_string(),
-        }
+        alsa_canonical_key(pcm, |t| resolver.get(t).copied())
     };
 
     // Seed grouping with in-use pcm_ids too: once a raw hw: stream
@@ -1667,15 +1682,18 @@ fn collect_input_devices_linux(
     out
 }
 
-/// `in_use` maps each pcm_id currently held open by a live capture
-/// stream to its running `(sample_rate, channels)`. Linux uses it to
-/// surface in-use cards from cache instead of probing them; other
-/// platforms ignore it.
+/// `in_use_input` / `in_use_output` map each pcm_id currently held open
+/// by a live capture / playback stream to its running `(sample_rate,
+/// channels)`. Linux uses them to surface in-use cards from cache
+/// instead of probing (input) or instead of letting a busy-device
+/// `supported_*_configs()` failure drop them (output); other platforms
+/// ignore them.
 #[allow(deprecated)]
 #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
 fn enumerate_audio_devices(
     include_output: bool,
-    in_use: &HashMap<String, (u32, u32)>,
+    in_use_input: &HashMap<String, (u32, u32)>,
+    in_use_output: &HashMap<String, (u32, u32)>,
 ) -> Vec<AudioDeviceInfo> {
     use cpal::traits::{DeviceTrait, HostTrait};
 
@@ -1706,7 +1724,7 @@ fn enumerate_audio_devices(
         {
             devices.extend(collect_input_devices_linux(
                 inputs,
-                in_use,
+                in_use_input,
                 &host_name,
                 default_input_name.as_deref(),
             ));
@@ -1732,6 +1750,46 @@ fn enumerate_audio_devices(
                 &host_name,
                 |d| d.supported_output_configs(),
             ));
+        }
+
+        // Linux: an output card held open (e.g. AIOC's shared in/out PCM
+        // while RX captures) makes supported_output_configs() fail, so
+        // collect_devices drops it above. Re-append configured/in-use
+        // outputs from cache — one per physical card, never opening the
+        // device — so a configured output never vanishes from detection.
+        #[cfg(target_os = "linux")]
+        {
+            use crate::audio::soundcard::{
+                alsa_canonical_key, build_card_resolver, is_recommended_pcm_id,
+                parse_proc_asound_cards,
+            };
+            let cards = std::fs::read_to_string("/proc/asound/cards")
+                .map(|c| parse_proc_asound_cards(&c))
+                .unwrap_or_default();
+            let resolver = build_card_resolver(&cards);
+            let out_kind: i32 = AudioDeviceKind::Output.into();
+            let mut seen_out_cards: std::collections::HashSet<String> = devices
+                .iter()
+                .filter(|d| d.kind == out_kind)
+                .map(|d| alsa_canonical_key(&d.stable_id, |t| resolver.get(t).copied()))
+                .collect();
+            for (pcm, (sr, ch)) in in_use_output {
+                let key = alsa_canonical_key(pcm, |t| resolver.get(t).copied());
+                if !seen_out_cards.insert(key) {
+                    continue; // card already present from collect_devices
+                }
+                devices.push(AudioDeviceInfo {
+                    name: alsa_card_description(pcm),
+                    stable_id: pcm.clone(),
+                    kind: out_kind,
+                    sample_rates: vec![*sr],
+                    channel_counts: vec![*ch],
+                    host_api: host_name.clone(),
+                    is_default: false,
+                    description: alsa_card_description(pcm),
+                    recommended: is_recommended_pcm_id(pcm),
+                });
+            }
         }
     }
 

--- a/pkg/flareschema/audio.go
+++ b/pkg/flareschema/audio.go
@@ -28,12 +28,17 @@ type AudioHost struct {
 // "output". IsDefault marks the host's default-input / default-output
 // pick (each direction has its own default).
 //
-// Recommended mirrors the flag graywolf-modem's web UI uses on the
-// user-facing device picker — set when the device's PCM identifier is
-// a stable `plughw:CARD=<name>` form (i.e. the card has a kernel-stable
-// name rather than a numeric index that can change across reboots).
-// The operator UI surfaces this as the "Recommended" label so the
-// triage view matches what the user saw when picking a device.
+// Recommended is the flare-side string heuristic only: set when the
+// device's PCM identifier is a stable `plughw:CARD=<name>` form.
+//
+// For capture devices this intentionally does NOT match the live web
+// picker. The runtime picker probes each device and
+// recommends the PCM form that actually streams (cheap USB chips fail
+// on plughw: and only work via raw hw:). `--list-audio` runs as a
+// separate short-lived process and cannot probe safely, so its
+// Recommended stays a cheap triage hint; the live picker is
+// authoritative. Keep in sync with the doc on graywolf-modem
+// is_recommended_pcm_id and the convergence-test note.
 type AudioDevice struct {
 	Name             string                   `json:"name"`
 	Direction        string                   `json:"direction"`

--- a/pkg/flareschema/convergence_test.go
+++ b/pkg/flareschema/convergence_test.go
@@ -98,6 +98,11 @@ func TestConvergenceListAudio(t *testing.T) {
 		t.Skip("graywolf-modem binary not found; build with `cargo build --release` to enable")
 	}
 
+	// NOTE: this test asserts the JSON *shape* contract only, not
+	// the value of `recommended`. The flare `--list-audio` Recommended
+	// is a string heuristic; the live web picker probe-verifies it and
+	// the two intentionally diverge for cheap USB capture chips. Do not
+	// add a cross-check expecting flare/live parity on `recommended`.
 	stdout, err := runModemListing(bin, "--list-audio")
 	if err != nil {
 		t.Fatalf("--list-audio: %v", err)


### PR DESCRIPTION
## Summary

Fixes audio capture/playback device detection on headless Linux (Pi OS Lite) with cheap USB audio adapters, plus the input-level scanner's behavior on in-use hardware.

**Capture detection**
- **Recommended is probe-verified.** Linux capture enumeration briefly opens each *idle* card and badges "Recommended" the PCM form that actually streams (no POLLERR), trying `plughw:CARD=<name>` first so AIOC / DigiRig keep their existing selection, falling back to raw `hw:` for chips whose plughw path fails.
- **One entry per physical card.** Numeric (`hw:CARD=1`) and symbolic (`hw:CARD=Device`) ALSA aliases are canonicalized via `/proc/asound/cards` (shared `alsa_canonical_key`).
- **In-use cards stay visible and are never probed.** A card held open by a live capture stream is surfaced from an in-use snapshot, not re-probed (probing in-use hardware can disrupt the running radio; cpal also stops listing a held raw `hw:` device).

**Playback detection**
- Symmetric per-physical-card dedup for outputs (no probing on the playback side; `recommended` stays the string heuristic).
- Configured/in-use output cards (e.g. the AIOC's shared in/out PCM, whose `supported_output_configs()` fails once RX holds the card) are surfaced from cache so a configured output never vanishes from detection.

**Input-level scanner**
- Same per-card dedup; a card a running channel holds reports a clear "in use by a running channel" status instead of cpal's misleading "device no longer available", and is not opened as a competing stream.

**Flare divergence (intentional)**
- The string `is_recommended_pcm_id` heuristic is now used only by `--list-audio` and the Linux output path; flare `recommended` and the live capture picker intentionally diverge (a separate short-lived `--list-audio` process can't probe safely). Documented in code, `pkg/flareschema/audio.go`, the convergence test, and `docs/wiki/invariants.md`.

`collect_devices` is now non-Linux only (macOS/Windows unchanged).

## Test plan

- [x] `cargo test` — pure-logic unit tests (proc/asound parse, CARD-token, canonical key, card grouping) pass.
- [x] `cargo check` + `go build` on the non-Linux host.
- [x] CI Linux build + clippy + Go + tests green on every commit.
- [x] Hardware (AIOC on a Pi-class Linux box): detected once, badged Recommended, survives mid-capture rescan -- input and output.
- [ ] Hardware retest: input-level scan on an in-use device reports the "in use" status (CI-validated, awaiting on-device confirmation).

Out of scope (pre-existing, possible follow-ups): AIOC capture path advertising 96 kHz-only via plughw; `default` output PCM flicker.

Refs #129
