### PR TITLE
fix(audio): cap rate at 48 kHz, native I16 capture format, clamp corrupt configs

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -506,3 +506,30 @@ Source:
 (`choose_stream_rate`, `spawn`),
 [`../../web/src/lib/sampleRate.js`](../../web/src/lib/sampleRate.js),
 [`../../pkg/configstore/migrate_audio_devices_clamp_sample_rate.go`](../../pkg/configstore/migrate_audio_devices_clamp_sample_rate.go).
+
+### 33. Capture stream format is device-advertised, never `default_input_config()`
+
+`soundcard::spawn` picks the input `SampleFormat` from the device's
+*advertised* supported configs at the chosen rate, preferring native
+`I16` (`pick_input_sample_format`). It must **never** open a capture
+stream using `device.default_input_config().sample_format()`.
+
+*Why:* On an ALSA `plughw:`/`default` PCM, cpal's
+`default_input_config()` returns **`F32`**. Opening an `F32` capture
+stream on a full-speed USB radio codec (AIOC and similar) makes cpal
+`alsa::poll()` return `POLLERR` on essentially every period -- the
+holding thread rebuilds, POLLERRs again, and loops forever (observed:
+24,344 errors in one session, RX stuck at zero with no fatal error).
+The *same hardware* streams the native `I16` config cleanly (`arecord
+-f S16_LE` and the detection probe both work). The detection probe
+(`pick_input_probe_config`) already selected I16; the runtime
+`spawn()` did not, so the probe verified a config the runtime never
+used. `pick_input_sample_format` and the probe now share
+`input_format_rank` so detection and runtime cannot drift. The
+sample-*rate* clamp (invariant 32) is necessary but independent: a
+clipping analog input or an `F32` plughw stream each kill RX on their
+own.
+
+Source:
+[`../../graywolf-modem/src/audio/soundcard.rs`](../../graywolf-modem/src/audio/soundcard.rs)
+(`pick_input_sample_format`, `input_format_rank`, `pick_input_probe_config`, `spawn`).

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -466,3 +466,43 @@ docs), [`../../pkg/aprs/fap_corpus_test.go`](../../pkg/aprs/fap_corpus_test.go),
 (`convertWeather`),
 [`../../pkg/historydb/historydb.go`](../../pkg/historydb/historydb.go)
 (`bootstrap` `user_version` backfill).
+### 32. Modem sample rate is capped at 48 kHz
+
+The modem never advertises, defaults to, or opens an audio stream
+above **48 kHz** (`audio::MODEM_MAX_SAMPLE_RATE`). Every Graywolf
+modem mode (AFSK 1200, G3RUH 9600, QPSK/8-PSK) is well served by
+48 kHz.
+
+*Why:* An ALSA `plughw:`/`default` PCM advertises a *synthetic*
+resample range (up to 192 kHz) via cpal `supported_*_configs()`
+even though the USB codec hardware runs at 48 kHz. The Audio
+Devices form used to auto-fill the **highest** advertised rate, so
+operators who ran "Detect Devices" persisted `sample_rate=96000`.
+At runtime the modem opened the stream at the inflated rate while
+the hardware ran 48 kHz; the demodulator clocked AFSK bit timing
+against the wrong rate and **every frame failed FCS -- RX went
+silent with no error** (anguilla.local, 2026-05-16). Defense in
+depth, all three layers required:
+
+1. **Enumeration** never lists >48 kHz: `STANDARD_SAMPLE_RATES`
+   stops at 48000, asserted by `audio::rate_invariants`.
+2. **UI** never defaults to a corrupt/max rate:
+   `pickDefaultSampleRate` prefers 48000 → 44100 → highest ≤48 kHz,
+   never above; the manual rate `<Select>` offers no 96000.
+3. **Runtime backstop**: `soundcard::choose_stream_rate` honors the
+   requested rate only when ≤48 kHz *and* covered by a real
+   supported range, else falls back to the device native rate
+   clamped to the ceiling. `AudioSource.sample_rate` reports the
+   rate **actually opened**, so the demod can never be silently
+   desynced by a bad config again.
+
+Migration 21 (`audio_devices_clamp_sample_rate`) repairs
+already-corrupted field databases (`sample_rate > 48000 → 48000`).
+
+Source:
+[`../../graywolf-modem/src/audio/mod.rs`](../../graywolf-modem/src/audio/mod.rs)
+(`MODEM_MAX_SAMPLE_RATE`, `STANDARD_SAMPLE_RATES`),
+[`../../graywolf-modem/src/audio/soundcard.rs`](../../graywolf-modem/src/audio/soundcard.rs)
+(`choose_stream_rate`, `spawn`),
+[`../../web/src/lib/sampleRate.js`](../../web/src/lib/sampleRate.js),
+[`../../pkg/configstore/migrate_audio_devices_clamp_sample_rate.go`](../../pkg/configstore/migrate_audio_devices_clamp_sample_rate.go).

