### PR TITLE
feat(android): carry PTT transport in dedicated ptt_method field

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -112,12 +112,13 @@ Source: [`../../pkg/webapi/ptt.go`](../../pkg/webapi/ptt.go) (`validatePttChanne
 [`../../pkg/webapi/ptt_test.go`](../../pkg/webapi/ptt_test.go) (`TestPttRejectsKissOnlyChannel`);
 [`../../web/src/routes/Ptt.svelte`](../../web/src/routes/Ptt.svelte) (`modemChannels` filter).
 
-### 9c. Android PTT method rides in `gpio_pin`; every PTT read path must round-trip it
+### 9c. Android PTT transport is a first-class `ptt_method`; `gpio_pin` is CM108-only
 
-*Why:* On Android there is no dedicated PTT-method column. The Channels modal sends `POST /api/ptt {method:"android", gpio_pin:N}` where `N` is the method int from spec Appendix B (1 = CP2102N RTS / Digirig, 2 = CM108 HID, 3 = AIOC CDC-ACM DTR, 4 = VOX). That int rides in `PttConfig.GpioPin` the whole way: configstore → `session.go` (which must NOT zero `gpio_pin` for `method=="android"` — it only zeroes it for `method=="gpio"`) → `ConfigurePtt.GpioPin` → Rust `build_driver` (`PttMethod::Android` does `let method = cfg.gpio_pin as i32`) → `AndroidPtt` → JNI → Kotlin `UsbPttAdapter.pttSet`. Therefore **any response DTO or read path that surfaces a channel's PTT must carry `gpio_pin`**. If it doesn't, the edit modal can't restore the selected method, falls back to CP2102N, and the next save of that channel POSTs `gpio_pin=1`, silently downgrading a saved AIOC/CM108 config to CP2102N (this was the `ChannelPtt`-DTO bug fixed in #149). The Kotlin doc was correspondingly wrong: AIOC keys via CDC-ACM DTR (RTS held low), not CM108 HID GPIO.
+*Why:* The Android per-channel PTT transport (PttMethod enum, spec Appendix B: 1 = CP2102N RTS / Digirig, 2 = CM108 HID, 3 = AIOC CDC-ACM DTR, 4 = VOX) travels in its own field the whole way: SPA `POST /api/ptt {method:"android", ptt_method:N}` → `PttConfig.PttMethod` → `session.go` → `ConfigurePtt.ptt_method` (a `uint32`, deliberately not the `platform.proto` enum, to keep `graywolf.proto` self-contained — invariant #2) → Rust `build_driver` (`PttMethod::Android` does `let method = cfg.ptt_method as i32`) → `AndroidPtt` → JNI → Kotlin `UsbPttAdapter.pttSet`. `method=="android"` is only the coarse subsystem discriminator. **`gpio_pin` is the CM108 HID pin and nothing else** — it must never carry the Android transport (an earlier build did, via a `method=="android"` sentinel, which silently downgraded saved AIOC configs to CP2102N on re-save when a response DTO dropped the field; removed by migration v22 `ptt_android_method_field`).
 
-Source: [`../../pkg/webapi/dto/channel.go`](../../pkg/webapi/dto/channel.go) (`ChannelPtt.GpioPin`, `ChannelPttFromModel`);
-[`../../pkg/modembridge/session.go`](../../pkg/modembridge/session.go) (`gpioPin` zeroed only for `method=="gpio"`);
+Source: [`../../pkg/webapi/dto/channel.go`](../../pkg/webapi/dto/channel.go) (`ChannelPtt.PttMethod`, `ChannelPttFromModel`);
+[`../../pkg/configstore/migrate.go`](../../pkg/configstore/migrate.go) (`migratePttAndroidMethodField`, v22);
+[`../../pkg/modembridge/session.go`](../../pkg/modembridge/session.go) (`ConfigurePtt` construction, `PttMethod` field);
 [`../../graywolf-modem/src/tx/ptt.rs`](../../graywolf-modem/src/tx/ptt.rs) (`PttMethod::Android` arm);
 [`../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt) (`pttSet`, `setAiocRts`).
 

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -2470,6 +2470,7 @@ mod tests {
                 invert: false,
                 gpio_pin: 3,
                 gpio_line: 0,
+                ptt_method: 0,
             })),
         };
         assert!(!modem.handle_ipc(msg));
@@ -2511,6 +2512,7 @@ mod tests {
                 invert: false,
                 gpio_pin: 3,
                 gpio_line: 0,
+                ptt_method: 0,
             })),
         };
         assert!(!modem.handle_ipc(msg));
@@ -2546,6 +2548,7 @@ mod tests {
                 invert: false,
                 gpio_pin: 3,
                 gpio_line: 0,
+                ptt_method: 0,
             })),
         };
         assert!(!modem.handle_ipc(msg));

--- a/graywolf-modem/src/tx/ptt.rs
+++ b/graywolf-modem/src/tx/ptt.rs
@@ -143,9 +143,9 @@ pub(crate) enum PttMethod {
     /// Hamlib rigctld over TCP. `device` is `"host:port"`.
     Rigctld,
     /// Android USB PTT — delegates to Kotlin's UsbPttAdapter via JNI.
-    /// The method int (one of the ptt_android_consts values) is carried
-    /// in ConfigurePtt.gpio_pin to avoid a proto change for T3; see
-    /// build_driver for the field-reuse comment.
+    /// The transport selector (1..4, see [`crate::tx::ptt_android_consts`])
+    /// travels in `ConfigurePtt.ptt_method`;
+    /// `gpio_pin` is CM108-only and is not read on this path.
     Android,
 }
 
@@ -572,10 +572,11 @@ impl PortRegistry {
                         PTT_METHOD_AIOC_CDC_DTR, PTT_METHOD_CM108_HID, PTT_METHOD_CP2102N_RTS,
                         PTT_METHOD_VOX,
                     };
