### PR TITLE
docs(specs): Android Bluetooth KISS TNC + unified PTT page

### DIFF
--- a/docs/superpowers/specs/2026-05-19-android-bluetooth-kiss-tnc-design.md
+++ b/docs/superpowers/specs/2026-05-19-android-bluetooth-kiss-tnc-design.md
@@ -1,0 +1,416 @@
+# Android Bluetooth KISS TNC Support — Design
+
+Date: 2026-05-19
+Status: Approved (brainstorming)
+Scope: Android app (Kotlin platform service + proto extension); Go-side KISS
+serial transport adapter; Svelte Kiss page Bluetooth picker. Desktop Linux
+and macOS unchanged.
+
+## Goal
+
+Let an Android-tablet operator add a Bluetooth-paired KISS TNC (Mobilinkd
+TNC3/TNC4, Kenwood TH-D74/D75, etc.) as a KISS interface in Graywolf:
+the Kotlin platform service holds the RFCOMM socket, the bytes stream over
+the existing platform UDS into the existing `pkg/kiss` serial data path
+via dependency injection, and the operator sees a Bluetooth interface
+type in `Kiss.svelte` with a bonded-device picker. Desktop continues to
+use the existing `rfcomm bind` → `/dev/rfcomm0` workflow (Linux) or
+`/dev/cu.*` path (macOS) under the existing **Serial** interface type
+with no changes.
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Platform scope | Android only | Desktop Linux/macOS already work via `rfcomm bind` + the existing serial-device-path field. The real gap is Android, which has no equivalent OS surface. |
+| BT radio scope | Classic SPP/RFCOMM | Covers Mobilinkd TNC3/4 and Kenwood TH-D74/D75 — all current KISS-over-BT TNCs. BLE/GATT is materially different and not used by any TNC operators are buying today. |
+| Pairing UX | Bonded devices only | Graywolf lists devices already paired in Android Settings; the OS pairing flow is well-supported and we don't reimplement it. |
+| Bytes transport | Byte-relay over the existing platform UDS | Kotlin owns the `BluetoothSocket`; new proto messages carry framed bytes; Go-side adapter implements `io.ReadWriteCloser` and is injected as `SerialConfig.OpenFunc`. Reuses every line of the existing KISS serial data path (`SerialSupervisor`, backoff, hot-reload, metrics). |
+| Wire enum | Reuse existing `KissTypeBluetooth` | The `bluetooth` value already exists in `pkg/configstore/models.go` as a placeholder; DTO validation already accepts it. No schema change. |
+| UI label | "Bluetooth Serial" | More honest about the path — RFCOMM is a serial-over-Bluetooth byte stream. Label is UI-only; wire/DB stays `bluetooth`. |
+| Device storage | MAC address in `KissInterface.Device` | Reuses the existing string column. Display name is re-resolved live from `BluetoothAdapter.bondedDevices` at render time. |
+| Auto-generated name | `kiss-bt-<sanitized-device-name>` | Mirrors `kiss-serial-<device>`; operator can override. |
+| Bonded-list refresh | Explicit Refresh button + `ACTION_BOND_STATE_CHANGED` receiver | Cheap, complementary; auto-refresh covers the common "I just paired one" case without a manual click. |
+| Type-select scope on Android | `Bluetooth Serial` + `Network` only | Serial-on-`/dev/ttyACM*` is blocked by the Android sandbox (would need a separate platformsvc relay; not in v1). TCP-server is niche on a tablet. |
+
+## Non-goals
+
+- No BLE/GATT-based TNC support.
+- No in-app Bluetooth discovery or PIN-pairing UI — the OS Settings flow handles bonding.
+- No KISS-over-Bluetooth client/server (a phone exposing Graywolf as a KISS BT server) — only the dial-out-to-bonded-TNC direction.
+- No USB-serial KISS TNC support on Android in v1 (the proto messages designed below are deliberately transport-agnostic so this can be added later as a one-line UI change + Kotlin opening a `UsbSerialPort` instead of a `BluetoothSocket`).
+- No desktop Linux/macOS UI changes; the existing Serial path under `Kiss.svelte` covers BT TNCs via `rfcomm bind` today.
+
+## Architecture
+
+### Overview
+
+```
+                                            (Android process)
+                                  +----------------------------+
++--------------+   platform UDS   |   GraywolfService (Kotlin) |
+|  Go child    |<================>|   platformsvc.PlatformServer
+|  pkg/kiss    |   SerialOpen/   |                            |
+|  serial path |   SerialData    |   BtSerialAdapter          |
+|              |   SerialClose   |     - BluetoothSocket      |
+|  injected    |   SerialError   |     - worker thread        |
+|  OpenFunc -->|                  |     - bondedDevices query  |
+|  ReadWriteCloser                |                            |
++--------------+                  +----------------------------+
+                                              |
+                                              | RFCOMM
+                                              v
+                                      [paired KISS TNC]
+```
+
+The Go side's `pkg/kiss/serial.go` already exposes `SerialConfig.OpenFunc`
+— an injectable function returning `(io.ReadWriteCloser, error)`. The
+entire KISS RX/TX data path, `SerialSupervisor`, backoff, hot-reload, and
+metrics consume that interface; they have no idea whether the underlying
+bytes come from a UART, a TCP socket, or an Android-relayed RFCOMM
+stream. The new Android transport implements an adapter that connects
+to the platform UDS, sends a `SerialOpen{kind:bluetooth, address:MAC}`
+request, and exposes `Read`/`Write`/`Close` methods backed by
+`SerialData` frames in both directions.
+
+### Proto additions (`proto/platform.proto`)
+
+Extend the existing `PlatformMessage` oneof with five new variants. The
+naming is deliberately transport-agnostic (`SerialOpen`, not
+`BluetoothSerialOpen`) so a future USB-serial KISS path reuses the same
+messages.
+
+```protobuf
+enum SerialKind {
+  SERIAL_KIND_UNSPECIFIED = 0;
+  SERIAL_KIND_BLUETOOTH   = 1;
+  // USB-serial reserved for future use (1209:7388 AIOC, 10c4:ea60 Digirig, etc.)
+  // SERIAL_KIND_USB         = 2;
+}
+
+message SerialOpen {
+  uint32     handle  = 1;  // client-chosen, lifecycle-scoped
+  SerialKind kind    = 2;
+  string     address = 3;  // bluetooth: MAC; usb: device path
+  // baud, parity, etc. omitted — RFCOMM is a stream, not a UART
+}
+
+message SerialData {
+  uint32 handle = 1;
+  bytes  data   = 2;  // raw bytes, no KISS framing here — that's Go's job
+}
+
+message SerialClose {
+  uint32 handle = 1;
+  string reason = 2;  // operator-visible if non-empty
+}
+
+message SerialError {
+  uint32 handle = 1;
+  string code   = 2;  // bond_lost | permission_denied | rfcomm_closed | io_error
+  string detail = 3;
+}
+
+message SerialOpenAck {
+  uint32 handle = 1;
+  bool   ok     = 2;
+  string error  = 3;  // non-empty when ok=false
+}
+
+// Bonded-device enumeration (no auto-refresh; called explicitly + on broadcast)
+message BondedBtDevicesRequest  {}
+message BondedBtDevicesResponse {
+  message Device {
+    string mac  = 1;
+    string name = 2;  // BluetoothDevice.getName() at query time
+    // BluetoothClass.MAJOR_AUDIO etc. omitted — operators pick by name
+  }
+  repeated Device devices = 1;
+}
+```
+
+Schema version bump on `Hello.schema_version` per the existing platform
+proto contract; mismatch logs warn + restarts (status quo).
+
+### Kotlin side (`android/app/src/main/kotlin/com/nw5w/graywolf/`)
+
+New file: `platformsvc/BtSerialAdapter.kt`. Responsibilities:
+
+1. **Bonded-device enumeration** in response to `BondedBtDevicesRequest`.
+   Reads `BluetoothAdapter.bondedDevices`. Filters to
+   `BluetoothClass.SERVICE_AUDIO`-or-unset device classes — the
+   Mobilinkd/Kenwood family advertises generic profiles. Per
+   memory `feedback_android_usb_open_worker_thread`, the BluetoothAdapter
+   query runs on a worker thread; main-thread access can block UI for
+   several seconds the first time the Bluetooth stack is touched.
+
+2. **RFCOMM connect** on `SerialOpen`. Uses
+   `BluetoothDevice.createRfcommSocketToServiceRecord(SPP_UUID)` where
+   `SPP_UUID = 00001101-0000-1000-8000-00805F9B34FB`. Per the same
+   memory, the `connect()` call **must** run on a worker thread —
+   blocking and slow. Reply `SerialOpenAck{ok=true, handle=N}` on
+   success, `SerialOpenAck{ok=false, error=...}` on failure.
+
+3. **Pump pair** after connect: one thread for the socket's
+   `InputStream` (reads chunks → emits `SerialData` proto), one for the
+   `OutputStream` (consumes `SerialData` proto received over UDS →
+   writes to socket). Closed on `SerialClose` from either side, on
+   socket EOF, or on bond-lost broadcast.
+
+4. **Lifecycle bookkeeping**: per-handle map of `(BluetoothSocket,
+   readThread, writeThread, closer)`. `Close()` joins threads with a
+   short timeout, swallows already-closed exceptions.
+
+5. **`ACTION_BOND_STATE_CHANGED` broadcast receiver** registered by
+   `GraywolfService`. On any state change, pushes an unsolicited
+   `BondedBtDevicesResponse` over the platform UDS so the SPA's bonded
+   list refreshes without polling.
+
+6. **Permission handling**: `BLUETOOTH_CONNECT` runtime permission
+   (API 31+). Requested at first attempt to enumerate or connect.
+   `SerialError{code:"permission_denied"}` if denied; the Kiss page
+   surfaces a recoverable banner with a "Grant Bluetooth permission" CTA.
+
+Manifest additions (in addition to existing entries):
+
+```xml
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+<!-- BLUETOOTH_SCAN intentionally omitted: bonded-only, no discovery -->
+```
+
+### Go side
+
+#### New file: `pkg/platformsvc/btserial.go` (build-tag `android`)
+
+```go
+// BtSerialOpen returns an io.ReadWriteCloser backed by an Android
+// platform-service RFCOMM relay to the bonded device at mac.
+// Suitable for direct injection as kiss.SerialConfig.OpenFunc.
+func (c *Client) BtSerialOpen(ctx context.Context, mac string) (io.ReadWriteCloser, error)
+
+// BondedBtDevices enumerates devices already paired in Android Settings.
+func (c *Client) BondedBtDevices(ctx context.Context) ([]BondedBtDevice, error)
+
+type BondedBtDevice struct {
+    MAC  string
+    Name string
+}
+```
+
+The returned `io.ReadWriteCloser` multiplexes `SerialData` frames keyed
+by a per-instance `handle`. `Read` blocks on the next inbound frame for
+this handle (or returns `io.EOF` on `SerialClose`/`SerialError`).
+`Write` chunks the input and emits one or more `SerialData` frames.
+`Close` sends `SerialClose` and tears down the handle's read pump.
+
+Frame multiplexing inside `pkg/platformsvc/client_impl.go`: a single
+reader goroutine dispatches inbound messages to per-handle channels (the
+existing pattern already used for GPS/Audio subscriptions). KISS data
+rates (1200/9600 baud equivalents) are trivial vs the UDS bandwidth, so
+no batching/coalescing is needed.
+
+#### Modified: `pkg/app/wiring.go` (Android build)
+
+When constructing the KISS manager (`Manager.StartSerial` dispatch path
+exercised by `pkg/webapi/kiss.go` `notifyKissManager`), pass a
+platform-aware `OpenFunc`:
+
+```go
+//go:build android
+func newKissSerialOpenFunc(psv *platformsvc.Client) kiss.OpenFunc {
+    return func(ctx context.Context, cfg kiss.SerialConfig) (io.ReadWriteCloser, error) {
+        if cfg.IsBluetooth() {
+            return psv.BtSerialOpen(ctx, cfg.Device) // MAC stored in Device column
+        }
+        // serial path on Android falls through to the default
+        // (returns an error today since /dev/tty* is sandbox-blocked)
+        return kiss.DefaultSerialOpen(cfg)
+    }
+}
+```
+
+Desktop builds (`//go:build !android`) construct `SerialConfig` with no
+`OpenFunc` override — the existing `defaultSerialOpen` (uses
+`go.bug.st/serial`) keeps handling `/dev/ttyUSB0`, `/dev/rfcomm0`, and
+`/dev/cu.*` paths exactly as today.
+
+#### Modified: `pkg/configstore/models.go`
+
+No schema change. The existing `KissInterface.InterfaceType` column
+already accepts `"bluetooth"` (per the explored enum constants); the
+`Device` column carries the MAC for BT interfaces, the device path for
+serial interfaces, the host for tcp-client, etc. `BaudRate` is unset
+(or zero) for BT.
+
+#### New REST endpoint: `GET /api/kiss/bonded-bt-devices`
+
+```go
+// Android only. Returns the live bonded-device list.
+type BondedBtDevicesResponse struct {
+    Devices []BondedBtDevice `json:"devices"`
+}
+type BondedBtDevice struct {
+    MAC  string `json:"mac"`
+    Name string `json:"name"`
+}
+```
+
+Handler shells out to `platformsvc.Client.BondedBtDevices`; returns
+`501 Not Implemented` on non-Android builds. The handler also subscribes
+to `BondedBtDevicesResponse` push messages and exposes them via a
+`GET /api/kiss/bonded-bt-devices/stream` SSE endpoint for live refresh
+on `ACTION_BOND_STATE_CHANGED`. (Optional in v1; a polling Refresh
+button covers the same need.)
+
+### UI changes (`web/src/routes/Kiss.svelte`)
+
+1. **Type select option set is platform-conditional.** Today shows
+   `TCP server`, `TCP client (dial out)`, `Serial`. Android replaces
+   this with `Bluetooth Serial` and `Network` (UI labels; wire values
+   remain `bluetooth` and `tcp-client`).
+
+2. **New Bluetooth branch in the add/edit form.** Rendered when
+   `form.type === 'bluetooth'`. Contains:
+   - A `<Select>` populated from `GET /api/kiss/bonded-bt-devices`,
+     showing `{name} {mac}` per option. Refresh button next to the
+     select calls the endpoint again. If the bonded list is empty,
+     render a help hint pointing at Android Settings → Bluetooth.
+   - **No baud-rate field** — RFCOMM is a byte stream.
+   - **No Mode select** — BT TNCs are always TNC-mode (they own the
+     modem and PTT). Mode is hardcoded to `tnc` server-side for
+     `bluetooth` type interfaces.
+
+3. **Interface name auto-fill.** When the operator selects a bonded
+   device, `form.name` is auto-set to `kiss-bt-<slug(name)>` if empty
+   or unchanged from a prior auto-fill. Operator can override.
+
+4. **Interface card detail row.** The list view labels the type as
+   "Bluetooth Serial" and shows the device's friendly name (resolved
+   client-side from the bonded-list cache, with MAC as `title=` for
+   tooltip).
+
+5. **`ACTION_BOND_STATE_CHANGED` handling.** When the SSE stream or a
+   polling refresh delivers a new bonded list, the open add/edit form
+   re-renders its options without losing the operator's other field
+   selections.
+
+## Data flow — add a BT KISS TNC
+
+1. Operator pairs Mobilinkd TNC4 in Android Settings → Bluetooth.
+2. Opens Graywolf SPA → Kiss page → `+ Add KISS`.
+3. Type select: picks `Bluetooth Serial`. Form shows the bonded picker.
+4. Bonded list populates from `GET /api/kiss/bonded-bt-devices` (Go
+   asks Kotlin via platformsvc; Kotlin returns the bonded list from
+   `BluetoothAdapter.bondedDevices`).
+5. Operator picks `Mobilinkd TNC4`. Name auto-fills to
+   `kiss-bt-mobilinkd-tnc4`. Operator picks a channel.
+6. `POST /api/kiss` writes a `KissInterface{Name, InterfaceType:"bluetooth",
+   Device: "00:1B:DC:0F:11:22", Channel:1, Mode:"tnc", ...}`.
+7. `notifyKissManager` dispatches to `Manager.StartSerial` with a
+   `SerialConfig{Device:"00:1B:DC:0F:11:22", OpenFunc:newKissSerialOpenFunc(...)}`.
+8. `SerialSupervisor` calls `OpenFunc`; the Android-build `OpenFunc`
+   sees the BT path and calls `psv.BtSerialOpen(ctx, mac)`.
+9. Platformsvc issues `SerialOpen{kind:BLUETOOTH, address:mac, handle:N}`.
+10. Kotlin `BtSerialAdapter` connects RFCOMM on a worker thread, replies
+    `SerialOpenAck{ok=true, handle:N}`, starts the pump pair.
+11. Go's `SerialSupervisor` is now reading/writing KISS frames over an
+    `io.ReadWriteCloser` that happens to be Bluetooth bytes. Inbound
+    KISS frames flow through the existing RX fanout exactly as a serial
+    KISS TNC's would; outbound KISS frames from the TX queue flow back.
+12. Kiss page status refreshes — interface card shows "Connected", frame
+    counters tick up.
+
+## Error handling
+
+| Failure | Detection | Response |
+|---|---|---|
+| Bonded device out of range mid-QSO | RFCOMM socket EOF; Kotlin pushes `SerialError{code:"rfcomm_closed"}` | Go-side `io.ReadWriteCloser.Read` returns `io.EOF`. `SerialSupervisor` runs its existing reconnect backoff (1s, 2s, 5s, 10s, capped). Kiss page card shows `Reconnecting…` state. When the TNC comes back into range and the next reconnect succeeds, the card flips to `Connected`. |
+| Bonded device unpaired by the operator mid-session | `ACTION_BOND_STATE_CHANGED` with `BOND_NONE` for our MAC | Kotlin closes the socket; `SerialError{code:"bond_lost"}`. Go marks the interface failed and stops the supervisor. Kiss page shows `Unpaired` state with a CTA "Pair in Settings → re-select device". |
+| `BLUETOOTH_CONNECT` permission denied | First connect attempt returns `permission_denied` | Kiss page shows a recoverable banner above the interface card with `Grant Bluetooth permission` button that triggers `requestPermission()`. Frame counters stay zero; no toast spam — one banner, one click to fix. |
+| TNC paired but powered off | `connect()` throws `IOException` | `SerialOpenAck{ok=false, error:"connect failed: <message>"}`. Supervisor backs off and retries. Kiss page card shows `Waiting for TNC` state. |
+| RFCOMM connect succeeds but no KISS frames ever arrive | KISS RX timeout (existing supervisor behavior) | Status stays `Connected` (the link is up) but the operator sees the frame counters not advancing. No code change — this is the operator's TNC misconfiguration to debug. |
+| Schema mismatch on `Hello.schema_version` after APK upgrade | Existing platformsvc handler | Existing behavior: log warn, terminate, restart. Status quo. |
+| Multiple Graywolf launches racing for the same TNC | Android `BluetoothSocket` is single-client per (device, UUID) | The second connect attempt fails; existing supervisor reports the error. Not a concern in practice (the foreground service is singleton). |
+
+## Testing
+
+### Go (`pkg/kiss/`, `pkg/platformsvc/`)
+
+- `pkg/platformsvc/btserial_test.go` (build-tag `android`): mock
+  `PlatformServer` exchanging the new proto messages with the client;
+  asserts the `io.ReadWriteCloser` round-trip semantics, EOF on
+  `SerialClose`, error on `SerialError`, multiplexed handles do not
+  cross-talk.
+- `pkg/kiss/serial_test.go` already exercises `SerialSupervisor` with
+  an injected `OpenFunc`; add a case that returns the test mock's
+  `ReadWriteCloser` and asserts KISS frame round-trip through the full
+  RX/TX path.
+- `pkg/webapi/kiss_test.go`: `notifyKissManager` builds a `SerialConfig`
+  with `OpenFunc` set when the interface is `type=bluetooth` on Android
+  builds. Drift guard: a build-tag-`!android` test asserts the
+  `OpenFunc` is nil on desktop so the default open is used.
+
+### Kotlin (`android/app/src/test/`)
+
+- `platformsvc/BtSerialAdapterTest.kt`: a fake `BluetoothAdapter`
+  surface returning a list of bonded `Device` shapes; asserts the
+  worker-thread dispatch (failing the test if any RFCOMM call lands on
+  the JUnit main thread), permission-denied handling, pump-pair
+  shutdown on close. Uses kotlinx-coroutines-test for thread control.
+- Round-trip integration test (build flavor `androidTest`): two
+  in-process pumps connected by a `LocalSocketPair` standing in for a
+  real RFCOMM socket; asserts bytes-in === bytes-out under chunking.
+
+### Manual hardware matrix (pre-release)
+
+Tracked in beta release notes per `.context/2026-05-01-android-app-design.md` §8.5:
+
+- Pixel 8 + Mobilinkd TNC4 + Baofeng UV-5R
+- Pixel 6a + Mobilinkd TNC3 + Yaesu FT-65R
+- Samsung A54 + Kenwood TH-D75 (Bluetooth mode)
+- Galaxy Fold 5 cover screen (320px viewport) bonded picker layout
+
+## Phasing
+
+| Phase | Deliverable | Effort |
+|---|---|---|
+| 1 | Proto extension: `platform.proto` new messages + Kotlin/Go regenerated bindings; drift guard passes. | 1 day |
+| 2 | Kotlin `BtSerialAdapter`: bonded enumeration, RFCOMM open on worker thread, pump pair, `ACTION_BOND_STATE_CHANGED` receiver. Unit tests. | 3 days |
+| 3 | Go `pkg/platformsvc/btserial.go` + `pkg/app/wiring.go` Android-build `OpenFunc` injection. `pkg/kiss` integration test. | 2 days |
+| 4 | Webapi `GET /api/kiss/bonded-bt-devices` (+ optional SSE stream). | 1 day |
+| 5 | `Kiss.svelte` Bluetooth branch: platform-conditional type select, bonded picker, name auto-fill, error banner. Card detail row relabel. | 2 days |
+| 6 | Permission flow polish (banner + `requestPermission` integration); error-state UX for bond-lost/unpaired. | 1 day |
+| 7 | Hardware matrix pass; handbook page (`docs/handbook/kiss-bluetooth.html`); wiki updates to `docs/wiki/code-map.md` (BtSerialAdapter row), `docs/wiki/system-topology.md` (TNC interfaces table gains Bluetooth row). | 2 days |
+
+Total: ~12 days. Ships independently from the PTT-tab unification work
+(see `2026-05-19-android-ptt-tab-design.md`); these two designs share no
+files.
+
+## What stays unchanged
+
+- `pkg/kiss/serial.go` `SerialSupervisor`, backoff, reconnect, hot-reload.
+- `pkg/kiss/manager.go` `StartSerial` dispatch.
+- `pkg/configstore/models.go` `KissInterface` schema (the `bluetooth`
+  enum value is already there).
+- Existing KISS metrics (`graywolf_kiss_serial_*` — the BT path lights
+  them up by virtue of using the same supervisor).
+- Desktop Linux/macOS `Kiss.svelte` flow.
+- `proto/graywolf.proto` (no changes; this is in `platform.proto`).
+
+## Wiki updates required at implementation time
+
+- `docs/wiki/code-map.md` — new row under the Kotlin platform-services
+  table for `BtSerialAdapter.kt`.
+- `docs/wiki/system-topology.md` — TNC interfaces (network) table gains
+  a `KISS over Bluetooth (Android)` row.
+- `docs/wiki/invariants.md` — possibly a new invariant N12 about the
+  "all RFCOMM open/close paths run on a worker thread" rule (extending
+  N11), or fold into N11. To decide during plan review.
+
+## References
+
+- Android architecture: `.context/2026-05-01-android-app-design.md` (esp. §3.3, §4.1, §10).
+- KISS serial implementation: `docs/superpowers/plans/2026-05-16-kiss-serial-transport.md`.
+- Companion design: `docs/superpowers/specs/2026-05-19-android-ptt-tab-design.md`.
+- Relevant memories: `feedback_android_usb_open_worker_thread`,
+  `feedback_uds_unlink_before_bind`, `feedback_hid_report_check_desktop_driver`.

