### PR TITLE
fix(android): persist + restore channel PTT method (repairs AIOC PTT)

### DIFF
--- a/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
@@ -22,8 +22,11 @@ import org.json.JSONObject
 
 /**
  * USB PTT adapter for POC-D. Owns the singletons that key/unkey radios via
- * USB wire toggling: CP2102N RTS for the Digirig PTT path, CM108 HID GPIO for
- * the AIOC path (and Digirig's secondary HID path).
+ * USB wire toggling: CP2102N RTS for the Digirig PTT path, CDC-ACM DTR (RTS
+ * held low) for the AIOC path, and CM108 HID GPIO for generic CM108-class
+ * hardware and Digirig's secondary HID path. (See AIOC inline note at line 54
+ * and POC-D results: AIOC firmware >=1.2.0 accepts HID Set_Report but does not
+ * drive the PTT GPIO; CDC-ACM is the actual PTT control path.)
  *
  * Lifecycle:
  *   GraywolfApp.onCreate    -> UsbPttAdapter.init(applicationContext)

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt
@@ -24,7 +24,7 @@ import org.json.JSONObject
  * USB PTT adapter for POC-D. Owns the singletons that key/unkey radios via
  * USB wire toggling: CP2102N RTS for the Digirig PTT path, CDC-ACM DTR (RTS
  * held low) for the AIOC path, and CM108 HID GPIO for generic CM108-class
- * hardware and Digirig's secondary HID path. (See AIOC inline note at line 54
+ * hardware and Digirig's secondary HID path. (See the AIOC inline note below
  * and POC-D results: AIOC firmware >=1.2.0 accepts HID Set_Report but does not
  * drive the PTT GPIO; CDC-ACM is the actual PTT control path.)
  *

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -112,6 +112,15 @@ Source: [`../../pkg/webapi/ptt.go`](../../pkg/webapi/ptt.go) (`validatePttChanne
 [`../../pkg/webapi/ptt_test.go`](../../pkg/webapi/ptt_test.go) (`TestPttRejectsKissOnlyChannel`);
 [`../../web/src/routes/Ptt.svelte`](../../web/src/routes/Ptt.svelte) (`modemChannels` filter).
 
+### 9c. Android PTT method rides in `gpio_pin`; every PTT read path must round-trip it
+
+*Why:* On Android there is no dedicated PTT-method column. The Channels modal sends `POST /api/ptt {method:"android", gpio_pin:N}` where `N` is the method int from spec Appendix B (1 = CP2102N RTS / Digirig, 2 = CM108 HID, 3 = AIOC CDC-ACM DTR, 4 = VOX). That int rides in `PttConfig.GpioPin` the whole way: configstore → `session.go` (which must NOT zero `gpio_pin` for `method=="android"` — it only zeroes it for `method=="gpio"`) → `ConfigurePtt.GpioPin` → Rust `build_driver` (`PttMethod::Android` does `let method = cfg.gpio_pin as i32`) → `AndroidPtt` → JNI → Kotlin `UsbPttAdapter.pttSet`. Therefore **any response DTO or read path that surfaces a channel's PTT must carry `gpio_pin`**. If it doesn't, the edit modal can't restore the selected method, falls back to CP2102N, and the next save of that channel POSTs `gpio_pin=1`, silently downgrading a saved AIOC/CM108 config to CP2102N (this was the `ChannelPtt`-DTO bug fixed in #149). The Kotlin doc was correspondingly wrong: AIOC keys via CDC-ACM DTR (RTS held low), not CM108 HID GPIO.
+
+Source: [`../../pkg/webapi/dto/channel.go`](../../pkg/webapi/dto/channel.go) (`ChannelPtt.GpioPin`, `ChannelPttFromModel`);
+[`../../pkg/modembridge/session.go`](../../pkg/modembridge/session.go) (`gpioPin` zeroed only for `method=="gpio"`);
+[`../../graywolf-modem/src/tx/ptt.rs`](../../graywolf-modem/src/tx/ptt.rs) (`PttMethod::Android` arm);
+[`../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt) (`pttSet`, `setAiocRts`).
+
 ### 10. Gitignored output dirs are not canonical
 
 *Why:* `target/`, `bin/`, `dist/`, `rust-bin/`, `rust-artifacts/`, `web/dist/`, `.worktrees/`, `.context/`, `*.db*` regenerate from sources and are gitignored, so never reference them as authoritative.

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -8429,6 +8429,10 @@
                 "detail": {
                     "type": "string"
                 },
+                "gpio_pin": {
+                    "description": "GpioPin carries the CM108 HID pin (cm108 method) and, on Android,\nthe PTT method int (1..4, spec Appendix B) reused as a carrier so\nthe channel edit modal can restore the selected method. 0 = unset.",
+                    "type": "integer"
+                },
                 "method": {
                     "type": "string"
                 }

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -1044,6 +1044,12 @@ definitions:
         type: boolean
       detail:
         type: string
+      gpio_pin:
+        description: |-
+          GpioPin carries the CM108 HID pin (cm108 method) and, on Android,
+          the PTT method int (1..4, spec Appendix B) reused as a carrier so
+          the channel edit modal can restore the selected method. 0 = unset.
+        type: integer
       method:
         type: string
     type: object

--- a/pkg/webapi/dto/channel.go
+++ b/pkg/webapi/dto/channel.go
@@ -136,6 +136,10 @@ type ChannelPtt struct {
 	Method     string `json:"method"`
 	Configured bool   `json:"configured"`
 	Detail     string `json:"detail,omitempty"`
+	// GpioPin carries the CM108 HID pin (cm108 method) and, on Android,
+	// the PTT method int (1..4, spec Appendix B) reused as a carrier so
+	// the channel edit modal can restore the selected method. 0 = unset.
+	GpioPin uint32 `json:"gpio_pin,omitempty"`
 }
 
 // ChannelBacking describes the runtime backing — modem and/or KISS-TNC
@@ -258,6 +262,7 @@ func ChannelPttFromModel(p configstore.PttConfig) ChannelPtt {
 		Method:     method,
 		Configured: method != PttMethodNone,
 		Detail:     pttDetail(p, method),
+		GpioPin:    p.GpioPin,
 	}
 }
 

--- a/pkg/webapi/dto/channel_test.go
+++ b/pkg/webapi/dto/channel_test.go
@@ -217,3 +217,17 @@ func TestChannelPttFromModel(t *testing.T) {
 		})
 	}
 }
+
+// TestChannelPttFromModel_GpioPin verifies that the GPIO pin (CM108 HID pin
+// and Android PTT method int) round-trips through the DTO so the channel edit
+// modal can restore the selected method.
+func TestChannelPttFromModel_GpioPin(t *testing.T) {
+	in := configstore.PttConfig{ChannelID: 7, Method: "android", GpioPin: 3}
+	got := ChannelPttFromModel(in)
+	if got.Method != "android" {
+		t.Fatalf("method: got %q want android", got.Method)
+	}
+	if got.GpioPin != 3 {
+		t.Fatalf("gpio_pin: got %d want 3 (AIOC method int must round-trip to the SPA modal)", got.GpioPin)
+	}
+}

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2287,6 +2287,12 @@ export interface components {
         "dto.ChannelPtt": {
             configured?: boolean;
             detail?: string;
+            /**
+             * @description GpioPin carries the CM108 HID pin (cm108 method) and, on Android,
+             *     the PTT method int (1..4, spec Appendix B) reused as a carrier so
+             *     the channel edit modal can restore the selected method. 0 = unset.
+             */
+            gpio_pin?: number;
             method?: string;
         };
         "dto.ChannelRequest": {

--- a/web/src/lib/channelPtt.roundtrip.test.js
+++ b/web/src/lib/channelPtt.roundtrip.test.js
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Contract: GET /api/channels .ptt for an Android channel MUST include
+// gpio_pin so ChannelEditModal can restore androidPttMethod. This mirrors
+// the restore predicate in ChannelEditModal.svelte (row.ptt?.method ===
+// 'android' && row.ptt?.gpio_pin).
+test('android ptt row exposes gpio_pin for modal restore', () => {
+  const row = { id: 1, ptt: { method: 'android', configured: true, gpio_pin: 3 } };
+  const restored =
+    row.ptt?.method === 'android' && row.ptt?.gpio_pin ? row.ptt.gpio_pin : 1;
+  assert.equal(restored, 3, 'AIOC (3) must restore, not fall back to CP2102N (1)');
+});


### PR DESCRIPTION
## Summary

- `GET /api/channels` dropped `ptt.gpio_pin` from the `ChannelPtt` response DTO, so the channel-edit modal could never restore the Android PTT method and reset to the CP2102N default on every open. Worse, the next save of any channel then POSTed `gpio_pin=1`, **silently overwriting a persisted AIOC config (gpio_pin=3) with CP2102N** -- which is why AIOC PTT "stopped working."
- Fix: carry `gpio_pin` through `ChannelPtt` / `ChannelPttFromModel` (additive, `omitempty` -> backward compatible). The rest of the chain (write path, `session.go`, Rust `build_driver`, Kotlin `setAiocRts` DTR/RTS) was already correct -- verified by tracing against POC-D.
- OpenAPI spec regenerated; web round-trip contract test added; corrected the `UsbPttAdapter` class doc that wrongly claimed AIOC keys via CM108 HID (it is CDC-ACM DTR, per POC-D).

Follows #147 (phases 2-4c, merged). 5 commits, isolated to the PTT round-trip.

## Test Plan

- [x] `go test ./pkg/webapi/dto/ ./pkg/webapi/` -- pass
- [x] web `node --test` channel suites -- 13/13 pass
- [x] `make docs-check` -- no OpenAPI drift
- [x] On-device (Topicon T865 + AIOC): set PTT=AIOC, save, reopen -> shows AIOC; re-save unrelated field -> still AIOC (no clobber); PTT test keys the radio