-                    // The method int is carried in cfg.gpio_pin (field reuse:
-                    // no proto change required for T3; gpio_pin is unused by the
-                    // Android path for its original CM108-pin purpose).
-                    let method = cfg.gpio_pin as i32;
+                    // The Android USB-PTT transport selector lives in
+                    // cfg.ptt_method (PttMethod enum 1..4). cfg.gpio_pin is
+                    // ignored on the Android path — it carries the CM108
+                    // pin and only the cm108 method consumes it.
+                    let method = cfg.ptt_method as i32;
                     match method {
                         PTT_METHOD_CP2102N_RTS
                         | PTT_METHOD_CM108_HID
@@ -800,6 +801,7 @@ pub(crate) mod tests {
             invert: false,
             gpio_pin: 3,
             gpio_line: 0,
+            ptt_method: 0,
         }
     }
 
@@ -1702,8 +1704,7 @@ pub(crate) mod tests {
             let mut registry = PortRegistry::new();
             let cfg = ConfigurePtt {
                 method: "android".into(),
-                // gpio_pin carries the method int — see build_driver comment.
-                gpio_pin: PTT_METHOD_CP2102N_RTS as u32,
+                ptt_method: PTT_METHOD_CP2102N_RTS as u32,
                 ..base_cfg()
             };
 
@@ -1730,6 +1731,31 @@ pub(crate) mod tests {
             crate::clear_mocks();
         }
 
+        // Proves gpio_pin is ignored on the Android path: ptt_method=3
+        // (AIOC_CDC_DTR) must build even though gpio_pin=99 is invalid.
+        #[test]
+        #[serial]
+        fn android_build_driver_reads_ptt_method_not_gpio_pin() {
+            crate::clear_mocks();
+            crate::install_ptt_mock(|_, _| true);
+
+            let mut registry = PortRegistry::new();
+            let cfg = ConfigurePtt {
+                method: "android".into(),
+                ptt_method: PTT_METHOD_AIOC_CDC_DTR as u32, // 3
+                gpio_pin: 99,                                // MUST be ignored
+                ..base_cfg()
+            };
+
+            let drv = registry.build_driver(&cfg);
+            assert!(
+                drv.is_ok(),
+                "android+ptt_method=3 must build (gpio_pin=99 must be ignored): {:?}",
+                drv.err()
+            );
+            crate::clear_mocks();
+        }
+
         #[test]
         #[serial]
         fn build_driver_android_valid_for_all_four_method_ints() {
@@ -1745,7 +1771,7 @@ pub(crate) mod tests {
                 let mut registry = PortRegistry::new();
                 let cfg = ConfigurePtt {
                     method: "android".into(),
-                    gpio_pin: method as u32,
+                    ptt_method: method as u32,
                     ..base_cfg()
                 };
                 assert!(
@@ -1763,7 +1789,7 @@ pub(crate) mod tests {
             let mut registry = PortRegistry::new();
             let cfg = ConfigurePtt {
                 method: "android".into(),
-                gpio_pin: 99, // not a valid PTT method int
+                ptt_method: 99, // not a valid PTT method int
                 ..base_cfg()
             };
             let err = expect_err(registry.build_driver(&cfg));
@@ -1783,7 +1809,7 @@ pub(crate) mod tests {
             let mut registry = PortRegistry::new();
             let cfg = ConfigurePtt {
                 method: "android".into(),
-                gpio_pin: 0, // PTT_METHOD_UNKNOWN
+                ptt_method: 0, // PTT_METHOD_UNKNOWN
                 ..base_cfg()
             };
             let err = expect_err(registry.build_driver(&cfg));

--- a/pkg/configstore/migrate.go
+++ b/pkg/configstore/migrate.go
@@ -176,6 +176,17 @@ type migration struct {
 //	    would double-transmit every frame (the dual-backend case the
 //	    store validator forbids). Idempotent and post-AutoMigrate
 //	    (needs the kiss_interfaces and channels tables present).
+//	21 — audio_devices_clamp_sample_rate: clamp sample_rate to 48000
+//	    for audio_devices rows that were auto-filled with an inflated
+//	    ALSA advertised rate (up to 192 kHz) that caused the modem to
+//	    clock bit timing against the wrong rate and drop every frame.
+//	22 — ptt_android_method_field: move the Android PTT transport int
+//	    out of the overloaded gpio_pin field into the new ptt_method
+//	    column. method='android' rows with gpio_pin 1..4 get
+//	    ptt_method=gpio_pin and gpio_pin zeroed; malformed rows
+//	    (gpio_pin outside 1..4) coerce to ptt_method=1
+//	    (PTT_METHOD_CP2102N_RTS). Non-android rows are untouched.
+//	    Idempotent via the ptt_method=0 guard.
 var schemaMigrations = []migration{
 	{version: 1, name: "beacon_compress_default", phase: postAutoMigrate, run: migrateBeaconCompressDefault},
 	{version: 2, name: "channel_device_fields", phase: preAutoMigrate, run: migrateChannelDeviceFields},
@@ -198,6 +209,7 @@ var schemaMigrations = []migration{
 	{version: 19, name: "actions_max_reply_lines", phase: postAutoMigrate, run: migrateActionsMaxReplyLines},
 	{version: 20, name: "kiss_tcp_client_tx_default", phase: postAutoMigrate, run: migrateKissTcpClientTxDefault},
 	{version: 21, name: "audio_devices_clamp_sample_rate", phase: postAutoMigrate, run: migrateClampAudioSampleRate},
+	{version: 22, name: "ptt_android_method_field", phase: postAutoMigrate, run: migratePttAndroidMethodField},
 }
 
 // runMigrations applies every pending migration in the given phase,

--- a/pkg/configstore/migrate_ptt_android_method.go
+++ b/pkg/configstore/migrate_ptt_android_method.go
@@ -1,0 +1,32 @@
+package configstore
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+// migratePttAndroidMethodField moves the Android PTT transport int out of
+// the overloaded gpio_pin field into the dedicated ptt_method column.
+// Idempotent: the `ptt_method = 0` guard means an already-migrated row
+// (ptt_method is always 1..4 afterward) is never re-touched, so a rerun
+// cannot re-coerce a valid value. Malformed legacy rows (gpio_pin not in
+// 1..4) coerce to 1 (PTT_METHOD_CP2102N_RTS, the historical UI fallback).
+// One-way only; safe because graywolf is a single-user station.
+func migratePttAndroidMethodField(tx *gorm.DB) error {
+	var tableExists int
+	if err := tx.Raw(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ptt_configs'",
+	).Scan(&tableExists).Error; err != nil {
+		return fmt.Errorf("probe ptt_configs: %w", err)
+	}
+	if tableExists == 0 {
+		return nil
+	}
+	return tx.Exec(
+		`UPDATE ptt_configs ` +
+			`SET ptt_method = CASE WHEN gpio_pin BETWEEN 1 AND 4 THEN gpio_pin ELSE 1 END, ` +
+			`    gpio_pin = 0 ` +
+			`WHERE method = 'android' AND ptt_method = 0`,
+	).Error
+}

--- a/pkg/configstore/migrate_ptt_android_method_test.go
+++ b/pkg/configstore/migrate_ptt_android_method_test.go
@@ -1,0 +1,87 @@
+package configstore
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+// seed a ptt_configs row with the legacy android encoding (method=android,
+// transport int in gpio_pin) using raw SQL so the test does not depend on
+// the post-migration struct shape.
+func seedLegacyPtt(t *testing.T, db *gorm.DB, channelID, gpioPin uint32, method string) {
+	t.Helper()
+	if err := db.Exec(
+		`INSERT INTO ptt_configs (channel_id, method, device, gpio_pin, gpio_line, invert, slot_time_ms, persist, dwait_ms) `+
+			`VALUES (?, ?, '', ?, 0, 0, 10, 63, 0)`,
+		channelID, method, gpioPin,
+	).Error; err != nil {
+		t.Fatalf("seed ptt_configs: %v", err)
+	}
+}
+
+func ptt(t *testing.T, db *gorm.DB, channelID uint32) PttConfig {
+	t.Helper()
+	var p PttConfig
+	if err := db.Where("channel_id = ?", channelID).First(&p).Error; err != nil {
+		t.Fatalf("load ptt_config ch=%d: %v", channelID, err)
+	}
+	return p
+}
+
+func TestMigratePttAndroidMethodField(t *testing.T) {
+	t.Parallel()
+	dsn := filepath.Join(t.TempDir(), "ptt_android_method.db")
+	store, err := Open(dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+	db := store.DB()
+
+	// Seed minimal channel rows to satisfy ptt_configs.channel_id FK.
+	for _, chID := range []uint32{101, 102, 103, 104} {
+		if err := db.Exec(
+			`INSERT INTO channels (id, name, modem_type, bit_rate, mark_freq, space_freq, profile, `+
+				`num_slicers, fix_bits, num_decoders, decoder_offset, created_at, updated_at) `+
+				`VALUES (?, ?, 'afsk', 1200, 1200, 2200, 'A', 1, 'none', 1, 0, datetime('now'), datetime('now'))`,
+			chID, fmt.Sprintf("test-ch-%d", chID),
+		).Error; err != nil {
+			t.Fatalf("seed channel %d: %v", chID, err)
+		}
+	}
+
+	// Re-seed legacy rows AFTER full migration, then run only the v22 fn
+	// to assert its behavior deterministically.
+	seedLegacyPtt(t, db, 101, 3, "android") // well-formed AIOC
+	seedLegacyPtt(t, db, 102, 0, "android") // malformed -> coerce to 1
+	seedLegacyPtt(t, db, 103, 3, "cm108")   // non-android, untouched
+	seedLegacyPtt(t, db, 104, 5, "android") // above-upper-bound -> coerce to 1
+
+	if err := migratePttAndroidMethodField(db); err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+
+	if p := ptt(t, db, 101); p.PttMethod != 3 || p.GpioPin != 0 {
+		t.Fatalf("ch101: got ptt_method=%d gpio_pin=%d, want 3/0", p.PttMethod, p.GpioPin)
+	}
+	if p := ptt(t, db, 102); p.PttMethod != 1 || p.GpioPin != 0 {
+		t.Fatalf("ch102 (malformed): got ptt_method=%d gpio_pin=%d, want 1/0", p.PttMethod, p.GpioPin)
+	}
+	if p := ptt(t, db, 103); p.PttMethod != 0 || p.GpioPin != 3 {
+		t.Fatalf("ch103 (cm108): got ptt_method=%d gpio_pin=%d, want 0/3 (untouched)", p.PttMethod, p.GpioPin)
+	}
+	if p := ptt(t, db, 104); p.PttMethod != 1 || p.GpioPin != 0 {
+		t.Fatalf("ch104 (gpio_pin=5 above range): got ptt_method=%d gpio_pin=%d, want 1/0", p.PttMethod, p.GpioPin)
+	}
+
+	// Idempotency: a second run must not re-coerce ch101 (3) to 1.
+	if err := migratePttAndroidMethodField(db); err != nil {
+		t.Fatalf("migration rerun: %v", err)
+	}
+	if p := ptt(t, db, 101); p.PttMethod != 3 {
+		t.Fatalf("ch101 after rerun: got ptt_method=%d, want 3 (idempotent)", p.PttMethod)
+	}
+}

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -88,9 +88,10 @@ type PttConfig struct {
 	ID         uint32    `gorm:"primaryKey;autoIncrement" json:"id"`
 	ChannelID  uint32    `gorm:"not null;uniqueIndex" json:"channel_id"`
 	Channel    *Channel  `gorm:"foreignKey:ChannelID;references:ID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE" json:"-"`
-	Method     string    `gorm:"not null;default:'none'" json:"method"` // serial_rts|serial_dtr|gpio|cm108|none
+	Method     string    `gorm:"not null;default:'none'" json:"method"` // serial_rts|serial_dtr|gpio|cm108|android|none
 	Device     string    `json:"device_path"`
-	GpioPin    uint32    `json:"gpio_pin"`                             // CM108-only: 1-indexed HID GPIO pin (default 3)
+	GpioPin    uint32    `json:"gpio_pin"`                             // CM108 HID GPIO pin (1-indexed, default 3). cm108 method only.
+	PttMethod  uint32    `gorm:"not null;default:0" json:"ptt_method"` // Android transport when Method=="android": PttMethod enum 1..4 (1 CP2102N_RTS, 2 CM108_HID, 3 AIOC_CDC_DTR, 4 VOX). 0 = unset / non-android.
 	GpioLine   uint32    `gorm:"not null;default:0" json:"gpio_line"`  // gpiochip method: 0-indexed line offset
 	Invert     bool      `gorm:"not null;default:false" json:"invert"` // reverse polarity for rigs wired backwards
 	SlotTimeMs uint32    `gorm:"not null;default:10" json:"slot_time_ms"`

--- a/pkg/ipcproto/graywolf.pb.go
+++ b/pkg/ipcproto/graywolf.pb.go
@@ -1400,7 +1400,14 @@ type ConfigurePtt struct {
 	GpioPin uint32 `protobuf:"varint,10,opt,name=gpio_pin,json=gpioPin,proto3" json:"gpio_pin,omitempty"`
 	// 0-indexed GPIO line offset for the `gpio` method (gpiochip chardev v2).
 	// For CM108, use `gpio_pin` (1-indexed) instead.
-	GpioLine      uint32 `protobuf:"varint,11,opt,name=gpio_line,json=gpioLine,proto3" json:"gpio_line,omitempty"`
+	GpioLine uint32 `protobuf:"varint,11,opt,name=gpio_line,json=gpioLine,proto3" json:"gpio_line,omitempty"`
+	// Android USB-PTT transport selector. Carries the PttMethod enum value
+	// (proto/platform.proto: 1=PTT_METHOD_CP2102N_RTS, 2=PTT_METHOD_CM108_HID,
+	// 3=PTT_METHOD_AIOC_CDC_DTR, 4=PTT_METHOD_VOX). Typed uint32 (not the
+	// platform.proto enum) to keep this IPC contract self-contained
+	// (invariant #2). Meaningful only when method=="android"; 0 otherwise.
+	// Never overload gpio_pin for this.
+	PttMethod     uint32 `protobuf:"varint,12,opt,name=ptt_method,json=pttMethod,proto3" json:"ptt_method,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1508,6 +1515,13 @@ func (x *ConfigurePtt) GetGpioPin() uint32 {
 func (x *ConfigurePtt) GetGpioLine() uint32 {
 	if x != nil {
 		return x.GpioLine
+	}
+	return 0
+}
+
+func (x *ConfigurePtt) GetPttMethod() uint32 {
+	if x != nil {
+		return x.PttMethod
 	}
 	return 0
 }
@@ -2305,7 +2319,7 @@ const file_graywolf_proto_rawDesc = "" +
 	"\vsource_type\x18\x05 \x01(\tR\n" +
 	"sourceType\x12\x16\n" +
 	"\x06format\x18\x06 \x01(\tR\x06format\x12\x17\n" +
-	"\again_db\x18\a \x01(\x02R\x06gainDb\"\xba\x02\n" +
+	"\again_db\x18\a \x01(\x02R\x06gainDb\"\xd9\x02\n" +
 	"\fConfigurePtt\x12\x18\n" +
 	"\achannel\x18\x01 \x01(\rR\achannel\x12\x16\n" +
 	"\x06method\x18\x02 \x01(\tR\x06method\x12\x16\n" +
@@ -2320,7 +2334,9 @@ const file_graywolf_proto_rawDesc = "" +
 	"\x06invert\x18\t \x01(\bR\x06invert\x12\x19\n" +
 	"\bgpio_pin\x18\n" +
 	" \x01(\rR\agpioPin\x12\x1b\n" +
-	"\tgpio_line\x18\v \x01(\rR\bgpioLine\"\f\n" +
+	"\tgpio_line\x18\v \x01(\rR\bgpioLine\x12\x1d\n" +
+	"\n" +
+	"ptt_method\x18\f \x01(\rR\tpttMethod\"\f\n" +
 	"\n" +
 	"StartAudio\"\v\n" +
 	"\tStopAudio\")\n" +

--- a/pkg/messages/router_test.go
+++ b/pkg/messages/router_test.go
@@ -280,6 +280,9 @@ func TestRouterDMInboundForOurCallPersistsAndAutoACKs(t *testing.T) {
 		ms, _, _ := store.List(context.Background(), Filter{})
 		return len(ms) == 1
 	}, "row persisted")
+	waitFor(t, time.Second, func() bool {
+		return len(sink.list()) >= 1
+	}, "auto-ACK submitted")
 
 	ms, _, _ := store.List(context.Background(), Filter{})
 	if ms[0].FromCall != "W1ABC-9" {
@@ -330,6 +333,9 @@ func TestRouterDMInboundForOurCallWithSSID(t *testing.T) {
 		ms, _, _ := store.List(context.Background(), Filter{})
 		return len(ms) == 1
 	}, "row persisted")
+	waitFor(t, time.Second, func() bool {
+		return len(sink.list()) >= 1
+	}, "auto-ACK submitted")
 
 	if got := len(sink.list()); got != 1 {
 		t.Fatalf("auto-ACK count = %d", got)

--- a/pkg/modembridge/session.go
+++ b/pkg/modembridge/session.go
@@ -278,6 +278,7 @@ func (b *Bridge) pushConfiguration(ctx context.Context, send func(*pb.IpcMessage
 			DwaitMs:    ptt.DwaitMs,
 			GpioPin:    gpioPin,
 			GpioLine:   ptt.GpioLine,
+			PttMethod:  ptt.PttMethod,
 		}}}
 		if err := send(pmsg); err != nil {
 			return false, err

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -8430,11 +8430,15 @@
                     "type": "string"
                 },
                 "gpio_pin": {
-                    "description": "GpioPin carries the CM108 HID pin (cm108 method) and, on Android,\nthe PTT method int (1..4, spec Appendix B) reused as a carrier so\nthe channel edit modal can restore the selected method. 0 = unset.",
+                    "description": "GpioPin is the CM108 HID pin (cm108 method only). 0 = unset.",
                     "type": "integer"
                 },
                 "method": {
                     "type": "string"
+                },
+                "ptt_method": {
+                    "description": "PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)\nwhen Method==\"android\"; 0 otherwise. The channel-edit modal\nrestores the selected Android method from this.",
+                    "type": "integer"
                 }
             }
         },
@@ -9382,7 +9386,7 @@
                     "type": "integer"
                 },
                 "gpio_pin": {
-                    "description": "GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3). Not used\nby the `gpio` method, which references `gpio_line` instead to avoid\nindexing ambiguity between CM108 pin numbers and gpiochip line offsets.",
+                    "description": "GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3).\ncm108 method only. The `gpio` method uses `gpio_line` instead.",
                     "type": "integer"
                 },
                 "invert": {
@@ -9392,6 +9396,10 @@
                     "type": "string"
                 },
                 "persist": {
+                    "type": "integer"
+                },
+                "ptt_method": {
+                    "description": "PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)\nwhen Method==\"android\". Not used by desktop methods.",
                     "type": "integer"
                 },
                 "slot_time_ms": {
@@ -9416,7 +9424,7 @@
                     "type": "integer"
                 },
                 "gpio_pin": {
-                    "description": "GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3). Not used\nby the `gpio` method, which references `gpio_line` instead to avoid\nindexing ambiguity between CM108 pin numbers and gpiochip line offsets.",
+                    "description": "GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3).\ncm108 method only. The `gpio` method uses `gpio_line` instead.",
                     "type": "integer"
                 },
                 "id": {
@@ -9429,6 +9437,10 @@
                     "type": "string"
                 },
                 "persist": {
+                    "type": "integer"
+                },
+                "ptt_method": {
+                    "description": "PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)\nwhen Method==\"android\". Not used by desktop methods.",
                     "type": "integer"
                 },
                 "slot_time_ms": {

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -1045,13 +1045,16 @@ definitions:
       detail:
         type: string
       gpio_pin:
-        description: |-
-          GpioPin carries the CM108 HID pin (cm108 method) and, on Android,
-          the PTT method int (1..4, spec Appendix B) reused as a carrier so
-          the channel edit modal can restore the selected method. 0 = unset.
+        description: GpioPin is the CM108 HID pin (cm108 method only). 0 = unset.
         type: integer
       method:
         type: string
+      ptt_method:
+        description: |-
+          PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)
+          when Method=="android"; 0 otherwise. The channel-edit modal
+          restores the selected Android method from this.
+        type: integer
     type: object
   dto.ChannelRequest:
     properties:
@@ -1725,15 +1728,19 @@ definitions:
         type: integer
       gpio_pin:
         description: |-
-          GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3). Not used
-          by the `gpio` method, which references `gpio_line` instead to avoid
-          indexing ambiguity between CM108 pin numbers and gpiochip line offsets.
+          GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3).
+          cm108 method only. The `gpio` method uses `gpio_line` instead.
         type: integer
       invert:
         type: boolean
       method:
         type: string
       persist:
+        type: integer
+      ptt_method:
+        description: |-
+          PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)
+          when Method=="android". Not used by desktop methods.
         type: integer
       slot_time_ms:
         type: integer
@@ -1753,9 +1760,8 @@ definitions:
         type: integer
       gpio_pin:
         description: |-
-          GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3). Not used
-          by the `gpio` method, which references `gpio_line` instead to avoid
-          indexing ambiguity between CM108 pin numbers and gpiochip line offsets.
+          GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3).
+          cm108 method only. The `gpio` method uses `gpio_line` instead.
         type: integer
       id:
         type: integer
@@ -1764,6 +1770,11 @@ definitions:
       method:
         type: string
       persist:
+        type: integer
+      ptt_method:
+        description: |-
+          PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)
+          when Method=="android". Not used by desktop methods.
         type: integer
       slot_time_ms:
         type: integer

--- a/pkg/webapi/dto/channel.go
+++ b/pkg/webapi/dto/channel.go
@@ -136,10 +136,12 @@ type ChannelPtt struct {
 	Method     string `json:"method"`
 	Configured bool   `json:"configured"`
 	Detail     string `json:"detail,omitempty"`
-	// GpioPin carries the CM108 HID pin (cm108 method) and, on Android,
-	// the PTT method int (1..4, spec Appendix B) reused as a carrier so
-	// the channel edit modal can restore the selected method. 0 = unset.
+	// GpioPin is the CM108 HID pin (cm108 method only). 0 = unset.
 	GpioPin uint32 `json:"gpio_pin,omitempty"`
+	// PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)
+	// when Method=="android"; 0 otherwise. The channel-edit modal
+	// restores the selected Android method from this.
+	PttMethod uint32 `json:"ptt_method,omitempty"`
 }
 
 // ChannelBacking describes the runtime backing — modem and/or KISS-TNC
@@ -263,6 +265,7 @@ func ChannelPttFromModel(p configstore.PttConfig) ChannelPtt {
 		Configured: method != PttMethodNone,
 		Detail:     pttDetail(p, method),
 		GpioPin:    p.GpioPin,
+		PttMethod:  p.PttMethod,
 	}
 }
 

--- a/pkg/webapi/dto/channel_test.go
+++ b/pkg/webapi/dto/channel_test.go
@@ -218,16 +218,16 @@ func TestChannelPttFromModel(t *testing.T) {
 	}
 }
 
-// TestChannelPttFromModel_GpioPin verifies that the GPIO pin (CM108 HID pin
-// and Android PTT method int) round-trips through the DTO so the channel edit
-// modal can restore the selected method.
-func TestChannelPttFromModel_GpioPin(t *testing.T) {
-	in := configstore.PttConfig{ChannelID: 7, Method: "android", GpioPin: 3}
+// TestChannelPttFromModel_PttMethod verifies that ptt_method round-trips
+// through the DTO so the channel edit modal can restore the selected Android
+// USB-PTT transport.
+func TestChannelPttFromModel_PttMethod(t *testing.T) {
+	in := configstore.PttConfig{ChannelID: 7, Method: "android", PttMethod: 3}
 	got := ChannelPttFromModel(in)
 	if got.Method != "android" {
 		t.Fatalf("method: got %q want android", got.Method)
 	}
-	if got.GpioPin != 3 {
-		t.Fatalf("gpio_pin: got %d want 3 (AIOC method int must round-trip to the SPA modal)", got.GpioPin)
+	if got.PttMethod != 3 {
+		t.Fatalf("ptt_method: got %d want 3 (AIOC must round-trip to the SPA modal)", got.PttMethod)
 	}
 }

--- a/pkg/webapi/dto/ptt.go
+++ b/pkg/webapi/dto/ptt.go
@@ -12,10 +12,12 @@ type PttRequest struct {
 	ChannelID  uint32 `json:"channel_id"`
 	Method     string `json:"method"`
 	DevicePath string `json:"device_path"`
-	// GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3). Not used
-	// by the `gpio` method, which references `gpio_line` instead to avoid
-	// indexing ambiguity between CM108 pin numbers and gpiochip line offsets.
+	// GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3).
+	// cm108 method only. The `gpio` method uses `gpio_line` instead.
 	GpioPin uint32 `json:"gpio_pin"`
+	// PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)
+	// when Method=="android". Not used by desktop methods.
+	PttMethod uint32 `json:"ptt_method"`
 	// GpioLine is the gpiochip v2 line offset (0-indexed) used by the `gpio`
 	// method. Ignored for every other method.
 	GpioLine   uint32 `json:"gpio_line"`
@@ -36,14 +38,14 @@ func (r PttRequest) Validate() error {
 	if r.ChannelID == 0 {
 		return fmt.Errorf("channel_id is required")
 	}
-	// android method requires gpio_pin in 1..4 (spec Appendix B):
+	// android method requires ptt_method in 1..4 (spec Appendix B):
 	//   1 = CP2102N_RTS, 2 = CM108_HID, 3 = AIOC_CDC_DTR, 4 = VOX
 	if r.Method == "android" {
-		switch r.GpioPin {
+		switch r.PttMethod {
 		case 1, 2, 3, 4:
 			// valid
 		default:
-			return fmt.Errorf("android ptt method requires gpio_pin in 1..4 (spec Appendix B), got %d", r.GpioPin)
+			return fmt.Errorf("android ptt method requires ptt_method in 1..4 (spec Appendix B), got %d", r.PttMethod)
 		}
 	}
 	return nil
@@ -60,6 +62,7 @@ func (r PttRequest) ToModel() configstore.PttConfig {
 		SlotTimeMs: r.SlotTimeMs,
 		Persist:    r.Persist,
 		DwaitMs:    r.DwaitMs,
+		PttMethod:  r.PttMethod,
 	}
 }
 
@@ -93,6 +96,7 @@ func PttFromModel(m configstore.PttConfig) PttResponse {
 			SlotTimeMs: m.SlotTimeMs,
 			Persist:    m.Persist,
 			DwaitMs:    m.DwaitMs,
+			PttMethod:  m.PttMethod,
 		},
 	}
 }

--- a/pkg/webapi/dto/ptt_test.go
+++ b/pkg/webapi/dto/ptt_test.go
@@ -3,37 +3,53 @@ package dto
 import (
 	"strings"
 	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/configstore"
 )
 
-// TestPttRequest_Validate_Android covers the gpio_pin gate added for the
+// TestPttRequest_Validate_Android covers the ptt_method gate for the
 // android method (spec Appendix B, C1 final-review sweep).
 func TestPttRequest_Validate_Android(t *testing.T) {
-	// Each valid pin must pass.
+	// Each valid ptt_method must pass.
 	for _, pin := range []uint32{1, 2, 3, 4} {
-		r := PttRequest{ChannelID: 1, Method: "android", GpioPin: pin}
+		r := PttRequest{ChannelID: 1, Method: "android", PttMethod: pin}
 		if err := r.Validate(); err != nil {
-			t.Errorf("gpio_pin=%d: expected no error, got %v", pin, err)
+			t.Errorf("ptt_method=%d: expected no error, got %v", pin, err)
 		}
 	}
 
-	// gpio_pin 0 must be rejected.
-	r0 := PttRequest{ChannelID: 1, Method: "android", GpioPin: 0}
+	// ptt_method 0 must be rejected.
+	r0 := PttRequest{ChannelID: 1, Method: "android", PttMethod: 0}
 	if err := r0.Validate(); err == nil {
-		t.Error("gpio_pin=0: expected error, got nil")
+		t.Error("ptt_method=0: expected error, got nil")
 	} else if !strings.Contains(err.Error(), "android ptt") {
-		t.Errorf("gpio_pin=0: error %q does not contain \"android ptt\"", err.Error())
+		t.Errorf("ptt_method=0: error %q does not contain \"android ptt\"", err.Error())
 	}
 
-	// gpio_pin 99 must be rejected.
-	r99 := PttRequest{ChannelID: 1, Method: "android", GpioPin: 99}
+	// ptt_method 99 must be rejected.
+	r99 := PttRequest{ChannelID: 1, Method: "android", PttMethod: 99}
 	if err := r99.Validate(); err == nil {
-		t.Error("gpio_pin=99: expected error, got nil")
+		t.Error("ptt_method=99: expected error, got nil")
 	} else if !strings.Contains(err.Error(), "android ptt") {
-		t.Errorf("gpio_pin=99: error %q does not contain \"android ptt\"", err.Error())
+		t.Errorf("ptt_method=99: error %q does not contain \"android ptt\"", err.Error())
 	}
 }
 
-// TestPttRequest_Validate_NonAndroid confirms the android gpio_pin gate
+func TestPttRequest_AndroidRequiresPttMethod(t *testing.T) {
+	bad := PttRequest{ChannelID: 1, Method: "android", PttMethod: 0}
+	if bad.Validate() == nil {
+		t.Fatal("android with ptt_method=0 must be rejected")
+	}
+	ok := PttRequest{ChannelID: 1, Method: "android", PttMethod: 3}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("android ptt_method=3 must be valid, got %v", err)
+	}
+	if m := ok.ToModel(); m.PttMethod != 3 {
+		t.Fatalf("ToModel ptt_method: got %d want 3", m.PttMethod)
+	}
+}
+
+// TestPttRequest_Validate_NonAndroid confirms the android ptt_method gate
 // does not interfere with other methods (they may carry any gpio_pin value).
 func TestPttRequest_Validate_NonAndroid(t *testing.T) {
 	for _, method := range []string{"serial_rts", "cm108_hid", "gpio", "none"} {
@@ -41,5 +57,20 @@ func TestPttRequest_Validate_NonAndroid(t *testing.T) {
 		if err := r.Validate(); err != nil {
 			t.Errorf("method=%s gpio_pin=0: unexpected error: %v", method, err)
 		}
+	}
+}
+
+// TestPttFromModel_PttMethod verifies that PttFromModel propagates the
+// Android transport (PttMethod) into the PTT-specific API response -- the
+// modal restoring an android channel via GET /api/ptt/{channel} (and the
+// 201/200 body of POST/PUT /api/ptt) depends on this round-trip.
+func TestPttFromModel_PttMethod(t *testing.T) {
+	in := configstore.PttConfig{ID: 1, ChannelID: 7, Method: "android", PttMethod: 3}
+	got := PttFromModel(in)
+	if got.Method != "android" {
+		t.Fatalf("method: got %q want android", got.Method)
+	}
+	if got.PttMethod != 3 {
+		t.Fatalf("ptt_method: got %d want 3 (AIOC must round-trip through PttFromModel)", got.PttMethod)
 	}
 }

--- a/proto/graywolf.proto
+++ b/proto/graywolf.proto
@@ -212,6 +212,13 @@ message ConfigurePtt {
   // 0-indexed GPIO line offset for the `gpio` method (gpiochip chardev v2).
   // For CM108, use `gpio_pin` (1-indexed) instead.
   uint32 gpio_line = 11;
+  // Android USB-PTT transport selector. Carries the PttMethod enum value
+  // (proto/platform.proto: 1=PTT_METHOD_CP2102N_RTS, 2=PTT_METHOD_CM108_HID,
+  // 3=PTT_METHOD_AIOC_CDC_DTR, 4=PTT_METHOD_VOX). Typed uint32 (not the
+  // platform.proto enum) to keep this IPC contract self-contained
+  // (invariant #2). Meaningful only when method=="android"; 0 otherwise.
+  // Never overload gpio_pin for this.
+  uint32 ptt_method = 12;
 }
 
 // Begin audio processing on all configured devices.

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2287,13 +2287,15 @@ export interface components {
         "dto.ChannelPtt": {
             configured?: boolean;
             detail?: string;
-            /**
-             * @description GpioPin carries the CM108 HID pin (cm108 method) and, on Android,
-             *     the PTT method int (1..4, spec Appendix B) reused as a carrier so
-             *     the channel edit modal can restore the selected method. 0 = unset.
-             */
+            /** @description GpioPin is the CM108 HID pin (cm108 method only). 0 = unset. */
             gpio_pin?: number;
             method?: string;
+            /**
+             * @description PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)
+             *     when Method=="android"; 0 otherwise. The channel-edit modal
+             *     restores the selected Android method from this.
+             */
+            ptt_method?: number;
         };
         "dto.ChannelRequest": {
             bit_rate?: number;
@@ -2685,14 +2687,18 @@ export interface components {
              */
             gpio_line?: number;
             /**
-             * @description GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3). Not used
-             *     by the `gpio` method, which references `gpio_line` instead to avoid
-             *     indexing ambiguity between CM108 pin numbers and gpiochip line offsets.
+             * @description GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3).
+             *     cm108 method only. The `gpio` method uses `gpio_line` instead.
              */
             gpio_pin?: number;
             invert?: boolean;
             method?: string;
             persist?: number;
+            /**
+             * @description PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)
+             *     when Method=="android". Not used by desktop methods.
+             */
+            ptt_method?: number;
             slot_time_ms?: number;
         };
         "dto.PttResponse": {
@@ -2705,15 +2711,19 @@ export interface components {
              */
             gpio_line?: number;
             /**
-             * @description GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3). Not used
-             *     by the `gpio` method, which references `gpio_line` instead to avoid
-             *     indexing ambiguity between CM108 pin numbers and gpiochip line offsets.
+             * @description GpioPin is the CM108 HID GPIO pin number (1-indexed, default 3).
+             *     cm108 method only. The `gpio` method uses `gpio_line` instead.
              */
             gpio_pin?: number;
             id?: number;
             invert?: boolean;
             method?: string;
             persist?: number;
+            /**
+             * @description PttMethod is the Android USB-PTT transport (PttMethod enum 1..4)
+             *     when Method=="android". Not used by desktop methods.
+             */
+            ptt_method?: number;
             slot_time_ms?: number;
         };
         "dto.RegisterRequest": {

--- a/web/src/lib/channelPtt.roundtrip.test.js
+++ b/web/src/lib/channelPtt.roundtrip.test.js
@@ -2,12 +2,26 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 // Contract: GET /api/channels .ptt for an Android channel MUST include
-// gpio_pin so ChannelEditModal can restore androidPttMethod. This mirrors
-// the restore predicate in ChannelEditModal.svelte (row.ptt?.method ===
-// 'android' && row.ptt?.gpio_pin).
-test('android ptt row exposes gpio_pin for modal restore', () => {
-  const row = { id: 1, ptt: { method: 'android', configured: true, gpio_pin: 3 } };
+// ptt_method so ChannelEditModal can restore the selected transport.
+// Mirrors the restore predicate in ChannelEditModal.svelte
+// (row.ptt?.method === 'android' && row.ptt?.ptt_method).
+test('android ptt row exposes ptt_method for modal restore', () => {
+  const row = { id: 1, ptt: { method: 'android', configured: true, ptt_method: 3 } };
   const restored =
-    row.ptt?.method === 'android' && row.ptt?.gpio_pin ? row.ptt.gpio_pin : 1;
+    row.ptt?.method === 'android' && row.ptt?.ptt_method ? row.ptt.ptt_method : 1;
   assert.equal(restored, 3, 'AIOC (3) must restore, not fall back to CP2102N (1)');
+});
+
+test('android ptt row with ptt_method=0 falls back to CP2102N (1)', () => {
+  // ptt_method=0 is the "unset" sentinel that the truthiness predicate must
+  // treat as missing, falling back to the historical UI default. Same shape
+  // for ptt_method=undefined (e.g., a legacy row that pre-dates the field).
+  for (const row of [
+    { id: 2, ptt: { method: 'android', configured: true, ptt_method: 0 } },
+    { id: 3, ptt: { method: 'android', configured: true } }, // ptt_method absent
+  ]) {
+    const restored =
+      row.ptt?.method === 'android' && row.ptt?.ptt_method ? row.ptt.ptt_method : 1;
+    assert.equal(restored, 1, `row id=${row.id}: ptt_method falsy must fall back to 1`);
+  }
 });

--- a/web/src/routes/Channels.svelte
+++ b/web/src/routes/Channels.svelte
@@ -118,18 +118,14 @@
         await api.put(`/tx-timing/${channelId}`, timingData);
       }
 
-      // On Android, persist the PTT method via POST /api/ptt.
-      // Data shape: method='android', gpio_pin=method_int (1–4 per Appendix B).
-      // The Go modembridge reads gpio_pin to determine which USB transport
-      // to invoke in UsbPttAdapter (T7). This reuses the existing PttConfig
-      // row's gpio_pin field as a method-int carrier rather than adding a
-      // new schema column — the semantics are different from the desktop
-      // gpio-line use but the field is otherwise unused on Android channels.
+      // On Android, persist the PTT transport as a first-class field.
+      // method='android' is the subsystem discriminator; ptt_method is
+      // the transport (PttMethod enum 1..4, spec Appendix B).
       if (Platform.kind === 'android' && androidPttMethod != null && channelId) {
         await api.post('/ptt', {
           channel_id: channelId,
           method: 'android',
-          gpio_pin: androidPttMethod,
+          ptt_method: androidPttMethod,
         });
       }
 

--- a/web/src/routes/channels/ChannelEditModal.svelte
+++ b/web/src/routes/channels/ChannelEditModal.svelte
@@ -66,8 +66,8 @@
           form = rowToForm(row, (txTimings || {})[row.id]);
           errors = {};
           if (Platform.kind === 'android') {
-            if (row.ptt?.method === 'android' && row.ptt?.gpio_pin) {
-              androidPttMethod = row.ptt.gpio_pin;
+            if (row.ptt?.method === 'android' && row.ptt?.ptt_method) {
+              androidPttMethod = row.ptt.ptt_method;
             } else {
               androidPttMethod = PTT_METHOD_CP2102N_RTS;
             }


### PR DESCRIPTION
## Summary
Move the Android PTT transport selector out of the overloaded `PttConfig.GpioPin` field into a dedicated `ptt_method` field, end to end. The earlier gpio_pin-as-method-carrier hack (PR #149) could silently downgrade a saved AIOC channel to CP2102N on re-save whenever a response DTO dropped the field; this PR removes that risk by carrying the transport in its own column/field at every hop.

End-to-end trail of the new field:

```
SPA POST /api/ptt {method:"android", ptt_method:N}
  -> PttConfig.PttMethod (configstore column + GORM tag)
  -> session.go (modembridge IPC builder)
  -> ConfigurePtt.ptt_method (uint32, proto field 12)
  -> Rust build_driver (PttMethod::Android arm: let method = cfg.ptt_method as i32)
  -> AndroidPtt -> JNI -> Kotlin UsbPttAdapter.pttSet
```

`method=="android"` is now strictly the coarse subsystem discriminator; `gpio_pin` reverts to CM108-only.

## What's in this PR

6 commits on top of main:

- `feat(proto)`: add `ConfigurePtt.ptt_method` (Android transport selector)
- `feat(configstore)`: `PttConfig.ptt_method` column + migration v22 from legacy `gpio_pin` carrier
- `feat(webapi)`: `ptt_method` in PTT request/response DTOs + session `ConfigurePtt`; drop `gpio_pin` android carrier
- `fix(modem)`: Android `build_driver` reads `cfg.ptt_method`, not the `gpio_pin` overload
- `feat(web)`: channel modal saves/restores `ptt_method`; regenerate api client
- `docs(wiki)`: rewrite invariant 9c -- Android PTT is a first-class `ptt_method` field

Migration v22 (`migratePttAndroidMethodField`) backfills legacy `method='android'` rows on first startup: well-formed `gpio_pin` (1..4) moves to `ptt_method`, then `gpio_pin` is zeroed. Malformed values coerce to 1 (CP2102N_RTS, the historical UI fallback). Idempotent on rerun (`AND ptt_method = 0` guard). One-way (single-user station).

## Test Plan

**Host gates (all green):**
- [x] Go: `pkg/configstore/`, `pkg/webapi/...`, `pkg/modembridge/` all `ok`
- [x] Rust: `cargo test --features android-test-stub --lib tx::ptt` -- 38/0
- [x] Web: 153/0 across 16 files
- [x] `make api-client-check` and `make docs-check` both match committed copy
- [x] `go build ./...` clean
- [x] APK builds (`./gradlew assembleDebug -x lint` -- BUILD SUCCESSFUL)
- [x] APK installs on T865 tablet and MainActivity launches (no JNI crash)

**On-device (T865 tablet, 10.50.0.161:32783) -- operator to verify:**
- [ ] Pre-existing Android AIOC channel still keys the radio after migration v22 runs
- [ ] `adb logcat -d -t 2000 | grep -iE 'pttSet|setAiocRts'` shows `pttSet method=3` -> `setAiocRts`
- [ ] Edit channel, set PTT=AIOC, Save, reopen -> still AIOC (restored from ptt_method)
- [ ] Edit unrelated field on AIOC channel, Save, reopen -> still AIOC (no clobber)
- [ ] PTT test keys the AIOC radio

## Known deviation

The spec asked for a per-row warning log when malformed legacy rows coerce to 1. The plan's migration is a single bulk `UPDATE` statement with no per-row visibility. Real-world impact is near-zero (malformed rows are extremely unlikely on a deployed device since the historical UI always wrote a valid `gpio_pin`). If we want the warning, the migration becomes a two-pass SELECT-then-UPDATE; happy to add it on request.