--- a/docs/superpowers/specs/2026-05-19-android-ptt-tab-design.md
+++ b/docs/superpowers/specs/2026-05-19-android-ptt-tab-design.md
@@ -1,0 +1,340 @@
+# Unified PTT Page — Design
+
+Date: 2026-05-19
+Status: Approved (brainstorming)
+Scope: `web/src/routes/Ptt.svelte` + companion sub-components;
+removal of the Android PTT block from `web/src/routes/channels/ChannelEditModal.svelte`
+and the corresponding save-branch in `web/src/routes/Channels.svelte`.
+Backend, proto, and `PttConfig` schema unchanged.
+
+## Goal
+
+Replace the per-platform PTT-config UI divergence introduced by PR #157
+with a single `Ptt.svelte` that works for both Android and desktop. The
+PTT tab becomes the only place an operator configures push-to-talk on
+any platform — consistent with every other Graywolf setting tab and
+ending the "Android PTT lives inside the Channels modal" friction.
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Data model | Keep `PttConfig` per-channel everywhere | PR #157 already added `PttConfig.PttMethod` as a first-class column (migration v22). On Android the "station PTT" feel falls out naturally: Android has at most one modem-backed channel, so at most one PTT row. No new singleton table, no v23 migration. |
+| API surface | Keep `/api/ptt` endpoints unchanged | One set of handlers. No Android-only endpoint. |
+| Proto / IPC | `ConfigurePtt.ppt_method` path unchanged | Already plumbed end-to-end by PR #157 per invariant 9c. |
+| Component shape | One `Ptt.svelte`; method options array branches by platform | Same shell, same card, same dialogs. ~20 lines of data differ between platforms; zero logic divergence. |
+| Add/edit modal | Split into two dialogs (Change Method → Change Device) | Replaces today's single cramped modal. UX win on desktop too. |
+| Channel selector | Auto-hide when exactly one modem-backed channel needs a PTT row | Generic rule, not Android-specific. Single-radio desktop users get the same nicety. |
+| `+ Add PTT` button | Visible only when at least one modem-backed channel has no PttConfig row | Same conditional both platforms. On Android the button disappears once the row exists. |
+| Detected-vs-Recommended classification | Server-side flag on each device row | Identical JS rendering both platforms. Desktop already classifies via `/api/ptt/available`; Android response from `UsbDeviceListRequest` gets the same `recommended: bool` shape. |
+| Test PTT | 1-second key/unkey from the modal footer | Traverses the full real proto/JNI/Kotlin chain so it verifies the whole path. |
+| `Off` method | Explicit method (no PTT keying), not "no row exists" | Lets an operator say "I have no PTT here, don't warn me." |
+| `ppt_method` integer | Internal only; not surfaced in UI | Operators see method labels; the enum integer stays in code, logs, and invariant 9c documentation. |
+
+## Non-goals
+
+- No new station-global singleton table. The earlier proposal that
+  introduced `android_ppt_configs` is explicitly dropped.
+- No data migration. `PttConfig` rows from PR #157 are read by the new
+  UI as-is.
+- No removal of the read-only PTT indicator on the Channels page card —
+  that's a useful "what keys this channel" surface and stays.
+- No changes to `proto/graywolf.proto`, `pkg/modembridge/session.go`
+  `ConfigurePtt` construction, or `android/.../UsbPttAdapter.kt`
+  dispatch. These all work correctly today.
+- No "VOX as the operator-default fallback" behavior. VOX is an explicit
+  method choice; absence of config means `method='none'`.
+
+## Architecture
+
+### What's shared vs branched (the contract)
+
+| Surface | Status | Notes |
+|---|---|---|
+| `PttConfig` schema | **Shared** | As-is post PR #157. |
+| `/api/ptt` GET/POST/PUT/DELETE | **Shared** | No new endpoint. |
+| `ConfigurePtt` proto path | **Shared** | Unchanged. |
+| `Ptt.svelte` page shell (header, readiness strip, grid, detected sections, modal hosts) | **Shared** | Same component file. |
+| PTT card template | **Shared** | Two-row Method/Device with `Change ›` buttons, `Test PTT (1s)` in footer. |
+| Dialog A chrome (method picker) | **Shared** | `<MethodPicker/>` sub-component. |
+| Dialog B chrome (device picker) | **Shared** | `<DevicePicker/>` sub-component. |
+| Channel-selector auto-hide rule | **Shared** | Hide when exactly one modem-backed channel needs a PttConfig row. |
+| Detected/Recommended classification | **Shared rendering** | `recommended: bool` flag comes from the server. |
+| **Dialog A method options** | **Branched** (data only) | Two arrays of method objects keyed off platform. ~20 lines of data, not logic. |
+| **Dialog B device source** | **Branched** (backend) | Android: `UsbDeviceListRequest` filtered by class. Desktop: existing `/api/ptt/available` + `/api/ptt/gpio-chips/{chip}/lines`. |
+
+### Component layout (`web/src/routes/`)
+
+```
+Ptt.svelte                  -- the page; renders shell + grid + dialogs
+  ptt/
+    PttCard.svelte          -- the two-row Method/Device card with Test PTT
+    DialogChangeMethod.svelte   -- Dialog A; props: method options array, current method
+    DialogChangeDevice.svelte   -- Dialog B; props: method, device source adapter
+    MethodPicker.svelte         -- radio-card list, takes method[] array
+    DevicePicker.svelte         -- list with selection + permission state
+    devices/
+      androidDeviceSource.js    -- queries platformsvc via /api/ptt/available
+      desktopDeviceSource.js    -- queries /api/ptt/available, /api/ptt/gpio-chips
+      methodOptions.android.js  -- the 5 Android methods (off + Digirig + AIOC + CM108 HID + VOX)
+      methodOptions.desktop.js  -- the 6 desktop methods (off + serial_rts + serial_dtr + gpio + cm108 + rigctld)
+```
+
+Platform branching is confined to `ptt/devices/`. Everything else is
+platform-blind.
+
+### Method option arrays (the entire divergence)
+
+```js
+// methodOptions.android.js
+export const ANDROID_METHODS = [
+  { wire: { method: 'none' },                       label: 'Off — no PTT',
+    meta: 'Graywolf does not key the radio.' },
+  { wire: { method: 'android', ppt_method: 1 },     label: 'Digirig (CP2102N RTS)',
+    meta: 'USB-serial RTS keys the radio. Most common option.',
+    deviceClass: 'cp2102n' },
+  { wire: { method: 'android', ppt_method: 3 },     label: 'AIOC (CDC-ACM DTR)',
+    meta: 'For AIOC firmware ≥ 1.2.0. DTR=1 / RTS=0.',
+    deviceClass: 'cdc-acm' },
+  { wire: { method: 'android', ppt_method: 2 },     label: 'CM108 HID GPIO',
+    meta: 'Generic CM108-class adapters with GPIO 3 wired externally to PTT. Not for Digirig or AIOC.',
+    deviceClass: 'hid-cm108' },
+  { wire: { method: 'android', ppt_method: 4 },     label: 'VOX (no keying)',
+    meta: 'Radio detects audio and keys itself. No USB device required.',
+    deviceClass: null },
+];
+
+// methodOptions.desktop.js
+export const DESKTOP_METHODS = [
+  { wire: { method: 'none' },        label: 'Off — no PTT', /* ... */ },
+  { wire: { method: 'serial_rts' },  label: 'Serial RTS', /* ... */ },
+  { wire: { method: 'serial_dtr' },  label: 'Serial DTR', /* ... */ },
+  { wire: { method: 'gpio' },        label: 'GPIO', /* ... */ },
+  { wire: { method: 'cm108' },       label: 'CM108 HID GPIO', /* ... */ },
+  { wire: { method: 'rigctld' },     label: 'rigctld', /* ... */ },
+];
+```
+
+`Ptt.svelte` picks one based on `Platform.kind === 'android'` (same
+client-side detection PR #157 already uses) and passes it to
+`<MethodPicker/>`. No conditional rendering branches in the templates.
+
+### `/api/ptt/available` Android-side wiring
+
+Today the handler enumerates host devices on desktop. On Android, the
+handler should return a unified `[]PttDevice` shape sourced from
+`UsbDeviceListRequest` over platformsvc:
+
+```go
+type PttDevice struct {
+    Path        string `json:"path"`        // android: empty (use VID:PID); desktop: /dev/ttyUSB0
+    Description string `json:"description"`
+    Type        string `json:"type"`        // "serial" | "cm108" | "gpio" | "usb-cdc-acm" | "usb-cp2102n" | "usb-hid"
+    USBVendor   string `json:"usb_vendor,omitempty"`
+    USBProduct  string `json:"usb_product,omitempty"`
+    Recommended bool   `json:"recommended"` // server-side classification
+    Warning     string `json:"warning,omitempty"`
+    HasPermission *bool `json:"has_permission,omitempty"` // android-only; tri-state for desktop's N/A
+}
+```
+
+Server-side classification rules:
+
+- **Android**: VID:PID `10c4:ea60` (CP2102N) → recommended, type
+  `usb-cp2102n`. `1209:7388` (AIOC) → recommended, type `usb-cdc-acm`.
+  CM108-family VID:PIDs (`0d8c:013c`, etc.) → recommended *only if*
+  GPIO output reporting is supported, type `usb-hid`. Other USB devices
+  → not recommended, listed under "Other detected devices".
+- **Desktop**: existing rules (CP2102/AIOC/CM108 = recommended,
+  generic serial ports = other). Unchanged.
+
+### Channel-selector auto-hide
+
+Implementation in `Ptt.svelte`:
+
+```svelte
+const modemBackedChannels = $derived(
+  channels.filter(c => c.input_device_id != null && c.mode !== 'packet')
+);
+const channelsNeedingPtt = $derived(
+  modemBackedChannels.filter(c => !pttConfigs.has(c.id))
+);
+const showChannelSelector = $derived(channelsNeedingPtt.length > 1);
+const showAddButton = $derived(channelsNeedingPtt.length > 0);
+```
+
+When adding (not editing) and `showChannelSelector` is false, the
+channel for the new `PttConfig` row is auto-set to `channelsNeedingPtt[0].id`
+and the selector is omitted. Editing always omits the selector
+(channel is fixed to the row being edited).
+
+### Two-dialog flow
+
+```
+[ Station PTT card ]
+   |
+   |-- [Change Method ›]  -->  Dialog A (MethodPicker)
+   |                              |
+   |                              |-- Save & next ›
+   |                              |     |
+   |                              |     |-- method needs device? --> Dialog B
+   |                              |     |-- method is Off/VOX?    --> close, save
+   |
+   |-- [Change Device ›]  -->  Dialog B (DevicePicker, filtered by current method)
+                                  |
+                                  |-- Save --> close, save
+                                  |-- < Back --> Dialog A
+```
+
+For first-time setup (no PTT row yet), clicking `+ Add PTT` opens
+Dialog A. After picking a USB-requiring method and `Save & next ›`, B
+opens automatically. `Off` / `VOX` skip B and close.
+
+For the detected-device shortcut on the Recommended cards: clicking a
+recommended device opens Dialog B directly with the matching method
+pre-selected and the device pre-selected. One Save and you're done.
+Clicking a card under "Other" opens Dialog A first (method isn't
+obvious) and falls through normally.
+
+## UI removal — what comes out
+
+`web/src/routes/channels/ChannelEditModal.svelte`:
+- Remove `import AndroidPttFields from './AndroidPttFields.svelte'`.
+- Remove the `androidPttMethod` state.
+- Remove the `{#if Platform.kind === 'android'} <AndroidPttFields .../> {/if}` block.
+- Remove the `androidPttMethod` field from `handleSave`'s payload.
+
+`web/src/routes/channels/AndroidPttFields.svelte`:
+- Delete the file. The functionality lives in `Ptt.svelte` now.
+
+`web/src/routes/Channels.svelte`:
+- Remove the `androidPttMethod` parameter from `handleSave`'s callback signature.
+- Remove the `if (Platform.kind === 'android' && androidPttMethod != null && channelId) { await api.post('/ppt', ...) }` save branch.
+
+The Channels page's read-only PTT indicator row (added pre-PR #157)
+stays — operators want at-a-glance visibility of "what keys this channel"
+without leaving the Channels page.
+
+## Data flow — Android first-time setup
+
+1. Operator opens PTT tab on Android tablet. No PttConfig rows yet.
+2. Readiness strip shows "No PTT configured." `+ Add PTT` visible.
+3. Click `+ Add PTT` → Dialog A opens. Method options = `ANDROID_METHODS`.
+   Channel selector hidden (one modem-backed channel; auto-selected).
+4. Operator picks `Digirig (CP2102N RTS)` → `Save & next ›`.
+5. Dialog B opens. Device list filtered to `deviceClass: 'cp2102n'`.
+   Shows the connected CP2102N device with "Permission OK" or "Request permission".
+6. Operator selects the device → `Save`.
+7. Frontend `POST /api/ptt { channel_id: <auto>, method: 'android', ppt_method: 1, device_path: '...' }`.
+8. Existing `pkg/webapi/ptt.go` `upsertPttConfig` handler writes the row.
+9. `pkg/modembridge/session.go` builds `ConfigurePtt{ppt_method: 1, ...}` per invariant 9c.
+10. Rust modem dispatches to `AndroidPtt`; JNI relays to Kotlin
+    `UsbPttAdapter.keyCp2102nRts()`.
+11. Card flips to "Active". Operator clicks `Test PTT (1s)`; the same
+    chain fires for a brief key+unkey to verify everything.
+
+## Data flow — multi-radio desktop edit
+
+1. Operator already has three PTT configs (2m Serial RTS, 70cm GPIO, 6m rigctld).
+2. PTT tab renders three cards.
+3. Operator wants to swap the GPIO line on 70cm.
+4. Clicks `Change Device ›` on the 70cm card. Dialog B opens with
+   method = `gpio` already known; Dialog A is bypassed.
+5. Dialog B fetches `/api/ptt/gpio-chips/{chip}/lines` (existing endpoint),
+   shows the available lines on the chosen chip. Operator picks a different line.
+6. `Save` → `PUT /api/ptt/{channel_id}` with the new `gpio_line` value.
+
+## Error handling
+
+Same handler-level error paths as today's Ptt.svelte (invalid device
+path, KISS-only channel rejection by `validatePttChannelBacking`,
+rigctld test-connection failure, etc.). Two new UI-level edge cases:
+
+| Failure | Detection | Response |
+|---|---|---|
+| Operator opens PTT tab with no modem-backed channels | `channels.filter(...modem-backed).length === 0` | Empty state: "No PTT-eligible channels. PTT applies to audio-modem channels — configure a modem-backed channel on the Channels page first." `+ Add PTT` button disabled. (Same message on both platforms.) |
+| Android: chosen USB device's permission is later revoked (rare; user does it explicitly) | `/api/ppt/available` returns the device with `has_permission: false` | The Station PTT card shows a warning badge and a "Re-grant permission" CTA next to the device row. Test PTT fails fast with the same error. |
+| Dialog B is opened but no devices of the required class are detected | Empty list from the device source | Dialog B body shows an empty-state card explaining what device is needed (e.g., "Plug in a Digirig — looking for a CP2102N USB-serial device") with a Refresh button. |
+
+## Testing
+
+### Svelte unit tests (`web/src/routes/ptt/`)
+
+- `MethodPicker.test.js`: feeds in `ANDROID_METHODS`, asserts radio
+  rendering, selected state, change events. Same test with `DESKTOP_METHODS`.
+- `DevicePicker.test.js`: feeds a mock device list with mixed
+  `recommended` and `has_permission` states; asserts filtering by
+  method's `deviceClass`, permission-prompt CTA wiring, empty state.
+- `Ptt.routing.test.js` (integration): mounts `Ptt.svelte` with mocked
+  `/api/ptt` and `/api/ptt/available` responses; asserts the "click
+  Recommended → Dialog B opens with method preselected → Save → POST"
+  shortcut, and the standalone "+ Add PTT → Dialog A → Save & next →
+  Dialog B → Save → POST" flow.
+- `Ptt.channelSelector.test.js`: asserts the auto-hide rule
+  (`channelsNeedingPtt.length > 1` → visible; else hidden+auto-filled).
+
+### Go (`pkg/webapi/`)
+
+- `pkg/webapi/ptt_test.go` already exercises the `upsertPttConfig`
+  handler. Add a case: POST with `{method:'android', ppt_method:N}`
+  succeeds and persists; verify the `ChannelPttFromModel` summary in
+  the GET response.
+- `pkg/webapi/ptt_devices_test.go` (new): asserts the `Recommended`
+  flag is set correctly for the Android device shapes (CP2102N → true,
+  AIOC → true, FT232R → false).
+
+### Channels-modal removal regression test
+
+- `web/src/routes/channels/ChannelEditModal.test.js`: after the
+  AndroidPttFields removal, assert that opening the modal on Android
+  (`Platform.kind === 'android'`) does NOT render any PTT-related
+  elements. Existing channel-only fields (callsign, audio devices, mode,
+  etc.) render unchanged.
+
+### Manual
+
+- Android tablet: full first-time Digirig setup via the new flow;
+  swap to AIOC method (re-prompts for device); Test PTT fires per the
+  USB analyzer trace.
+- Desktop Linux multi-radio: three PttConfig rows; edit each via the
+  split-dialog flow; verify no data loss vs the existing single-modal flow.
+- Single-radio desktop: channel selector auto-hides; `+ Add PTT`
+  disappears after the one row is created.
+
+## Phasing
+
+| Phase | Deliverable | Effort |
+|---|---|---|
+| 1 | Extract sub-components from current `Ptt.svelte`: `PttCard.svelte`, `MethodPicker.svelte`, `DevicePicker.svelte`. No behavior change; pass-through props mirror today's modal. | 2 days |
+| 2 | Split single modal into `DialogChangeMethod.svelte` + `DialogChangeDevice.svelte` with the auto-chain flow. Card gains two `Change …` buttons. Existing desktop methods only at this phase — Android methods land in phase 4. | 2 days |
+| 3 | Channel-selector auto-hide rule + `+ Add PTT` visibility rule. Generic, both platforms. | 1 day |
+| 4 | Add `methodOptions.android.js` + `methodOptions.desktop.js`. Wire `Platform.kind` selector. Add Android device-source backed by `/api/ptt/available` (Android branch returns USB device list). | 2 days |
+| 5 | Server-side `Recommended` classification: emit `recommended: bool` on every device row in `/api/ptt/available`. Update `DevicePicker` to render the Recommended/Other split. | 2 days |
+| 6 | Click-to-configure shortcut on Recommended cards: open Dialog B directly with method + device preselected. | 1 day |
+| 7 | Remove `AndroidPttFields.svelte`, the `{#if Platform.kind === 'android'}` block from `ChannelEditModal.svelte`, and the Android save-branch from `Channels.svelte`. ChannelEditModal regression test. | 1 day |
+| 8 | Wiki updates: `docs/wiki/code-map.md` (Ptt sub-component rows, AndroidPttFields removed); `docs/wiki/invariants.md` (note that PTT config lives only in the PTT tab; channel modal is channel-only). | 0.5 day |
+
+Total: ~11.5 days. Phases 1–3 are pure-desktop refactor wins; the
+Android unification lands in phases 4–7. Each phase ships independently.
+
+## What stays unchanged
+
+- `pkg/configstore/models.go` `PttConfig` schema.
+- `pkg/configstore/migrate.go` (no migration v23).
+- `pkg/webapi/ptt.go` handler signatures and routes.
+- `pkg/webapi/dto/ptt.go` request/response shapes (the existing
+  `ppt_method` field carries Android transports as before).
+- `pkg/modembridge/session.go` `ConfigurePtt` construction.
+- `proto/graywolf.proto` `ConfigurePtt` message.
+- `graywolf-modem/src/tx/ptt.rs` `PttMethod::Android` arm.
+- `android/.../usb/UsbPttAdapter.kt` `keyCp2102nRts`/`keyCm108Hid`/`keyAiocCdcRts` functions.
+- Channels page read-only PTT indicator row.
+- Desktop Linux/macOS PTT data flow.
+
+## References
+
+- PR #157: introduced the Android-in-channels divergence this design reverses.
+- Invariant 9c (`docs/wiki/invariants.md`): the `ppt_method` first-class field contract — preserved by this design.
+- Companion design: `docs/superpowers/specs/2026-05-19-android-bluetooth-kiss-tnc-design.md`.
+- Android architecture context: `.context/2026-05-01-android-app-design.md` (esp. §3.3, §5.2, §5.5).
+- Relevant memories: `feedback_ui_design_quality`, `feedback_single_user_station`, `feedback_chonky_ui_workflow`, `feedback_chonky_input_alignment`.


### PR DESCRIPTION
Two related Android-focused design specs:

- 2026-05-19-android-bluetooth-kiss-tnc-design.md: BT-paired KISS TNCs (Mobilinkd, Kenwood TH-D74/D75, etc.) via a Kotlin BluetoothSocket relay over the existing platform UDS, feeding the unchanged pkg/kiss serial path through an injected OpenFunc. Bonded-only picker; no in-app pairing. Desktop unchanged (existing rfcomm bind workflow on Linux, /dev/cu.* on macOS).

- 2026-05-19-android-ptt-tab-design.md: undoes PR #157's per-platform PTT divergence. One Ptt.svelte for both Android and desktop; per-channel PttConfig schema preserved (no migration); add/edit modal split into Change Method and Change Device dialogs; Android PTT block removed from ChannelEditModal.svelte.