### PR TITLE
build(release): add 32-bit ARM (armhf) Linux build for older Raspberry Pi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
             arch: arm64
             platform: linux
             use_cross: true
+          - os: ubuntu-latest
+            target: arm-unknown-linux-gnueabihf
+            arch: arm
+            platform: linux
+            use_cross: true
           - os: macos-15
             target: x86_64-apple-darwin
             arch: amd64
@@ -180,9 +185,10 @@ jobs:
 
       - name: Arrange Rust binaries for GoReleaser
         run: |
-          mkdir -p rust-bin/{linux_amd64,linux_arm64,darwin_amd64,darwin_arm64,windows_amd64}
+          mkdir -p rust-bin/{linux_amd64,linux_arm64,linux_arm,darwin_amd64,darwin_arm64,windows_amd64}
           cp rust-artifacts/rust-linux-amd64/graywolf-modem       rust-bin/linux_amd64/
           cp rust-artifacts/rust-linux-arm64/graywolf-modem       rust-bin/linux_arm64/
+          cp rust-artifacts/rust-linux-arm/graywolf-modem         rust-bin/linux_arm/
           cp rust-artifacts/rust-darwin-amd64/graywolf-modem      rust-bin/darwin_amd64/
           cp rust-artifacts/rust-darwin-arm64/graywolf-modem      rust-bin/darwin_arm64/
           cp rust-artifacts/rust-windows-amd64/graywolf-modem.exe rust-bin/windows_amd64/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,9 +24,16 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - "6"
     ignore:
       - goos: windows
         goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: darwin
+        goarch: arm
 
 archives:
   - id: graywolf