--- a/graywolf-modem/src/audio/mod.rs
+++ b/graywolf-modem/src/audio/mod.rs
@@ -16,10 +16,21 @@ pub mod flac;
 pub mod soundcard;
 pub mod stdin_raw;
 
+/// The highest sample rate the modem will ever operate a stream at.
+///
+/// Every Graywolf modem mode (AFSK 1200, G3RUH 9600, QPSK/8-PSK) is well
+/// served by 48 kHz; nothing needs hi-fi rates. We deliberately never
+/// advertise, default to, or open a stream above this. Rates above 48 kHz
+/// are a trap on USB audio: an ALSA `plughw:`/`default` PCM advertises a
+/// synthetic resample range (up to 192 kHz) even though the hardware codec
+/// runs at 48 kHz, and a stream opened at the inflated rate desyncs the
+/// demodulator's bit timing — every frame fails FCS, RX goes silent.
+pub const MODEM_MAX_SAMPLE_RATE: u32 = 48_000;
+
 /// Sample rates we advertise when enumerating device capabilities. Covers
-/// common amateur-radio rates (8–48 kHz) plus the 96 kHz hi-fi rate that
-/// some USB devices support.
-pub const STANDARD_SAMPLE_RATES: &[u32] = &[8000, 11025, 16000, 22050, 44100, 48000, 96000];
+/// the common amateur-radio rates. Capped at [`MODEM_MAX_SAMPLE_RATE`] —
+/// see that constant for why we never go above 48 kHz.
+pub const STANDARD_SAMPLE_RATES: &[u32] = &[8000, 11025, 16000, 22050, 44100, 48000];
 
 /// Preferred sample rates for quick level scans, in priority order.
 /// 48 kHz is native for most USB audio; 44.1 kHz is the CD-standard fallback.
