### PR TITLE
feat(web): promote Logs to a top-level nav tab

### DIFF
--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -19,6 +19,7 @@
     { path: '/messages', label: 'Messages', icon: 'message-square', badge: 'messages' },
     { path: '/terminal', label: 'Terminal', svgIcon: 'terminal', badge: 'terminal' },
     { path: '/actions', label: 'Actions', svgIcon: 'zap' },
+    { path: '/logs', label: 'Logs', svgIcon: 'logs' },
   ];
 
   const navGroups = [
@@ -34,7 +35,6 @@
         { path: '/gps', label: 'GPS' },
         { path: '/igate', label: 'iGate' },
         { path: '/kiss', label: 'KISS' },
-        { path: '/logs', label: 'Logs' },
         { path: '/preferences/maps', label: 'Maps' },
         { path: '/preferences/messages', label: 'Messaging' },
         { path: '/position-log', label: 'Position Log' },
@@ -206,6 +206,23 @@
                 stroke-linejoin="round"
               >
                 <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+              </svg>
+            {:else if item.svgIcon === 'logs'}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
+                <path d="M14 3v5h5" />
+                <line x1="9" y1="13" x2="15" y2="13" />
+                <line x1="9" y1="17" x2="15" y2="17" />
               </svg>
             {/if}
             {#if unread > 0}


### PR DESCRIPTION
Moves the **Logs** entry out of the Settings group and into the main top-level nav, placed directly below **Actions**.

## Changes
- `web/src/components/Sidebar.svelte`
  - Removed `{ path: '/logs', label: 'Logs' }` from the Settings `navGroups` list.
  - Added `{ path: '/logs', label: 'Logs', svgIcon: 'logs' }` to `mainItems`, after Actions.
  - Added a new inline file-text SVG branch for `svgIcon === 'logs'` (chonky-ui's Lucide allowlist has no logs glyph, so this matches the existing inline-SVG pattern used by `globe`/`dashboard`/`terminal`/`zap`).

## Notes
- The `/logs` route itself is unchanged; only its nav placement moved.
- Sidebar and mobile drawer share the same nav snippet, so both update together. The mobile top bar hardcodes only Dashboard/Map/Messages/Terminal, so no change needed there.
- Verified: Svelte compile clean, no warnings; exactly one `/logs` nav entry.