### PR TITLE
fix: channel-picker tooltip no longer shows phantom 'no audio input device' on KISS-only channels

### DIFF
--- a/pkg/webapi/channels.go
+++ b/pkg/webapi/channels.go
@@ -234,9 +234,11 @@ func computeChannelBacking(
 	// rejecting zero; the pointer check is the authoritative signal.
 	hasModem := ch.InputDeviceID != nil
 	modem := dto.ChannelModemBacking{Active: hasModem && modemRunning}
-	if !hasModem {
-		modem.Reason = "no audio input device"
-	} else if !modemRunning {
+	// A channel with no audio input device has no modem at all; the
+	// modem sub-object is dead state. Leaving Reason empty stops it
+	// leaking through the channel-picker tooltip on KISS-only and
+	// unbound channels (the summary already conveys the real state).
+	if hasModem && !modemRunning {
 		modem.Reason = "modem subprocess not running"
 	}
 

--- a/pkg/webapi/channels_backing_test.go
+++ b/pkg/webapi/channels_backing_test.go
@@ -86,6 +86,51 @@ func TestComputeChannelBacking_TxCapabilityMatrix(t *testing.T) {
 	}
 }
 
+// TestComputeChannelBacking_ModemReason asserts the modem sub-object's
+// Reason is empty whenever no audio modem is configured (InputDeviceID
+// == nil), regardless of whether a KISS-TNC is attached. The string
+// "no audio input device" must only ever describe a real modem.
+func TestComputeChannelBacking_ModemReason(t *testing.T) {
+	u := configstore.U32Ptr
+
+	t.Run("kiss-only channel: modem reason empty, summary kiss-tnc", func(t *testing.T) {
+		ch := configstore.Channel{ID: 42, Name: "ch", InputDeviceID: nil}
+		ifaces := []configstore.KissInterface{
+			{ID: 7, Name: "tnc", Channel: 42, Mode: configstore.KissModeTnc},
+		}
+		statuses := map[uint32]kiss.InterfaceStatus{7: {State: kiss.StateConnected}}
+		b := computeChannelBacking(ch, ifaces, statuses, false)
+		if b.Modem.Reason != "" {
+			t.Errorf("Modem.Reason = %q, want \"\"", b.Modem.Reason)
+		}
+		if b.Summary != dto.ChannelBackingSummaryKissTnc {
+			t.Errorf("Summary = %q, want kiss-tnc", b.Summary)
+		}
+	})
+
+	t.Run("unbound channel: modem reason empty", func(t *testing.T) {
+		ch := configstore.Channel{ID: 43, Name: "u", InputDeviceID: nil}
+		b := computeChannelBacking(ch, nil, nil, false)
+		if b.Modem.Reason != "" {
+			t.Errorf("Modem.Reason = %q, want \"\"", b.Modem.Reason)
+		}
+	})
+
+	t.Run("modem channel, subprocess down: reason still set", func(t *testing.T) {
+		ch := configstore.Channel{ID: 44, Name: "m", InputDeviceID: u(1), OutputDeviceID: 2}
+		b := computeChannelBacking(ch, nil, nil, false)
+		if b.Modem.Reason != "modem subprocess not running" {
+			t.Errorf("Modem.Reason = %q, want \"modem subprocess not running\"", b.Modem.Reason)
+		}
+		if b.Modem.Active != false {
+			t.Errorf("Modem.Active = %v, want false", b.Modem.Active)
+		}
+		if b.Summary != dto.ChannelBackingSummaryModem {
+			t.Errorf("Summary = %q, want %q", b.Summary, dto.ChannelBackingSummaryModem)
+		}
+	})
+}
+
 // TestComputeChannelBacking_TxIgnoresKissModemMode asserts that KISS
 // interfaces in modem-mode (not TNC-mode) do NOT count as a TX backend
 // — they are phase-3 TX paths for the modem, not for the governor.

--- a/pkg/webapi/channels_test.go
+++ b/pkg/webapi/channels_test.go
@@ -251,8 +251,11 @@ func TestComputeChannelBacking_Unbound(t *testing.T) {
 	if b.Modem.Active {
 		t.Errorf("modem.active should be false")
 	}
-	if b.Modem.Reason == "" {
-		t.Errorf("expected reason on unbound modem")
+	// Modem.Reason must be empty on an unbound channel: no audio
+	// modem was ever configured, so the modem sub-object is dead
+	// state. The summary already conveys the real state.
+	if b.Modem.Reason != "" {
+		t.Errorf("modem.reason = %q, want \"\"", b.Modem.Reason)
 	}
 }
 

--- a/pkg/webapi/dto/channel.go
+++ b/pkg/webapi/dto/channel.go
@@ -196,8 +196,10 @@ const (
 
 // ChannelModemBacking reports whether an audio modem currently serves
 // this channel. Active is true when the channel has a bound input audio
-// device and the modem subprocess is running. Reason is populated when
-// Active is false; empty otherwise.
+// device and the modem subprocess is running. Reason is populated only
+// when a modem is configured but its subprocess is not running; it is
+// empty for a running modem and for channels with no audio modem at all
+// (KISS-only or unbound), where the modem sub-object is dead state.
 type ChannelModemBacking struct {
 	Active bool   `json:"active"`
 	Reason string `json:"reason,omitempty"`

--- a/web/src/lib/channelBacking.js
+++ b/web/src/lib/channelBacking.js
@@ -73,15 +73,25 @@ export function ariaLabel(ch) {
   return parts.join(', ');
 }
 
-// Tooltip text: prefer an explicit modem reason; fall back to the
-// concatenated KISS-TNC last_error values. Empty when nothing to show.
+// Tooltip text, summary-aware so a KISS-only channel never shows the
+// modem's dead-state reason. Switch on backing.summary:
+//   kiss-tnc → joined non-empty kiss_tnc[].last_error
+//   modem    → modem.reason
+//   else     → '' (unbound / unknown — nothing to surface)
+// There is deliberately no SUMMARY_UNBOUND constant; unbound is the
+// default branch.
 export function tooltipText(backing) {
   if (!backing) return '';
-  if (backing.modem && backing.modem.reason) return backing.modem.reason;
-  const errs = (backing.kiss_tnc || [])
-    .map((e) => e.last_error)
-    .filter((s) => typeof s === 'string' && s.length > 0);
-  return errs.join('; ');
+  if (backing.summary === SUMMARY_KISS_TNC) {
+    const errs = (backing.kiss_tnc || [])
+      .map((e) => e.last_error)
+      .filter((s) => typeof s === 'string' && s.length > 0);
+    return errs.join('; ');
+  }
+  if (backing.summary === SUMMARY_MODEM) {
+    return backing.modem && backing.modem.reason ? backing.modem.reason : '';
+  }
+  return '';
 }
 
 // TX-capability reason wire constants. Mirror of

--- a/web/src/lib/channelBacking.test.js
+++ b/web/src/lib/channelBacking.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  tooltipText,
+  SUMMARY_MODEM,
+  SUMMARY_KISS_TNC,
+} from './channelBacking.js';
+
+test('tooltipText: kiss-tnc summary joins kiss errors, never modem reason', () => {
+  const backing = {
+    summary: SUMMARY_KISS_TNC,
+    modem: { reason: 'no audio input device' },
+    kiss_tnc: [
+      { last_error: 'serial open failed: permission denied' },
+      { last_error: '' },
+      { last_error: 'device closed' },
+    ],
+  };
+  assert.equal(
+    tooltipText(backing),
+    'serial open failed: permission denied; device closed',
+  );
+});
+
+test('tooltipText: kiss-tnc summary with no errors is empty', () => {
+  const backing = {
+    summary: SUMMARY_KISS_TNC,
+    modem: { reason: 'no audio input device' },
+    kiss_tnc: [{ last_error: '' }],
+  };
+  assert.equal(tooltipText(backing), '');
+});
+
+test('tooltipText: modem summary returns modem reason', () => {
+  const backing = {
+    summary: SUMMARY_MODEM,
+    modem: { reason: 'modem subprocess not running' },
+    kiss_tnc: [],
+  };
+  assert.equal(tooltipText(backing), 'modem subprocess not running');
+});
+
+test('tooltipText: unbound / unknown summary is empty', () => {
+  assert.equal(tooltipText({ summary: 'unbound', modem: { reason: 'x' } }), '');
+  assert.equal(tooltipText(null), '');
+  assert.equal(tooltipText({}), '');
+  assert.equal(tooltipText({ summary: SUMMARY_KISS_TNC }), '');
+  assert.equal(tooltipText({ summary: SUMMARY_MODEM }), '');
+});


### PR DESCRIPTION
## Summary

Operator bug: the channel-picker tooltip wrongly displayed **"no audio input device"** on KISS-only channels (a channel backed by a TNC but no audio modem). The modem sub-object is meaningless dead state on such channels, but both the server and the client surfaced its reason string.

This is **PR 1 of 2** from the KISS serial transport plan — an independent, standalone tooltip fix intended for a **patch release**. PR 2 (serial transport, minor release) follows separately and does not depend on this.

## Changes

**Server (`336619b`)** — `pkg/webapi`
- `computeChannelBacking` only sets `modem.Reason` when a real modem exists and its subprocess is down (`hasModem && !modemRunning`). KISS-only / unbound channels now get an empty `modem.Reason`; the `summary` already conveys the real state.
- `ChannelModemBacking` DTO doc-invariant comment corrected to match the new contract (it had asserted `Reason` is set whenever `Active` is false).
- New `TestComputeChannelBacking_ModemReason`; one pre-existing test that encoded the old buggy behavior updated to the new contract (not skipped).

**Client (`0420f17`)** — `web/src/lib/channelBacking.js`
- `tooltipText` is now summary-aware: switches on `backing.summary` first (`kiss-tnc` → joined non-empty `kiss_tnc[].last_error`; `modem` → `modem.reason`; else → `''`) instead of reading `modem.reason` before the summary.
- New `web/src/lib/channelBacking.test.js` (4 cases, all branches incl. the trap case).

Defense-in-depth: each side is independently correct, so a rolling restart (old server / new client or vice versa) still renders the right tooltip.

## End-to-end behavior

| Channel state | Operator sees |
|---|---|
| Modem running | empty (healthy) |
| Modem subprocess down | "modem subprocess not running" |
| KISS-only, TNC `last_error` set | the real TNC error text |
| KISS-only, no errors | empty (**the original complaint, fixed**) |
| Unbound | empty |

No legitimate tooltip regressed.

## Tests

- `go test ./pkg/webapi/` — ok
- `go vet ./pkg/webapi/` — clean
- web `npm test` — 160/160 pass (4 new)

## Release

Patch release per the project release workflow, to be cut after merge.