@@ -63,3 +74,26 @@ impl AudioSource {
 pub const CHUNK_QUEUE_DEPTH: usize = 64;
 
 pub type SampleSink = SyncSender<AudioChunk>;
+
+#[cfg(test)]
+mod rate_invariants {
+    use super::*;
+
+    #[test]
+    fn standard_rates_never_exceed_modem_ceiling() {
+        for &r in STANDARD_SAMPLE_RATES {
+            assert!(
+                r <= MODEM_MAX_SAMPLE_RATE,
+                "advertised rate {r} exceeds modem ceiling {MODEM_MAX_SAMPLE_RATE}; \
+                 rates above 48 kHz desync the demod on USB plughw devices"
+            );
+        }
+    }
+
+    #[test]
+    fn scan_rates_never_exceed_modem_ceiling() {
+        for &r in PREFERRED_SCAN_RATES {
+            assert!(r <= MODEM_MAX_SAMPLE_RATE, "scan rate {r} exceeds ceiling");
+        }
+    }
+}

--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -218,7 +218,35 @@ pub fn spawn(
     // own thread that also runs a small park loop to keep it alive.
     let stop_for_thread = stop.clone();
     let stream_failed_for_thread = stream_failed.clone();
-    let sample_format = supported.sample_format();
+    // Never trust default_input_config()'s format: on an ALSA plughw:/
+    // default PCM it is F32, which POLLERR-loops cpal forever on cheap
+    // USB radio codecs (AIOC). Pick the format the device actually
+    // advertises at our rate, preferring native I16 (what arecord and
+    // the detection probe use and what streams reliably). Fall back to
+    // the cpal default only if the device advertises nothing usable.
+    let input_cfgs: Vec<(u16, SampleFormat, u32, u32)> = device
+        .supported_input_configs()
+        .map(|it| {
+            it.map(|c| {
+                (
+                    c.channels(),
+                    c.sample_format(),
+                    c.min_sample_rate(),
+                    c.max_sample_rate(),
+                )
+            })
+            .collect()
+        })
+        .unwrap_or_default();
+    // Format and channels are chosen independently (rate-filtered): a
+    // converting `plughw:`/`default` PCM accepts any (channels, format)
+    // pair via software conversion, which is the only realistic graywolf
+    // capture path. A non-converting raw `hw:` device that advertised
+    // format and channels only as disjoint configs would reject the
+    // combination, but cpal surfaces that as a build error via ready_tx
+    // (loud, non-fatal) rather than a silent failure.
+    let sample_format = pick_input_sample_format(&input_cfgs, stream_rate)
+        .unwrap_or_else(|| supported.sample_format());
     let (ready_tx, ready_rx) = channel::<Result<(), String>>();
 
     let join = thread::Builder::new()
@@ -615,12 +643,7 @@ pub fn pick_input_probe_config(dev: &Device) -> Result<(SampleFormat, StreamConf
             if cfg.channels() < b.channels() {
                 return false;
             }
-            let rank = |f: SampleFormat| match f {
-                SampleFormat::I16 => 0,
-                SampleFormat::F32 => 1,
-                _ => 2,
-            };
-            rank(cfg.sample_format()) >= rank(b.sample_format())
+            input_format_rank(cfg.sample_format()) >= input_format_rank(b.sample_format())
         });
         if !dominated_by_best {
             best = Some(cfg);
@@ -640,6 +663,41 @@ pub fn pick_input_probe_config(dev: &Device) -> Result<(SampleFormat, StreamConf
             buffer_size: cpal::BufferSize::Default,
         },
     ))
+}
+
+/// Rank for input sample-format preference: lower is better. Native
+/// integer `I16` first (every cheap USB radio codec runs it and ALSA
+/// `plughw:` streams it without resampling jitter), then `F32`, then
+/// the rest. Single source of truth shared by the runtime stream and
+/// the detection probe.
+fn input_format_rank(f: SampleFormat) -> u8 {
+    match f {
+        SampleFormat::I16 => 0,
+        SampleFormat::F32 => 1,
+        _ => 2,
+    }
+}
+
+/// Pick the sample format to actually open a capture stream with, given
+/// the device's supported `(channels, format, min_rate, max_rate)`
+/// configs and the rate we will open at.
+///
+/// `default_input_config()` on an ALSA `plughw:`/`default` PCM hands back
+/// `F32`; cpal opening that synthetic config on a full-speed USB gadget
+/// POLLERR-loops forever and RX dies, even though the same hardware
+/// streams `I16` (native) cleanly -- proven on the AIOC. We therefore
+/// never trust `default_input_config()` for the format; we pick the
+/// best format the device actually advertises *at the chosen rate*,
+/// preferring native `I16`, exactly as the detection probe does.
+pub fn pick_input_sample_format(
+    configs: &[(u16, SampleFormat, u32, u32)],
+    rate: u32,
+) -> Option<SampleFormat> {
+    configs
+        .iter()
+        .filter(|&&(_ch, _f, min, max)| rate >= min && rate <= max)
+        .min_by_key(|&&(_ch, f, _min, _max)| input_format_rank(f))
+        .map(|&(_ch, f, _min, _max)| f)
 }
 
 /// Decide the sample rate to actually open a stream at, given the