@@ -39,6 +46,7 @@ archives:
       {{- .Version }}_
       {{- if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_
       {{- if eq .Arch "amd64" }}x86_64
+      {{- else if and (eq .Arch "arm") (eq .Arm "6") }}armv6l
       {{- else }}{{ .Arch }}{{ end }}
     files:
       - LICENSE*

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,3 +2,11 @@
 pre-build = [
     "dpkg --add-architecture arm64 && apt-get update && apt-get install -y libasound2-dev:arm64 libudev-dev:arm64 unzip && curl -Lo /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip && unzip -o /tmp/protoc.zip -d /usr/local bin/protoc && chmod +x /usr/local/bin/protoc && rm /tmp/protoc.zip",
 ]
+
+# 32-bit ARMv6 hard-float for Raspbian on older Raspberry Pi (Pi 1, Pi 2,
+# original Pi Zero / Zero W). Cortex-A7 (Pi 2) is ARMv7 but runs ARMv6
+# binaries, so a single armv6 build covers all 32-bit Pi models.
+[target.arm-unknown-linux-gnueabihf]
+pre-build = [
+    "dpkg --add-architecture armhf && apt-get update && apt-get install -y libasound2-dev:armhf libudev-dev:armhf unzip && curl -Lo /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip && unzip -o /tmp/protoc.zip -d /usr/local bin/protoc && chmod +x /usr/local/bin/protoc && rm /tmp/protoc.zip",
+]

--- a/docs/handbook/installation.html
+++ b/docs/handbook/installation.html
@@ -85,7 +85,9 @@
 
         <p>
           Download the <code>.deb</code> package for your architecture
-          (amd64 or arm64) from the
+          (<code>amd64</code>, <code>arm64</code>, or <code>armhf</code> for
+          older 32-bit Raspberry Pi hardware -- Pi 1, Pi 2, Pi Zero, Zero W)
+          from the
           <a href="https://github.com/chrissnell/graywolf/releases">GitHub Releases</a>
           page, then install it:
         </p>

--- a/docs/wiki/build-pipelines.md
+++ b/docs/wiki/build-pipelines.md
@@ -11,6 +11,7 @@ Release pipeline definition: [`../../.goreleaser.yml`](../../.goreleaser.yml).
 | Go binary + web only (skip Rust) | `make graywolf-quick` (= `web` + `go build`) | same as above, minus `target/release/graywolf-modem` | `bin/graywolf` only; reuses existing `bin/graywolf-modem` | Manual; safe when `proto/` + `VERSION` unchanged |
 | Rust modem (native dev) | `make release` | `graywolf-modem/`, `proto/graywolf.proto`, `VERSION` | `target/release/graywolf-modem` (workspace root, not `graywolf-modem/target/`) | Manual; see [invariant 1](invariants.md) |
 | Rust modem (cross arm64) | `cross` per [`../../Cross.toml`](../../Cross.toml) | same + Docker image with aarch64 ALSA/udev libs and protoc | `target/<triple>/release/graywolf-modem` | Release CI |
+| Rust modem (cross armv6) | `cross` per [`../../Cross.toml`](../../Cross.toml) target `arm-unknown-linux-gnueabihf` | same + Docker image with armhf ALSA/udev libs and protoc | `target/arm-unknown-linux-gnueabihf/release/graywolf-modem` | Release CI; one ARMv6 build covers Pi 1, Pi 2, Pi Zero / Zero W (Pi 2 is ARMv7 but runs ARMv6 binaries) |
 | Web UI | `make web` (`npm install`, `npm run build`) | `web/src/`, `package.json`, themes, public, generated TS client | `web/dist/` (gitignored, then `go:embed` -- [invariant 12](invariants.md)) | Triggered by `make graywolf` / `make all` / `make api-client` |
 | TS API client | `make api-client` (`make docs` + `npm run api:generate`) | `pkg/webapi/docs/gen/swagger.{json,yaml}` | `web/src/api/generated/api.d.ts` (committed) | `make bump-*`; CI guard `api-client-check` |
 | Proto codegen (Go) | `make proto` (`protoc --go_out`) | [`../../proto/graywolf.proto`](../../proto/graywolf.proto) | `pkg/ipcproto/graywolf.pb.go` (committed) | Manual after proto edits |
@@ -24,7 +25,7 @@ Release pipeline definition: [`../../.goreleaser.yml`](../../.goreleaser.yml).
 | OCI image | goreleaser `dockers:` + [`../../Dockerfile.goreleaser`](../../Dockerfile.goreleaser), [`../../Dockerfile.goreleaser.arm64`](../../Dockerfile.goreleaser.arm64) | Go binary + `graywolf-modem-{amd64,arm64}` | `ghcr.io/chrissnell/graywolf:<tag>-{amd64,arm64}`, manifest list `:<tag>` and `:latest` | Tag push |
 | Arch AUR | [`../../packaging/aur/PKGBUILD`](../../packaging/aur/PKGBUILD) (pkgname `graywolf-aprs`) | github archive of the tag, `.service`, `.sysusers` | AUR (off-repo upload by maintainer) | `make bump-*` rewrites `pkgver` in `PKGBUILD` and `.SRCINFO` |
 | Windows NSIS installer | [`../../packaging/nsis/graywolf.nsi`](../../packaging/nsis/graywolf.nsi) (`makensis`) | `BINARY_PATH`, `MODEM_PATH`, `APP_VERSION`, `APP_VERSION_NUMERIC` | `graywolf_<ver>_Windows_x86_64.exe` | Manual; outside goreleaser |
-| Pre-built rust-bin (CI) | rust-build matrix in `.github/workflows/release.yml` | Per-target `cargo build --release` | `rust-bin/<os>_<arch>/graywolf-modem[.exe]`, plus top-level `graywolf-modem-{amd64,arm64}` for the docker context | Tag push |
+| Pre-built rust-bin (CI) | rust-build matrix in `.github/workflows/release.yml` | Per-target `cargo build --release` (Linux amd64, arm64, arm; macOS amd64, arm64; Windows amd64) | `rust-bin/<os>_<arch>/graywolf-modem[.exe]`, plus top-level `graywolf-modem-{amd64,arm64}` for the docker context (no 32-bit ARM docker image) | Tag push |
 
 ## CI workflows
 


### PR DESCRIPTION
## Summary
- Adds `goarch: arm` with `goarm: 6` to the goreleaser build matrix, plus a matching `arm-unknown-linux-gnueabihf` cross-rs target so the Rust modem cross-compiles for armhf in CI.
- Extends the `rust-build` matrix in `.github/workflows/release.yml` with the new Linux/arm cross target and arranges the artifact under `rust-bin/linux_arm/` for goreleaser's nfpm packaging.
- One ARMv6 build covers Pi 1, Pi 2, Pi Zero and Zero W -- Pi 2's Cortex-A7 is ARMv7 but happily executes ARMv6 binaries, so a single artifact serves the 32-bit Pi lineup.
- Ships as `graywolf_<ver>_armhf.deb` (debian) and `graywolf_<ver>_linux_armv6l.tar.gz` (tarball). No 32-bit ARM Docker image; the OCI manifest stays amd64/arm64 only.
- Handbook + wiki updated to reflect the new arch.

## Test plan
- [ ] Push the branch and watch the `Rust (linux-arm)` matrix job build the modem with cross.
- [ ] On a tag push, confirm goreleaser produces `graywolf_<ver>_armhf.deb` and `graywolf_<ver>_linux_armv6l.tar.gz` artifacts.
- [ ] Install the `.deb` on a Pi 1 / Pi Zero / Pi Zero W running Raspbian and verify `graywolf` + `graywolf-modem` start under systemd.
- [ ] Spot-check on a Pi 2 (ARMv7) that the same `.deb` runs.

Refs #153