### PR TITLE
fix(webauth): reject over-72-byte passwords with a clear 400

### DIFF
--- a/pkg/webauth/auth.go
+++ b/pkg/webauth/auth.go
@@ -5,10 +5,21 @@ package webauth
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"golang.org/x/crypto/bcrypt"
 )
+
+// MaxPasswordBytes is the longest password bcrypt will accept. bcrypt
+// silently caps input at 72 bytes and golang.org/x/crypto/bcrypt rejects
+// anything longer outright, so reject it ourselves with a clear error
+// rather than surfacing the library's internal message.
+const MaxPasswordBytes = 72
+
+// ErrPasswordTooLong is returned by HashPassword when the password exceeds
+// MaxPasswordBytes. Callers should map it to a client-facing 400.
+var ErrPasswordTooLong = errors.New("password exceeds 72 bytes")
 
 const (
 	bcryptCost = 10
@@ -23,6 +34,9 @@ const (
 
 // HashPassword returns a bcrypt hash suitable for storage.
 func HashPassword(password string) (string, error) {
+	if len(password) > MaxPasswordBytes {
+		return "", ErrPasswordTooLong
+	}
 	h, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
 	if err != nil {
 		return "", fmt.Errorf("hash password: %w", err)

--- a/pkg/webauth/auth_test.go
+++ b/pkg/webauth/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -53,6 +54,51 @@ func TestHashAndCheckPassword(t *testing.T) {
 	}
 	if err := CheckPassword(hash, "wrong"); err == nil {
 		t.Fatal("wrong password should not match")
+	}
+}
+
+func TestHashPasswordTooLong(t *testing.T) {
+	// Exactly at the limit must still hash.
+	if _, err := HashPassword(strings.Repeat("a", MaxPasswordBytes)); err != nil {
+		t.Fatalf("%d-byte password should hash, got %v", MaxPasswordBytes, err)
+	}
+	// One byte over must be rejected with the sentinel, not bcrypt's
+	// internal "password length exceeds 72 bytes" message.
+	_, err := HashPassword(strings.Repeat("a", MaxPasswordBytes+1))
+	if !errors.Is(err, ErrPasswordTooLong) {
+		t.Fatalf("expected ErrPasswordTooLong, got %v", err)
+	}
+}
+
+// TestCreateFirstUserPasswordTooLong is the regression for issue #123: an
+// over-long password must come back as a clean 400 with an actionable
+// message, not a 500 "failed to create user".
+func TestCreateFirstUserPasswordTooLong(t *testing.T) {
+	s := testAuthStore(t)
+	h := &Handlers{Auth: s}
+
+	body, _ := json.Marshal(setupRequest{
+		Username: "admin",
+		Password: strings.Repeat("x", 100), // password-manager default
+	})
+	req := httptest.NewRequest("POST", "/api/auth/setup", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.CreateFirstUser(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	if got := resp["error"]; got != "password must not exceed 72 bytes" {
+		t.Fatalf("unexpected error message: %q", got)
+	}
+
+	// No user should have been created.
+	if count, _ := s.UserCount(context.Background()); count != 0 {
+		t.Fatalf("expected 0 users after rejected setup, got %d", count)
 	}
 }
 

--- a/pkg/webauth/handlers.go
+++ b/pkg/webauth/handlers.go
@@ -248,9 +248,17 @@ func (h *Handlers) CreateFirstUser(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "username and password required")
 		return
 	}
+	if len(req.Password) > MaxPasswordBytes {
+		jsonError(w, http.StatusBadRequest, "password must not exceed 72 bytes")
+		return
+	}
 
 	hash, err := HashPassword(req.Password)
 	if err != nil {
+		if errors.Is(err, ErrPasswordTooLong) {
+			jsonError(w, http.StatusBadRequest, "password must not exceed 72 bytes")
+			return
+		}
 		h.logger().ErrorContext(r.Context(), "handler failed", "op", "setup.hash_password", "err", err)
 		jsonError(w, http.StatusInternalServerError, "failed to create user")
 		return

--- a/web/src/routes/Login.svelte
+++ b/web/src/routes/Login.svelte
@@ -28,6 +28,9 @@
     if (!username.trim()) e.username = 'Username is required';
     if (!password) e.password = 'Password is required';
     if (password.length < 8) e.password = 'Minimum 8 characters';
+    // bcrypt rejects anything past 72 bytes; measure UTF-8 length so a
+    // multibyte password can't slip past a naive character count.
+    if (new TextEncoder().encode(password).length > 72) e.password = 'Maximum 72 characters';
     if (setupMode && password !== passwordConfirm) e.passwordConfirm = 'Passwords do not match';
     errors = e;
     return Object.keys(e).length === 0;


### PR DESCRIPTION
## Summary
- Creating the first user with a password longer than bcrypt's 72-byte limit (e.g. a 100-char password-manager default) failed the hash and returned a generic `500 "failed to create user"` with no actionable detail (issue #123).
- Added `MaxPasswordBytes` (72) + `ErrPasswordTooLong` sentinel in `pkg/webauth/auth.go`; `HashPassword` now rejects over-long input before calling bcrypt (covers all callers).
- `CreateFirstUser` returns a clean `400` with `password must not exceed 72 bytes` (explicit guard + sentinel mapping) instead of logging an ERROR and returning 500 for what is user input.
- `Login.svelte` `validate()` now measures UTF-8 byte length and shows an inline `Maximum 72 characters` error before submit; the backend message also propagates verbatim to the toast as a fallback.

## Test plan
- `GOWORK=off go test ./pkg/webauth/` — passes, incl. new `TestHashPasswordTooLong` (72 OK, 73 → `ErrPasswordTooLong`) and `TestCreateFirstUserPasswordTooLong` (100-char password → 400, correct error body, no user created).
- `GOWORK=off go build ./...` and `go vet ./pkg/webauth/` — clean.
- Frontend: change is one line of plain JS in the setup form's `validate()`; not built locally (no `web/node_modules` in worktree) — verify in CI / manually: 100-char password shows inline "Maximum 72 characters" and never reaches the backend.

Refs #123