@@ -1192,6 +1250,43 @@ fn fill_output_u16(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pick_input_format_prefers_i16_over_f32_at_rate() {
+        // The real AIOC case: a synthetic plug PCM advertises F32 (and
+        // a huge range) alongside the native I16/48k config. Must pick
+        // I16 -- F32 here is what POLLERR-loops cpal.
+        let cfgs = [
+            (2u16, SampleFormat::F32, 4_000u32, 4_294_967_295u32),
+            (1u16, SampleFormat::I16, 48_000u32, 48_000u32),
+        ];
+        assert_eq!(pick_input_sample_format(&cfgs, 48_000), Some(SampleFormat::I16));
+    }
+
+    #[test]
+    fn pick_input_format_uses_f32_when_no_i16_at_rate() {
+        let cfgs = [(1u16, SampleFormat::F32, 8_000u32, 48_000u32)];
+        assert_eq!(pick_input_sample_format(&cfgs, 48_000), Some(SampleFormat::F32));
+        // F32 ranked above non-I16/F32 formats.
+        let cfgs2 = [
+            (1u16, SampleFormat::U16, 8_000u32, 48_000u32),
+            (1u16, SampleFormat::F32, 8_000u32, 48_000u32),
+        ];
+        assert_eq!(pick_input_sample_format(&cfgs2, 48_000), Some(SampleFormat::F32));
+    }
+
+    #[test]
+    fn pick_input_format_respects_rate_bounds() {
+        // I16 exists but only outside the target rate; F32 covers it.
+        let cfgs = [
+            (1u16, SampleFormat::I16, 8_000u32, 16_000u32),
+            (1u16, SampleFormat::F32, 8_000u32, 48_000u32),
+        ];
+        assert_eq!(pick_input_sample_format(&cfgs, 48_000), Some(SampleFormat::F32));
+        // Nothing covers the rate.
+        assert_eq!(pick_input_sample_format(&cfgs, 96_000), None);
+        assert_eq!(pick_input_sample_format(&[], 48_000), None);
+    }
 
     #[test]
     fn choose_stream_rate_honors_sane_supported_request() {

--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -173,14 +173,35 @@ pub fn spawn(
         .default_input_config()
         .map_err(|e| format!("device default config: {}", e))?;
 
+    // Safety net for corrupt persisted config: clamp the requested rate
+    // to one the device actually supports and the modem can decode (never
+    // above MODEM_MAX_SAMPLE_RATE). A stale `sample_rate=96000` from a
+    // plughw device that really runs 48 kHz is rejected here instead of
+    // silently desyncing the demod's bit timing.
+    let supported_ranges: Vec<(u32, u32)> = device
+        .supported_input_configs()
+        .map(|it| it.map(|c| (c.min_sample_rate(), c.max_sample_rate())).collect())
+        .unwrap_or_default();
+    let stream_rate = choose_stream_rate(
+        cfg.sample_rate,
+        supported.sample_rate(),
+        &supported_ranges,
+    );
+    if stream_rate != cfg.sample_rate {
+        eprintln!(
+            "graywolf-modem: input rate {} Hz unsupported/corrupt; opening at {} Hz instead",
+            cfg.sample_rate, stream_rate
+        );
+    }
+
     let channels = negotiate_channels(
-        &device, cfg.sample_rate, cfg.channels.max(1) as u16, "input",
+        &device, stream_rate, cfg.channels.max(1) as u16, "input",
         |d| d.supported_input_configs(),
     )?;
 
     let stream_config = StreamConfig {
         channels,
-        sample_rate: cfg.sample_rate,
+        sample_rate: stream_rate,
         buffer_size: cpal::BufferSize::Default,
     };
 
@@ -326,7 +347,9 @@ pub fn spawn(
         .map_err(|e| format!("cpal {}", e))?;
 
     Ok(AudioSource {
-        sample_rate: cfg.sample_rate,
+        // Report the rate actually opened, not the requested one, so the
+        // demodulator clocks bit timing against real audio.
+        sample_rate: stream_rate,
         thread: Some(join),
         stop,
     })
@@ -617,6 +640,32 @@ pub fn pick_input_probe_config(dev: &Device) -> Result<(SampleFormat, StreamConf
             buffer_size: cpal::BufferSize::Default,
         },
     ))
+}
+
+/// Decide the sample rate to actually open a stream at, given the
+/// operator-configured `requested` rate, the device's `native` rate
+/// (cpal `default_*_config().sample_rate()`), and the device's advertised
+/// `supported` (min,max) ranges.
+///
+/// This is the safety net for corrupt persisted config: an ALSA
+/// `plughw:`/`default` PCM advertises a synthetic resample range up to
+/// 192 kHz even though the codec runs at 48 kHz, so a stale
+/// `sample_rate=96000` in the DB would otherwise open a stream the demod
+/// then clocks at the wrong rate (every frame fails FCS, RX dies). We
+/// never open above [`super::MODEM_MAX_SAMPLE_RATE`], honor `requested`
+/// only when it is sane and actually covered by a supported range, and
+/// otherwise fall back to the device's native rate clamped to the ceiling.
+pub fn choose_stream_rate(requested: u32, native: u32, supported: &[(u32, u32)]) -> u32 {
+    let ceiling = super::MODEM_MAX_SAMPLE_RATE;
+    let in_range = |r: u32| supported.iter().any(|&(lo, hi)| r >= lo && r <= hi);
+
+    if requested != 0 && requested <= ceiling && in_range(requested) {
+        return requested;
+    }
+    if native != 0 && native <= ceiling {
+        return native;
+    }
+    ceiling
 }
 
 /// Briefly open `dev` for capture and report whether it actually streams.
@@ -1143,6 +1192,32 @@ fn fill_output_u16(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn choose_stream_rate_honors_sane_supported_request() {
+        // 48 kHz, in range, at/under ceiling → use it as-is.
+        assert_eq!(choose_stream_rate(48_000, 48_000, &[(8_000, 48_000)]), 48_000);
+        assert_eq!(choose_stream_rate(44_100, 48_000, &[(8_000, 48_000)]), 44_100);
+    }
+
+    #[test]
+    fn choose_stream_rate_rejects_request_above_ceiling() {
+        // Corrupt 96 kHz from a plughw device whose synthetic range
+        // covers it — must NOT be honored; fall back to native 48 kHz.
+        assert_eq!(choose_stream_rate(96_000, 48_000, &[(8_000, 192_000)]), 48_000);
+        // 88.2 kHz "supported" by the plug plugin — still rejected.
+        assert_eq!(choose_stream_rate(88_200, 44_100, &[(8_000, 192_000)]), 44_100);
+    }
+
+    #[test]
+    fn choose_stream_rate_clamps_bad_native_and_unset_request() {
+        // plughw default itself lies (native=96k) → clamp to ceiling.
+        assert_eq!(choose_stream_rate(96_000, 96_000, &[(8_000, 192_000)]), 48_000);
+        // requested unset (0) → device native.
+        assert_eq!(choose_stream_rate(0, 48_000, &[(8_000, 48_000)]), 48_000);
+        // requested not covered by any supported range → native.
+        assert_eq!(choose_stream_rate(44_100, 48_000, &[(48_000, 48_000)]), 48_000);
+    }
 
     /// Helper: turn a slice of mono samples into the `next()` closure the
     /// `fill_output_*` functions expect.

--- a/pkg/configstore/migrate.go
+++ b/pkg/configstore/migrate.go
@@ -197,6 +197,7 @@ var schemaMigrations = []migration{
 	{version: 18, name: "actions_uppercase_names", phase: postAutoMigrate, run: migrateActionsUppercaseNames},
 	{version: 19, name: "actions_max_reply_lines", phase: postAutoMigrate, run: migrateActionsMaxReplyLines},
 	{version: 20, name: "kiss_tcp_client_tx_default", phase: postAutoMigrate, run: migrateKissTcpClientTxDefault},
+	{version: 21, name: "audio_devices_clamp_sample_rate", phase: postAutoMigrate, run: migrateClampAudioSampleRate},
 }
 
 // runMigrations applies every pending migration in the given phase,

--- a/pkg/configstore/migrate_audio_devices_clamp_sample_rate.go
+++ b/pkg/configstore/migrate_audio_devices_clamp_sample_rate.go
@@ -1,0 +1,21 @@
+package configstore
+
+import "gorm.io/gorm"
+
+// migrateClampAudioSampleRate repairs audio_devices rows whose persisted
+// sample_rate exceeds the modem's operating ceiling (48 kHz).
+//
+// An ALSA `plughw:`/`default` PCM advertises a synthetic resample range
+// (up to 192 kHz) even though the USB codec runs at 48 kHz. The Audio
+// Devices form used to auto-fill the highest advertised rate, so operators
+// who ran "Detect Devices" persisted sample_rate=96000. At runtime the
+// modem opened the stream at the inflated rate while the hardware ran
+// 48 kHz; the demodulator clocked bit timing against the wrong rate and
+// every frame failed FCS -- RX went silent with no error.
+//
+// 48 kHz serves every Graywolf modem mode, so clamping is lossless.
+// Idempotent: rows already at or below 48 kHz are left untouched.
+func migrateClampAudioSampleRate(tx *gorm.DB) error {
+	return tx.Exec(
+		"UPDATE audio_devices SET sample_rate = 48000 WHERE sample_rate > 48000").Error
+}

--- a/pkg/configstore/migrate_audio_devices_clamp_sample_rate_test.go
+++ b/pkg/configstore/migrate_audio_devices_clamp_sample_rate_test.go
@@ -1,0 +1,69 @@
+package configstore
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestMigrateClampAudioSampleRate verifies corrupt >48 kHz sample rates
+// (the plughw 96000/192000 trap) are clamped to 48000, while sane rows
+// are left exactly as-is. A second invocation must be a no-op.
+func TestMigrateClampAudioSampleRate(t *testing.T) {
+	t.Parallel()
+	dsn := filepath.Join(t.TempDir(), "clamp_sr.db")
+	store, err := Open(dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+
+	rows := []struct {
+		id   uint32
+		name string
+		rate uint32
+	}{
+		{1, "aioc-corrupt-96k", 96000},
+		{2, "digirig-corrupt-192k", 192000},
+		{3, "good-48k", 48000},
+		{4, "good-44k1", 44100},
+		{5, "good-8k", 8000},
+	}
+	for _, r := range rows {
+		if err := store.DB().Exec(
+			`INSERT INTO audio_devices(id, name, direction, source_type, sample_rate,
+			created_at, updated_at)
+			VALUES (?, ?, 'input', 'soundcard', ?, datetime('now'), datetime('now'))`,
+			r.id, r.name, r.rate).Error; err != nil {
+			t.Fatalf("insert %s: %v", r.name, err)
+		}
+	}
+
+	if err := migrateClampAudioSampleRate(store.DB()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	check := func(id uint32, want uint32) {
+		t.Helper()
+		var got uint32
+		if err := store.DB().Raw(
+			`SELECT sample_rate FROM audio_devices WHERE id=?`, id).Scan(&got).Error; err != nil {
+			t.Fatalf("scan id=%d: %v", id, err)
+		}
+		if got != want {
+			t.Errorf("id=%d: sample_rate=%d, want %d", id, got, want)
+		}
+	}
+
+	check(1, 48000) // 96000 -> clamped
+	check(2, 48000) // 192000 -> clamped
+	check(3, 48000) // untouched
+	check(4, 44100) // untouched
+	check(5, 8000)  // untouched
+
+	// Idempotence: second run changes nothing.
+	if err := migrateClampAudioSampleRate(store.DB()); err != nil {
+		t.Fatalf("second invocation: %v", err)
+	}
+	check(1, 48000)
+	check(4, 44100)
+}

--- a/web/src/lib/sampleRate.js
+++ b/web/src/lib/sampleRate.js
@@ -1,0 +1,17 @@
+// Pure helper: choose a safe default sample rate for the Audio Devices
+// form. Kept Svelte-free so node --test can exercise it.
+//
+// Never returns a rate above 48 kHz. A corrupt persisted 96000 (from an
+// ALSA plughw device that advertises a synthetic resample range while the
+// codec really runs 48 kHz) desyncs the modem demodulator — every frame
+// fails FCS and RX goes silent. 48 kHz serves every Graywolf modem mode.
+const MAX = 48000;
+
+export function pickDefaultSampleRate(rates) {
+  const list = Array.isArray(rates) ? rates.filter((r) => Number.isFinite(r)) : [];
+  if (list.includes(MAX)) return MAX;
+  if (list.includes(44100)) return 44100;
+  const atOrBelow = list.filter((r) => r <= MAX);
+  if (atOrBelow.length > 0) return Math.max(...atOrBelow);
+  return MAX;
+}

--- a/web/src/lib/sampleRate.test.js
+++ b/web/src/lib/sampleRate.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { pickDefaultSampleRate } from './sampleRate.js';
+
+test('prefers 48000 when offered', () => {
+  assert.equal(pickDefaultSampleRate([8000, 11025, 16000, 22050, 44100, 48000]), 48000);
+  // Even when a higher (corrupt) rate is present, never pick above 48k.
+  assert.equal(pickDefaultSampleRate([48000, 96000]), 48000);
+});
+
+test('falls back to 44100 when 48000 absent', () => {
+  assert.equal(pickDefaultSampleRate([8000, 44100]), 44100);
+});
+
+test('otherwise picks the highest rate at or below 48000', () => {
+  assert.equal(pickDefaultSampleRate([8000, 16000, 32000]), 32000);
+});
+
+test('never returns a rate above 48000; defaults safely', () => {
+  assert.equal(pickDefaultSampleRate([96000, 192000]), 48000);
+  assert.equal(pickDefaultSampleRate([]), 48000);
+  assert.equal(pickDefaultSampleRate(undefined), 48000);
+  assert.equal(pickDefaultSampleRate(null), 48000);
+});

--- a/web/src/routes/AudioDevices.svelte
+++ b/web/src/routes/AudioDevices.svelte
@@ -3,6 +3,7 @@
   import { Button, Input, Select, Badge, AlertDialog, Checkbox } from '@chrissnell/chonky-ui';
   import { api } from '../lib/api.js';
   import { toasts } from '../lib/stores.js';
+  import { pickDefaultSampleRate } from '../lib/sampleRate.js';
   import PageHeader from '../components/PageHeader.svelte';
   import Modal from '../components/Modal.svelte';
   import FormField from '../components/FormField.svelte';
@@ -165,7 +166,7 @@
     form = {
       name: dev.description || dev.name,
       device_path: dev.path,
-      sample_rate: String((dev.sample_rates || [48000]).at(-1)),
+      sample_rate: String(pickDefaultSampleRate(dev.sample_rates)),
       source_type: 'soundcard',
       direction: dev.is_input ? 'input' : 'output',
     };
@@ -481,7 +482,6 @@
       { value: '16000', label: '16000 Hz' },
       { value: '44100', label: '44100 Hz' },
       { value: '48000', label: '48000 Hz' },
-      { value: '96000', label: '96000 Hz' },
     ]} />
   </FormField>
   <div class="modal-actions">


### PR DESCRIPTION
## Problem

RX went fully silent on a production digi (anguilla.local). Investigation surfaced **three independent real defects** in the audio path; the first two are fixed here, the third was an analog issue at the site (radio audio overdriving the AIOC ADC into hard clipping — fixed by the operator lowering the radio's audio output).

### 1. Corrupt persisted sample rate (96 kHz)
An ALSA `plughw:`/`default` PCM advertises a synthetic resample range up to 192 kHz via cpal even though the codec runs 48 kHz. The Audio Devices form auto-filled the **highest** advertised rate (`.at(-1)`), so "Detect Devices" persisted `sample_rate=96000`. The modem opened at 96000 while hardware ran 48000 → demod bit timing 2× off → every frame failed FCS, RX silent, no error.

### 2. cpal `default_input_config()` = F32 → POLLERR loop
`spawn()` opened the capture stream using `device.default_input_config().sample_format()`. On a `plughw:`/`default` PCM that is **F32**; opening F32 on a full-speed USB radio codec (AIOC) makes `alsa::poll()` return `POLLERR` every period — rebuild, POLLERR, forever (**24,344 errors in one session**, RX stuck at zero, no fatal error). The same hardware streams native **I16** cleanly (`arecord -f S16_LE` and the detection probe both work). The probe already chose I16; the runtime didn't — it verified a config it never used.

## Fix (defense in depth)

| Layer | Change |
|-------|--------|
| Enumeration | Drop 96000 from `STANDARD_SAMPLE_RATES`; add `MODEM_MAX_SAMPLE_RATE=48000` + `rate_invariants` tests |
| UI | `pickDefaultSampleRate` prefers 48000 → 44100 → highest ≤48 kHz, never above; remove 96000 from manual select |
| Runtime rate backstop | `soundcard::choose_stream_rate` honors requested rate only when ≤48 kHz **and** in a real supported range, else device-native clamped to ceiling; `AudioSource.sample_rate` reports the rate actually opened |
| Runtime format fix | `soundcard::pick_input_sample_format` selects the format the device advertises at the chosen rate, preferring native **I16**; `spawn()` never trusts `default_input_config()`. Shares `input_format_rank` with the detection probe so they can't drift |
| Migration | v21 `audio_devices_clamp_sample_rate` repairs already-corrupted field DBs (`sample_rate>48000 → 48000`) |

Wiki invariants 31 (≤48 kHz, three layers) and 32 (capture format is device-advertised, never `default_input_config()`).

## Tests (TDD, RED→GREEN)

- Rust: `rate_invariants` (2), `choose_stream_rate` (3), `pick_input_sample_format` (3) — full modem lib suite **171/171**
- Web: `sampleRate.test.js` (4) — node `--test`
- Go: `TestMigrateClampAudioSampleRate` (clamp + idempotence) — `pkg/configstore` suite green
- `go build ./...`, `pkg/modembridge` + `pkg/webapi` green, `vite build` green

## Field validation (anguilla.local)

- POLLERR **24,344 → 0** after the capture path opened native I16 (validated by repointing `source_path` to the raw `hw:` PCM, which only advertises I16; the format fix achieves the same for the persisted `plughw:` path since `arecord -f S16_LE` on `plughw:` streams clean).
- After the operator corrected the over-hot analog input level, RX decodes (`rx_frames` climbing, `rx_bad_fcs=0`).

## Out of scope / notes

- Pre-existing unrelated failing web test `web/src/lib/settings/messages-preferences-store.test.js` on `main`; untouched.
- Same corruption event also orphaned channels 1–4 (digipeater/tx_timing referrers) on anguilla — config-hygiene follow-up, separate.
- Defect #3 (analog clipping) was a site wiring/level issue, no code change.