### PR TITLE
Limit select dropdown height and make it scroll for #150

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -106,6 +106,15 @@ input, select, textarea, button {
   line-height: 1;
 }
 
+/* chonky-ui's Select dropdown (bits-ui [data-select-content]) sets no
+   max-height, so a long option list (e.g. SymbolPicker's 37-entry
+   overlay-character menu) grows past the viewport. Cap it at roughly
+   seven rows and scroll the rest. */
+[data-select-content] {
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar {
   width: 8px;


### PR DESCRIPTION
First time really digging into svelte, so this probably gets low style points. Maybe you want this PR on https://github.com/chrissnell/chonky/blob/main/packages/chonky-ui/src/lib/css/chonky.css instead of in graywolf.

Fixes #150 