### PR TITLE
Android Bluetooth KISS TNC support

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -95,10 +95,12 @@ dependencies {
     implementation("com.google.android.material:material:1.12.0")
     implementation("com.github.mik3y:usb-serial-for-android:3.10.0")
     implementation("com.google.protobuf:protobuf-javalite:3.25.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.11.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
 }
 
 val jniLibsDir = file("src/main/jniLibs")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,14 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <!-- Legacy permissions for API 30 and below (minSdk=28). -->
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <!-- BLUETOOTH_SCAN intentionally omitted: bonded-only, no discovery. -->
+
     <uses-feature android:name="android.hardware.usb.host" android:required="false"/>
 
     <application

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
@@ -230,7 +230,7 @@ class GraywolfService : Service() {
         platformServer = PlatformServer(
             socketPath = platformSocketPath(),
             serverVersion = BuildConfig.VERSION_NAME,
-            schemaVersion = 1,
+            schemaVersion = 2,
         ).also { it.start() }
         gpsAdapter = GpsAdapter(this, platformServer!!).also { it.start() }
 

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.Manifest
+import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothManager
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
@@ -48,6 +49,42 @@ class GraywolfService : Service() {
             if (intent.action == ACTION_STOP) {
                 Log.i(TAG, "stop action received; shutting down")
                 stopSelf()
+            }
+        }
+    }
+
+    /**
+     * ACTION_BOND_STATE_CHANGED listener: tears down any open RFCOMM
+     * sockets to a now-unpaired device, and refreshes the bonded list on
+     * the Go side when a new pairing completes. The system broadcasts
+     * this intent without requiring BLUETOOTH_CONNECT to receive (the
+     * permission is only needed for direct API reads).
+     */
+    private val bondReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action != BluetoothDevice.ACTION_BOND_STATE_CHANGED) return
+            val device: BluetoothDevice? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+            }
+            val mac = device?.address ?: return
+            val newState = intent.getIntExtra(
+                BluetoothDevice.EXTRA_BOND_STATE,
+                BluetoothDevice.ERROR,
+            )
+            val adapter = btSerialAdapter ?: return
+            when (newState) {
+                BluetoothDevice.BOND_NONE -> {
+                    Log.i(TAG, "bond lost mac=$mac; closing any open RFCOMM handles")
+                    adapter.onBondLost(mac)
+                }
+                BluetoothDevice.BOND_BONDED -> {
+                    Log.i(TAG, "bonded mac=$mac; pushing refreshed bonded list")
+                    adapter.handleBondedRequest()
+                }
+                else -> { /* BOND_BONDING or other transient -- ignore */ }
             }
         }
     }
@@ -154,9 +191,19 @@ class GraywolfService : Service() {
                 IntentFilter(ACTION_STOP),
                 Context.RECEIVER_NOT_EXPORTED,
             )
+            registerReceiver(
+                bondReceiver,
+                IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED),
+                Context.RECEIVER_NOT_EXPORTED,
+            )
         } else {
             @Suppress("UnspecifiedRegisterReceiverFlag")
             registerReceiver(stopReceiver, IntentFilter(ACTION_STOP))
+            @Suppress("UnspecifiedRegisterReceiverFlag")
+            registerReceiver(
+                bondReceiver,
+                IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED),
+            )
         }
         val stopIntent = Intent(ACTION_STOP).setPackage(packageName)
         val stopPending = PendingIntent.getBroadcast(
@@ -286,6 +333,9 @@ class GraywolfService : Service() {
         ModemBridge.modemStop()
         try {
             unregisterReceiver(stopReceiver)
+        } catch (_: IllegalArgumentException) { /* idempotent */ }
+        try {
+            unregisterReceiver(bondReceiver)
         } catch (_: IllegalArgumentException) { /* idempotent */ }
         super.onDestroy()
     }

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.Manifest
+import android.bluetooth.BluetoothManager
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import androidx.core.content.ContextCompat
@@ -27,7 +28,9 @@ import com.nw5w.graywolf.binaries.GoLauncher
 import com.nw5w.graywolf.binaries.Supervisor
 import com.nw5w.graywolf.gps.GpsAdapter
 import com.nw5w.graywolf.jni.ModemBridge
+import com.nw5w.graywolf.platformsvc.BtSerialAdapter
 import com.nw5w.graywolf.platformsvc.PlatformServer
+import com.nw5w.graywolf.platformsvc.SystemBluetoothFacade
 import com.nw5w.graywolf.usb.UsbPttAdapter
 import java.io.File
 
@@ -37,6 +40,7 @@ class GraywolfService : Service() {
     private var goLauncher: GoLauncher? = null
     private var platformServer: PlatformServer? = null
     private var gpsAdapter: GpsAdapter? = null
+    private var btSerialAdapter: BtSerialAdapter? = null
     private val supervisor = Supervisor(onRestart = ::supervisorRestart)
 
     private val stopReceiver = object : BroadcastReceiver() {
@@ -234,6 +238,17 @@ class GraywolfService : Service() {
         ).also { it.start() }
         gpsAdapter = GpsAdapter(this, platformServer!!).also { it.start() }
 
+        // Bluetooth-classic KISS TNC adapter. Wired AFTER PlatformServer.start()
+        // because its sendMessage callback closes over platformServer.broadcastBt.
+        // Tolerates a missing BluetoothAdapter (devices without BT, or BT off):
+        // SystemBluetoothFacade no-ops bondedDevices and rejects connectRfcomm.
+        val btManager = getSystemService(BluetoothManager::class.java)
+        val btFacade = SystemBluetoothFacade(btManager?.adapter)
+        btSerialAdapter = BtSerialAdapter(
+            facade = btFacade,
+            sendMessage = { msg -> platformServer!!.broadcastBt(msg) },
+        ).also { platformServer!!.attachBtAdapter(it) }
+
         if (!bootModem()) {
             stopSelf()
             return
@@ -263,6 +278,10 @@ class GraywolfService : Service() {
         audioTxPump?.stop()
         audioTxPump = null
         UsbPttAdapter.closeAll()
+        // Adapter shutdown emits any final SerialClose frames via broadcastBt
+        // -- it MUST run before platformServer.stop() tears the socket down.
+        btSerialAdapter?.shutdown()
+        btSerialAdapter = null
         platformServer?.stop()
         ModemBridge.modemStop()
         try {

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
@@ -25,6 +25,10 @@ class MainActivity : Activity() {
     private val mainHandler = Handler(Looper.getMainLooper())
     private var didReloadOnError = false
     private var batteryOptIntentChecked = false
+    // Pending JS callback id for an in-flight BLUETOOTH_CONNECT permission
+    // request. Cleared in onRequestPermissionsResult after we post the
+    // window.__btResult dispatch back to the WebView.
+    private var pendingBtPermCallback: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -49,6 +53,7 @@ class MainActivity : Activity() {
                 WebAppInterface(
                     tokenProvider = { (application as GraywolfApp).bearerToken },
                     webView = it,
+                    requestBtPermission = ::requestBluetoothPermission,
                 ),
                 "GraywolfWebInterface",
             )
@@ -87,7 +92,63 @@ class MainActivity : Activity() {
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == REQ_PERMS) startEverything()
+        if (requestCode == REQ_PERMS) {
+            startEverything()
+            return
+        }
+        if (requestCode == REQ_BT_PERMS) {
+            val granted = grantResults.isNotEmpty() &&
+                grantResults[0] == PackageManager.PERMISSION_GRANTED
+            val callbackId = pendingBtPermCallback
+            pendingBtPermCallback = null
+            if (callbackId != null) postBtResult(callbackId, granted)
+        }
+    }
+
+    /**
+     * Request the BLUETOOTH_CONNECT runtime permission and report the result
+     * back to the WebView via window.__btResult(callbackId, granted).
+     *
+     * On API <31 the permission is install-time (the legacy BLUETOOTH /
+     * BLUETOOTH_ADMIN entries in the manifest cover us) so we resolve the
+     * callback immediately with granted=true.
+     *
+     * If the permission is already granted, we likewise short-circuit.
+     *
+     * Otherwise we store the callbackId, fire requestPermissions(), and let
+     * onRequestPermissionsResult() post the result.
+     */
+    fun requestBluetoothPermission(callbackId: String) {
+        if (!CALLBACK_ID_RE.matches(callbackId)) {
+            Log.w(TAG, "rejected invalid bt callbackId: $callbackId")
+            return
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            // API <31: legacy BLUETOOTH / BLUETOOTH_ADMIN are install-time.
+            postBtResult(callbackId, true)
+            return
+        }
+        if (checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
+            postBtResult(callbackId, true)
+            return
+        }
+        pendingBtPermCallback = callbackId
+        requestPermissions(arrayOf(Manifest.permission.BLUETOOTH_CONNECT), REQ_BT_PERMS)
+    }
+
+    // Dispatch the BT permission result back into the SPA. callbackId is
+    // re-validated against CALLBACK_ID_RE before JS interpolation so a
+    // malformed value can't escape the string literal.
+    private fun postBtResult(callbackId: String, granted: Boolean) {
+        if (!CALLBACK_ID_RE.matches(callbackId)) {
+            Log.w(TAG, "refusing to post bt result for invalid callbackId: $callbackId")
+            return
+        }
+        webView.post {
+            val script = "window.__btResult && window.__btResult('$callbackId', $granted)"
+            Log.d(TAG, "btResult callbackId=$callbackId granted=$granted")
+            webView.evaluateJavascript(script, null)
+        }
     }
 
     private fun startEverything() {
@@ -142,6 +203,11 @@ class MainActivity : Activity() {
     companion object {
         private const val TAG = "MainActivity"
         private const val REQ_PERMS = 0x101
+        // Distinct request code for BLUETOOTH_CONNECT runtime permission so
+        // onRequestPermissionsResult can route the result to the SPA's
+        // pending callback instead of the startup-perms code path.
+        private const val REQ_BT_PERMS = 0x102
+        private val CALLBACK_ID_RE = Regex("^[A-Za-z0-9_-]+$")
         private const val PREFS_NAME = "graywolf-prefs"
         private const val PREF_BATTERY_OPT_REQUESTED = "battery_opt_whitelist_requested_v1"
 

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
@@ -19,6 +19,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.nw5w.graywolf.webview.WebAppInterface
+import com.nw5w.graywolf.webview.WebBridgeIds
 
 class MainActivity : Activity() {
     private lateinit var webView: WebView
@@ -119,28 +120,36 @@ class MainActivity : Activity() {
      * onRequestPermissionsResult() post the result.
      */
     fun requestBluetoothPermission(callbackId: String) {
-        if (!CALLBACK_ID_RE.matches(callbackId)) {
+        if (!WebBridgeIds.CALLBACK_ID_RE.matches(callbackId)) {
             Log.w(TAG, "rejected invalid bt callbackId: $callbackId")
             return
         }
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-            // API <31: legacy BLUETOOTH / BLUETOOTH_ADMIN are install-time.
-            postBtResult(callbackId, true)
-            return
+        // requestPermissions() is documented to run on the main thread, and
+        // pendingBtPermCallback is read on the main thread by
+        // onRequestPermissionsResult. @JavascriptInterface methods are invoked
+        // on the WebView binder thread, so hop to the main looper before
+        // touching either. The postBtResult short-circuits already target the
+        // main thread via webView.post inside postBtResult.
+        mainHandler.post {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                // API <31: legacy BLUETOOTH / BLUETOOTH_ADMIN are install-time.
+                postBtResult(callbackId, true)
+                return@post
+            }
+            if (checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
+                postBtResult(callbackId, true)
+                return@post
+            }
+            pendingBtPermCallback = callbackId
+            requestPermissions(arrayOf(Manifest.permission.BLUETOOTH_CONNECT), REQ_BT_PERMS)
         }
-        if (checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
-            postBtResult(callbackId, true)
-            return
-        }
-        pendingBtPermCallback = callbackId
-        requestPermissions(arrayOf(Manifest.permission.BLUETOOTH_CONNECT), REQ_BT_PERMS)
     }
 
     // Dispatch the BT permission result back into the SPA. callbackId is
     // re-validated against CALLBACK_ID_RE before JS interpolation so a
     // malformed value can't escape the string literal.
     private fun postBtResult(callbackId: String, granted: Boolean) {
-        if (!CALLBACK_ID_RE.matches(callbackId)) {
+        if (!WebBridgeIds.CALLBACK_ID_RE.matches(callbackId)) {
             Log.w(TAG, "refusing to post bt result for invalid callbackId: $callbackId")
             return
         }
@@ -207,7 +216,6 @@ class MainActivity : Activity() {
         // onRequestPermissionsResult can route the result to the SPA's
         // pending callback instead of the startup-perms code path.
         private const val REQ_BT_PERMS = 0x102
-        private val CALLBACK_ID_RE = Regex("^[A-Za-z0-9_-]+$")
         private const val PREFS_NAME = "graywolf-prefs"
         private const val PREF_BATTERY_OPT_REQUESTED = "battery_opt_whitelist_requested_v1"
 

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BluetoothFacade.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BluetoothFacade.kt
@@ -1,0 +1,56 @@
+package com.nw5w.graywolf.platformsvc
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothSocket
+import java.util.UUID
+
+/** Simple bonded-device record passed up to Go. */
+data class BondedDevice(val mac: String, val name: String)
+
+/** Thin interface around BluetoothAdapter to allow unit testing. */
+interface BluetoothFacade {
+    suspend fun bondedDevices(): List<BondedDevice>
+    /** Throws on connect failure. MUST be called from a worker thread. */
+    suspend fun connectRfcomm(mac: String): BluetoothSocket
+    fun isBonded(mac: String): Boolean
+}
+
+/** Production implementation backed by the system BluetoothAdapter. */
+class SystemBluetoothFacade(
+    private val adapter: BluetoothAdapter?,
+) : BluetoothFacade {
+    companion object {
+        val SPP_UUID: UUID = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB")
+    }
+
+    override suspend fun bondedDevices(): List<BondedDevice> {
+        val a = adapter ?: return emptyList()
+        return a.bondedDevices.orEmpty().map {
+            BondedDevice(mac = it.address, name = it.name ?: it.address)
+        }
+    }
+
+    override fun isBonded(mac: String): Boolean {
+        val a = adapter ?: return false
+        return a.bondedDevices.orEmpty().any { it.address == mac }
+    }
+
+    override suspend fun connectRfcomm(mac: String): BluetoothSocket {
+        val a = adapter ?: error("Bluetooth not available on this device")
+        val device: BluetoothDevice = a.getRemoteDevice(mac)
+        val socket = device.createRfcommSocketToServiceRecord(SPP_UUID)
+        socket.connect() // blocking; caller MUST be on a worker thread
+        return socket
+    }
+}
+
+/** Test double. */
+class FakeBluetoothFacade(
+    private val bonded: List<BondedDevice>,
+) : BluetoothFacade {
+    override suspend fun bondedDevices(): List<BondedDevice> = bonded
+    override fun isBonded(mac: String): Boolean = bonded.any { it.mac == mac }
+    override suspend fun connectRfcomm(mac: String): BluetoothSocket =
+        error("FakeBluetoothFacade does not support real RFCOMM; override for integration tests")
+}

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt
@@ -1,0 +1,59 @@
+package com.nw5w.graywolf.platformsvc
+
+import android.util.Log
+import com.nw5w.graywolf.platformproto.BondedBtDevicesResponse
+import com.nw5w.graywolf.platformproto.PlatformMessage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * BtSerialAdapter handles Bluetooth-classic SPP/RFCOMM byte relay for the
+ * platform service. All BluetoothAdapter / RFCOMM calls run on the
+ * worker dispatcher; never the main thread.
+ *
+ * sendMessage is the callback the PlatformServer wires up to push frames
+ * back to the connected Go client.
+ */
+class BtSerialAdapter(
+    private val facade: BluetoothFacade,
+    private val workerDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val sendMessage: (PlatformMessage) -> Unit,
+) {
+    private val tag = "BtSerialAdapter"
+    private val scope = CoroutineScope(SupervisorJob() + workerDispatcher)
+
+    fun handleBondedRequest() {
+        scope.launch {
+            val devices = try {
+                facade.bondedDevices()
+            } catch (sec: SecurityException) {
+                Log.w(tag, "BLUETOOTH_CONNECT permission missing", sec)
+                emptyList()
+            }
+            val resp = BondedBtDevicesResponse.newBuilder().apply {
+                devices.forEach {
+                    addDevices(
+                        BondedBtDevicesResponse.Device.newBuilder()
+                            .setMac(it.mac)
+                            .setName(it.name)
+                            .build()
+                    )
+                }
+            }.build()
+            sendMessage(
+                PlatformMessage.newBuilder()
+                    .setBondedBtDevicesResponse(resp)
+                    .build()
+            )
+        }
+    }
+
+    fun shutdown() {
+        // tear down all handles (filled in Task 2.4)
+        scope.coroutineContext[Job]?.cancel()
+    }
+}

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt
@@ -45,7 +45,6 @@ class BtSerialAdapter(
         val mac: String,
         val socket: BluetoothSocket,
         val readJob: Job,
-        val writeJob: Job?,    // null until first writer activity if you use a queue model
         val mutex: Mutex = Mutex(),
     )
 
@@ -97,7 +96,7 @@ class BtSerialAdapter(
                 return@launch
             }
             val readJob = scope.launch { readPump(handle, socket) }
-            handles[handle] = HandleState(mac, socket, readJob, null)
+            handles[handle] = HandleState(mac, socket, readJob)
             sendAck(handle, ok = true, err = "")
         }
     }
@@ -123,8 +122,11 @@ class BtSerialAdapter(
         val handle = req.handle.toUInt()
         val state = handles.remove(handle) ?: return
         scope.launch {
-            try { state.readJob.cancelAndJoin() } catch (_: Throwable) {}
+            // socket.close() first: the read pump is blocked in a native JNI
+            // inputStream.read() that coroutine cancellation cannot interrupt;
+            // closing the socket unblocks it via IOException.
             try { state.socket.close() } catch (_: Throwable) {}
+            try { state.readJob.cancelAndJoin() } catch (_: Throwable) {}
         }
     }
 

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt
@@ -1,14 +1,28 @@
 package com.nw5w.graywolf.platformsvc
 
+import android.bluetooth.BluetoothSocket
 import android.util.Log
+import com.google.protobuf.ByteString
 import com.nw5w.graywolf.platformproto.BondedBtDevicesResponse
 import com.nw5w.graywolf.platformproto.PlatformMessage
+import com.nw5w.graywolf.platformproto.SerialClose
+import com.nw5w.graywolf.platformproto.SerialData
+import com.nw5w.graywolf.platformproto.SerialError
+import com.nw5w.graywolf.platformproto.SerialKind
+import com.nw5w.graywolf.platformproto.SerialOpen
+import com.nw5w.graywolf.platformproto.SerialOpenAck
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * BtSerialAdapter handles Bluetooth-classic SPP/RFCOMM byte relay for the
@@ -25,6 +39,15 @@ class BtSerialAdapter(
 ) {
     private val tag = "BtSerialAdapter"
     private val scope = CoroutineScope(SupervisorJob() + workerDispatcher)
+    private val handles = ConcurrentHashMap<UInt, HandleState>()
+
+    private data class HandleState(
+        val mac: String,
+        val socket: BluetoothSocket,
+        val readJob: Job,
+        val writeJob: Job?,    // null until first writer activity if you use a queue model
+        val mutex: Mutex = Mutex(),
+    )
 
     fun handleBondedRequest() {
         scope.launch {
@@ -52,8 +75,131 @@ class BtSerialAdapter(
         }
     }
 
+    fun handleSerialOpen(req: SerialOpen) {
+        val handle = req.handle.toUInt()
+        val mac = req.address
+        if (req.kind != SerialKind.SERIAL_KIND_BLUETOOTH) {
+            sendAck(handle, ok = false, err = "unsupported_kind: ${req.kind}")
+            return
+        }
+        if (!facade.isBonded(mac)) {
+            sendAck(handle, ok = false, err = "not_bonded: $mac")
+            return
+        }
+        scope.launch {
+            val socket = try {
+                facade.connectRfcomm(mac)
+            } catch (sec: SecurityException) {
+                sendAck(handle, ok = false, err = "permission_denied")
+                return@launch
+            } catch (e: IOException) {
+                sendAck(handle, ok = false, err = "connect failed: ${e.message ?: "io_error"}")
+                return@launch
+            }
+            val readJob = scope.launch { readPump(handle, socket) }
+            handles[handle] = HandleState(mac, socket, readJob, null)
+            sendAck(handle, ok = true, err = "")
+        }
+    }
+
+    fun handleSerialData(req: SerialData) {
+        val handle = req.handle.toUInt()
+        val state = handles[handle] ?: return
+        val bytes = req.data.toByteArray()
+        scope.launch {
+            state.mutex.withLock {
+                try {
+                    state.socket.outputStream.write(bytes)
+                    state.socket.outputStream.flush()
+                } catch (e: IOException) {
+                    sendError(handle, "io_error", e.message ?: "")
+                    closeQuietly(handle, "write failed")
+                }
+            }
+        }
+    }
+
+    fun handleSerialClose(req: SerialClose) {
+        val handle = req.handle.toUInt()
+        val state = handles.remove(handle) ?: return
+        scope.launch {
+            try { state.readJob.cancelAndJoin() } catch (_: Throwable) {}
+            try { state.socket.close() } catch (_: Throwable) {}
+        }
+    }
+
+    /** Called by GraywolfService on ACTION_BOND_STATE_CHANGED transitioning to BOND_NONE. */
+    fun onBondLost(mac: String) {
+        handles.entries
+            .filter { it.value.mac.equals(mac, ignoreCase = true) }
+            .forEach { (handle, _) ->
+                sendError(handle, "bond_lost", "device $mac unpaired")
+                closeQuietly(handle, "bond_lost")
+            }
+        // Then push the refreshed bonded list:
+        handleBondedRequest()
+    }
+
     fun shutdown() {
-        // tear down all handles (filled in Task 2.4)
-        scope.coroutineContext[Job]?.cancel()
+        handles.keys.toList().forEach { closeQuietly(it, "shutdown") }
+        runBlocking { scope.coroutineContext[Job]?.cancelAndJoin() }
+    }
+
+    private suspend fun readPump(handle: UInt, socket: BluetoothSocket) {
+        val buf = ByteArray(4096)
+        try {
+            while (true) {
+                val n = socket.inputStream.read(buf)
+                if (n < 0) {
+                    sendError(handle, "rfcomm_closed", "EOF")
+                    closeQuietly(handle, "rfcomm EOF")
+                    return
+                }
+                if (n == 0) continue
+                sendMessage(
+                    PlatformMessage.newBuilder().setSerialData(
+                        SerialData.newBuilder()
+                            .setHandle(handle.toInt())
+                            .setData(ByteString.copyFrom(buf, 0, n))
+                            .build()
+                    ).build()
+                )
+            }
+        } catch (e: IOException) {
+            sendError(handle, "io_error", e.message ?: "")
+            closeQuietly(handle, "read failed")
+        }
+    }
+
+    private fun sendAck(handle: UInt, ok: Boolean, err: String) {
+        sendMessage(PlatformMessage.newBuilder().setSerialOpenAck(
+            SerialOpenAck.newBuilder()
+                .setHandle(handle.toInt())
+                .setOk(ok)
+                .setError(err)
+                .build()
+        ).build())
+    }
+
+    private fun sendError(handle: UInt, code: String, detail: String) {
+        sendMessage(PlatformMessage.newBuilder().setSerialError(
+            SerialError.newBuilder()
+                .setHandle(handle.toInt())
+                .setCode(code)
+                .setDetail(detail)
+                .build()
+        ).build())
+    }
+
+    private fun closeQuietly(handle: UInt, reason: String) {
+        val state = handles.remove(handle) ?: return
+        try { state.socket.close() } catch (_: Throwable) {}
+        state.readJob.cancel()
+        sendMessage(PlatformMessage.newBuilder().setSerialClose(
+            SerialClose.newBuilder()
+                .setHandle(handle.toInt())
+                .setReason(reason)
+                .build()
+        ).build())
     }
 }

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/PlatformServer.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/PlatformServer.kt
@@ -39,6 +39,19 @@ class PlatformServer(
     @Volatile private var activeOutputs: List<OutputStream> = emptyList()
     private val outputsLock = Object()
 
+    @Volatile private var btSerialAdapter: BtSerialAdapter? = null
+
+    /**
+     * Attach the BtSerialAdapter after construction. Wired this way because
+     * BtSerialAdapter's sendMessage callback references broadcastBt on this
+     * server, so the server must exist before the adapter is built. Safe
+     * to call at most once during onCreate; serveClient consults the field
+     * with a nullable read.
+     */
+    fun attachBtAdapter(adapter: BtSerialAdapter) {
+        btSerialAdapter = adapter
+    }
+
     fun subscribeGpsFix(cb: (GpsFix) -> Unit) {
         gpsFixSubs.add(cb)
     }
@@ -65,6 +78,16 @@ class PlatformServer(
 
     fun broadcastGnssStatus(status: GnssStatusUpdate) =
         broadcast(PlatformMessage.newBuilder().setGnssStatus(status).build())
+
+    /**
+     * Typed wrapper used by BtSerialAdapter to push asynchronous frames
+     * (SerialOpenAck, SerialData, SerialError, SerialClose,
+     * BondedBtDevicesResponse) to the connected Go client. The adapter
+     * already builds a fully-formed PlatformMessage, so this just forwards
+     * to broadcast. Kept distinct from the raw private broadcast() to
+     * preserve typed-intent at every call site.
+     */
+    fun broadcastBt(msg: PlatformMessage) = broadcast(msg)
 
     /**
      * Production startup. Binds an android.net.LocalServerSocket at
@@ -160,6 +183,50 @@ class PlatformServer(
         try {
             while (running) {
                 val req = WireCodec.readFrame(input)
+                // Bluetooth-serial notifications are fire-and-forget: replies
+                // are produced asynchronously by BtSerialAdapter via the
+                // broadcastBt path. Dispatch directly and skip the synchronous
+                // response branch. Treat a null adapter as a no-op so unit
+                // tests (which never attach one) still work.
+                when (req.bodyCase) {
+                    PlatformMessage.BodyCase.SERIAL_OPEN -> {
+                        val adapter = btSerialAdapter
+                        if (adapter == null) {
+                            Log.d(TAG, "SERIAL_OPEN with no BtSerialAdapter attached; dropping")
+                        } else {
+                            adapter.handleSerialOpen(req.serialOpen)
+                        }
+                        continue
+                    }
+                    PlatformMessage.BodyCase.SERIAL_DATA -> {
+                        val adapter = btSerialAdapter
+                        if (adapter == null) {
+                            Log.d(TAG, "SERIAL_DATA with no BtSerialAdapter attached; dropping")
+                        } else {
+                            adapter.handleSerialData(req.serialData)
+                        }
+                        continue
+                    }
+                    PlatformMessage.BodyCase.SERIAL_CLOSE -> {
+                        val adapter = btSerialAdapter
+                        if (adapter == null) {
+                            Log.d(TAG, "SERIAL_CLOSE with no BtSerialAdapter attached; dropping")
+                        } else {
+                            adapter.handleSerialClose(req.serialClose)
+                        }
+                        continue
+                    }
+                    PlatformMessage.BodyCase.BONDED_BT_DEVICES_REQUEST -> {
+                        val adapter = btSerialAdapter
+                        if (adapter == null) {
+                            Log.d(TAG, "BONDED_BT_DEVICES_REQUEST with no BtSerialAdapter attached; dropping")
+                        } else {
+                            adapter.handleBondedRequest()
+                        }
+                        continue
+                    }
+                    else -> { /* fall through to synchronous-handler path */ }
+                }
                 val handler: MessageHandler = when (req.bodyCase) {
                     PlatformMessage.BodyCase.HELLO ->
                         HelloHandler(serverVersion, schemaVersion)

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
@@ -13,6 +13,14 @@ import com.nw5w.graywolf.usb.UsbPttAdapter
  *   listUsbDevices()            — JSON array of attached USB devices + permission state
  *   requestUsbPermission(...)   — async system permission dialog; result via window.__usbResult
  *
+ * Phase 6 (Bluetooth KISS TNC) adds:
+ *   requestBluetoothPermission(callbackId) — async runtime permission dialog
+ *                                            for BLUETOOTH_CONNECT (API 31+);
+ *                                            result via window.__btResult
+ *
+ * The Bluetooth permission flow is delegated to MainActivity via the
+ * `requestBtPermission` lambda because requestPermissions() lives on Activity.
+ *
  * POC-C TX-test and non-USB PTT trigger methods remain absent; phase 5 rewires
  * PTT through the proto path.
  */
@@ -20,6 +28,7 @@ class WebAppInterface(
     private val tokenProvider: () -> String,
     private val webView: WebView,
     private val adapter: UsbPttAdapter = UsbPttAdapter,
+    private val requestBtPermission: (callbackId: String) -> Unit = {},
 ) {
     @JavascriptInterface
     fun getBearerToken(): String = tokenProvider()
@@ -64,6 +73,31 @@ class WebAppInterface(
                 webView.evaluateJavascript(script, null)
             }
         }
+    }
+
+    /**
+     * Request the BLUETOOTH_CONNECT runtime permission (API 31+).
+     *
+     * The actual permission dialog must be fired from the Activity, so we
+     * delegate to the lambda supplied by MainActivity. Result is posted back
+     * into the WebView via:
+     *   window.__btResult(callbackId, granted: boolean)
+     *
+     * On API <31 the legacy BLUETOOTH/BLUETOOTH_ADMIN install-time perms
+     * cover us; MainActivity's implementation fires the callback with
+     * granted=true immediately in that case.
+     *
+     * callbackId is validated to match ^[A-Za-z0-9_-]+$ before being passed
+     * downstream — defense-in-depth against string-escape attacks even
+     * though MainActivity validates again before JS interpolation.
+     */
+    @JavascriptInterface
+    fun requestBluetoothPermission(callbackId: String) {
+        if (!CALLBACK_ID_RE.matches(callbackId)) {
+            Log.w(TAG, "rejected invalid bt callbackId: $callbackId")
+            return
+        }
+        requestBtPermission(callbackId)
     }
 
     companion object {

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebAppInterface.kt
@@ -62,7 +62,7 @@ class WebAppInterface(
      */
     @JavascriptInterface
     fun requestUsbPermission(vid: Int, pid: Int, callbackId: String) {
-        if (!CALLBACK_ID_RE.matches(callbackId)) {
+        if (!WebBridgeIds.CALLBACK_ID_RE.matches(callbackId)) {
             Log.w(TAG, "rejected invalid callbackId: $callbackId")
             return
         }
@@ -93,7 +93,7 @@ class WebAppInterface(
      */
     @JavascriptInterface
     fun requestBluetoothPermission(callbackId: String) {
-        if (!CALLBACK_ID_RE.matches(callbackId)) {
+        if (!WebBridgeIds.CALLBACK_ID_RE.matches(callbackId)) {
             Log.w(TAG, "rejected invalid bt callbackId: $callbackId")
             return
         }
@@ -102,6 +102,5 @@ class WebAppInterface(
 
     companion object {
         private const val TAG = "WebAppInterface"
-        private val CALLBACK_ID_RE = Regex("^[A-Za-z0-9_-]+$")
     }
 }

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebBridgeIds.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/webview/WebBridgeIds.kt
@@ -1,0 +1,14 @@
+package com.nw5w.graywolf.webview
+
+/**
+ * Shared identifier validation for the WebView <-> native JS bridge.
+ *
+ * Any callbackId or other token that gets interpolated into JS executed by
+ * webView.evaluateJavascript(...) MUST match CALLBACK_ID_RE first. Keeping
+ * the regex in one place prevents drift between MainActivity and
+ * WebAppInterface, where divergent rules would silently break the
+ * defense-in-depth check against string-escape attacks.
+ */
+internal object WebBridgeIds {
+    val CALLBACK_ID_RE = Regex("^[A-Za-z0-9_-]+$")
+}

--- a/android/app/src/test/kotlin/com/nw5w/graywolf/platformsvc/BluetoothFacadeTest.kt
+++ b/android/app/src/test/kotlin/com/nw5w/graywolf/platformsvc/BluetoothFacadeTest.kt
@@ -1,0 +1,17 @@
+package com.nw5w.graywolf.platformsvc
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BluetoothFacadeTest {
+    @Test fun fakeFacade_returnsConfiguredBondedDevices() = runTest {
+        val fake = FakeBluetoothFacade(bonded = listOf(
+            BondedDevice("AA:BB:CC:00:00:01", "Mobilinkd TNC4"),
+            BondedDevice("AA:BB:CC:00:00:02", "TH-D75"),
+        ))
+        val devices = fake.bondedDevices()
+        assertEquals(2, devices.size)
+        assertEquals("Mobilinkd TNC4", devices[0].name)
+    }
+}

--- a/android/app/src/test/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapterTest.kt
+++ b/android/app/src/test/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapterTest.kt
@@ -1,6 +1,9 @@
 package com.nw5w.graywolf.platformsvc
 
 import com.nw5w.graywolf.platformproto.PlatformMessage
+import com.nw5w.graywolf.platformproto.SerialClose
+import com.nw5w.graywolf.platformproto.SerialKind
+import com.nw5w.graywolf.platformproto.SerialOpen
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -26,5 +29,40 @@ class BtSerialAdapterTest {
         assertEquals(2, resp.devicesCount)
         assertEquals("Mobilinkd TNC4", resp.getDevices(0).name)
         assertTrue(resp.getDevices(0).mac == "AA:BB:CC:00:00:01")
+    }
+
+    @Test fun serialOpen_notBonded_replies_with_ack_error() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val facade = FakeBluetoothFacade(bonded = emptyList())
+        val sent = mutableListOf<PlatformMessage>()
+        val adapter = BtSerialAdapter(facade, dispatcher) { sent.add(it) }
+
+        adapter.handleSerialOpen(
+            SerialOpen.newBuilder()
+                .setHandle(42)
+                .setKind(SerialKind.SERIAL_KIND_BLUETOOTH)
+                .setAddress("AA:BB:CC:00:00:99")
+                .build()
+        )
+        advanceUntilIdle()
+
+        val acks = sent.filter { it.hasSerialOpenAck() }.map { it.serialOpenAck }
+        assertEquals(1, acks.size)
+        assertEquals(42, acks[0].handle.toInt())
+        assertEquals(false, acks[0].ok)
+        assertTrue(acks[0].error.contains("not_bonded") || acks[0].error.contains("not bonded"))
+    }
+
+    @Test fun closeHandle_sendsClose_and_stopsPumps() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        // The bookkeeping path: closing a non-existent handle is a no-op,
+        // does not crash, and does not emit a SerialClose.
+        val facade = FakeBluetoothFacade(bonded = listOf(BondedDevice("AA:BB:CC:00:00:01", "X")))
+        val sent = mutableListOf<PlatformMessage>()
+        val adapter = BtSerialAdapter(facade, dispatcher) { sent.add(it) }
+
+        adapter.handleSerialClose(SerialClose.newBuilder().setHandle(999).setReason("test").build())
+        advanceUntilIdle()
+        assertTrue(sent.isEmpty())
     }
 }

--- a/android/app/src/test/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapterTest.kt
+++ b/android/app/src/test/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapterTest.kt
@@ -1,0 +1,30 @@
+package com.nw5w.graywolf.platformsvc
+
+import com.nw5w.graywolf.platformproto.PlatformMessage
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BtSerialAdapterTest {
+    @Test fun bondedDevicesRequest_returnsAllPaired() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val facade = FakeBluetoothFacade(bonded = listOf(
+            BondedDevice("AA:BB:CC:00:00:01", "Mobilinkd TNC4"),
+            BondedDevice("AA:BB:CC:00:00:02", "TH-D75"),
+        ))
+        val sent = mutableListOf<PlatformMessage>()
+        val adapter = BtSerialAdapter(facade, dispatcher) { sent.add(it) }
+
+        adapter.handleBondedRequest()
+        advanceUntilIdle()
+
+        assertEquals(1, sent.size)
+        val resp = sent[0].bondedBtDevicesResponse
+        assertEquals(2, resp.devicesCount)
+        assertEquals("Mobilinkd TNC4", resp.getDevices(0).name)
+        assertTrue(resp.getDevices(0).mac == "AA:BB:CC:00:00:01")
+    }
+}

--- a/android/app/src/test/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapterTest.kt
+++ b/android/app/src/test/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapterTest.kt
@@ -53,10 +53,10 @@ class BtSerialAdapterTest {
         assertTrue(acks[0].error.contains("not_bonded") || acks[0].error.contains("not bonded"))
     }
 
-    @Test fun closeHandle_sendsClose_and_stopsPumps() = runTest {
+    @Test fun closeNonexistentHandle_isNoOp() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
-        // The bookkeeping path: closing a non-existent handle is a no-op,
-        // does not crash, and does not emit a SerialClose.
+        // Closing an unknown handle must not crash and must emit nothing.
+        // Does NOT cover open/close lifecycle of a live socket.
         val facade = FakeBluetoothFacade(bonded = listOf(BondedDevice("AA:BB:CC:00:00:01", "X")))
         val sent = mutableListOf<PlatformMessage>()
         val adapter = BtSerialAdapter(facade, dispatcher) { sent.add(it) }

--- a/android/app/src/test/kotlin/com/nw5w/graywolf/webview/WebAppInterfaceTest.kt
+++ b/android/app/src/test/kotlin/com/nw5w/graywolf/webview/WebAppInterfaceTest.kt
@@ -35,7 +35,13 @@ class WebAppInterfaceTest {
         webView: WebView = mockWebView(),
         adapter: UsbPttAdapter = UsbPttAdapter,
         token: String = "tok",
-    ) = WebAppInterface(tokenProvider = { token }, webView = webView, adapter = adapter)
+        requestBtPermission: (String) -> Unit = {},
+    ) = WebAppInterface(
+        tokenProvider = { token },
+        webView = webView,
+        adapter = adapter,
+        requestBtPermission = requestBtPermission,
+    )
 
     // -----------------------------------------------------------------------
     // getBearerToken — unchanged from phase 3
@@ -159,6 +165,24 @@ class WebAppInterfaceTest {
 
         verify(adapter, never()).requestPermissionFor(any(), any(), any())
         verify(wv, never()).evaluateJavascript(any(), any())
+    }
+
+    // -----------------------------------------------------------------------
+    // requestBluetoothPermission — delegates to the injected lambda
+    // -----------------------------------------------------------------------
+    @Test
+    fun `requestBluetoothPermission with valid callbackId delegates to lambda`() {
+        val captured = mutableListOf<String>()
+        iface(requestBtPermission = { captured += it }).requestBluetoothPermission("bt-id-123")
+        assertEquals(listOf("bt-id-123"), captured)
+    }
+
+    @Test
+    fun `requestBluetoothPermission with malformed callbackId is rejected`() {
+        val captured = mutableListOf<String>()
+        iface(requestBtPermission = { captured += it })
+            .requestBluetoothPermission("foo'); alert(1)")
+        assertEquals(emptyList<String>(), captured)
     }
 
     // -----------------------------------------------------------------------

--- a/cmd/graywolf/main_android.go
+++ b/cmd/graywolf/main_android.go
@@ -24,7 +24,11 @@ import (
 	"github.com/chrissnell/graywolf/pkg/platformsvc"
 )
 
-const platformSchemaVersion = 1
+// platformSchemaVersion mirrors the pkg/platformsvc package constant so
+// the wire-schema version is a single source of truth across the Go
+// binary and the Kotlin PlatformServer. Drift between this and Kotlin's
+// `schemaVersion` is caught by pkg/platformsvc/schema_version_test.go.
+const platformSchemaVersion = platformsvc.SchemaVersion
 
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{

--- a/docs/handbook/index.html
+++ b/docs/handbook/index.html
@@ -49,6 +49,7 @@
       <a href="kiss.html">KISS TNC</a>
       <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
       <a href="kiss-serial.html">KISS over Serial</a>
+      <a href="kiss-bluetooth.html">KISS over Bluetooth</a>
       <a href="agwpe.html">AGWPE</a>
       <a href="gps.html">GPS</a>
       <div class="sidebar-section">Operations</div>

--- a/docs/handbook/kiss-bluetooth.html
+++ b/docs/handbook/kiss-bluetooth.html
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>KISS over Bluetooth &mdash; Graywolf Handbook</title>
+  <link rel="stylesheet" href="handbook.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="index.html" class="site-logo">
+      <img src="img/graywolf-logo.svg" alt="" />
+      <span>graywolf <span class="handbook-label">handbook</span></span>
+    </a>
+    <div class="header-actions">
+      <button class="theme-toggle" aria-label="Toggle theme">[ dark ]</button>
+    </div>
+  </div>
+</header>
+
+<div class="layout">
+  <aside class="sidebar">
+    <nav>
+      <div class="sidebar-section">Getting Started</div>
+      <a href="index.html">Introduction</a>
+      <a href="installation.html">Installation</a>
+      <a href="callsign.html">Station Callsign</a>
+      <div class="sidebar-section">Radio</div>
+      <a href="audio.html">Audio Devices</a>
+      <a href="channels.html">Radio Channels</a>
+      <a href="ptt.html">Push-to-Talk</a>
+      <div class="sidebar-section">APRS</div>
+      <a href="beacons.html">Beacons</a>
+      <a href="digipeater.html">Digipeater</a>
+      <a href="igate.html">iGate</a>
+      <a href="messaging.html">Messaging</a>
+      <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
+      <a href="livemap.html">Live Map</a>
+      <div class="sidebar-section">Packet</div>
+      <a href="ax25-terminal.html">AX.25 Terminal</a>
+      <div class="sidebar-section">Interfaces</div>
+      <a href="kiss.html">KISS TNC</a>
+      <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
+      <a href="kiss-serial.html">KISS over Serial</a>
+      <a href="kiss-bluetooth.html">KISS over Bluetooth</a>
+      <a href="agwpe.html">AGWPE</a>
+      <a href="gps.html">GPS</a>
+      <div class="sidebar-section">Operations</div>
+      <a href="history-database.html">Position Log</a>
+      <a href="logs.html">Logs</a>
+      <a href="monitoring.html">Monitoring</a>
+      <a href="simulation.html">Simulation</a>
+      <a href="maps.html">Maps</a>
+      <a href="preferences.html">Preferences</a>
+      <a href="architecture.html">Architecture</a>
+      <div class="sidebar-section">Reference</div>
+      <a href="configurations.html">Known-Working Configs</a>
+      <a href="api.html">REST API Reference</a>
+    </nav>
+  </aside>
+
+  <main class="content">
+    <h1>KISS over Bluetooth</h1>
+    <p class="subtitle">Talk to a Bluetooth-paired hardware TNC from the graywolf Android tablet build.</p>
+
+    <h2>Overview</h2>
+
+    <p>
+      Many handheld TNCs &mdash; Mobilinkd TNC3 and TNC4, the Kenwood
+      TH-D74 and TH-D75 in Bluetooth mode, and others &mdash; expose a
+      KISS interface over the Bluetooth Serial Port Profile (SPP). When
+      graywolf runs on an Android tablet, it can connect to one of these
+      TNCs and use it as a full radio channel: beacon into it, digipeat
+      across it, and iGate from it. The TNC handles all RF carrier
+      sensing, timing, and actual transmission; graywolf is just the
+      packet router on top.
+    </p>
+
+    <div class="callout info">
+      <span class="callout-icon">i</span>
+      <div class="callout-body">
+        <p>
+          This interface is available <strong>only on the Android tablet
+          build</strong> of graywolf. Linux, macOS, and Windows desktops
+          do not see Bluetooth as a KISS interface type &mdash; on those
+          platforms, use <a href="kiss-serial.html">KISS over Serial</a>
+          instead, including for Bluetooth-paired TNCs that present
+          themselves as a virtual serial port (e.g.&nbsp;<code>/dev/rfcomm0</code>
+          on Linux).
+        </p>
+      </div>
+    </div>
+
+    <p>
+      Graywolf does not pair Bluetooth devices itself. Pairing happens in
+      Android's Settings app, the same way you would pair a headset or a
+      keyboard. Once a TNC is paired (Android calls this "bonded"), it
+      shows up in graywolf's KISS interface form as a selectable device.
+    </p>
+
+    <h2>Setup</h2>
+
+    <h3>Step 1 &mdash; Pair the TNC in Android Settings</h3>
+
+    <ol class="steps">
+      <li>Power on the TNC and put it into pairing mode. Consult the
+        TNC's manual for the procedure (Mobilinkd TNCs typically enter
+        pairing mode by holding the button at power-on; the radios have
+        a Bluetooth menu).</li>
+      <li>On the tablet, open <strong>Settings &rarr; Connected devices
+        &rarr; Pair new device</strong> (the exact path varies by Android
+        version).</li>
+      <li>Pick the TNC from the scan list and complete pairing. The TNC
+        should then appear under <strong>Paired devices</strong>.</li>
+      <li>Confirm the TNC is in KISS mode. Some TNCs ship in a
+        human-readable command mode by default and must be switched. The
+        TNC's configuration app (for example, the Mobilinkd app) sets
+        this.</li>
+    </ol>
+
+    <h3>Step 2 &mdash; Grant Bluetooth permission to graywolf</h3>
+
+    <p>
+      The first time you open the KISS Interfaces page in graywolf, the
+      Bluetooth section shows a prompt to grant Bluetooth permission. Tap
+      <strong>Grant Bluetooth permission</strong> and accept the system
+      dialog. Without this permission graywolf cannot list bonded devices.
+    </p>
+
+    <h3>Step 3 &mdash; Create a KISS-only channel</h3>
+
+    <ol class="steps">
+      <li>Open <strong>Radio &rarr; Channels</strong> in the web UI.</li>
+      <li>Click <strong>+ Add Channel</strong>.</li>
+      <li>In the channel-type segmented control at the top of the form,
+        choose <strong>KISS-TNC only</strong>. A KISS-only channel is a
+        logical routing lane, not a modulated radio channel.</li>
+      <li>Name it to reflect the attached TNC (for example,
+        <code>TNC4</code> or <code>TH-D75</code>). Give it a channel
+        number that does not collide with your existing RF channels.</li>
+      <li>Click <strong>Save</strong>. The channel appears on the list
+        with a <strong>KISS-TNC only</strong> badge. Its backing shows
+        <strong>&mdash; Unbound</strong> until you attach the Bluetooth
+        interface below.</li>
+    </ol>
+
+    <h3>Step 4 &mdash; Create a Bluetooth KISS interface</h3>
+
+    <ol class="steps">
+      <li>Open <strong>Interfaces &rarr; KISS TNC</strong> (the page is
+        titled <strong>KISS Interfaces</strong>).</li>
+      <li>Click <strong>+ Add KISS Interface</strong>.</li>
+      <li>In the <strong>Type</strong> field, choose
+        <strong>Bluetooth Serial</strong>. On the Android build this is
+        the default. (If the Type field does not offer Bluetooth Serial,
+        you are not on the Android build.)</li>
+      <li>The <strong>Device</strong> dropdown lists every Bluetooth
+        device currently paired in Android Settings. Pick your TNC. The
+        list shows the device name and MAC address.</li>
+      <li>In the <strong>Channel</strong> picker, select the KISS-only
+        channel you just created.</li>
+      <li>Set <strong>Mode</strong> to <strong>TNC</strong>. In TNC mode
+        the interface is treated as a radio, not a software client. This
+        also reveals the transmit opt-in checkbox.</li>
+      <li>Check the box labeled <strong>Allow digipeater/beacon/iGate to
+        transmit on this interface</strong> to allow graywolf's TX
+        pipeline to send frames to the TNC. Without this checkbox the
+        interface only receives.</li>
+      <li>Click <strong>Create</strong>. Graywolf opens the RFCOMM
+        connection to the TNC. The row's status badge shows
+        <strong>Connected</strong> once the link comes up. The channel's
+        backing on the Channels page flips to
+        <strong>&#x25CF; Live</strong>.</li>
+    </ol>
+
+    <p>
+      The interface card lists the TNC's name and MAC address so you can
+      tell connected TNCs apart at a glance.
+    </p>
+
+    <div class="callout warn">
+      <span class="callout-icon">!</span>
+      <div class="callout-body">
+        <p>
+          Make sure the TNC is in KISS mode before saving the interface
+          in graywolf. Graywolf opens the Bluetooth connection and begins
+          speaking KISS immediately; it does not send any mode-switch
+          commands.
+        </p>
+      </div>
+    </div>
+
+    <h2>Reconnect Behavior</h2>
+
+    <p>
+      If the TNC moves out of range, is powered off, or the Bluetooth
+      link drops for any reason, graywolf backs off and automatically
+      retries the connection. You do not need to restart the app. When
+      the TNC is back in range and powered on, graywolf reconnects and
+      the channel returns to <strong>&#x25CF; Live</strong> status.
+    </p>
+
+    <p>
+      Editing the device or mode on the KISS Interfaces page and clicking
+      Save triggers a hot reload: graywolf closes the existing connection
+      and re-opens with the new settings.
+    </p>
+
+    <p>
+      If you unpair the TNC in Android Settings while graywolf is
+      running, the interface card's status flips to
+      <strong>Unpaired</strong>. Re-pair the device in Android Settings,
+      then refresh the KISS Interfaces page; the bonded-device list will
+      include it again.
+    </p>
+
+    <h2>Troubleshooting</h2>
+
+    <div class="box">
+      <div class="box-body">
+        <table>
+          <thead>
+            <tr><th>Symptom</th><th>Likely cause</th><th>Fix</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Device dropdown is empty when adding the interface</td>
+              <td>Bluetooth permission not granted to graywolf</td>
+              <td>Tap <strong>Grant Bluetooth permission</strong> in the
+                form, accept the system dialog, then re-open the form.</td>
+            </tr>
+            <tr>
+              <td>Device dropdown is still empty after granting
+                permission</td>
+              <td>TNC is not paired in Android yet</td>
+              <td>Pair the TNC in <strong>Android Settings &rarr;
+                Connected devices</strong>, then tap
+                <strong>Refresh</strong> in the form.</td>
+            </tr>
+            <tr>
+              <td>Interface status stuck on <strong>Reconnecting</strong></td>
+              <td>TNC is off, out of range, or asleep</td>
+              <td>Power on the TNC and bring it within Bluetooth range
+                (roughly 10 m / 30 ft). Graywolf reconnects on its own.</td>
+            </tr>
+            <tr>
+              <td>Status flips to <strong>Unpaired</strong></td>
+              <td>TNC was removed from Android's paired-devices list</td>
+              <td>Re-pair the TNC in Android Settings, then refresh the
+                KISS Interfaces page.</td>
+            </tr>
+            <tr>
+              <td>Connected, but no frames decode</td>
+              <td>TNC is not actually in KISS mode &mdash; it is sitting
+                at the command prompt</td>
+              <td>Switch the TNC into KISS mode using its configuration
+                app (Mobilinkd app, Kenwood radio menu, etc.).</td>
+            </tr>
+            <tr>
+              <td>Beacon scheduled but nothing transmits</td>
+              <td>Transmit checkbox is off, or channel is unbound</td>
+              <td>Open the KISS interface, confirm <strong>Mode</strong>
+                is TNC and <strong>Allow digipeater/beacon/iGate to
+                transmit on this interface</strong> is checked. Confirm
+                the channel's backing on the Channels page shows
+                <strong>&#x25CF; Live</strong>.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <h2>Notes</h2>
+
+    <ul>
+      <li><strong>Pairing happens in Android, not in graywolf.</strong>
+        Graywolf only lists devices that Android already considers
+        bonded. There is no in-app pair button.</li>
+      <li><strong>No baud rate setting.</strong> Bluetooth RFCOMM is
+        framed at the protocol level; there is no baud rate to set on
+        the graywolf side. The TNC's internal radio baud rate (1200 or
+        9600) is configured on the TNC itself.</li>
+      <li><strong>One Bluetooth interface per TNC.</strong> Each
+        Bluetooth KISS interface owns a single RFCOMM connection to one
+        paired device. If you have multiple TNCs paired, add one
+        interface per TNC and bind each to its own KISS-only channel.</li>
+      <li><strong>Connection is supervised.</strong> If the link drops,
+        graywolf retries with exponential backoff up to a configurable
+        ceiling. The interface card shows the current state
+        (<strong>Connected</strong>, <strong>Reconnecting</strong>,
+        <strong>Unpaired</strong>).</li>
+    </ul>
+
+    <h2>Related Pages</h2>
+
+    <ul>
+      <li><a href="kiss.html">KISS TNC</a> &mdash; overview of all KISS
+        interface types.</li>
+      <li><a href="kiss-serial.html">KISS over Serial</a> &mdash; the
+        equivalent setup on Linux, macOS, and Windows, where
+        Bluetooth-paired TNCs are reached through a virtual serial
+        port.</li>
+      <li><a href="channels.html">Radio Channels</a> &mdash; channel
+        types, backing, and TX timing.</li>
+    </ul>
+
+    <nav class="page-nav">
+      <a href="kiss-serial.html">
+        <span class="label">Previous</span>
+        KISS over Serial
+      </a>
+      <a href="agwpe.html" class="next">
+        <span class="label">Next</span>
+        AGWPE
+      </a>
+    </nav>
+  </main>
+</div>
+
+<footer class="site-footer">
+  graywolf &middot; modern APRS station
+</footer>
+
+<script src="handbook.js"></script>
+</body>
+</html>

--- a/docs/handbook/kiss-serial.html
+++ b/docs/handbook/kiss-serial.html
@@ -49,6 +49,7 @@
       <a href="kiss.html">KISS TNC</a>
       <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
       <a href="kiss-serial.html">KISS over Serial</a>
+      <a href="kiss-bluetooth.html">KISS over Bluetooth</a>
       <a href="agwpe.html">AGWPE</a>
       <a href="gps.html">GPS</a>
       <div class="sidebar-section">Operations</div>

--- a/docs/handbook/kiss.html
+++ b/docs/handbook/kiss.html
@@ -49,6 +49,7 @@
       <a href="kiss.html">KISS TNC</a>
       <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
       <a href="kiss-serial.html">KISS over Serial</a>
+      <a href="kiss-bluetooth.html">KISS over Bluetooth</a>
       <a href="agwpe.html">AGWPE</a>
       <a href="gps.html">GPS</a>
       <div class="sidebar-section">Operations</div>
@@ -107,8 +108,8 @@
             </tr>
             <tr>
               <td><strong>Bluetooth</strong></td>
-              <td>Bluetooth serial profile</td>
-              <td>Mobile APRS apps (APRSdroid, etc.)</td>
+              <td>Graywolf opens an RFCOMM (Bluetooth serial) connection to a paired hardware TNC. Android tablet build only.</td>
+              <td>Mobilinkd TNCs, Kenwood TH-D74/D75 in Bluetooth mode, other Bluetooth-SPP TNCs. See <a href="kiss-bluetooth.html">KISS over Bluetooth</a>.</td>
             </tr>
           </tbody>
         </table>

--- a/docs/handbook/remote-kiss-tnc.html
+++ b/docs/handbook/remote-kiss-tnc.html
@@ -49,6 +49,7 @@
       <a href="kiss.html">KISS TNC</a>
       <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
       <a href="kiss-serial.html">KISS over Serial</a>
+      <a href="kiss-bluetooth.html">KISS over Bluetooth</a>
       <a href="agwpe.html">AGWPE</a>
       <a href="gps.html">GPS</a>
       <div class="sidebar-section">Operations</div>

--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -218,6 +218,31 @@ PMTiles infrastructure (manifest gen, R2 sync, Cloudflare Worker) is in
 [`../../pkg/updatescheck/checker.go`](../../pkg/updatescheck/checker.go)
 polls GitHub Releases once per day and serves the snapshot via webapi `/api/updates`.
 
+## Android Kotlin platform service (`android/app/`)
+
+Kotlin code that backs the Android tablet build. The webview hosts the
+graywolf Go binary in-process; everything platform-specific (USB, audio,
+GPS, Bluetooth) lives on the Kotlin side and is reached through the
+platform UDS via proto messages defined in
+[`../../proto/platform.proto`](../../proto/platform.proto). Handbook:
+[`../handbook/installation.html`](../handbook/installation.html) (Android
+section), [`../handbook/kiss-bluetooth.html`](../handbook/kiss-bluetooth.html).
+
+| Concern | File |
+|---|---|
+| Activity + webview host | `com/nw5w/graywolf/MainActivity.kt`, `webview/WebAppInterface.kt` |
+| Foreground service + Go binary supervisor | `GraywolfService.kt`, `binaries/Supervisor.kt`, `binaries/GoLauncher.kt` |
+| Modem JNI bridge | `jni/ModemBridge.kt` |
+| Platform UDS server + proto codec | `platformsvc/PlatformServer.kt`, `platformsvc/MessageHandler.kt`, `platformsvc/WireCodec.kt` |
+| USB PTT adapter (CM108 / CP2102N / AIOC / VOX) | `usb/UsbPttAdapter.kt`, `usb/PttMethodConsts.kt` |
+| Bluetooth facade + permission/bond receivers | `platformsvc/BluetoothFacade.kt` |
+| RFCOMM byte relay for KISS-over-Bluetooth | `platformsvc/BtSerialAdapter.kt` -- owns one `BluetoothSocket` per handle; pump pair on worker thread; multiplexes through the platform UDS via `SerialOpen` / `SerialData` / `SerialClose` / `SerialError` proto messages |
+| Audio capture / playback pumps | `audio/AudioPump.kt`, `audio/AudioTxPump.kt`, `audio/AudioTxTest.kt` |
+| GPS adapter | `gps/GpsAdapter.kt` |
+
+The blocking-call-on-worker-thread rule that applies to USB and
+Bluetooth code on this surface is [invariant 35](invariants.md).
+
 ## Packaging (`packaging/`)
 
 | Target | Path |

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -557,3 +557,28 @@ The two switches are independent; omitting #2 means a config write calls `Stop()
 
 Source: [`../../pkg/app/wiring.go`](../../pkg/app/wiring.go) (`kissComponent`),
 [`../../pkg/webapi/kiss.go`](../../pkg/webapi/kiss.go) (`notifyKissManager`).
+
+### 35. All blocking Bluetooth and USB calls run on a worker thread
+
+`BluetoothSocket.connect`, `BluetoothAdapter.bondedDevices`,
+`BluetoothSocket.inputStream.read`, `UsbDeviceConnection.controlTransfer`,
+and HID Set_Report calls are blocking JNI/native invocations. Main-thread
+invocation can block UI for several seconds the first time the corresponding
+stack is touched, leading to ANR ("Application Not Responding") dialogs on
+Android.
+
+*Why:* feedback memory `feedback_android_usb_open_worker_thread` -- phase-4b
+USB enumeration on the main thread caused a 5-second ANR. The lesson is
+general to any blocking native call.
+
+*How to apply:* Kotlin code touching `BluetoothAdapter`, `BluetoothSocket`,
+`UsbDeviceConnection`, or `HidDevice` MUST dispatch onto an IO/worker
+dispatcher (`Dispatchers.IO`, a dedicated `SingleThreadExecutor`, or a
+worker `Thread`). Calls arriving FROM the `@JavascriptInterface` binder
+thread that need a main-thread API surface (`requestPermissions` etc.) may
+`mainHandler.post { ... }` only that AndroidManifest-API call; the actual
+blocking work still belongs on a worker thread.
+
+Source: [`../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt),
+[`../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BluetoothFacade.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BluetoothFacade.kt),
+[`../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt).

--- a/docs/wiki/system-topology.md
+++ b/docs/wiki/system-topology.md
@@ -47,6 +47,7 @@ sibling of the graywolf binary, `./target/release/graywolf-modem`, `$PATH`
 | KISS over TCP (server) | configurable via UI | [`../../pkg/kiss/server.go`](../../pkg/kiss/server.go) | [`../handbook/kiss.html`](../handbook/kiss.html) |
 | KISS over TCP (client, dial-out) | configurable | [`../../pkg/kiss/client.go`](../../pkg/kiss/client.go) | [`../handbook/remote-kiss-tnc.html`](../handbook/remote-kiss-tnc.html) |
 | KISS over Serial | configurable via UI | [`../../pkg/kiss/serial.go`](../../pkg/kiss/serial.go) | [`../handbook/kiss-serial.html`](../handbook/kiss-serial.html) |
+| KISS over Bluetooth (Android) | configurable via UI (Android tablet build only) | [`../../pkg/kiss/serial.go`](../../pkg/kiss/serial.go) (shared supervisor) + [`../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt) (RFCOMM byte relay) | [`../handbook/kiss-bluetooth.html`](../handbook/kiss-bluetooth.html) |
 | AGWPE over TCP | `0.0.0.0:8000` (default when unset) | [`../../pkg/agw/`](../../pkg/agw/), [`../../pkg/webapi/dto/agw.go`](../../pkg/webapi/dto/agw.go) | [`../handbook/agwpe.html`](../handbook/agwpe.html) |
 
 Adding a KISS InterfaceType requires updating dispatch in two independent places -- see [invariant 34](invariants.md).

--- a/pkg/app/btsource_android.go
+++ b/pkg/app/btsource_android.go
@@ -1,0 +1,46 @@
+//go:build android
+
+package app
+
+import (
+	"context"
+
+	"github.com/chrissnell/graywolf/pkg/webapi"
+)
+
+// platformBtSource adapts the App's live platformsvc.Client to
+// webapi.BondedBtDevicesSource. The adapter reads a.platformClient on
+// each call rather than capturing it at construction time so a late
+// SetPlatformClient call (or a reconnect that swaps the underlying
+// client) is reflected immediately — matching the pattern used by the
+// other webapi setters wired in pkg/app/wiring.go.
+type platformBtSource struct{ app *App }
+
+// BondedBtDevices forwards to the injected platformsvc client and
+// converts platformsvc.BondedBtDevice into the webapi wire type. Returns
+// an empty (non-nil) slice when the platform client isn't ready yet so
+// the handler ships [] rather than 500.
+func (p platformBtSource) BondedBtDevices(ctx context.Context) ([]webapi.BondedBtDevice, error) {
+	c := p.app.platformClient
+	if c == nil {
+		return []webapi.BondedBtDevice{}, nil
+	}
+	devs, err := c.BondedBtDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]webapi.BondedBtDevice, 0, len(devs))
+	for _, d := range devs {
+		out = append(out, webapi.BondedBtDevice{MAC: d.MAC, Name: d.Name})
+	}
+	return out, nil
+}
+
+// btSourceForWebapi returns the webapi.BondedBtDevicesSource adapter
+// backed by the App's platformsvc client. Returned unconditionally on
+// Android — the adapter itself handles a nil client gracefully — so the
+// handler responds 200 (with [] when the bond set is empty or the client
+// isn't connected yet) rather than 501.
+func (a *App) btSourceForWebapi() webapi.BondedBtDevicesSource {
+	return platformBtSource{app: a}
+}

--- a/pkg/app/btsource_android.go
+++ b/pkg/app/btsource_android.go
@@ -10,10 +10,14 @@ import (
 
 // platformBtSource adapts the App's live platformsvc.Client to
 // webapi.BondedBtDevicesSource. The adapter reads a.platformClient on
-// each call rather than capturing it at construction time so a late
-// SetPlatformClient call (or a reconnect that swaps the underlying
-// client) is reflected immediately — matching the pattern used by the
-// other webapi setters wired in pkg/app/wiring.go.
+// each call (not at construction) so a future late SetPlatformClient
+// or reconnect-swap is reflected immediately. Today main_android.go
+// calls SetPlatformClient before a.Run so the difference is
+// theoretical — kissSerialOpenFunc in kiss_openfunc_android.go captures
+// the client once at construction and works fine — but the per-call
+// form keeps the door open for late-binding without surprising the
+// UI's polling loop, at no measurable cost (one pointer load per
+// /api/kiss/bonded-bt-devices request).
 type platformBtSource struct{ app *App }
 
 // BondedBtDevices forwards to the injected platformsvc client and

--- a/pkg/app/btsource_default.go
+++ b/pkg/app/btsource_default.go
@@ -1,0 +1,11 @@
+//go:build !android
+
+package app
+
+import "github.com/chrissnell/graywolf/pkg/webapi"
+
+// btSourceForWebapi returns nil on non-Android builds so the webapi
+// handler responds 501 Not Implemented to GET /api/kiss/bonded-bt-devices.
+// Desktop platforms have no platformsvc client to enumerate bonded
+// Bluetooth devices through.
+func (a *App) btSourceForWebapi() webapi.BondedBtDevicesSource { return nil }

--- a/pkg/app/kiss_openfunc_android.go
+++ b/pkg/app/kiss_openfunc_android.go
@@ -1,0 +1,56 @@
+//go:build android
+
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"regexp"
+
+	"github.com/chrissnell/graywolf/pkg/kiss"
+)
+
+// btSerialOpener is the narrow surface the factory needs from platformsvc.
+// Defining it here makes the factory unit-testable without dragging the
+// full platformsvc.Client surface into the test.
+type btSerialOpener interface {
+	BtSerialOpen(ctx context.Context, mac string) (io.ReadWriteCloser, error)
+}
+
+// macRe matches MAC-48 in either colon-separated or hyphen-separated form.
+var macRe = regexp.MustCompile(`^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$`)
+
+// errNotSupportedOnAndroid is returned when wiring tries to open a raw
+// serial device path on Android. The Android sandbox blocks /dev/tty*
+// anyway, so this surfaces the configuration mistake immediately rather
+// than letting it fail later inside go.bug.st/serial.
+var errNotSupportedOnAndroid = errors.New("kiss: serial device path not supported on Android (use Bluetooth interface)")
+
+// newKissSerialOpenFunc returns an OpenFunc that routes MAC-style device
+// strings to platformsvc.BtSerialOpen and rejects raw device paths.
+// Returns nil when psv is nil so the supervisor falls back to its default
+// open (which on Android would also fail, but lets the supervisor surface
+// the error consistently).
+func newKissSerialOpenFunc(psv btSerialOpener) kiss.OpenFunc {
+	if psv == nil {
+		return nil
+	}
+	return func(device string, _ uint32) (io.ReadWriteCloser, error) {
+		if macRe.MatchString(device) {
+			return psv.BtSerialOpen(context.Background(), device)
+		}
+		return nil, errNotSupportedOnAndroid
+	}
+}
+
+// kissSerialOpenFunc is the build-tag-aware accessor used by wiring.go
+// when constructing kiss.SerialConfig. On Android it returns an OpenFunc
+// that routes MAC-style device strings through the injected platformsvc
+// client; if no platform client is wired yet, it returns nil.
+func (a *App) kissSerialOpenFunc() kiss.OpenFunc {
+	if a.platformClient == nil {
+		return nil
+	}
+	return newKissSerialOpenFunc(a.platformClient)
+}

--- a/pkg/app/kiss_openfunc_android_test.go
+++ b/pkg/app/kiss_openfunc_android_test.go
@@ -1,0 +1,75 @@
+//go:build android
+
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+// fakePsv records BtSerialOpen calls and returns a canned rwc/err.
+type fakePsv struct {
+	macSeen string
+	rwc     io.ReadWriteCloser
+	err     error
+}
+
+func (f *fakePsv) BtSerialOpen(_ context.Context, mac string) (io.ReadWriteCloser, error) {
+	f.macSeen = mac
+	return f.rwc, f.err
+}
+
+type nopRWC struct{}
+
+func (nopRWC) Read(_ []byte) (int, error)  { return 0, io.EOF }
+func (nopRWC) Write(_ []byte) (int, error) { return 0, nil }
+func (nopRWC) Close() error                { return nil }
+
+func TestNewKissSerialOpenFunc_Android_BluetoothMAC_RoutesThroughPsv(t *testing.T) {
+	f := &fakePsv{rwc: nopRWC{}}
+	open := newKissSerialOpenFunc(f)
+	if open == nil {
+		t.Fatal("expected non-nil OpenFunc")
+	}
+	rwc, err := open("AA:BB:CC:00:00:01", 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if rwc == nil {
+		t.Fatalf("rwc=nil")
+	}
+	if f.macSeen != "AA:BB:CC:00:00:01" {
+		t.Fatalf("mac=%q", f.macSeen)
+	}
+}
+
+func TestNewKissSerialOpenFunc_Android_HyphenMAC_RoutesThroughPsv(t *testing.T) {
+	f := &fakePsv{rwc: nopRWC{}}
+	open := newKissSerialOpenFunc(f)
+	if _, err := open("aa-bb-cc-00-00-01", 0); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if f.macSeen != "aa-bb-cc-00-00-01" {
+		t.Fatalf("mac=%q", f.macSeen)
+	}
+}
+
+func TestNewKissSerialOpenFunc_Android_NonMAC_RejectsWithoutCallingPsv(t *testing.T) {
+	f := &fakePsv{}
+	open := newKissSerialOpenFunc(f)
+	_, err := open("/dev/ttyUSB0", 9600)
+	if !errors.Is(err, errNotSupportedOnAndroid) {
+		t.Fatalf("err=%v want errNotSupportedOnAndroid", err)
+	}
+	if f.macSeen != "" {
+		t.Fatalf("BtSerialOpen called with %q", f.macSeen)
+	}
+}
+
+func TestNewKissSerialOpenFunc_Android_NilClient_ReturnsNil(t *testing.T) {
+	if got := newKissSerialOpenFunc(nil); got != nil {
+		t.Fatalf("expected nil OpenFunc when psv=nil; got non-nil")
+	}
+}

--- a/pkg/app/kiss_openfunc_default.go
+++ b/pkg/app/kiss_openfunc_default.go
@@ -1,0 +1,14 @@
+//go:build !android
+
+package app
+
+import "github.com/chrissnell/graywolf/pkg/kiss"
+
+// newKissSerialOpenFunc returns nil on desktop builds so SerialSupervisor
+// uses the package's defaultSerialOpen (go.bug.st/serial).
+func newKissSerialOpenFunc(_ any) kiss.OpenFunc { return nil }
+
+// kissSerialOpenFunc is the build-tag-aware accessor used by wiring.go
+// when constructing kiss.SerialConfig. On desktop builds it returns nil
+// so SerialSupervisor falls back to defaultSerialOpen.
+func (a *App) kissSerialOpenFunc() kiss.OpenFunc { return nil }

--- a/pkg/app/kiss_openfunc_default_test.go
+++ b/pkg/app/kiss_openfunc_default_test.go
@@ -1,0 +1,18 @@
+//go:build !android
+
+package app
+
+import "testing"
+
+func TestNewKissSerialOpenFunc_NonAndroid_IsNil(t *testing.T) {
+	if got := newKissSerialOpenFunc(nil); got != nil {
+		t.Fatalf("expected nil on non-Android; got non-nil")
+	}
+}
+
+func TestApp_KissSerialOpenFunc_NonAndroid_IsNil(t *testing.T) {
+	a := &App{}
+	if got := a.kissSerialOpenFunc(); got != nil {
+		t.Fatalf("expected nil on non-Android; got non-nil")
+	}
+}

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -1228,6 +1228,12 @@ func (a *App) wireHTTP(ctx context.Context) error {
 	apiSrv.SetAX25Manager(a.ax25Mgr)
 	apiSrv.SetPacketLog(a.plog)
 
+	// Bluetooth bonded-devices source. Android returns a live adapter
+	// backed by the platformsvc client (see btsource_android.go);
+	// desktop builds return nil so GET /api/kiss/bonded-bt-devices
+	// responds 501 Not Implemented (see btsource_default.go).
+	apiSrv.SetBtSource(a.btSourceForWebapi())
+
 	// Actions service runs the listener-addressee reload + test-fire
 	// path the REST handlers reach for. Skipped when wireActions
 	// declined to construct one (e.g. headless RF-only mode without a

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -1742,10 +1742,33 @@ func (a *App) kissComponent() namedComponent {
 						TncIngressBurst:     ki.TncIngressBurst,
 						AllowTxFromGovernor: ki.AllowTxFromGovernor,
 						OnReload:            a.notifyTxBackendReload,
+						OpenFunc:            a.kissSerialOpenFunc(),
+					})
+					continue
+				case configstore.KissTypeBluetooth:
+					// Bluetooth RFCOMM has no baud and the SPP TNC always
+					// owns the modem, so force BaudRate=0 and Mode=ModeTnc
+					// regardless of DTO input. The MAC lives in ki.Device.
+					if ki.Device == "" {
+						continue
+					}
+					a.kissMgr.StartSerial(ctx, ki.ID, kiss.SerialConfig{
+						Name:                name,
+						Device:              ki.Device,
+						BaudRate:            0,
+						Mode:                kiss.ModeTnc,
+						ChannelMap:          map[uint8]uint32{0: ch},
+						ReconnectInitMs:     ki.ReconnectInitMs,
+						ReconnectMaxMs:      ki.ReconnectMaxMs,
+						Logger:              a.logger,
+						TncIngressRateHz:    ki.TncIngressRateHz,
+						TncIngressBurst:     ki.TncIngressBurst,
+						AllowTxFromGovernor: ki.AllowTxFromGovernor,
+						OnReload:            a.notifyTxBackendReload,
+						OpenFunc:            a.kissSerialOpenFunc(),
 					})
 					continue
 				default:
-					// bluetooth not wired yet; skip.
 					continue
 				}
 				a.kissMgr.Start(ctx, ki.ID, kiss.ServerConfig{

--- a/pkg/kiss/serial.go
+++ b/pkg/kiss/serial.go
@@ -22,6 +22,11 @@ import (
 	"go.bug.st/serial"
 )
 
+// OpenFunc is the type of SerialConfig.OpenFunc. Exported so build-tagged
+// factories in other packages can return it without duplicating the
+// signature.
+type OpenFunc = func(device string, baud uint32) (io.ReadWriteCloser, error)
+
 // SerialConfig mirrors the ClientConfig supervisor-knob surface for a
 // serial KISS transport. Sink / RxIngress / InterfaceID /
 // OnDecodeError / OnFrameIngress / Clock are deliberately NOT here:

--- a/pkg/kiss/serial_test.go
+++ b/pkg/kiss/serial_test.go
@@ -271,3 +271,95 @@ func TestSerialSupervisor_RxRoundTrip(t *testing.T) {
 	cancel()
 	sup.close()
 }
+
+// TestSerialSupervisor_BluetoothShapedConfig_RxRoundTrip proves that the
+// SerialSupervisor accepts the exact shape pkg/app/wiring.go uses for the
+// KissTypeBluetooth case — MAC-style device string, BaudRate=0,
+// Mode=ModeTnc — and that the OpenFunc round-trip works identically to
+// the serial path. The injected OpenFunc returns a net.Pipe end the way
+// platformsvc.BtSerialOpen returns an RFCOMM-multiplexed io.ReadWriteCloser
+// on Android; the supervisor doesn't care which is which.
+//
+// Mode=ModeTnc means RX dispatches via the TNC rate limiter rather than
+// the Sink, so this test asserts the OnFrameIngress hook fires (the same
+// hook server.go uses for ingress accounting) — that is sufficient proof
+// the frame round-tripped through ServeTransport.
+func TestSerialSupervisor_BluetoothShapedConfig_RxRoundTrip(t *testing.T) {
+	srvSide, cliSide := net.Pipe()
+	rwc := struct {
+		io.ReadWriteCloser
+	}{srvSide}
+
+	const mac = "AA:BB:CC:DD:EE:FF"
+
+	var (
+		ingressMu  sync.Mutex
+		ingressN   int
+		ingressMod Mode
+	)
+	srv := NewServer(ServerConfig{
+		Name:       "bt-rx",
+		Mode:       ModeTnc, // BT TNCs always own the modem
+		ChannelMap: map[uint8]uint32{0: 7},
+		OnFrameIngress: func(m Mode) {
+			ingressMu.Lock()
+			defer ingressMu.Unlock()
+			ingressN++
+			ingressMod = m
+		},
+	})
+
+	var openMac string
+	var openBaud uint32
+	sup := NewSerial(SerialConfig{
+		Name:            "bt",
+		Device:          mac,
+		BaudRate:        0, // RFCOMM has no baud
+		Mode:            ModeTnc,
+		ReconnectInitMs: 10,
+		ReconnectMaxMs:  20,
+		OpenFunc: func(device string, baud uint32) (io.ReadWriteCloser, error) {
+			openMac = device
+			openBaud = baud
+			return rwc, nil
+		},
+	}, srv)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sup.run(ctx)
+	waitState(t, sup, StateConnected)
+
+	if openMac != mac {
+		t.Fatalf("OpenFunc device = %q, want %q", openMac, mac)
+	}
+	if openBaud != 0 {
+		t.Fatalf("OpenFunc baud = %d, want 0 (RFCOMM has no baud)", openBaud)
+	}
+
+	ax := kissUIFrameBytes(t, "bt-hello")
+	frame := Encode(0, ax)
+	go func() { _, _ = cliSide.Write(frame) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ingressMu.Lock()
+		n := ingressN
+		ingressMu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	ingressMu.Lock()
+	gotN := ingressN
+	gotMode := ingressMod
+	ingressMu.Unlock()
+	if gotN == 0 {
+		t.Fatal("OnFrameIngress never fired — BT-shaped OpenFunc round-trip failed")
+	}
+	if gotMode != ModeTnc {
+		t.Fatalf("ingress mode = %v, want ModeTnc", gotMode)
+	}
+	cancel()
+	sup.close()
+}

--- a/pkg/platformproto/platform.pb.go
+++ b/pkg/platformproto/platform.pb.go
@@ -244,6 +244,55 @@ func (ErrorCode) EnumDescriptor() ([]byte, []int) {
 	return file_platform_proto_rawDescGZIP(), []int{3}
 }
 
+// SerialKind classifies a transport-agnostic byte stream the platform
+// service is asked to open. Open-ended so a future USB-serial KISS path
+// can reuse the same SerialOpen/Data/Close family.
+type SerialKind int32
+
+const (
+	SerialKind_SERIAL_KIND_UNSPECIFIED SerialKind = 0
+	SerialKind_SERIAL_KIND_BLUETOOTH   SerialKind = 1 // SERIAL_KIND_USB reserved for future use.
+)
+
+// Enum value maps for SerialKind.
+var (
+	SerialKind_name = map[int32]string{
+		0: "SERIAL_KIND_UNSPECIFIED",
+		1: "SERIAL_KIND_BLUETOOTH",
+	}
+	SerialKind_value = map[string]int32{
+		"SERIAL_KIND_UNSPECIFIED": 0,
+		"SERIAL_KIND_BLUETOOTH":   1,
+	}
+)
+
+func (x SerialKind) Enum() *SerialKind {
+	p := new(SerialKind)
+	*p = x
+	return p
+}
+
+func (x SerialKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SerialKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_platform_proto_enumTypes[4].Descriptor()
+}
+
+func (SerialKind) Type() protoreflect.EnumType {
+	return &file_platform_proto_enumTypes[4]
+}
+
+func (x SerialKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SerialKind.Descriptor instead.
+func (SerialKind) EnumDescriptor() ([]byte, []int) {
+	return file_platform_proto_rawDescGZIP(), []int{4}
+}
+
 // Top-level envelope. Every message on the wire is a PlatformMessage.
 // Wire framing (matches pkg/modembridge/framing.go):
 //
@@ -269,6 +318,13 @@ type PlatformMessage struct {
 	//	*PlatformMessage_AudioRouteChanged
 	//	*PlatformMessage_Error
 	//	*PlatformMessage_GnssStatus
+	//	*PlatformMessage_SerialOpen
+	//	*PlatformMessage_SerialOpenAck
+	//	*PlatformMessage_SerialData
+	//	*PlatformMessage_SerialClose
+	//	*PlatformMessage_SerialError
+	//	*PlatformMessage_BondedBtDevicesRequest
+	//	*PlatformMessage_BondedBtDevicesResponse
 	Body          isPlatformMessage_Body `protobuf_oneof:"body"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -464,6 +520,69 @@ func (x *PlatformMessage) GetGnssStatus() *GnssStatusUpdate {
 	return nil
 }
 
+func (x *PlatformMessage) GetSerialOpen() *SerialOpen {
+	if x != nil {
+		if x, ok := x.Body.(*PlatformMessage_SerialOpen); ok {
+			return x.SerialOpen
+		}
+	}
+	return nil
+}
+
+func (x *PlatformMessage) GetSerialOpenAck() *SerialOpenAck {
+	if x != nil {
+		if x, ok := x.Body.(*PlatformMessage_SerialOpenAck); ok {
+			return x.SerialOpenAck
+		}
+	}
+	return nil
+}
+
+func (x *PlatformMessage) GetSerialData() *SerialData {
+	if x != nil {
+		if x, ok := x.Body.(*PlatformMessage_SerialData); ok {
+			return x.SerialData
+		}
+	}
+	return nil
+}
+
+func (x *PlatformMessage) GetSerialClose() *SerialClose {
+	if x != nil {
+		if x, ok := x.Body.(*PlatformMessage_SerialClose); ok {
+			return x.SerialClose
+		}
+	}
+	return nil
+}
+
+func (x *PlatformMessage) GetSerialError() *SerialError {
+	if x != nil {
+		if x, ok := x.Body.(*PlatformMessage_SerialError); ok {
+			return x.SerialError
+		}
+	}
+	return nil
+}
+
+func (x *PlatformMessage) GetBondedBtDevicesRequest() *BondedBtDevicesRequest {
+	if x != nil {
+		if x, ok := x.Body.(*PlatformMessage_BondedBtDevicesRequest); ok {
+			return x.BondedBtDevicesRequest
+		}
+	}
+	return nil
+}
+
+func (x *PlatformMessage) GetBondedBtDevicesResponse() *BondedBtDevicesResponse {
+	if x != nil {
+		if x, ok := x.Body.(*PlatformMessage_BondedBtDevicesResponse); ok {
+			return x.BondedBtDevicesResponse
+		}
+	}
+	return nil
+}
+
 type isPlatformMessage_Body interface {
 	isPlatformMessage_Body()
 }
@@ -536,6 +655,34 @@ type PlatformMessage_GnssStatus struct {
 	GnssStatus *GnssStatusUpdate `protobuf:"bytes,17,opt,name=gnss_status,json=gnssStatus,proto3,oneof"` // server → client; pushed alongside GpsFix
 }
 
+type PlatformMessage_SerialOpen struct {
+	SerialOpen *SerialOpen `protobuf:"bytes,18,opt,name=serial_open,json=serialOpen,proto3,oneof"`
+}
+
+type PlatformMessage_SerialOpenAck struct {
+	SerialOpenAck *SerialOpenAck `protobuf:"bytes,19,opt,name=serial_open_ack,json=serialOpenAck,proto3,oneof"`
+}
+
+type PlatformMessage_SerialData struct {
+	SerialData *SerialData `protobuf:"bytes,20,opt,name=serial_data,json=serialData,proto3,oneof"`
+}
+
+type PlatformMessage_SerialClose struct {
+	SerialClose *SerialClose `protobuf:"bytes,21,opt,name=serial_close,json=serialClose,proto3,oneof"`
+}
+
+type PlatformMessage_SerialError struct {
+	SerialError *SerialError `protobuf:"bytes,22,opt,name=serial_error,json=serialError,proto3,oneof"`
+}
+
+type PlatformMessage_BondedBtDevicesRequest struct {
+	BondedBtDevicesRequest *BondedBtDevicesRequest `protobuf:"bytes,23,opt,name=bonded_bt_devices_request,json=bondedBtDevicesRequest,proto3,oneof"`
+}
+
+type PlatformMessage_BondedBtDevicesResponse struct {
+	BondedBtDevicesResponse *BondedBtDevicesResponse `protobuf:"bytes,24,opt,name=bonded_bt_devices_response,json=bondedBtDevicesResponse,proto3,oneof"`
+}
+
 func (*PlatformMessage_Hello) isPlatformMessage_Body() {}
 
 func (*PlatformMessage_GpsFix) isPlatformMessage_Body() {}
@@ -569,6 +716,20 @@ func (*PlatformMessage_AudioRouteChanged) isPlatformMessage_Body() {}
 func (*PlatformMessage_Error) isPlatformMessage_Body() {}
 
 func (*PlatformMessage_GnssStatus) isPlatformMessage_Body() {}
+
+func (*PlatformMessage_SerialOpen) isPlatformMessage_Body() {}
+
+func (*PlatformMessage_SerialOpenAck) isPlatformMessage_Body() {}
+
+func (*PlatformMessage_SerialData) isPlatformMessage_Body() {}
+
+func (*PlatformMessage_SerialClose) isPlatformMessage_Body() {}
+
+func (*PlatformMessage_SerialError) isPlatformMessage_Body() {}
+
+func (*PlatformMessage_BondedBtDevicesRequest) isPlatformMessage_Body() {}
+
+func (*PlatformMessage_BondedBtDevicesResponse) isPlatformMessage_Body() {}
 
 type Hello struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1787,11 +1948,427 @@ func (x *GnssStatusUpdate) GetSats() []*SatInfo {
 	return nil
 }
 
+type SerialOpen struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Handle        uint32                 `protobuf:"varint,1,opt,name=handle,proto3" json:"handle,omitempty"`
+	Kind          SerialKind             `protobuf:"varint,2,opt,name=kind,proto3,enum=graywolf.platform.SerialKind" json:"kind,omitempty"`
+	Address       string                 `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"` // bluetooth: MAC ("AA:BB:CC:DD:EE:FF")
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SerialOpen) Reset() {
+	*x = SerialOpen{}
+	mi := &file_platform_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SerialOpen) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SerialOpen) ProtoMessage() {}
+
+func (x *SerialOpen) ProtoReflect() protoreflect.Message {
+	mi := &file_platform_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SerialOpen.ProtoReflect.Descriptor instead.
+func (*SerialOpen) Descriptor() ([]byte, []int) {
+	return file_platform_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *SerialOpen) GetHandle() uint32 {
+	if x != nil {
+		return x.Handle
+	}
+	return 0
+}
+
+func (x *SerialOpen) GetKind() SerialKind {
+	if x != nil {
+		return x.Kind
+	}
+	return SerialKind_SERIAL_KIND_UNSPECIFIED
+}
+
+func (x *SerialOpen) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+type SerialOpenAck struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Handle        uint32                 `protobuf:"varint,1,opt,name=handle,proto3" json:"handle,omitempty"`
+	Ok            bool                   `protobuf:"varint,2,opt,name=ok,proto3" json:"ok,omitempty"`
+	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SerialOpenAck) Reset() {
+	*x = SerialOpenAck{}
+	mi := &file_platform_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SerialOpenAck) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SerialOpenAck) ProtoMessage() {}
+
+func (x *SerialOpenAck) ProtoReflect() protoreflect.Message {
+	mi := &file_platform_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SerialOpenAck.ProtoReflect.Descriptor instead.
+func (*SerialOpenAck) Descriptor() ([]byte, []int) {
+	return file_platform_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *SerialOpenAck) GetHandle() uint32 {
+	if x != nil {
+		return x.Handle
+	}
+	return 0
+}
+
+func (x *SerialOpenAck) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
+}
+
+func (x *SerialOpenAck) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+type SerialData struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Handle        uint32                 `protobuf:"varint,1,opt,name=handle,proto3" json:"handle,omitempty"`
+	Data          []byte                 `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SerialData) Reset() {
+	*x = SerialData{}
+	mi := &file_platform_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SerialData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SerialData) ProtoMessage() {}
+
+func (x *SerialData) ProtoReflect() protoreflect.Message {
+	mi := &file_platform_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SerialData.ProtoReflect.Descriptor instead.
+func (*SerialData) Descriptor() ([]byte, []int) {
+	return file_platform_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *SerialData) GetHandle() uint32 {
+	if x != nil {
+		return x.Handle
+	}
+	return 0
+}
+
+func (x *SerialData) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+type SerialClose struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Handle        uint32                 `protobuf:"varint,1,opt,name=handle,proto3" json:"handle,omitempty"`
+	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SerialClose) Reset() {
+	*x = SerialClose{}
+	mi := &file_platform_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SerialClose) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SerialClose) ProtoMessage() {}
+
+func (x *SerialClose) ProtoReflect() protoreflect.Message {
+	mi := &file_platform_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SerialClose.ProtoReflect.Descriptor instead.
+func (*SerialClose) Descriptor() ([]byte, []int) {
+	return file_platform_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *SerialClose) GetHandle() uint32 {
+	if x != nil {
+		return x.Handle
+	}
+	return 0
+}
+
+func (x *SerialClose) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+type SerialError struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Handle        uint32                 `protobuf:"varint,1,opt,name=handle,proto3" json:"handle,omitempty"`
+	Code          string                 `protobuf:"bytes,2,opt,name=code,proto3" json:"code,omitempty"` // bond_lost | permission_denied | rfcomm_closed | io_error | not_bonded
+	Detail        string                 `protobuf:"bytes,3,opt,name=detail,proto3" json:"detail,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SerialError) Reset() {
+	*x = SerialError{}
+	mi := &file_platform_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SerialError) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SerialError) ProtoMessage() {}
+
+func (x *SerialError) ProtoReflect() protoreflect.Message {
+	mi := &file_platform_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SerialError.ProtoReflect.Descriptor instead.
+func (*SerialError) Descriptor() ([]byte, []int) {
+	return file_platform_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *SerialError) GetHandle() uint32 {
+	if x != nil {
+		return x.Handle
+	}
+	return 0
+}
+
+func (x *SerialError) GetCode() string {
+	if x != nil {
+		return x.Code
+	}
+	return ""
+}
+
+func (x *SerialError) GetDetail() string {
+	if x != nil {
+		return x.Detail
+	}
+	return ""
+}
+
+type BondedBtDevicesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BondedBtDevicesRequest) Reset() {
+	*x = BondedBtDevicesRequest{}
+	mi := &file_platform_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BondedBtDevicesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BondedBtDevicesRequest) ProtoMessage() {}
+
+func (x *BondedBtDevicesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_platform_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BondedBtDevicesRequest.ProtoReflect.Descriptor instead.
+func (*BondedBtDevicesRequest) Descriptor() ([]byte, []int) {
+	return file_platform_proto_rawDescGZIP(), []int{26}
+}
+
+type BondedBtDevicesResponse struct {
+	state         protoimpl.MessageState            `protogen:"open.v1"`
+	Devices       []*BondedBtDevicesResponse_Device `protobuf:"bytes,1,rep,name=devices,proto3" json:"devices,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BondedBtDevicesResponse) Reset() {
+	*x = BondedBtDevicesResponse{}
+	mi := &file_platform_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BondedBtDevicesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BondedBtDevicesResponse) ProtoMessage() {}
+
+func (x *BondedBtDevicesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_platform_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BondedBtDevicesResponse.ProtoReflect.Descriptor instead.
+func (*BondedBtDevicesResponse) Descriptor() ([]byte, []int) {
+	return file_platform_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *BondedBtDevicesResponse) GetDevices() []*BondedBtDevicesResponse_Device {
+	if x != nil {
+		return x.Devices
+	}
+	return nil
+}
+
+type BondedBtDevicesResponse_Device struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Mac           string                 `protobuf:"bytes,1,opt,name=mac,proto3" json:"mac,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BondedBtDevicesResponse_Device) Reset() {
+	*x = BondedBtDevicesResponse_Device{}
+	mi := &file_platform_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BondedBtDevicesResponse_Device) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BondedBtDevicesResponse_Device) ProtoMessage() {}
+
+func (x *BondedBtDevicesResponse_Device) ProtoReflect() protoreflect.Message {
+	mi := &file_platform_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BondedBtDevicesResponse_Device.ProtoReflect.Descriptor instead.
+func (*BondedBtDevicesResponse_Device) Descriptor() ([]byte, []int) {
+	return file_platform_proto_rawDescGZIP(), []int{27, 0}
+}
+
+func (x *BondedBtDevicesResponse_Device) GetMac() string {
+	if x != nil {
+		return x.Mac
+	}
+	return ""
+}
+
+func (x *BondedBtDevicesResponse_Device) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
 var File_platform_proto protoreflect.FileDescriptor
 
 const file_platform_proto_rawDesc = "" +
 	"\n" +
-	"\x0eplatform.proto\x12\x11graywolf.platform\"\xc0\t\n" +
+	"\x0eplatform.proto\x12\x11graywolf.platform\"\xed\r\n" +
 	"\x0fPlatformMessage\x120\n" +
 	"\x05hello\x18\x01 \x01(\v2\x18.graywolf.platform.HelloH\x00R\x05hello\x124\n" +
 	"\agps_fix\x18\x02 \x01(\v2\x19.graywolf.platform.GpsFixH\x00R\x06gpsFix\x12F\n" +
@@ -1814,7 +2391,16 @@ const file_platform_proto_rawDesc = "" +
 	"\x13audio_route_changed\x18\x0f \x01(\v2$.graywolf.platform.AudioRouteChangedH\x00R\x11audioRouteChanged\x120\n" +
 	"\x05error\x18\x10 \x01(\v2\x18.graywolf.platform.ErrorH\x00R\x05error\x12F\n" +
 	"\vgnss_status\x18\x11 \x01(\v2#.graywolf.platform.GnssStatusUpdateH\x00R\n" +
-	"gnssStatusB\x06\n" +
+	"gnssStatus\x12@\n" +
+	"\vserial_open\x18\x12 \x01(\v2\x1d.graywolf.platform.SerialOpenH\x00R\n" +
+	"serialOpen\x12J\n" +
+	"\x0fserial_open_ack\x18\x13 \x01(\v2 .graywolf.platform.SerialOpenAckH\x00R\rserialOpenAck\x12@\n" +
+	"\vserial_data\x18\x14 \x01(\v2\x1d.graywolf.platform.SerialDataH\x00R\n" +
+	"serialData\x12C\n" +
+	"\fserial_close\x18\x15 \x01(\v2\x1e.graywolf.platform.SerialCloseH\x00R\vserialClose\x12C\n" +
+	"\fserial_error\x18\x16 \x01(\v2\x1e.graywolf.platform.SerialErrorH\x00R\vserialError\x12f\n" +
+	"\x19bonded_bt_devices_request\x18\x17 \x01(\v2).graywolf.platform.BondedBtDevicesRequestH\x00R\x16bondedBtDevicesRequest\x12i\n" +
+	"\x1abonded_bt_devices_response\x18\x18 \x01(\v2*.graywolf.platform.BondedBtDevicesResponseH\x00R\x17bondedBtDevicesResponseB\x06\n" +
 	"\x04body\"|\n" +
 	"\x05Hello\x12%\n" +
 	"\x0eschema_version\x18\x01 \x01(\rR\rschemaVersion\x12%\n" +
@@ -1906,7 +2492,33 @@ const file_platform_proto_rawDesc = "" +
 	"\fsats_in_view\x18\x01 \x01(\rR\n" +
 	"satsInView\x12\x1b\n" +
 	"\tsats_used\x18\x02 \x01(\rR\bsatsUsed\x12.\n" +
-	"\x04sats\x18\x03 \x03(\v2\x1a.graywolf.platform.SatInfoR\x04sats*}\n" +
+	"\x04sats\x18\x03 \x03(\v2\x1a.graywolf.platform.SatInfoR\x04sats\"q\n" +
+	"\n" +
+	"SerialOpen\x12\x16\n" +
+	"\x06handle\x18\x01 \x01(\rR\x06handle\x121\n" +
+	"\x04kind\x18\x02 \x01(\x0e2\x1d.graywolf.platform.SerialKindR\x04kind\x12\x18\n" +
+	"\aaddress\x18\x03 \x01(\tR\aaddress\"M\n" +
+	"\rSerialOpenAck\x12\x16\n" +
+	"\x06handle\x18\x01 \x01(\rR\x06handle\x12\x0e\n" +
+	"\x02ok\x18\x02 \x01(\bR\x02ok\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"8\n" +
+	"\n" +
+	"SerialData\x12\x16\n" +
+	"\x06handle\x18\x01 \x01(\rR\x06handle\x12\x12\n" +
+	"\x04data\x18\x02 \x01(\fR\x04data\"=\n" +
+	"\vSerialClose\x12\x16\n" +
+	"\x06handle\x18\x01 \x01(\rR\x06handle\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\"Q\n" +
+	"\vSerialError\x12\x16\n" +
+	"\x06handle\x18\x01 \x01(\rR\x06handle\x12\x12\n" +
+	"\x04code\x18\x02 \x01(\tR\x04code\x12\x16\n" +
+	"\x06detail\x18\x03 \x01(\tR\x06detail\"\x18\n" +
+	"\x16BondedBtDevicesRequest\"\x96\x01\n" +
+	"\x17BondedBtDevicesResponse\x12K\n" +
+	"\adevices\x18\x01 \x03(\v21.graywolf.platform.BondedBtDevicesResponse.DeviceR\adevices\x1a.\n" +
+	"\x06Device\x12\x10\n" +
+	"\x03mac\x18\x01 \x01(\tR\x03mac\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name*}\n" +
 	"\tGpsSource\x12\x16\n" +
 	"\x12GPS_SOURCE_UNKNOWN\x10\x00\x12\x1c\n" +
 	"\x18GPS_SOURCE_ANDROID_FUSED\x10\x01\x12\x1a\n" +
@@ -1931,7 +2543,11 @@ const file_platform_proto_rawDesc = "" +
 	"\x16ERROR_INVALID_ARGUMENT\x10\x03\x12\x1b\n" +
 	"\x17ERROR_PERMISSION_DENIED\x10\x04\x12\x13\n" +
 	"\x0fERROR_NOT_FOUND\x10\x05\x12\x12\n" +
-	"\x0eERROR_INTERNAL\x10\x06Bc\n" +
+	"\x0eERROR_INTERNAL\x10\x06*D\n" +
+	"\n" +
+	"SerialKind\x12\x1b\n" +
+	"\x17SERIAL_KIND_UNSPECIFIED\x10\x00\x12\x19\n" +
+	"\x15SERIAL_KIND_BLUETOOTH\x10\x01Bc\n" +
 	"\x1fcom.nw5w.graywolf.platformprotoP\x01Z>github.com/chrissnell/graywolf/pkg/platformproto;platformprotob\x06proto3"
 
 var (
@@ -1946,70 +2562,88 @@ func file_platform_proto_rawDescGZIP() []byte {
 	return file_platform_proto_rawDescData
 }
 
-var file_platform_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_platform_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_platform_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_platform_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_platform_proto_goTypes = []any{
-	(GpsSource)(0),                  // 0: graywolf.platform.GpsSource
-	(UsbClass)(0),                   // 1: graywolf.platform.UsbClass
-	(PttMethod)(0),                  // 2: graywolf.platform.PttMethod
-	(ErrorCode)(0),                  // 3: graywolf.platform.ErrorCode
-	(*PlatformMessage)(nil),         // 4: graywolf.platform.PlatformMessage
-	(*Hello)(nil),                   // 5: graywolf.platform.Hello
-	(*GpsFix)(nil),                  // 6: graywolf.platform.GpsFix
-	(*BatteryState)(nil),            // 7: graywolf.platform.BatteryState
-	(*UsbDevice)(nil),               // 8: graywolf.platform.UsbDevice
-	(*UsbAttach)(nil),               // 9: graywolf.platform.UsbAttach
-	(*UsbDetach)(nil),               // 10: graywolf.platform.UsbDetach
-	(*UsbDeviceListRequest)(nil),    // 11: graywolf.platform.UsbDeviceListRequest
-	(*UsbDeviceListResponse)(nil),   // 12: graywolf.platform.UsbDeviceListResponse
-	(*UsbSelectRequest)(nil),        // 13: graywolf.platform.UsbSelectRequest
-	(*UsbSelectResponse)(nil),       // 14: graywolf.platform.UsbSelectResponse
-	(*PttKeyRequest)(nil),           // 15: graywolf.platform.PttKeyRequest
-	(*PttUnkeyRequest)(nil),         // 16: graywolf.platform.PttUnkeyRequest
-	(*PttAck)(nil),                  // 17: graywolf.platform.PttAck
-	(*AudioDeviceListRequest)(nil),  // 18: graywolf.platform.AudioDeviceListRequest
-	(*AudioDevice)(nil),             // 19: graywolf.platform.AudioDevice
-	(*AudioDeviceListResponse)(nil), // 20: graywolf.platform.AudioDeviceListResponse
-	(*AudioRouteChanged)(nil),       // 21: graywolf.platform.AudioRouteChanged
-	(*Error)(nil),                   // 22: graywolf.platform.Error
-	(*SatInfo)(nil),                 // 23: graywolf.platform.SatInfo
-	(*GnssStatusUpdate)(nil),        // 24: graywolf.platform.GnssStatusUpdate
+	(GpsSource)(0),                         // 0: graywolf.platform.GpsSource
+	(UsbClass)(0),                          // 1: graywolf.platform.UsbClass
+	(PttMethod)(0),                         // 2: graywolf.platform.PttMethod
+	(ErrorCode)(0),                         // 3: graywolf.platform.ErrorCode
+	(SerialKind)(0),                        // 4: graywolf.platform.SerialKind
+	(*PlatformMessage)(nil),                // 5: graywolf.platform.PlatformMessage
+	(*Hello)(nil),                          // 6: graywolf.platform.Hello
+	(*GpsFix)(nil),                         // 7: graywolf.platform.GpsFix
+	(*BatteryState)(nil),                   // 8: graywolf.platform.BatteryState
+	(*UsbDevice)(nil),                      // 9: graywolf.platform.UsbDevice
+	(*UsbAttach)(nil),                      // 10: graywolf.platform.UsbAttach
+	(*UsbDetach)(nil),                      // 11: graywolf.platform.UsbDetach
+	(*UsbDeviceListRequest)(nil),           // 12: graywolf.platform.UsbDeviceListRequest
+	(*UsbDeviceListResponse)(nil),          // 13: graywolf.platform.UsbDeviceListResponse
+	(*UsbSelectRequest)(nil),               // 14: graywolf.platform.UsbSelectRequest
+	(*UsbSelectResponse)(nil),              // 15: graywolf.platform.UsbSelectResponse
+	(*PttKeyRequest)(nil),                  // 16: graywolf.platform.PttKeyRequest
+	(*PttUnkeyRequest)(nil),                // 17: graywolf.platform.PttUnkeyRequest
+	(*PttAck)(nil),                         // 18: graywolf.platform.PttAck
+	(*AudioDeviceListRequest)(nil),         // 19: graywolf.platform.AudioDeviceListRequest
+	(*AudioDevice)(nil),                    // 20: graywolf.platform.AudioDevice
+	(*AudioDeviceListResponse)(nil),        // 21: graywolf.platform.AudioDeviceListResponse
+	(*AudioRouteChanged)(nil),              // 22: graywolf.platform.AudioRouteChanged
+	(*Error)(nil),                          // 23: graywolf.platform.Error
+	(*SatInfo)(nil),                        // 24: graywolf.platform.SatInfo
+	(*GnssStatusUpdate)(nil),               // 25: graywolf.platform.GnssStatusUpdate
+	(*SerialOpen)(nil),                     // 26: graywolf.platform.SerialOpen
+	(*SerialOpenAck)(nil),                  // 27: graywolf.platform.SerialOpenAck
+	(*SerialData)(nil),                     // 28: graywolf.platform.SerialData
+	(*SerialClose)(nil),                    // 29: graywolf.platform.SerialClose
+	(*SerialError)(nil),                    // 30: graywolf.platform.SerialError
+	(*BondedBtDevicesRequest)(nil),         // 31: graywolf.platform.BondedBtDevicesRequest
+	(*BondedBtDevicesResponse)(nil),        // 32: graywolf.platform.BondedBtDevicesResponse
+	(*BondedBtDevicesResponse_Device)(nil), // 33: graywolf.platform.BondedBtDevicesResponse.Device
 }
 var file_platform_proto_depIdxs = []int32{
-	5,  // 0: graywolf.platform.PlatformMessage.hello:type_name -> graywolf.platform.Hello
-	6,  // 1: graywolf.platform.PlatformMessage.gps_fix:type_name -> graywolf.platform.GpsFix
-	7,  // 2: graywolf.platform.PlatformMessage.battery_state:type_name -> graywolf.platform.BatteryState
-	9,  // 3: graywolf.platform.PlatformMessage.usb_attach:type_name -> graywolf.platform.UsbAttach
-	10, // 4: graywolf.platform.PlatformMessage.usb_detach:type_name -> graywolf.platform.UsbDetach
-	11, // 5: graywolf.platform.PlatformMessage.usb_list_req:type_name -> graywolf.platform.UsbDeviceListRequest
-	12, // 6: graywolf.platform.PlatformMessage.usb_list_resp:type_name -> graywolf.platform.UsbDeviceListResponse
-	13, // 7: graywolf.platform.PlatformMessage.usb_select_req:type_name -> graywolf.platform.UsbSelectRequest
-	14, // 8: graywolf.platform.PlatformMessage.usb_select_resp:type_name -> graywolf.platform.UsbSelectResponse
-	15, // 9: graywolf.platform.PlatformMessage.ptt_key_req:type_name -> graywolf.platform.PttKeyRequest
-	16, // 10: graywolf.platform.PlatformMessage.ptt_unkey_req:type_name -> graywolf.platform.PttUnkeyRequest
-	17, // 11: graywolf.platform.PlatformMessage.ptt_ack:type_name -> graywolf.platform.PttAck
-	18, // 12: graywolf.platform.PlatformMessage.audio_list_req:type_name -> graywolf.platform.AudioDeviceListRequest
-	20, // 13: graywolf.platform.PlatformMessage.audio_list_resp:type_name -> graywolf.platform.AudioDeviceListResponse
-	21, // 14: graywolf.platform.PlatformMessage.audio_route_changed:type_name -> graywolf.platform.AudioRouteChanged
-	22, // 15: graywolf.platform.PlatformMessage.error:type_name -> graywolf.platform.Error
-	24, // 16: graywolf.platform.PlatformMessage.gnss_status:type_name -> graywolf.platform.GnssStatusUpdate
-	0,  // 17: graywolf.platform.GpsFix.source:type_name -> graywolf.platform.GpsSource
-	1,  // 18: graywolf.platform.UsbDevice.classes:type_name -> graywolf.platform.UsbClass
-	8,  // 19: graywolf.platform.UsbAttach.device:type_name -> graywolf.platform.UsbDevice
-	1,  // 20: graywolf.platform.UsbDeviceListRequest.class_filter:type_name -> graywolf.platform.UsbClass
-	8,  // 21: graywolf.platform.UsbDeviceListResponse.devices:type_name -> graywolf.platform.UsbDevice
-	2,  // 22: graywolf.platform.PttKeyRequest.method:type_name -> graywolf.platform.PttMethod
-	2,  // 23: graywolf.platform.PttUnkeyRequest.method:type_name -> graywolf.platform.PttMethod
-	19, // 24: graywolf.platform.AudioDeviceListResponse.devices:type_name -> graywolf.platform.AudioDevice
-	19, // 25: graywolf.platform.AudioRouteChanged.current_inputs:type_name -> graywolf.platform.AudioDevice
-	19, // 26: graywolf.platform.AudioRouteChanged.current_outputs:type_name -> graywolf.platform.AudioDevice
-	3,  // 27: graywolf.platform.Error.code:type_name -> graywolf.platform.ErrorCode
-	23, // 28: graywolf.platform.GnssStatusUpdate.sats:type_name -> graywolf.platform.SatInfo
-	29, // [29:29] is the sub-list for method output_type
-	29, // [29:29] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	6,  // 0: graywolf.platform.PlatformMessage.hello:type_name -> graywolf.platform.Hello
+	7,  // 1: graywolf.platform.PlatformMessage.gps_fix:type_name -> graywolf.platform.GpsFix
+	8,  // 2: graywolf.platform.PlatformMessage.battery_state:type_name -> graywolf.platform.BatteryState
+	10, // 3: graywolf.platform.PlatformMessage.usb_attach:type_name -> graywolf.platform.UsbAttach
+	11, // 4: graywolf.platform.PlatformMessage.usb_detach:type_name -> graywolf.platform.UsbDetach
+	12, // 5: graywolf.platform.PlatformMessage.usb_list_req:type_name -> graywolf.platform.UsbDeviceListRequest
+	13, // 6: graywolf.platform.PlatformMessage.usb_list_resp:type_name -> graywolf.platform.UsbDeviceListResponse
+	14, // 7: graywolf.platform.PlatformMessage.usb_select_req:type_name -> graywolf.platform.UsbSelectRequest
+	15, // 8: graywolf.platform.PlatformMessage.usb_select_resp:type_name -> graywolf.platform.UsbSelectResponse
+	16, // 9: graywolf.platform.PlatformMessage.ptt_key_req:type_name -> graywolf.platform.PttKeyRequest
+	17, // 10: graywolf.platform.PlatformMessage.ptt_unkey_req:type_name -> graywolf.platform.PttUnkeyRequest
+	18, // 11: graywolf.platform.PlatformMessage.ptt_ack:type_name -> graywolf.platform.PttAck
+	19, // 12: graywolf.platform.PlatformMessage.audio_list_req:type_name -> graywolf.platform.AudioDeviceListRequest
+	21, // 13: graywolf.platform.PlatformMessage.audio_list_resp:type_name -> graywolf.platform.AudioDeviceListResponse
+	22, // 14: graywolf.platform.PlatformMessage.audio_route_changed:type_name -> graywolf.platform.AudioRouteChanged
+	23, // 15: graywolf.platform.PlatformMessage.error:type_name -> graywolf.platform.Error
+	25, // 16: graywolf.platform.PlatformMessage.gnss_status:type_name -> graywolf.platform.GnssStatusUpdate
+	26, // 17: graywolf.platform.PlatformMessage.serial_open:type_name -> graywolf.platform.SerialOpen
+	27, // 18: graywolf.platform.PlatformMessage.serial_open_ack:type_name -> graywolf.platform.SerialOpenAck
+	28, // 19: graywolf.platform.PlatformMessage.serial_data:type_name -> graywolf.platform.SerialData
+	29, // 20: graywolf.platform.PlatformMessage.serial_close:type_name -> graywolf.platform.SerialClose
+	30, // 21: graywolf.platform.PlatformMessage.serial_error:type_name -> graywolf.platform.SerialError
+	31, // 22: graywolf.platform.PlatformMessage.bonded_bt_devices_request:type_name -> graywolf.platform.BondedBtDevicesRequest
+	32, // 23: graywolf.platform.PlatformMessage.bonded_bt_devices_response:type_name -> graywolf.platform.BondedBtDevicesResponse
+	0,  // 24: graywolf.platform.GpsFix.source:type_name -> graywolf.platform.GpsSource
+	1,  // 25: graywolf.platform.UsbDevice.classes:type_name -> graywolf.platform.UsbClass
+	9,  // 26: graywolf.platform.UsbAttach.device:type_name -> graywolf.platform.UsbDevice
+	1,  // 27: graywolf.platform.UsbDeviceListRequest.class_filter:type_name -> graywolf.platform.UsbClass
+	9,  // 28: graywolf.platform.UsbDeviceListResponse.devices:type_name -> graywolf.platform.UsbDevice
+	2,  // 29: graywolf.platform.PttKeyRequest.method:type_name -> graywolf.platform.PttMethod
+	2,  // 30: graywolf.platform.PttUnkeyRequest.method:type_name -> graywolf.platform.PttMethod
+	20, // 31: graywolf.platform.AudioDeviceListResponse.devices:type_name -> graywolf.platform.AudioDevice
+	20, // 32: graywolf.platform.AudioRouteChanged.current_inputs:type_name -> graywolf.platform.AudioDevice
+	20, // 33: graywolf.platform.AudioRouteChanged.current_outputs:type_name -> graywolf.platform.AudioDevice
+	3,  // 34: graywolf.platform.Error.code:type_name -> graywolf.platform.ErrorCode
+	24, // 35: graywolf.platform.GnssStatusUpdate.sats:type_name -> graywolf.platform.SatInfo
+	4,  // 36: graywolf.platform.SerialOpen.kind:type_name -> graywolf.platform.SerialKind
+	33, // 37: graywolf.platform.BondedBtDevicesResponse.devices:type_name -> graywolf.platform.BondedBtDevicesResponse.Device
+	38, // [38:38] is the sub-list for method output_type
+	38, // [38:38] is the sub-list for method input_type
+	38, // [38:38] is the sub-list for extension type_name
+	38, // [38:38] is the sub-list for extension extendee
+	0,  // [0:38] is the sub-list for field type_name
 }
 
 func init() { file_platform_proto_init() }
@@ -2035,14 +2669,21 @@ func file_platform_proto_init() {
 		(*PlatformMessage_AudioRouteChanged)(nil),
 		(*PlatformMessage_Error)(nil),
 		(*PlatformMessage_GnssStatus)(nil),
+		(*PlatformMessage_SerialOpen)(nil),
+		(*PlatformMessage_SerialOpenAck)(nil),
+		(*PlatformMessage_SerialData)(nil),
+		(*PlatformMessage_SerialClose)(nil),
+		(*PlatformMessage_SerialError)(nil),
+		(*PlatformMessage_BondedBtDevicesRequest)(nil),
+		(*PlatformMessage_BondedBtDevicesResponse)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_platform_proto_rawDesc), len(file_platform_proto_rawDesc)),
-			NumEnums:      4,
-			NumMessages:   21,
+			NumEnums:      5,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/platformsvc/btserial.go
+++ b/pkg/platformsvc/btserial.go
@@ -1,0 +1,43 @@
+//go:build android
+
+package platformsvc
+
+import (
+	"context"
+	"fmt"
+
+	pb "github.com/chrissnell/graywolf/pkg/platformproto"
+)
+
+// BondedBtDevice is the Go-side view of an Android Bluetooth bond entry
+// returned by Client.BondedBtDevices. MAC is the colon-separated uppercase
+// address (e.g. "AA:BB:CC:DD:EE:FF"); Name is the user-visible label set
+// at bond time and may be empty if the device never advertised one.
+type BondedBtDevice struct {
+	MAC  string
+	Name string
+}
+
+// BondedBtDevices issues a one-shot request to the platform service for
+// the current bonded-Bluetooth-device set. Order matches the platform's
+// view at the moment of the request; subsequent bond/unbond events do not
+// stream back here (use the platform-service's bond-state broadcast for
+// live updates).
+func (c *clientImpl) BondedBtDevices(ctx context.Context) ([]BondedBtDevice, error) {
+	req := &pb.PlatformMessage{Body: &pb.PlatformMessage_BondedBtDevicesRequest{
+		BondedBtDevicesRequest: &pb.BondedBtDevicesRequest{},
+	}}
+	resp, err := c.roundTrip(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	body := resp.GetBondedBtDevicesResponse()
+	if body == nil {
+		return nil, fmt.Errorf("platformsvc: expected BondedBtDevicesResponse, got %T", resp.GetBody())
+	}
+	out := make([]BondedBtDevice, 0, len(body.GetDevices()))
+	for _, d := range body.GetDevices() {
+		out = append(out, BondedBtDevice{MAC: d.GetMac(), Name: d.GetName()})
+	}
+	return out, nil
+}

--- a/pkg/platformsvc/btserial.go
+++ b/pkg/platformsvc/btserial.go
@@ -4,7 +4,10 @@ package platformsvc
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"sync"
 
 	pb "github.com/chrissnell/graywolf/pkg/platformproto"
 )
@@ -17,6 +20,27 @@ type BondedBtDevice struct {
 	MAC  string
 	Name string
 }
+
+// SerialErrorErr is returned by btReadWriteCloser.Read when the platform
+// service reports an out-of-band stream failure (e.g. "bond_lost",
+// "rfcomm_closed"). Distinct from io.EOF (which signals normal close) so
+// callers can decide whether to surface the cause to the operator.
+type SerialErrorErr struct {
+	Code   string
+	Detail string
+}
+
+func (e *SerialErrorErr) Error() string {
+	if e.Detail == "" {
+		return fmt.Sprintf("platformsvc: serial error: %s", e.Code)
+	}
+	return fmt.Sprintf("platformsvc: serial error: %s: %s", e.Code, e.Detail)
+}
+
+// btSerialMaxChunk caps the payload size of a single SerialData frame.
+// writeFrame enforces a 64 KiB hard limit (header + payload); chunking at
+// 4 KiB keeps overhead low and matches typical KISS frame sizes.
+const btSerialMaxChunk = 4 * 1024
 
 // BondedBtDevices issues a one-shot request to the platform service for
 // the current bonded-Bluetooth-device set. Order matches the platform's
@@ -40,4 +64,225 @@ func (c *clientImpl) BondedBtDevices(ctx context.Context) ([]BondedBtDevice, err
 		out = append(out, BondedBtDevice{MAC: d.GetMac(), Name: d.GetName()})
 	}
 	return out, nil
+}
+
+// BtSerialOpen opens an RFCOMM SPP stream to the bonded device at mac and
+// returns an io.ReadWriteCloser. The returned handle multiplexes onto the
+// shared UDS connection; multiple BtSerialOpen calls coexist, each routed
+// by its 32-bit handle ID. The caller must Close when done so the platform
+// service tears down the RFCOMM socket and releases the bond reference.
+func (c *clientImpl) BtSerialOpen(ctx context.Context, mac string) (io.ReadWriteCloser, error) {
+	if c.closed.Load() {
+		return nil, ErrClosed
+	}
+
+	handle := c.nextBtHandle()
+	inbound := c.registerBtHandle(handle)
+
+	req := &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialOpen{
+		SerialOpen: &pb.SerialOpen{
+			Handle:  handle,
+			Kind:    pb.SerialKind_SERIAL_KIND_BLUETOOTH,
+			Address: mac,
+		},
+	}}
+	if err := c.send(req); err != nil {
+		c.removeBtHandle(handle)
+		return nil, fmt.Errorf("platformsvc: send SerialOpen: %w", err)
+	}
+
+	// Wait for SerialOpenAck (or an early SerialError on this handle).
+	for {
+		select {
+		case <-ctx.Done():
+			c.removeBtHandle(handle)
+			// Best-effort: tell the server we're abandoning this handle
+			// so it can tear down any in-progress connect attempt.
+			_ = c.send(&pb.PlatformMessage{Body: &pb.PlatformMessage_SerialClose{
+				SerialClose: &pb.SerialClose{Handle: handle, Reason: "client_cancel"},
+			}})
+			return nil, ctx.Err()
+		case <-c.closeCh:
+			c.removeBtHandle(handle)
+			return nil, ErrClosed
+		case msg, ok := <-inbound:
+			if !ok {
+				c.removeBtHandle(handle)
+				return nil, ErrDisconnected
+			}
+			switch b := msg.GetBody().(type) {
+			case *pb.PlatformMessage_SerialOpenAck:
+				ack := b.SerialOpenAck
+				if !ack.GetOk() {
+					c.removeBtHandle(handle)
+					return nil, fmt.Errorf("platformsvc: SerialOpen denied: %s", ack.GetError())
+				}
+				return newBtReadWriteCloser(c, handle, inbound), nil
+			case *pb.PlatformMessage_SerialError:
+				se := b.SerialError
+				c.removeBtHandle(handle)
+				return nil, &SerialErrorErr{Code: se.GetCode(), Detail: se.GetDetail()}
+			case *pb.PlatformMessage_SerialClose:
+				c.removeBtHandle(handle)
+				return nil, fmt.Errorf("platformsvc: server closed before ack: %s", b.SerialClose.GetReason())
+			default:
+				// Unexpected payload for this handle before ack; ignore
+				// and keep waiting. (Defensive: dispatch only routes the
+				// four serial_* variants here, so this branch is dead
+				// code today.)
+			}
+		}
+	}
+}
+
+// btReadWriteCloser is a multiplexed RFCOMM stream over the platform-service
+// UDS. Read blocks on the per-handle inbound channel; Write chunks the
+// caller's bytes into ≤4 KiB SerialData frames; Close is idempotent and
+// sends a final SerialClose to the server.
+type btReadWriteCloser struct {
+	c       *clientImpl
+	handle  uint32
+	inbound chan *pb.PlatformMessage
+
+	// buf holds overflow bytes from a previous Read when the caller's
+	// buffer was smaller than the incoming SerialData payload.
+	bufMu sync.Mutex
+	buf   []byte
+
+	// closed fires once when Close is invoked, unblocking any in-flight
+	// Read. closeOnce guards both the channel close and the SerialClose
+	// emit so Close is safe to call from any goroutine.
+	closed    chan struct{}
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func newBtReadWriteCloser(c *clientImpl, handle uint32, inbound chan *pb.PlatformMessage) *btReadWriteCloser {
+	return &btReadWriteCloser{
+		c:       c,
+		handle:  handle,
+		inbound: inbound,
+		closed:  make(chan struct{}),
+	}
+}
+
+// Read implements io.Reader. Returns io.EOF when the server emits
+// SerialClose, *SerialErrorErr on SerialError, and forwards SerialData
+// bytes (stashing any tail that exceeds p's capacity).
+func (r *btReadWriteCloser) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	// Drain any stashed overflow first.
+	r.bufMu.Lock()
+	if len(r.buf) > 0 {
+		n := copy(p, r.buf)
+		r.buf = r.buf[n:]
+		if len(r.buf) == 0 {
+			r.buf = nil
+		}
+		r.bufMu.Unlock()
+		return n, nil
+	}
+	r.bufMu.Unlock()
+
+	for {
+		select {
+		case <-r.closed:
+			return 0, io.EOF
+		case msg, ok := <-r.inbound:
+			if !ok {
+				return 0, io.EOF
+			}
+			switch b := msg.GetBody().(type) {
+			case *pb.PlatformMessage_SerialData:
+				data := b.SerialData.GetData()
+				if len(data) == 0 {
+					continue
+				}
+				n := copy(p, data)
+				if n < len(data) {
+					tail := make([]byte, len(data)-n)
+					copy(tail, data[n:])
+					r.bufMu.Lock()
+					// Stash for the next Read. There's no concurrent
+					// reader by contract; defensive lock guards against
+					// misuse without changing semantics.
+					r.buf = append(r.buf, tail...)
+					r.bufMu.Unlock()
+				}
+				return n, nil
+			case *pb.PlatformMessage_SerialClose:
+				return 0, io.EOF
+			case *pb.PlatformMessage_SerialError:
+				se := b.SerialError
+				return 0, &SerialErrorErr{Code: se.GetCode(), Detail: se.GetDetail()}
+			case *pb.PlatformMessage_SerialOpenAck:
+				// Spurious post-open ack — drop and keep reading.
+				continue
+			default:
+				// Unknown payload routed to this handle; defensive drop.
+				continue
+			}
+		}
+	}
+}
+
+// Write implements io.Writer. Chunks p into ≤4 KiB SerialData frames and
+// sends each in order. Returns the number of bytes successfully written
+// (which always equals len(p) on a nil error return).
+func (r *btReadWriteCloser) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	select {
+	case <-r.closed:
+		return 0, io.ErrClosedPipe
+	default:
+	}
+	written := 0
+	for written < len(p) {
+		chunkEnd := written + btSerialMaxChunk
+		if chunkEnd > len(p) {
+			chunkEnd = len(p)
+		}
+		chunk := p[written:chunkEnd]
+		msg := &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialData{
+			SerialData: &pb.SerialData{
+				Handle: r.handle,
+				Data:   append([]byte(nil), chunk...),
+			},
+		}}
+		if err := r.c.send(msg); err != nil {
+			if written > 0 {
+				return written, err
+			}
+			return 0, err
+		}
+		written = chunkEnd
+	}
+	return written, nil
+}
+
+// Close releases the handle. Sends a final SerialClose to the server so
+// the RFCOMM socket can be torn down and unregisters the per-handle
+// channel. Safe to call multiple times; only the first invocation
+// performs I/O. Returns the underlying send error from the first call
+// (if any) for subsequent callers too.
+func (r *btReadWriteCloser) Close() error {
+	r.closeOnce.Do(func() {
+		close(r.closed)
+		msg := &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialClose{
+			SerialClose: &pb.SerialClose{Handle: r.handle, Reason: "client_close"},
+		}}
+		err := r.c.send(msg)
+		// Suppress "not connected" / closed-client errors — Close on a
+		// dead connection is not actionable to the caller.
+		if err != nil && !errors.Is(err, ErrClosed) {
+			r.closeErr = err
+		}
+		r.c.removeBtHandle(r.handle)
+	})
+	return r.closeErr
 }

--- a/pkg/platformsvc/btserial.go
+++ b/pkg/platformsvc/btserial.go
@@ -203,13 +203,13 @@ func (r *btReadWriteCloser) Read(p []byte) (int, error) {
 				}
 				n := copy(p, data)
 				if n < len(data) {
-					tail := make([]byte, len(data)-n)
-					copy(tail, data[n:])
 					r.bufMu.Lock()
 					// Stash for the next Read. There's no concurrent
 					// reader by contract; defensive lock guards against
-					// misuse without changing semantics.
-					r.buf = append(r.buf, tail...)
+					// misuse without changing semantics. append() copies
+					// data[n:] into its own backing array, so no extra
+					// defensive copy is needed.
+					r.buf = append(r.buf, data[n:]...)
 					r.bufMu.Unlock()
 				}
 				return n, nil
@@ -243,10 +243,7 @@ func (r *btReadWriteCloser) Write(p []byte) (int, error) {
 	}
 	written := 0
 	for written < len(p) {
-		chunkEnd := written + btSerialMaxChunk
-		if chunkEnd > len(p) {
-			chunkEnd = len(p)
-		}
+		chunkEnd := min(written+btSerialMaxChunk, len(p))
 		chunk := p[written:chunkEnd]
 		msg := &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialData{
 			SerialData: &pb.SerialData{

--- a/pkg/platformsvc/btserial_test.go
+++ b/pkg/platformsvc/btserial_test.go
@@ -1,0 +1,44 @@
+//go:build android
+
+package platformsvc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pb "github.com/chrissnell/graywolf/pkg/platformproto"
+)
+
+func TestBondedBtDevices_returnsDevices(t *testing.T) {
+	respond := func(req *pb.PlatformMessage) *pb.PlatformMessage {
+		if req.GetBondedBtDevicesRequest() == nil {
+			return nil
+		}
+		return &pb.PlatformMessage{Body: &pb.PlatformMessage_BondedBtDevicesResponse{
+			BondedBtDevicesResponse: &pb.BondedBtDevicesResponse{
+				Devices: []*pb.BondedBtDevicesResponse_Device{
+					{Mac: "AA:BB:CC:DD:EE:FF", Name: "Mobilinkd TNC4"},
+					{Mac: "11:22:33:44:55:66", Name: ""},
+				},
+			},
+		}}
+	}
+	withFakeClient(t, respond, func(c *clientImpl) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		got, err := c.BondedBtDevices(ctx)
+		if err != nil {
+			t.Fatalf("BondedBtDevices: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("expected 2 devices, got %d", len(got))
+		}
+		if got[0].MAC != "AA:BB:CC:DD:EE:FF" || got[0].Name != "Mobilinkd TNC4" {
+			t.Errorf("device[0] = %+v", got[0])
+		}
+		if got[1].MAC != "11:22:33:44:55:66" || got[1].Name != "" {
+			t.Errorf("device[1] = %+v", got[1])
+		}
+	})
+}

--- a/pkg/platformsvc/btserial_test.go
+++ b/pkg/platformsvc/btserial_test.go
@@ -3,7 +3,12 @@
 package platformsvc
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,4 +46,257 @@ func TestBondedBtDevices_returnsDevices(t *testing.T) {
 			t.Errorf("device[1] = %+v", got[1])
 		}
 	})
+}
+
+// btTestServer is a per-test driver for BtSerialOpen: it owns the server
+// half of the pipe, reads incoming frames in a goroutine, and lets the
+// test push response frames at will.
+type btTestServer struct {
+	t       *testing.T
+	conn    net.Conn
+	inMu    sync.Mutex
+	inbound []*pb.PlatformMessage
+	in      chan *pb.PlatformMessage
+	stopCh  chan struct{}
+	wg      sync.WaitGroup
+}
+
+func newBtTestServer(t *testing.T) (*btTestServer, *clientImpl) {
+	t.Helper()
+	clientConn, serverConn := net.Pipe()
+	srv := &btTestServer{
+		t:      t,
+		conn:   serverConn,
+		in:     make(chan *pb.PlatformMessage, 16),
+		stopCh: make(chan struct{}),
+	}
+	srv.wg.Add(1)
+	go srv.readLoop()
+	c := newClient("").(*clientImpl)
+	c.injectConn(clientConn)
+	return srv, c
+}
+
+func (s *btTestServer) readLoop() {
+	defer s.wg.Done()
+	for {
+		msg, err := readFrame(s.conn)
+		if err != nil {
+			return
+		}
+		s.inMu.Lock()
+		s.inbound = append(s.inbound, msg)
+		s.inMu.Unlock()
+		select {
+		case s.in <- msg:
+		default:
+		}
+	}
+}
+
+func (s *btTestServer) waitFor(t *testing.T, match func(*pb.PlatformMessage) bool, timeout time.Duration) *pb.PlatformMessage {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case msg := <-s.in:
+			if match(msg) {
+				return msg
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for matching frame")
+			return nil
+		}
+	}
+}
+
+func (s *btTestServer) send(t *testing.T, msg *pb.PlatformMessage) {
+	t.Helper()
+	if err := writeFrame(s.conn, msg); err != nil {
+		t.Fatalf("server send: %v", err)
+	}
+}
+
+func (s *btTestServer) close() {
+	close(s.stopCh)
+	s.conn.Close()
+	s.wg.Wait()
+}
+
+func TestBtSerialOpen_roundTrip(t *testing.T) {
+	srv, c := newBtTestServer(t)
+	defer srv.close()
+
+	// Drive BtSerialOpen + a write + a read in a goroutine; let the
+	// server respond inline so we don't deadlock on net.Pipe.
+	openDone := make(chan error, 1)
+	rwcCh := make(chan io.ReadWriteCloser, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		rwc, err := c.BtSerialOpen(ctx, "AA:BB:CC:DD:EE:FF")
+		if err != nil {
+			openDone <- err
+			return
+		}
+		rwcCh <- rwc
+		openDone <- nil
+	}()
+
+	// Expect SerialOpen, ack it.
+	open := srv.waitFor(t, func(m *pb.PlatformMessage) bool {
+		return m.GetSerialOpen() != nil
+	}, 2*time.Second)
+	if got, want := open.GetSerialOpen().GetAddress(), "AA:BB:CC:DD:EE:FF"; got != want {
+		t.Fatalf("SerialOpen address: got %q want %q", got, want)
+	}
+	if open.GetSerialOpen().GetKind() != pb.SerialKind_SERIAL_KIND_BLUETOOTH {
+		t.Fatalf("SerialOpen kind: got %v", open.GetSerialOpen().GetKind())
+	}
+	handle := open.GetSerialOpen().GetHandle()
+	srv.send(t, &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialOpenAck{
+		SerialOpenAck: &pb.SerialOpenAck{Handle: handle, Ok: true},
+	}})
+
+	if err := <-openDone; err != nil {
+		t.Fatalf("BtSerialOpen: %v", err)
+	}
+	rwc := <-rwcCh
+	defer rwc.Close()
+
+	// Write some bytes, expect them as SerialData frames on the server.
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := rwc.Write([]byte("KISS"))
+		writeDone <- err
+	}()
+	data := srv.waitFor(t, func(m *pb.PlatformMessage) bool {
+		return m.GetSerialData() != nil
+	}, 2*time.Second)
+	if !bytes.Equal(data.GetSerialData().GetData(), []byte("KISS")) {
+		t.Fatalf("client wrote %q", data.GetSerialData().GetData())
+	}
+	if got := data.GetSerialData().GetHandle(); got != handle {
+		t.Fatalf("handle mismatch: got %d want %d", got, handle)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Server echoes data; client Read should surface it.
+	srv.send(t, &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialData{
+		SerialData: &pb.SerialData{Handle: handle, Data: []byte("ACK!")},
+	}})
+	buf := make([]byte, 16)
+	n, err := rwc.Read(buf)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !bytes.Equal(buf[:n], []byte("ACK!")) {
+		t.Fatalf("Read got %q", buf[:n])
+	}
+}
+
+func TestBtSerialOpen_serverClose_returnsEOF(t *testing.T) {
+	srv, c := newBtTestServer(t)
+	defer srv.close()
+
+	openDone := make(chan io.ReadWriteCloser, 1)
+	openErr := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		rwc, err := c.BtSerialOpen(ctx, "AA:BB:CC:DD:EE:FF")
+		if err != nil {
+			openErr <- err
+			return
+		}
+		openDone <- rwc
+	}()
+
+	open := srv.waitFor(t, func(m *pb.PlatformMessage) bool {
+		return m.GetSerialOpen() != nil
+	}, 2*time.Second)
+	handle := open.GetSerialOpen().GetHandle()
+	srv.send(t, &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialOpenAck{
+		SerialOpenAck: &pb.SerialOpenAck{Handle: handle, Ok: true},
+	}})
+
+	var rwc io.ReadWriteCloser
+	select {
+	case rwc = <-openDone:
+	case err := <-openErr:
+		t.Fatalf("BtSerialOpen: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("BtSerialOpen did not return")
+	}
+	defer rwc.Close()
+
+	// Server sends SerialClose on this handle; Read must return io.EOF.
+	srv.send(t, &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialClose{
+		SerialClose: &pb.SerialClose{Handle: handle, Reason: "rfcomm_closed"},
+	}})
+
+	buf := make([]byte, 16)
+	n, err := rwc.Read(buf)
+	if err != io.EOF {
+		t.Fatalf("Read err: got %v (%d bytes) want io.EOF", err, n)
+	}
+}
+
+func TestBtSerialOpen_serialError_returnsTypedError(t *testing.T) {
+	srv, c := newBtTestServer(t)
+	defer srv.close()
+
+	openDone := make(chan io.ReadWriteCloser, 1)
+	openErr := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		rwc, err := c.BtSerialOpen(ctx, "AA:BB:CC:DD:EE:FF")
+		if err != nil {
+			openErr <- err
+			return
+		}
+		openDone <- rwc
+	}()
+
+	open := srv.waitFor(t, func(m *pb.PlatformMessage) bool {
+		return m.GetSerialOpen() != nil
+	}, 2*time.Second)
+	handle := open.GetSerialOpen().GetHandle()
+	srv.send(t, &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialOpenAck{
+		SerialOpenAck: &pb.SerialOpenAck{Handle: handle, Ok: true},
+	}})
+
+	var rwc io.ReadWriteCloser
+	select {
+	case rwc = <-openDone:
+	case err := <-openErr:
+		t.Fatalf("BtSerialOpen: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("BtSerialOpen did not return")
+	}
+	defer rwc.Close()
+
+	srv.send(t, &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialError{
+		SerialError: &pb.SerialError{
+			Handle: handle,
+			Code:   "bond_lost",
+			Detail: "remote unbonded",
+		},
+	}})
+
+	buf := make([]byte, 16)
+	_, err := rwc.Read(buf)
+	var serr *SerialErrorErr
+	if !errors.As(err, &serr) {
+		t.Fatalf("Read err: got %T %v, want *SerialErrorErr", err, err)
+	}
+	if serr.Code != "bond_lost" {
+		t.Errorf("SerialErrorErr.Code = %q want %q", serr.Code, "bond_lost")
+	}
+	if serr.Detail != "remote unbonded" {
+		t.Errorf("SerialErrorErr.Detail = %q", serr.Detail)
+	}
 }

--- a/pkg/platformsvc/btserial_test.go
+++ b/pkg/platformsvc/btserial_test.go
@@ -57,7 +57,6 @@ type btTestServer struct {
 	inMu    sync.Mutex
 	inbound []*pb.PlatformMessage
 	in      chan *pb.PlatformMessage
-	stopCh  chan struct{}
 	wg      sync.WaitGroup
 }
 
@@ -65,10 +64,9 @@ func newBtTestServer(t *testing.T) (*btTestServer, *clientImpl) {
 	t.Helper()
 	clientConn, serverConn := net.Pipe()
 	srv := &btTestServer{
-		t:      t,
-		conn:   serverConn,
-		in:     make(chan *pb.PlatformMessage, 16),
-		stopCh: make(chan struct{}),
+		t:    t,
+		conn: serverConn,
+		in:   make(chan *pb.PlatformMessage, 16),
 	}
 	srv.wg.Add(1)
 	go srv.readLoop()
@@ -118,7 +116,6 @@ func (s *btTestServer) send(t *testing.T, msg *pb.PlatformMessage) {
 }
 
 func (s *btTestServer) close() {
-	close(s.stopCh)
 	s.conn.Close()
 	s.wg.Wait()
 }
@@ -298,5 +295,147 @@ func TestBtSerialOpen_serialError_returnsTypedError(t *testing.T) {
 	}
 	if serr.Detail != "remote unbonded" {
 		t.Errorf("SerialErrorErr.Detail = %q", serr.Detail)
+	}
+}
+
+// TestBtSerialOpen_clientClose_unblocksRead proves that calling the
+// underlying client's Close() wakes a blocked btReadWriteCloser.Read with
+// io.EOF instead of hanging on the now-orphaned per-handle channel.
+// Without drainBtHandles in Close(), this test would deadlock until the
+// test timeout. The 500 ms deadline is generous; the wakeup is effectively
+// immediate once the channel is closed.
+func TestBtSerialOpen_clientClose_unblocksRead(t *testing.T) {
+	srv, c := newBtTestServer(t)
+	defer srv.close()
+
+	openDone := make(chan io.ReadWriteCloser, 1)
+	openErr := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		rwc, err := c.BtSerialOpen(ctx, "AA:BB:CC:DD:EE:FF")
+		if err != nil {
+			openErr <- err
+			return
+		}
+		openDone <- rwc
+	}()
+
+	open := srv.waitFor(t, func(m *pb.PlatformMessage) bool {
+		return m.GetSerialOpen() != nil
+	}, 2*time.Second)
+	handle := open.GetSerialOpen().GetHandle()
+	srv.send(t, &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialOpenAck{
+		SerialOpenAck: &pb.SerialOpenAck{Handle: handle, Ok: true},
+	}})
+
+	var rwc io.ReadWriteCloser
+	select {
+	case rwc = <-openDone:
+	case err := <-openErr:
+		t.Fatalf("BtSerialOpen: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("BtSerialOpen did not return")
+	}
+
+	// Kick off a blocked Read; nothing on the wire so it parks on the
+	// inbound channel.
+	type readResult struct {
+		n   int
+		err error
+	}
+	readCh := make(chan readResult, 1)
+	go func() {
+		buf := make([]byte, 16)
+		n, err := rwc.Read(buf)
+		readCh <- readResult{n, err}
+	}()
+
+	// Give the reader a beat to actually block.
+	time.Sleep(20 * time.Millisecond)
+
+	// Closing the client drains btHandles -> Read sees channel close ->
+	// returns io.EOF.
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case res := <-readCh:
+		if res.err != io.EOF {
+			t.Fatalf("Read err after client Close: got %v want io.EOF", res.err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Read did not return within 500ms of client Close; drainBtHandles missing?")
+	}
+}
+
+// TestBtSerialOpen_serverDisconnect_unblocksRead proves the same property
+// for handleDisconnect: when the UDS dies (server-side conn.Close), the
+// client's drainBtHandles call from handleDisconnect must wake any blocked
+// per-handle Read with io.EOF.
+func TestBtSerialOpen_serverDisconnect_unblocksRead(t *testing.T) {
+	srv, c := newBtTestServer(t)
+	// Do not defer srv.close() — we close the server conn explicitly below
+	// to exercise the handleDisconnect path. Final cleanup of wg is via
+	// readLoop returning on the broken pipe.
+	defer c.Close()
+
+	openDone := make(chan io.ReadWriteCloser, 1)
+	openErr := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		rwc, err := c.BtSerialOpen(ctx, "AA:BB:CC:DD:EE:FF")
+		if err != nil {
+			openErr <- err
+			return
+		}
+		openDone <- rwc
+	}()
+
+	open := srv.waitFor(t, func(m *pb.PlatformMessage) bool {
+		return m.GetSerialOpen() != nil
+	}, 2*time.Second)
+	handle := open.GetSerialOpen().GetHandle()
+	srv.send(t, &pb.PlatformMessage{Body: &pb.PlatformMessage_SerialOpenAck{
+		SerialOpenAck: &pb.SerialOpenAck{Handle: handle, Ok: true},
+	}})
+
+	var rwc io.ReadWriteCloser
+	select {
+	case rwc = <-openDone:
+	case err := <-openErr:
+		t.Fatalf("BtSerialOpen: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("BtSerialOpen did not return")
+	}
+	defer rwc.Close()
+
+	type readResult struct {
+		n   int
+		err error
+	}
+	readCh := make(chan readResult, 1)
+	go func() {
+		buf := make([]byte, 16)
+		n, err := rwc.Read(buf)
+		readCh <- readResult{n, err}
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Closing the server side of the pipe causes the client's readLoop to
+	// hit an error and invoke handleDisconnect, which drains btHandles.
+	srv.conn.Close()
+	srv.wg.Wait()
+
+	select {
+	case res := <-readCh:
+		if res.err != io.EOF {
+			t.Fatalf("Read err after server disconnect: got %v want io.EOF", res.err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Read did not return within 500ms of server disconnect; drainBtHandles missing in handleDisconnect?")
 	}
 }

--- a/pkg/platformsvc/client.go
+++ b/pkg/platformsvc/client.go
@@ -20,6 +20,9 @@ type Client interface {
 	SelectUsbDevice(ctx context.Context, vid, pid uint16) (*UsbHandle, error)
 	KeyPtt(ctx context.Context, method PttMethod, handle *UsbHandle) (*PttAck, error)
 	UnkeyPtt(ctx context.Context, method PttMethod, handle *UsbHandle) (*PttAck, error)
+	// BondedBtDevices enumerates the currently-bonded Bluetooth devices on
+	// the Android side. One-shot request/response; safe to call repeatedly.
+	BondedBtDevices(ctx context.Context) ([]BondedBtDevice, error)
 	Close() error
 }
 

--- a/pkg/platformsvc/client.go
+++ b/pkg/platformsvc/client.go
@@ -2,7 +2,10 @@
 
 package platformsvc
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // Client is the typed Go API consumed by pkg/gps/android.go,
 // pkg/pttdevice/android.go, and the modembridge PTT relay (phases 4-5).
@@ -23,6 +26,12 @@ type Client interface {
 	// BondedBtDevices enumerates the currently-bonded Bluetooth devices on
 	// the Android side. One-shot request/response; safe to call repeatedly.
 	BondedBtDevices(ctx context.Context) ([]BondedBtDevice, error)
+	// BtSerialOpen opens an RFCOMM SPP stream to the bonded device at mac
+	// and returns a multiplexed io.ReadWriteCloser. Multiple handles may
+	// be open concurrently; each is routed independently by the dispatch
+	// layer. Close on the returned handle sends a final SerialClose to the
+	// server and unregisters the handle.
+	BtSerialOpen(ctx context.Context, mac string) (io.ReadWriteCloser, error)
 	Close() error
 }
 

--- a/pkg/platformsvc/client_impl.go
+++ b/pkg/platformsvc/client_impl.go
@@ -178,6 +178,7 @@ func (c *clientImpl) dispatch(msg *pb.PlatformMessage) {
 			*pb.PlatformMessage_UsbSelectResp,
 			*pb.PlatformMessage_PttAck,
 			*pb.PlatformMessage_AudioListResp,
+			*pb.PlatformMessage_BondedBtDevicesResponse,
 			*pb.PlatformMessage_Error:
 			c.mu.Lock()
 			ch := c.respCh

--- a/pkg/platformsvc/client_impl.go
+++ b/pkg/platformsvc/client_impl.go
@@ -25,6 +25,12 @@ type clientImpl struct {
 	closed  atomic.Bool
 	closeCh chan struct{}
 
+	// writeMu serializes writeFrame calls on c.conn. The frame format is
+	// [4-byte length][payload], split across two Write calls in writeFrame,
+	// so concurrent writers (roundTrip + async BtSerial write pump) would
+	// interleave header and body bytes without this guard.
+	writeMu sync.Mutex
+
 	subsMu         sync.Mutex
 	gpsFixSubs     []chan<- *GpsFix
 	gnssStatusSubs []chan<- *GnssStatusUpdate
@@ -34,6 +40,14 @@ type clientImpl struct {
 	// has no request_id field, so we serialize requests through requestMu.
 	requestMu sync.Mutex
 	respCh    chan *pb.PlatformMessage // re-set per request
+
+	// Multiplexed Bluetooth serial handles. Each open BtSerial stream gets
+	// a unique uint32 handle (atomic-allocated via btHandleCounter) and a
+	// dedicated inbound channel that the dispatch loop fans data/close/
+	// error frames into. btHandles is lazily allocated on first use.
+	btHandlesMu     sync.Mutex
+	btHandles       map[uint32]chan *pb.PlatformMessage
+	btHandleCounter uint32
 }
 
 func newClient(socketPath string) Client {
@@ -165,6 +179,14 @@ func (c *clientImpl) dispatch(msg *pb.PlatformMessage) {
 			default:
 			}
 		}
+	case *pb.PlatformMessage_SerialOpenAck:
+		c.deliverBtHandle(b.SerialOpenAck.GetHandle(), msg)
+	case *pb.PlatformMessage_SerialData:
+		c.deliverBtHandle(b.SerialData.GetHandle(), msg)
+	case *pb.PlatformMessage_SerialClose:
+		c.deliverBtHandle(b.SerialClose.GetHandle(), msg)
+	case *pb.PlatformMessage_SerialError:
+		c.deliverBtHandle(b.SerialError.GetHandle(), msg)
 	default:
 		// Response to an in-flight request. We only forward when the
 		// oneof body matches a request type we actually issue from
@@ -244,8 +266,11 @@ func (c *clientImpl) roundTrip(ctx context.Context, req *pb.PlatformMessage) (*p
 		return nil, errors.New("platformsvc: not connected")
 	}
 
-	if err := writeFrame(conn, req); err != nil {
-		return nil, fmt.Errorf("write: %w", err)
+	c.writeMu.Lock()
+	werr := writeFrame(conn, req)
+	c.writeMu.Unlock()
+	if werr != nil {
+		return nil, fmt.Errorf("write: %w", werr)
 	}
 	select {
 	case resp, ok := <-respCh:
@@ -261,6 +286,72 @@ func (c *clientImpl) roundTrip(ctx context.Context, req *pb.PlatformMessage) (*p
 		return nil, ctx.Err()
 	case <-c.closeCh:
 		return nil, ErrClosed
+	}
+}
+
+// send marshals and writes msg to the current connection without waiting
+// for a response. Used by async paths (BtSerial Write/Close) that do not
+// fit roundTrip's strict-ordered request/response model. writeMu serializes
+// frame writes so the 4-byte header and payload stay contiguous.
+func (c *clientImpl) send(msg *pb.PlatformMessage) error {
+	if c.closed.Load() {
+		return ErrClosed
+	}
+	c.mu.Lock()
+	conn := c.conn
+	c.mu.Unlock()
+	if conn == nil {
+		return errors.New("platformsvc: not connected")
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return writeFrame(conn, msg)
+}
+
+// nextBtHandle allocates a fresh non-zero handle ID for a new BtSerial
+// stream. The first allocated handle is 1; handles never repeat within a
+// client lifetime (uint32 wraparound is not a practical concern).
+func (c *clientImpl) nextBtHandle() uint32 {
+	return atomic.AddUint32(&c.btHandleCounter, 1)
+}
+
+// registerBtHandle creates a buffered inbound channel and records it under
+// btHandlesMu. Returns the channel for the caller to read from.
+func (c *clientImpl) registerBtHandle(handle uint32) chan *pb.PlatformMessage {
+	ch := make(chan *pb.PlatformMessage, 256)
+	c.btHandlesMu.Lock()
+	if c.btHandles == nil {
+		c.btHandles = make(map[uint32]chan *pb.PlatformMessage)
+	}
+	c.btHandles[handle] = ch
+	c.btHandlesMu.Unlock()
+	return ch
+}
+
+// removeBtHandle removes the inbound channel for handle. Idempotent; safe
+// to call multiple times. Does not close the channel — the caller is
+// responsible for any reader synchronization (e.g. via a separate done
+// signal).
+func (c *clientImpl) removeBtHandle(handle uint32) {
+	c.btHandlesMu.Lock()
+	delete(c.btHandles, handle)
+	c.btHandlesMu.Unlock()
+}
+
+// deliverBtHandle fans an incoming BT serial frame (Ack/Data/Close/Error)
+// to the per-handle channel. Non-blocking: if the channel is full the
+// frame is dropped. The 256-frame buffer makes this rare under normal
+// load; a sustained overflow indicates a stalled reader.
+func (c *clientImpl) deliverBtHandle(handle uint32, msg *pb.PlatformMessage) {
+	c.btHandlesMu.Lock()
+	ch := c.btHandles[handle]
+	c.btHandlesMu.Unlock()
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- msg:
+	default:
 	}
 }
 

--- a/pkg/platformsvc/client_impl.go
+++ b/pkg/platformsvc/client_impl.go
@@ -221,7 +221,9 @@ func (c *clientImpl) dispatch(msg *pb.PlatformMessage) {
 // handleDisconnect is called from readLoop when the underlying conn dies.
 // It closes the in-flight response channel (if any) so a caller blocked in
 // roundTrip's select wakes up immediately rather than deadlocking until
-// ctx expires. The reconnect loop sees c.conn == nil and re-dials.
+// ctx expires. It also drains btHandles so any blocked btReadWriteCloser.Read
+// wakes with io.EOF instead of hanging forever. The reconnect loop sees
+// c.conn == nil and re-dials.
 func (c *clientImpl) handleDisconnect(_ error) {
 	c.mu.Lock()
 	c.conn = nil
@@ -232,6 +234,7 @@ func (c *clientImpl) handleDisconnect(_ error) {
 		// Closing surfaces as `_, ok := <-respCh; !ok` in roundTrip.
 		close(respCh)
 	}
+	c.drainBtHandles()
 }
 
 func (c *clientImpl) Close() error {
@@ -243,10 +246,28 @@ func (c *clientImpl) Close() error {
 	conn := c.conn
 	c.conn = nil
 	c.mu.Unlock()
+	c.drainBtHandles()
 	if conn != nil {
 		return conn.Close()
 	}
 	return nil
+}
+
+// drainBtHandles closes every per-handle inbound channel and clears the
+// map. Called from handleDisconnect (UDS died) and Close (client shutdown)
+// so any goroutine blocked in btReadWriteCloser.Read wakes with io.EOF
+// instead of stalling on a now-orphaned channel. Safe when btHandles is
+// nil (initial state — never used). The map snapshot is taken under
+// btHandlesMu and the close() calls happen outside the lock to avoid
+// re-entering dispatch paths that also take btHandlesMu.
+func (c *clientImpl) drainBtHandles() {
+	c.btHandlesMu.Lock()
+	handles := c.btHandles
+	c.btHandles = nil
+	c.btHandlesMu.Unlock()
+	for _, ch := range handles {
+		close(ch)
+	}
 }
 
 // roundTrip serializes one request, awaits exactly one response.

--- a/pkg/platformsvc/schema_version.go
+++ b/pkg/platformsvc/schema_version.go
@@ -1,0 +1,9 @@
+package platformsvc
+
+// SchemaVersion is the wire-schema version negotiated by the platform
+// service Hello handshake. Kept in a non-build-tagged file so the Go
+// drift-guard test (schema_version_test.go) can read it on any host
+// without requiring GOOS=android. The Kotlin side must declare the
+// same value at GraywolfService.kt:schemaVersion — schema_version_test
+// asserts this.
+const SchemaVersion uint32 = 2

--- a/pkg/platformsvc/schema_version_test.go
+++ b/pkg/platformsvc/schema_version_test.go
@@ -1,0 +1,48 @@
+package platformsvc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+)
+
+// TestSchemaVersionMatchesKotlin parses GraywolfService.kt for its
+// `schemaVersion = N` literal and asserts it equals the Go-side
+// SchemaVersion constant. The platform-service handshake fails fast on
+// mismatch (ERROR_SCHEMA_MISMATCH); this test fires earlier, at build
+// time, so a forgotten Kotlin bump can't slip into a release.
+func TestSchemaVersionMatchesKotlin(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	pkgDir := filepath.Dir(thisFile)
+	repoRoot := filepath.Dir(filepath.Dir(pkgDir))
+
+	kotlinPath := filepath.Join(repoRoot, "android", "app", "src", "main", "kotlin",
+		"com", "nw5w", "graywolf", "GraywolfService.kt")
+	content, err := os.ReadFile(kotlinPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", kotlinPath, err)
+	}
+
+	// PlatformServer(... schemaVersion = N, ...) — the value passed at
+	// PlatformServer construction is the source of truth on the Kotlin side.
+	pattern := regexp.MustCompile(`schemaVersion\s*=\s*(\d+)`)
+	matches := pattern.FindAllStringSubmatch(string(content), -1)
+	if len(matches) == 0 {
+		t.Fatalf("no `schemaVersion = N` literal found in %s", kotlinPath)
+	}
+
+	for _, m := range matches {
+		var v uint32
+		if _, err := fmt.Sscanf(m[1], "%d", &v); err != nil {
+			t.Fatalf("parse %q: %v", m[1], err)
+		}
+		if v != SchemaVersion {
+			t.Fatalf("Kotlin schemaVersion = %d, Go SchemaVersion = %d (in %s).\n"+
+				"Bump both sides together when changing the wire schema.",
+				v, SchemaVersion, kotlinPath)
+		}
+	}
+}

--- a/pkg/platformsvc/types.go
+++ b/pkg/platformsvc/types.go
@@ -9,7 +9,7 @@ import (
 	pb "github.com/chrissnell/graywolf/pkg/platformproto"
 )
 
-const SchemaVersion uint32 = 1
+const SchemaVersion uint32 = 2
 
 type PttMethod = pb.PttMethod
 type UsbClass = pb.UsbClass

--- a/pkg/platformsvc/types.go
+++ b/pkg/platformsvc/types.go
@@ -9,8 +9,6 @@ import (
 	pb "github.com/chrissnell/graywolf/pkg/platformproto"
 )
 
-const SchemaVersion uint32 = 2
-
 type PttMethod = pb.PttMethod
 type UsbClass = pb.UsbClass
 type UsbDevice = pb.UsbDevice

--- a/pkg/releasenotes/notes.yaml
+++ b/pkg/releasenotes/notes.yaml
@@ -7,6 +7,30 @@
 # route the body references via [text](link) markdown; renderer only
 # accepts internal #/... routes.
 
+- version: "0.13.6"
+  date: "2026-05-19"
+  style: cta
+  schema_version: 1
+  title: "Android: connect to a KISS TNC over Bluetooth"
+  link: "#/kiss"
+  body: |
+    On Android tablets, you can now attach a Bluetooth-paired KISS TNC,
+    such as a Mobilinkd TNC3 or TNC4 or a Kenwood TH-D74 or D75, as a
+    KISS interface. Pair the TNC in Android Settings under Bluetooth
+    first, then in Graywolf go to the KISS page, click Add KISS
+    Interface, pick Bluetooth as the type, and choose your TNC from the
+    bonded device list.
+
+    The first time you open that list, Graywolf asks for permission to
+    see your paired Bluetooth devices. Grant it so the list can load.
+
+    There is no baud rate to set, since Bluetooth radio links do not
+    have one. The interface card shows the TNC name and address, and
+    flips to Connected when the TNC is in range and ready.
+
+    Desktop installs are unchanged. The new Bluetooth interface type
+    only appears on the Android tablet build.
+
 - version: "0.13.5"
   date: "2026-05-17"
   style: info

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -3416,6 +3416,43 @@
                 }
             }
         },
+        "/kiss/bonded-bt-devices": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "kiss"
+                ],
+                "summary": "List bonded Bluetooth devices (Android only)",
+                "operationId": "getBondedBtDevices",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/webapi.BondedBtDevicesResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/kiss/{id}": {
             "get": {
                 "security": [
@@ -10261,6 +10298,28 @@
                 "used": {
                     "description": "Used is true when another driver has claimed this line (e.g. SPI, I2C,\nUART, or a previously-running graywolf process).",
                     "type": "boolean"
+                }
+            }
+        },
+        "webapi.BondedBtDevice": {
+            "type": "object",
+            "properties": {
+                "mac": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "webapi.BondedBtDevicesResponse": {
+            "type": "object",
+            "properties": {
+                "devices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/webapi.BondedBtDevice"
+                    }
                 }
             }
         },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -2400,6 +2400,20 @@ definitions:
           UART, or a previously-running graywolf process).
         type: boolean
     type: object
+  webapi.BondedBtDevice:
+    properties:
+      mac:
+        type: string
+      name:
+        type: string
+    type: object
+  webapi.BondedBtDevicesResponse:
+    properties:
+      devices:
+        items:
+          $ref: '#/definitions/webapi.BondedBtDevice'
+        type: array
+    type: object
   webapi.ChannelReferrersResponse:
     properties:
       error:
@@ -5079,6 +5093,29 @@ paths:
       security:
         - CookieAuth: []
       summary: Reconnect a KISS tcp-client interface now
+      tags:
+        - kiss
+  /kiss/bonded-bt-devices:
+    get:
+      operationId: getBondedBtDevices
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/webapi.BondedBtDevicesResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: List bonded Bluetooth devices (Android only)
       tags:
         - kiss
   /maps/catalog:

--- a/pkg/webapi/docs/op_ids.go
+++ b/pkg/webapi/docs/op_ids.go
@@ -75,12 +75,13 @@ const (
 
 // KISS interfaces resource — /api/kiss (Phase 2).
 const (
-	OpListKiss      = "listKiss"
-	OpCreateKiss    = "createKiss"
-	OpGetKiss       = "getKiss"
-	OpUpdateKiss    = "updateKiss"
-	OpDeleteKiss    = "deleteKiss"
-	OpReconnectKiss = "reconnectKiss"
+	OpListKiss           = "listKiss"
+	OpCreateKiss         = "createKiss"
+	OpGetKiss            = "getKiss"
+	OpUpdateKiss         = "updateKiss"
+	OpDeleteKiss         = "deleteKiss"
+	OpReconnectKiss      = "reconnectKiss"
+	OpGetBondedBtDevices = "getBondedBtDevices"
 )
 
 // Tx-timing resource — /api/tx-timing (Phase 2). Keyed by channel id,

--- a/pkg/webapi/dto/kiss.go
+++ b/pkg/webapi/dto/kiss.go
@@ -94,8 +94,12 @@ func (r KissRequest) Validate() error {
 	if (r.Type == configstore.KissTypeSerial || r.Type == configstore.KissTypeBluetooth) && r.SerialDevice == "" {
 		return fmt.Errorf("serial_device is required for serial/bluetooth interfaces")
 	}
-	if (r.Type == configstore.KissTypeSerial || r.Type == configstore.KissTypeBluetooth) && r.BaudRate == 0 {
-		return fmt.Errorf("baud_rate is required for serial/bluetooth interfaces")
+	// Bluetooth/RFCOMM has no baud rate (the radio link runs at its
+	// own modulation rate), so the BaudRate check only applies to
+	// real serial devices. wiring.go hardcodes BaudRate=0 for the
+	// bluetooth path; rejecting it here would deadlock valid POSTs.
+	if r.Type == configstore.KissTypeSerial && r.BaudRate == 0 {
+		return fmt.Errorf("baud_rate is required for serial interfaces")
 	}
 	if r.Mode != "" && !configstore.ValidKissMode(r.Mode) {
 		return fmt.Errorf("invalid mode %q: must be %q or %q", r.Mode, configstore.KissModeModem, configstore.KissModeTnc)

--- a/pkg/webapi/dto/kiss_test.go
+++ b/pkg/webapi/dto/kiss_test.go
@@ -93,9 +93,10 @@ func TestKissFromModel_AllowTxFromGovernor_Roundtrip(t *testing.T) {
 	}
 }
 
-// TestKissRequest_Validate_BaudRate verifies that a serial/bluetooth
-// interface with baud_rate == 0 is rejected, a valid baud_rate is
-// accepted, and non-serial types are unaffected by the baud_rate check.
+// TestKissRequest_Validate_BaudRate verifies that a serial interface
+// with baud_rate == 0 is rejected, a valid baud_rate is accepted, and
+// non-serial types — including bluetooth/RFCOMM, which has no baud —
+// are unaffected by the baud_rate check.
 func TestKissRequest_Validate_BaudRate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -107,12 +108,18 @@ func TestKissRequest_Validate_BaudRate(t *testing.T) {
 			req: KissRequest{
 				Type: configstore.KissTypeSerial, SerialDevice: "/dev/ttyUSB0", BaudRate: 0,
 			},
-			wantErr: "baud_rate is required for serial/bluetooth interfaces",
+			wantErr: "baud_rate is required for serial interfaces",
 		},
 		{
 			name: "serial with non-zero baud_rate is accepted",
 			req: KissRequest{
 				Type: configstore.KissTypeSerial, SerialDevice: "/dev/ttyUSB0", BaudRate: 9600,
+			},
+		},
+		{
+			name: "bluetooth with zero baud_rate is accepted (RFCOMM has no baud)",
+			req: KissRequest{
+				Type: configstore.KissTypeBluetooth, SerialDevice: "00:11:22:33:44:55", BaudRate: 0,
 			},
 		},
 		{

--- a/pkg/webapi/kiss.go
+++ b/pkg/webapi/kiss.go
@@ -14,6 +14,11 @@ import (
 func (s *Server) registerKiss(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/kiss", s.listKiss)
 	mux.HandleFunc("POST /api/kiss", s.createKiss)
+	// Static segment before /{id} so the mux routes
+	// /api/kiss/bonded-bt-devices to handleGetBondedBtDevices rather than
+	// the {id} path. Go 1.22+ patterns prefer literal-over-wildcard
+	// already, but listing the literal first makes intent obvious.
+	mux.HandleFunc("GET /api/kiss/bonded-bt-devices", s.handleGetBondedBtDevices)
 	mux.HandleFunc("GET /api/kiss/{id}", s.getKiss)
 	mux.HandleFunc("PUT /api/kiss/{id}", s.updateKiss)
 	mux.HandleFunc("DELETE /api/kiss/{id}", s.deleteKiss)

--- a/pkg/webapi/kiss_bt.go
+++ b/pkg/webapi/kiss_bt.go
@@ -1,0 +1,71 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// BondedBtDevice is the wire representation of a single bonded Bluetooth
+// device returned by GET /api/kiss/bonded-bt-devices. MAC is the
+// colon-separated uppercase Bluetooth address (e.g. "AA:BB:CC:DD:EE:FF");
+// Name is the user-visible label set at bond time and may be empty if the
+// device never advertised one.
+type BondedBtDevice struct {
+	MAC  string `json:"mac"`
+	Name string `json:"name"`
+}
+
+// BondedBtDevicesResponse is the JSON payload returned by
+// GET /api/kiss/bonded-bt-devices. Devices is always serialized as a JSON
+// array (never null) — an empty bond set yields []. See
+// handleGetBondedBtDevices.
+type BondedBtDevicesResponse struct {
+	Devices []BondedBtDevice `json:"devices"`
+}
+
+// BondedBtDevicesSource is the narrow surface the bonded-BT handler
+// consumes. The Android build wires this through the platformsvc client
+// (see pkg/app/btsource_android.go); desktop builds leave it nil and the
+// handler returns 501 Not Implemented.
+type BondedBtDevicesSource interface {
+	BondedBtDevices(ctx context.Context) ([]BondedBtDevice, error)
+}
+
+// SetBtSource installs the Bluetooth bonded-devices source
+// post-construction. Called from pkg/app on Android builds; remains nil
+// elsewhere so the handler returns 501 on non-Android platforms.
+func (s *Server) SetBtSource(src BondedBtDevicesSource) { s.btSource = src }
+
+// handleGetBondedBtDevices returns the bonded Bluetooth devices visible
+// to the Android platform service. On non-Android builds (no source
+// wired) it returns 501 Not Implemented; on Android the response body is
+// {"devices": [...]}. An empty bond set returns an empty array, never null.
+//
+// @Summary  List bonded Bluetooth devices (Android only)
+// @Tags     kiss
+// @ID       getBondedBtDevices
+// @Produce  json
+// @Success  200 {object} BondedBtDevicesResponse
+// @Failure  500 {object} webtypes.ErrorResponse
+// @Failure  501 {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /kiss/bonded-bt-devices [get]
+func (s *Server) handleGetBondedBtDevices(w http.ResponseWriter, r *http.Request) {
+	if s.btSource == nil {
+		http.Error(w, "Bluetooth is only available on the Android platform service", http.StatusNotImplemented)
+		return
+	}
+	devs, err := s.btSource.BondedBtDevices(r.Context())
+	if err != nil {
+		http.Error(w, "failed to query bonded devices: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	out := BondedBtDevicesResponse{Devices: devs}
+	if out.Devices == nil {
+		// Never serialize null — operators / UI clients always expect [].
+		out.Devices = []BondedBtDevice{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}

--- a/pkg/webapi/kiss_bt.go
+++ b/pkg/webapi/kiss_bt.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+
+	"github.com/chrissnell/graywolf/pkg/webtypes"
 )
 
 // BondedBtDevice is the wire representation of a single bonded Bluetooth
@@ -53,12 +55,14 @@ func (s *Server) SetBtSource(src BondedBtDevicesSource) { s.btSource = src }
 // @Router   /kiss/bonded-bt-devices [get]
 func (s *Server) handleGetBondedBtDevices(w http.ResponseWriter, r *http.Request) {
 	if s.btSource == nil {
-		http.Error(w, "Bluetooth is only available on the Android platform service", http.StatusNotImplemented)
+		writeJSON(w, http.StatusNotImplemented, webtypes.ErrorResponse{
+			Error: "Bluetooth is only available on the Android platform service",
+		})
 		return
 	}
 	devs, err := s.btSource.BondedBtDevices(r.Context())
 	if err != nil {
-		http.Error(w, "failed to query bonded devices: "+err.Error(), http.StatusInternalServerError)
+		s.internalError(w, r, "list bonded bluetooth devices", err)
 		return
 	}
 	out := BondedBtDevicesResponse{Devices: devs}

--- a/pkg/webapi/kiss_bt_test.go
+++ b/pkg/webapi/kiss_bt_test.go
@@ -1,0 +1,129 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeBtSource lets the bonded-BT handler tests control the source's
+// response without standing up the platformsvc stack.
+type fakeBtSource struct {
+	devs []BondedBtDevice
+	err  error
+}
+
+func (f *fakeBtSource) BondedBtDevices(_ context.Context) ([]BondedBtDevice, error) {
+	return f.devs, f.err
+}
+
+// TestGetBondedBtDevices_Android_ReturnsList covers the happy path:
+// SetBtSource installed, handler returns 200 with the bonded list.
+func TestGetBondedBtDevices_Android_ReturnsList(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.SetBtSource(&fakeBtSource{devs: []BondedBtDevice{
+		{MAC: "AA:BB:CC:00:00:01", Name: "Mobilinkd TNC4"},
+	}})
+
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/kiss/bonded-bt-devices", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body)
+	}
+	var resp BondedBtDevicesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Devices) != 1 || resp.Devices[0].Name != "Mobilinkd TNC4" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if resp.Devices[0].MAC != "AA:BB:CC:00:00:01" {
+		t.Fatalf("unexpected MAC: %q", resp.Devices[0].MAC)
+	}
+}
+
+// TestGetBondedBtDevices_NonAndroid_Returns501 verifies that desktop /
+// non-Android builds (no SetBtSource call) return 501 Not Implemented,
+// not a 500 with a nil-deref or an empty list that pretends Bluetooth is
+// supported.
+func TestGetBondedBtDevices_NonAndroid_Returns501(t *testing.T) {
+	srv, _ := newTestServer(t) // no SetBtSource call
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/kiss/bonded-bt-devices", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body)
+	}
+}
+
+// TestGetBondedBtDevices_SourceError_Returns500 confirms that errors from
+// the source bubble up as 500 with the underlying error text appended.
+func TestGetBondedBtDevices_SourceError_Returns500(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.SetBtSource(&fakeBtSource{err: errors.New("boom")})
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/kiss/bonded-bt-devices", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "boom") {
+		t.Fatalf("expected error body to include source error, got %q", rec.Body.String())
+	}
+}
+
+// TestGetBondedBtDevices_EmptyList_ReturnsJSONArray pins the
+// never-serialize-null contract: an Android device with zero bonds must
+// return [] so the UI's array-iteration code doesn't have to special-case
+// null.
+func TestGetBondedBtDevices_EmptyList_ReturnsJSONArray(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.SetBtSource(&fakeBtSource{}) // nil slice from source
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/kiss/bonded-bt-devices", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body)
+	}
+	// Raw-body check: must contain "devices":[] and must NOT contain
+	// "devices":null. json.Unmarshal happily accepts both, so we have to
+	// inspect the wire shape directly.
+	body := rec.Body.String()
+	if strings.Contains(body, `"devices":null`) {
+		t.Fatalf("expected empty array on wire, got null: %s", body)
+	}
+	if !strings.Contains(body, `"devices":[]`) {
+		t.Fatalf("expected empty array on wire, got: %s", body)
+	}
+	var resp BondedBtDevicesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Devices == nil {
+		t.Fatal("expected empty slice, got nil — never serialize null")
+	}
+	if len(resp.Devices) != 0 {
+		t.Fatalf("expected zero devices, got %d", len(resp.Devices))
+	}
+}

--- a/pkg/webapi/kiss_bt_test.go
+++ b/pkg/webapi/kiss_bt_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/webtypes"
 )
 
 // fakeBtSource lets the bonded-BT handler tests control the source's
@@ -52,9 +54,9 @@ func TestGetBondedBtDevices_Android_ReturnsList(t *testing.T) {
 }
 
 // TestGetBondedBtDevices_NonAndroid_Returns501 verifies that desktop /
-// non-Android builds (no SetBtSource call) return 501 Not Implemented,
-// not a 500 with a nil-deref or an empty list that pretends Bluetooth is
-// supported.
+// non-Android builds (no SetBtSource call) return 501 Not Implemented
+// with a JSON webtypes.ErrorResponse body — not a 500 with a nil-deref
+// or an empty list that pretends Bluetooth is supported.
 func TestGetBondedBtDevices_NonAndroid_Returns501(t *testing.T) {
 	srv, _ := newTestServer(t) // no SetBtSource call
 	mux := http.NewServeMux()
@@ -67,10 +69,24 @@ func TestGetBondedBtDevices_NonAndroid_Returns501(t *testing.T) {
 	if rec.Code != http.StatusNotImplemented {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body)
 	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("expected application/json content-type, got %q", ct)
+	}
+	var errResp webtypes.ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("unmarshal error body: %v body=%s", err, rec.Body)
+	}
+	if errResp.Error == "" {
+		t.Fatalf("expected non-empty error field in 501 body, got %s", rec.Body)
+	}
 }
 
 // TestGetBondedBtDevices_SourceError_Returns500 confirms that errors from
-// the source bubble up as 500 with the underlying error text appended.
+// the source bubble up as 500 with a JSON webtypes.ErrorResponse body.
+// internalError deliberately strips the raw error from the response (and
+// logs it server-side instead) to avoid leaking driver/stack strings to
+// callers, so we assert only that the body is JSON-shaped with a
+// non-empty sanitized error message.
 func TestGetBondedBtDevices_SourceError_Returns500(t *testing.T) {
 	srv, _ := newTestServer(t)
 	srv.SetBtSource(&fakeBtSource{err: errors.New("boom")})
@@ -84,8 +100,20 @@ func TestGetBondedBtDevices_SourceError_Returns500(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body)
 	}
-	if !strings.Contains(rec.Body.String(), "boom") {
-		t.Fatalf("expected error body to include source error, got %q", rec.Body.String())
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("expected application/json content-type, got %q", ct)
+	}
+	var errResp webtypes.ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("unmarshal error body: %v body=%s", err, rec.Body)
+	}
+	if errResp.Error == "" {
+		t.Fatalf("expected non-empty error field in 500 body, got %s", rec.Body)
+	}
+	// internalError must NOT echo the raw underlying error to the client
+	// (it logs it server-side instead). Guard against accidental regression.
+	if strings.Contains(errResp.Error, "boom") {
+		t.Fatalf("500 body leaked raw source error: %q", errResp.Error)
 	}
 }
 

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -114,6 +114,12 @@ type Server struct {
 	// SetRemoteActions; nil until set, in which case the
 	// /api/remote-actions/* handlers return 503 via requireRemoteActions.
 	remoteActions *remoteactions.Service
+
+	// btSource enumerates bonded Bluetooth devices for
+	// GET /api/kiss/bonded-bt-devices. Wired post-construction via
+	// SetBtSource by pkg/app on Android builds; nil elsewhere, in which
+	// case the handler returns 501 Not Implemented.
+	btSource BondedBtDevicesSource
 }
 
 // ActionsService is the narrow surface the webapi handlers consume

--- a/proto/platform.proto
+++ b/proto/platform.proto
@@ -28,6 +28,13 @@ message PlatformMessage {
     AudioRouteChanged audio_route_changed = 15;
     Error error = 16;
     GnssStatusUpdate gnss_status = 17;  // server → client; pushed alongside GpsFix
+    SerialOpen serial_open = 18;
+    SerialOpenAck serial_open_ack = 19;
+    SerialData serial_data = 20;
+    SerialClose serial_close = 21;
+    SerialError serial_error = 22;
+    BondedBtDevicesRequest bonded_bt_devices_request = 23;
+    BondedBtDevicesResponse bonded_bt_devices_response = 24;
   }
 }
 
@@ -191,4 +198,51 @@ message GnssStatusUpdate {
   uint32 sats_in_view = 1;
   uint32 sats_used = 2;
   repeated SatInfo sats = 3;
+}
+
+// SerialKind classifies a transport-agnostic byte stream the platform
+// service is asked to open. Open-ended so a future USB-serial KISS path
+// can reuse the same SerialOpen/Data/Close family.
+enum SerialKind {
+  SERIAL_KIND_UNSPECIFIED = 0;
+  SERIAL_KIND_BLUETOOTH   = 1;
+  // SERIAL_KIND_USB reserved for future use.
+}
+
+message SerialOpen {
+  uint32     handle  = 1;
+  SerialKind kind    = 2;
+  string     address = 3;  // bluetooth: MAC ("AA:BB:CC:DD:EE:FF")
+}
+
+message SerialOpenAck {
+  uint32 handle = 1;
+  bool   ok     = 2;
+  string error  = 3;
+}
+
+message SerialData {
+  uint32 handle = 1;
+  bytes  data   = 2;
+}
+
+message SerialClose {
+  uint32 handle = 1;
+  string reason = 2;
+}
+
+message SerialError {
+  uint32 handle = 1;
+  string code   = 2;  // bond_lost | permission_denied | rfcomm_closed | io_error | not_bonded
+  string detail = 3;
+}
+
+message BondedBtDevicesRequest {}
+
+message BondedBtDevicesResponse {
+  message Device {
+    string mac  = 1;
+    string name = 2;
+  }
+  repeated Device devices = 1;
 }

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -790,6 +790,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/kiss/bonded-bt-devices": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List bonded Bluetooth devices (Android only) */
+        get: operations["getBondedBtDevices"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/kiss/{id}": {
         parameters: {
             query?: never;
@@ -3132,6 +3149,13 @@ export interface components {
              *     UART, or a previously-running graywolf process).
              */
             used?: boolean;
+        };
+        "webapi.BondedBtDevice": {
+            mac?: string;
+            name?: string;
+        };
+        "webapi.BondedBtDevicesResponse": {
+            devices?: components["schemas"]["webapi.BondedBtDevice"][];
         };
         "webapi.ChannelReferrersResponse": {
             error?: string;
@@ -6338,6 +6362,44 @@ export interface operations {
             };
             /** @description Internal Server Error */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getBondedBtDevices: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webapi.BondedBtDevicesResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Not Implemented */
+            501: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -67,6 +67,18 @@ export const api = {
   delete: (path) => request('DELETE', path),
 };
 
+// kissBt groups the KISS-over-Bluetooth helpers. Today there's only
+// the bonded-device list (Android-only; returns 501 on desktop), but
+// future endpoints in the same family (pair / unpair / probe) should
+// land here too.
+export const kissBt = {
+  // bondedDevices fetches the list of Android-paired Bluetooth devices
+  // suitable for a KISS interface. Shape: { devices: [{mac, name}] }.
+  // Returns 501 on desktop hosts; callers should surface a friendly
+  // message in that case.
+  bondedDevices: () => api.get('/kiss/bonded-bt-devices'),
+};
+
 // --- Mock data for development without backend ---
 
 function delay(data) {
@@ -99,6 +111,13 @@ const mockPttAvailable = [
 const mockKiss = [
   { id: 1, type: 'tcp', tcp_port: 8001, serial_device: '', baud_rate: 0 },
 ];
+
+const mockBondedBtDevices = {
+  devices: [
+    { mac: '00:11:22:33:44:55', name: 'Mobilinkd TNC3' },
+    { mac: 'AA:BB:CC:DD:EE:FF', name: 'Kenwood TH-D74' },
+  ],
+};
 
 const mockAgw = { tcp_port: 8000, monitor_port: 8002, enabled: true };
 
@@ -185,6 +204,7 @@ function getMockData(method, path, body) {
   if (path === '/kiss' && method === 'POST') return delay({ id: 2, ...body });
   if (path.match(/^\/kiss\/\d+$/) && method === 'PUT') return delay(body);
   if (path.match(/^\/kiss\/\d+$/) && method === 'DELETE') return delay(null);
+  if (path === '/kiss/bonded-bt-devices' && method === 'GET') return delay(mockBondedBtDevices);
 
   // AGW
   if (path === '/agw' && method === 'GET') return delay(mockAgw);

--- a/web/src/lib/platform.js
+++ b/web/src/lib/platform.js
@@ -24,4 +24,8 @@ function detectKind() {
 
 export const Platform = {
   get kind() { return detectKind(); },
+  // Convenience for the common "are we on Android?" gate. Backed by
+  // the same detectKind() call as `kind`, so toggling
+  // globalThis.GraywolfWebInterface between accesses flips this too.
+  get isAndroid() { return detectKind() === 'android'; },
 };

--- a/web/src/lib/platform.test.js
+++ b/web/src/lib/platform.test.js
@@ -30,3 +30,21 @@ test('Platform.kind is read each access (dynamic)', () => {
   assert.equal(Platform.kind, 'desktop');
 });
 
+test('Platform.isAndroid === false when bridge absent', () => {
+  assert.equal(Platform.isAndroid, false);
+});
+
+test('Platform.isAndroid === true when bridge present', () => {
+  globalThis.GraywolfWebInterface = { getBearerToken: () => 'tok' };
+  assert.equal(Platform.isAndroid, true);
+});
+
+test('Platform.isAndroid tracks bridge toggling dynamically', () => {
+  assert.equal(Platform.isAndroid, false);
+  globalThis.GraywolfWebInterface = { getBearerToken: () => 'tok' };
+  assert.equal(Platform.isAndroid, true);
+  delete globalThis.GraywolfWebInterface;
+  resetBridge();
+  assert.equal(Platform.isAndroid, false);
+});
+

--- a/web/src/routes/Kiss.bt.perm.test.js
+++ b/web/src/routes/Kiss.bt.perm.test.js
@@ -1,0 +1,145 @@
+// Unit tests for the Bluetooth-permission-grant helper used by Kiss.svelte
+// (Phase 6 of the Android Bluetooth KISS TNC plan).
+//
+// Mirrors the extracted-logic style of Channels.android.ptt.test.js: the
+// component itself has no headless harness, so the helper is reproduced
+// verbatim against a mocked JS bridge and verified end-to-end.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Verbatim copy of requestBtPerm() from Kiss.svelte so we exercise the
+// exact dispatcher-swap + try/catch behaviour without spinning up Svelte.
+// If the production helper changes, this copy must too — the diff between
+// the two is intentionally small and easy to spot in review.
+function requestBtPerm({ isAndroid, loadBondedDevices }) {
+  if (!isAndroid) return;
+  if (!globalThis.GraywolfWebInterface?.requestBluetoothPermission) return;
+  const callbackId = 'bt-' + Math.random().toString(36).slice(2);
+  const prev = globalThis.__btResult;
+  globalThis.__btResult = (id, granted) => {
+    if (id !== callbackId) return;
+    if (prev) globalThis.__btResult = prev;
+    else delete globalThis.__btResult;
+    if (granted) loadBondedDevices();
+  };
+  try {
+    globalThis.GraywolfWebInterface.requestBluetoothPermission(callbackId);
+  } catch (err) {
+    if (prev) globalThis.__btResult = prev;
+    else delete globalThis.__btResult;
+  }
+}
+
+beforeEach(() => {
+  delete globalThis.GraywolfWebInterface;
+  delete globalThis.__btResult;
+});
+
+afterEach(() => {
+  delete globalThis.GraywolfWebInterface;
+  delete globalThis.__btResult;
+});
+
+test('no-ops on desktop (isAndroid=false)', () => {
+  let loaded = 0;
+  // Even with a bridge present, the isAndroid gate must short-circuit.
+  globalThis.GraywolfWebInterface = {
+    requestBluetoothPermission: () => assert.fail('should not be called'),
+  };
+  requestBtPerm({ isAndroid: false, loadBondedDevices: () => loaded++ });
+  assert.equal(loaded, 0);
+  assert.equal(globalThis.__btResult, undefined);
+});
+
+test('no-ops on Android when the JS bridge is missing the method', () => {
+  let loaded = 0;
+  globalThis.GraywolfWebInterface = {}; // no requestBluetoothPermission
+  requestBtPerm({ isAndroid: true, loadBondedDevices: () => loaded++ });
+  assert.equal(loaded, 0);
+  assert.equal(globalThis.__btResult, undefined);
+});
+
+test('granted=true triggers loadBondedDevices and clears the dispatcher', () => {
+  let loaded = 0;
+  let capturedId = null;
+  globalThis.GraywolfWebInterface = {
+    requestBluetoothPermission: (id) => { capturedId = id; },
+  };
+
+  requestBtPerm({ isAndroid: true, loadBondedDevices: () => loaded++ });
+
+  assert.ok(capturedId && capturedId.startsWith('bt-'));
+  assert.equal(typeof globalThis.__btResult, 'function');
+
+  // Simulate the Kotlin side firing window.__btResult(id, true).
+  globalThis.__btResult(capturedId, true);
+
+  assert.equal(loaded, 1);
+  // Dispatcher is one-shot: should be torn down so a stray late
+  // callback can't re-trigger the bonded-device fetch.
+  assert.equal(globalThis.__btResult, undefined);
+});
+
+test('granted=false does not trigger loadBondedDevices', () => {
+  let loaded = 0;
+  let capturedId = null;
+  globalThis.GraywolfWebInterface = {
+    requestBluetoothPermission: (id) => { capturedId = id; },
+  };
+
+  requestBtPerm({ isAndroid: true, loadBondedDevices: () => loaded++ });
+  globalThis.__btResult(capturedId, false);
+
+  assert.equal(loaded, 0);
+  assert.equal(globalThis.__btResult, undefined);
+});
+
+test('mismatched callbackId is ignored and dispatcher is preserved', () => {
+  let loaded = 0;
+  globalThis.GraywolfWebInterface = {
+    requestBluetoothPermission: () => {},
+  };
+
+  requestBtPerm({ isAndroid: true, loadBondedDevices: () => loaded++ });
+  assert.equal(typeof globalThis.__btResult, 'function');
+
+  // A different in-flight id arrives — must be silently ignored.
+  globalThis.__btResult('other-id', true);
+  assert.equal(loaded, 0);
+  // Dispatcher still in place for the real callback.
+  assert.equal(typeof globalThis.__btResult, 'function');
+});
+
+test('thrown bridge error is swallowed and dispatcher is rolled back', () => {
+  let loaded = 0;
+  globalThis.GraywolfWebInterface = {
+    requestBluetoothPermission: () => { throw new Error('boom'); },
+  };
+
+  requestBtPerm({ isAndroid: true, loadBondedDevices: () => loaded++ });
+  // No throw escaping requestBtPerm, and the dispatcher is cleared
+  // (no previous handler to restore) so we don't leave a dangling
+  // closure on the global.
+  assert.equal(loaded, 0);
+  assert.equal(globalThis.__btResult, undefined);
+});
+
+test('previous __btResult dispatcher is restored after the callback fires', () => {
+  let loaded = 0;
+  let priorCalls = 0;
+  const priorDispatcher = () => { priorCalls++; };
+  globalThis.__btResult = priorDispatcher;
+
+  let capturedId = null;
+  globalThis.GraywolfWebInterface = {
+    requestBluetoothPermission: (id) => { capturedId = id; },
+  };
+
+  requestBtPerm({ isAndroid: true, loadBondedDevices: () => loaded++ });
+  globalThis.__btResult(capturedId, true);
+
+  assert.equal(loaded, 1);
+  // Restored, not deleted, because there was a prior handler.
+  assert.equal(globalThis.__btResult, priorDispatcher);
+});

--- a/web/src/routes/Kiss.svelte
+++ b/web/src/routes/Kiss.svelte
@@ -1,7 +1,8 @@
 <script>
   import { onMount, onDestroy } from 'svelte';
   import { Button, Input, Select, Badge, Checkbox } from '@chrissnell/chonky-ui';
-  import { api } from '../lib/api.js';
+  import { api, kissBt } from '../lib/api.js';
+  import { Platform } from '../lib/platform.js';
   import { toasts } from '../lib/stores.js';
   import PageHeader from '../components/PageHeader.svelte';
   import DataTable from '../components/DataTable.svelte';
@@ -77,11 +78,46 @@
     { key: 'status', label: 'Status' },
   ];
 
-  const typeOptions = [
-    { value: 'tcp', label: 'TCP (server)' },
+  // Platform-conditional type menu. On Android, operators see only
+  // the two interface types we actually support there: Bluetooth
+  // (serial-over-RFCOMM to a paired TNC) and TCP-Client (which we
+  // relabel "Network" because that's the term Android operators
+  // expect). Desktop keeps the full set including server-listen TCP
+  // and host-serial. Platform.isAndroid is read reactively so the
+  // menu re-derives if the JS bridge appears/disappears mid-session
+  // (rare, but the reactive shape costs us nothing).
+  const desktopTypeOptions = [
+    { value: 'tcp',        label: 'TCP (server)' },
     { value: 'tcp-client', label: 'TCP Client' },
-    { value: 'serial', label: 'Serial' },
+    { value: 'serial',     label: 'Serial' },
   ];
+  const androidTypeOptions = [
+    { value: 'bluetooth',  label: 'Bluetooth Serial' },
+    { value: 'tcp-client', label: 'Network' },
+  ];
+  let typeOptions = $derived(Platform.isAndroid ? androidTypeOptions : desktopTypeOptions);
+
+  // Bonded Bluetooth devices, fetched lazily the first time the
+  // operator switches the type select to "bluetooth" with the modal
+  // open. Refreshable via the Refresh button next to the picker.
+  let bondedDevices = $state([]);
+  let bondedLoading = $state(false);
+  let bondedError = $state('');
+
+  // Derived <Select> options for the bonded-device picker. First
+  // entry is a disabled placeholder so the field renders empty by
+  // default rather than auto-selecting the first paired device.
+  let bondedDeviceOptions = $derived([
+    {
+      value: '',
+      label: bondedLoading ? 'Loading…' : 'Select a bonded device',
+      disabled: true,
+    },
+    ...bondedDevices.map((d) => ({
+      value: d.mac,
+      label: `${d.name} (${d.mac})`,
+    })),
+  ]);
 
   const modeOptions = [
     { value: 'modem', label: 'Modem' },
@@ -198,6 +234,67 @@
       form._clientDefaultsApplied = true;
     }
   });
+
+  // Phase 5: Bluetooth-typed interfaces are always TNCs (the paired
+  // device IS the modem). Force Mode=tnc whenever the operator flips
+  // type to bluetooth so the Mode-gated UI (rate/burst, governor-TX
+  // checkbox) renders, and so buildPayload() doesn't try to send
+  // mode=modem to a server that would reject it.
+  $effect(() => {
+    if (form.type === 'bluetooth' && form.mode !== 'tnc') {
+      form.mode = 'tnc';
+    }
+  });
+
+  // Lazy-load bonded devices the first time the operator opens the
+  // modal AND selects bluetooth. Re-runs only when the gate
+  // conditions flip back to satisfied — operator can clear an error
+  // and click Refresh to retry without remounting.
+  $effect(() => {
+    if (
+      form.type === 'bluetooth' &&
+      modalOpen &&
+      bondedDevices.length === 0 &&
+      !bondedLoading &&
+      !bondedError
+    ) {
+      loadBondedDevices();
+    }
+  });
+
+  async function loadBondedDevices() {
+    bondedLoading = true;
+    bondedError = '';
+    try {
+      const resp = await kissBt.bondedDevices();
+      bondedDevices = resp?.devices ?? [];
+    } catch (err) {
+      bondedError = err?.message ?? 'Failed to load Bluetooth devices';
+    } finally {
+      bondedLoading = false;
+    }
+  }
+
+  // Auto-fill a friendly slug name when the operator picks a bonded
+  // device. Only overwrites empty names or names that look like a
+  // previous auto-fill (kiss-bt-*) so manually-named interfaces are
+  // preserved on re-pick. The form/DTO doesn't model a name field
+  // today, but interfaces carry .name server-side (used in the
+  // NeedsReconfig banner); leaving the helper in place means a
+  // future name input wires up for free.
+  function autofillBtName() {
+    if (!form.serial_device) return;
+    const d = bondedDevices.find((x) => x.mac === form.serial_device);
+    if (!d) return;
+    const slug = d.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    const autoName = `kiss-bt-${slug}`;
+    if (!form.name || (typeof form.name === 'string' && form.name.startsWith('kiss-bt-'))) {
+      form.name = autoName;
+    }
+  }
 
   function buildPayload() {
     const data = {
@@ -428,11 +525,13 @@
 {/snippet}
 
 <Modal bind:open={modalOpen} title={editing ? 'Edit KISS' : 'New KISS Interface'}>
-    <FormField label="Mode" id="kiss-mode" hint={modeHint}>
-      {#snippet children(describedBy)}
-        <Select id="kiss-mode" bind:value={form.mode} options={modeOptions} aria-describedby={describedBy} />
-      {/snippet}
-    </FormField>
+    {#if form.type !== 'bluetooth'}
+      <FormField label="Mode" id="kiss-mode" hint={modeHint}>
+        {#snippet children(describedBy)}
+          <Select id="kiss-mode" bind:value={form.mode} options={modeOptions} aria-describedby={describedBy} />
+        {/snippet}
+      </FormField>
+    {/if}
     <FormField label="Type" id="kiss-type">
       <Select id="kiss-type" bind:value={form.type} options={typeOptions} />
     </FormField>
@@ -455,7 +554,29 @@
       >
         <Input id="kiss-remote-port" bind:value={form.remote_port} type="number" min={1} max={65535} placeholder="8001" />
       </FormField>
-    {:else}
+    {:else if form.type === 'bluetooth'}
+      <FormField
+        label="Bonded device"
+        id="kiss-bt-device"
+        hint="Pair the TNC in Android Settings → Bluetooth first, then refresh."
+        error={bondedError}
+      >
+        <div class="bt-picker">
+          <Select
+            id="kiss-bt-device"
+            bind:value={form.serial_device}
+            options={bondedDeviceOptions}
+            onchange={autofillBtName}
+          />
+          <Button variant="secondary" onclick={loadBondedDevices} disabled={bondedLoading}>
+            Refresh
+          </Button>
+        </div>
+        {#if !bondedError && !bondedLoading && bondedDevices.length === 0}
+          <span class="bt-empty-hint">No paired Bluetooth devices found. Pair your TNC in Android Settings → Bluetooth, then click Refresh.</span>
+        {/if}
+      </FormField>
+    {:else if form.type === 'serial'}
       <FormField
         label="Serial Device"
         id="kiss-serial"
@@ -664,5 +785,26 @@
     font-size: 16px;
     color: var(--color-warning, #d4a72c);
     flex-shrink: 0;
+  }
+  /* Bluetooth bonded-device picker: Select + Refresh button on one
+     row. chonky inputs ship margin-bottom:1rem which shifts the
+     button down inside a flex row — override locally per the project
+     convention (see feedback_chonky_input_alignment in memory). */
+  .bt-picker {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .bt-picker :global(select),
+  .bt-picker :global(input) {
+    margin: 0 !important;
+    flex: 1 1 auto;
+  }
+  .bt-empty-hint {
+    display: block;
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--color-text-muted, #888);
+    line-height: 1.4;
   }
 </style>

--- a/web/src/routes/Kiss.svelte
+++ b/web/src/routes/Kiss.svelte
@@ -131,10 +131,33 @@
   // and nothing is loading or errored, surface the "pair in Android
   // Settings first" guidance through the FormField's hint slot so it
   // gets a stable id and is wired into aria-describedby on the Select.
+  //
+  // Phase 6 (Option A scope): an empty list is also what we see when
+  // BLUETOOTH_CONNECT was denied — BluetoothAdapter.bondedDevices
+  // raises a SecurityException which BtSerialAdapter swallows into an
+  // empty list. The two states are indistinguishable here, so the
+  // empty-list copy nudges the operator toward the "Grant Bluetooth
+  // permission" button rendered below the picker. A cleaner fix (a
+  // distinct permission_denied flag on the proto response) is deferred
+  // as a future enhancement; the empty-list-with-grant-button UX is
+  // good enough for v1.
   let bondedHint = $derived(
     !bondedLoading && !bondedError && bondedDevices.length === 0
-      ? 'No paired Bluetooth devices found. Pair your TNC in Android Settings → Bluetooth, then click Refresh.'
+      ? 'No paired Bluetooth devices found. Pair your TNC in Android Settings → Bluetooth, then click Refresh. If you have already paired the TNC but no devices appear, grant Bluetooth permission below.'
       : 'Pair the TNC in Android Settings → Bluetooth first, then refresh.',
+  );
+
+  // True when the bonded list is empty and we have nothing else to
+  // explain it — gate for the "Grant Bluetooth permission" button.
+  // Android-only; on desktop the bondedError already says "Bluetooth
+  // interfaces can only be configured from the Android app." so we
+  // skip the button there.
+  let showBtPermGrant = $derived(
+    Platform.isAndroid &&
+      form.type === 'bluetooth' &&
+      !bondedLoading &&
+      !bondedError &&
+      bondedDevices.length === 0,
   );
 
   const modeOptions = [
@@ -310,6 +333,50 @@
       bondedError = err?.message ?? 'Failed to load Bluetooth devices';
     } finally {
       bondedLoading = false;
+    }
+  }
+
+  // Phase 6 (Option A scope): prompt the operator to grant
+  // BLUETOOTH_CONNECT via the Android JS bridge, then re-poll the
+  // bonded-device list on success. The lambda is wired through
+  // MainActivity (which owns requestPermissions()); the WebAppInterface
+  // method exists only on Android, so the optional-chain on
+  // window.GraywolfWebInterface is the desktop guard.
+  //
+  // window.__btResult is wired up BEFORE invoking the bridge so a
+  // synchronous already-granted reply (API <31 or permission already
+  // granted) can't race past us. The dispatcher is one-shot: it only
+  // re-loads the bonded list when the id matches; other in-flight ids
+  // are ignored (none today, but defensive against a future caller).
+  //
+  // NOTE: A "Bond lost" UI state (the supervisor reports an
+  // ex-bonded device went Unpaired) is intentionally NOT plumbed here.
+  // That would require a new state on the backend response and a
+  // signal up through the supervisor; it's deferred as a future
+  // enhancement.
+  function requestBtPerm() {
+    if (!Platform.isAndroid) return;
+    if (!globalThis.GraywolfWebInterface?.requestBluetoothPermission) return;
+    // Prefix guarantees a non-empty alphanumeric id even if Math.random()
+    // returns 0 — matches the existing USB-grant pattern in AndroidPttFields.
+    const callbackId = 'bt-' + Math.random().toString(36).slice(2);
+    const prev = globalThis.__btResult;
+    globalThis.__btResult = (id, granted) => {
+      if (id !== callbackId) return;
+      // One-shot: restore (or clear) the previous handler so a stale
+      // callback fired after we tear down can't refire loadBondedDevices.
+      if (prev) globalThis.__btResult = prev;
+      else delete globalThis.__btResult;
+      if (granted) loadBondedDevices();
+    };
+    try {
+      globalThis.GraywolfWebInterface.requestBluetoothPermission(callbackId);
+    } catch (err) {
+      console.error('requestBluetoothPermission failed:', err);
+      // Roll back the dispatcher swap so a later callback for a
+      // different id isn't dropped on the floor.
+      if (prev) globalThis.__btResult = prev;
+      else delete globalThis.__btResult;
     }
   }
 
@@ -679,6 +746,20 @@
               Refresh
             </Button>
           </div>
+          {#if showBtPermGrant}
+            <!-- Phase 6 (Option A): the supervisor returns an empty
+                 bonded list both when nothing is paired AND when
+                 BLUETOOTH_CONNECT was denied (the SecurityException is
+                 swallowed in BtSerialAdapter). The grant button is
+                 Android-only and lets the operator fire the runtime
+                 permission dialog without bouncing through system
+                 Settings. -->
+            <div class="bt-perm-row">
+              <Button variant="secondary" onclick={requestBtPerm}>
+                Grant Bluetooth permission
+              </Button>
+            </div>
+          {/if}
         {/snippet}
       </FormField>
     {:else if form.type === 'serial'}
@@ -904,5 +985,12 @@
   .bt-picker :global(input) {
     margin: 0 !important;
     flex: 1 1 auto;
+  }
+  /* Grant-permission button row sits below the bt-picker; the small
+     top margin separates it from the picker without making the
+     control feel detached from the FormField. */
+  .bt-perm-row {
+    margin-top: 8px;
+    display: flex;
   }
 </style>

--- a/web/src/routes/Kiss.svelte
+++ b/web/src/routes/Kiss.svelte
@@ -186,6 +186,12 @@
     clockTimer = setInterval(() => {
       clockTick = (clockTick + 1) % CLOCK_TICK_MOD;
     }, CLOCK_TICK_MS);
+    // Pre-warm the bonded list on Android so the table can show
+    // friendly names for Bluetooth rows immediately on first paint.
+    // Uses a silent fetch — if it fails we just fall back to bare
+    // MACs in the table, and the operator will see the real error
+    // when they open the modal and trigger the lazy loader there.
+    if (Platform.isAndroid) prewarmBondedDevices();
   });
 
   onDestroy(() => {
@@ -275,6 +281,19 @@
     }
   }
 
+  // Silent background fetch used only to pre-populate friendly names
+  // in the table. Failures are intentionally not surfaced — the modal
+  // path (loadBondedDevices) is the one that reports errors to the
+  // operator when it's actionable.
+  async function prewarmBondedDevices() {
+    try {
+      const resp = await kissBt.bondedDevices();
+      if (Array.isArray(resp?.devices)) bondedDevices = resp.devices;
+    } catch {
+      /* swallow — falls back to bare MACs in the table */
+    }
+  }
+
   // Auto-fill a friendly slug name when the operator picks a bonded
   // device. Only overwrites empty names or names that look like a
   // previous auto-fill (kiss-bt-*) so manually-named interfaces are
@@ -357,6 +376,36 @@
     commitSave();
   }
 
+  // labelForType maps the stored interface-type discriminator to the
+  // operator-facing label. The tcp-client relabel to "Network" on
+  // Android mirrors typeOptions so the modal and the table stay in
+  // sync. Falls through to the raw type for forward-compat with any
+  // server-side type we don't recognize yet.
+  function labelForType(t) {
+    switch (t) {
+      case 'tcp':        return 'TCP (server)';
+      case 'tcp-client': return Platform.isAndroid ? 'Network' : 'TCP Client';
+      case 'serial':     return 'Serial';
+      case 'bluetooth':  return 'Bluetooth Serial';
+      default:           return t;
+    }
+  }
+
+  // friendlyDevice returns a human-readable endpoint string for the
+  // interface row. For bluetooth rows we cross-reference the cached
+  // bondedDevices list (populated when the modal was open) so the
+  // operator sees "Mobilinkd TNC3 (AA:BB:...)" instead of a bare MAC.
+  // Falls back to the bare device id when we don't have a name yet
+  // (e.g. table rendered before the modal has ever been opened).
+  function friendlyDevice(iface) {
+    const dev = iface.device || iface.serial_device || '';
+    if (iface.type !== 'bluetooth') return dev;
+    const match = bondedDevices.find(
+      (d) => d.mac === iface.device || d.mac === iface.serial_device,
+    );
+    return match ? `${match.name} (${dev})` : dev;
+  }
+
   function describeRow(row) {
     const mode = modeLabels[row.mode] || 'Modem';
     if (row.type === 'tcp') return `TCP server on port ${row.tcp_port}, ${mode}`;
@@ -365,6 +414,10 @@
       const dev = (row.serial_device || '').trim();
       return dev ? `serial ${dev}, ${mode}` : `serial, ${mode}`;
     }
+    if (row.type === 'bluetooth') {
+      const dev = friendlyDevice(row);
+      return dev ? `bluetooth ${dev}, ${mode}` : `bluetooth, ${mode}`;
+    }
     return `#${row.id}, ${mode}`;
   }
 
@@ -372,6 +425,7 @@
     if (row.type === 'tcp') return `:${row.tcp_port}`;
     if (row.type === 'tcp-client') return `${row.remote_host}:${row.remote_port}`;
     if (row.type === 'serial') return row.serial_device || '—';
+    if (row.type === 'bluetooth') return friendlyDevice(row) || '—';
     return '—';
   }
 
@@ -467,11 +521,13 @@
 
 {#snippet typeCell(value, _row)}
   {#if value === 'tcp-client'}
-    <Badge variant="info">TCP Client</Badge>
+    <Badge variant="info">{labelForType(value)}</Badge>
   {:else if value === 'tcp'}
     <Badge>TCP Server</Badge>
+  {:else if value === 'bluetooth'}
+    <Badge variant="info">{labelForType(value)}</Badge>
   {:else if value === 'serial'}
-    <Badge>Serial</Badge>
+    <Badge>{labelForType(value)}</Badge>
   {:else}
     <Badge>{value || '—'}</Badge>
   {/if}
@@ -516,6 +572,8 @@
           {/if}
         {:else if row.type === 'tcp'}
           <div class="detail-row"><span class="detail-label">Listening:</span> <span>:{row.tcp_port}</span></div>
+        {:else if row.type === 'bluetooth'}
+          <div class="detail-row"><span class="detail-label">Device:</span> <span>{friendlyDevice(row) || '—'}</span></div>
         {:else}
           <div class="detail-row"><span class="detail-label">Device:</span> <span>{row.serial_device || '—'}</span></div>
         {/if}

--- a/web/src/routes/Kiss.svelte
+++ b/web/src/routes/Kiss.svelte
@@ -103,21 +103,39 @@
   let bondedDevices = $state([]);
   let bondedLoading = $state(false);
   let bondedError = $state('');
+  // Inline save-time validation error. Surfaced via the bonded-device
+  // FormField's `error` prop alongside any network error from the
+  // lazy loader. Cleared whenever the operator picks a device or the
+  // modal reopens.
+  let saveError = $state('');
 
-  // Derived <Select> options for the bonded-device picker. First
-  // entry is a disabled placeholder so the field renders empty by
-  // default rather than auto-selecting the first paired device.
-  let bondedDeviceOptions = $derived([
-    {
-      value: '',
-      label: bondedLoading ? 'Loading…' : 'Select a bonded device',
-      disabled: true,
-    },
-    ...bondedDevices.map((d) => ({
+  // Derived <Select> options for the bonded-device picker. chonky-ui's
+  // Select doesn't honor `disabled` on individual options (it only
+  // propagates value+label), so we don't ship a fake placeholder
+  // entry — the Select's own `placeholder` prop handles the empty
+  // state correctly. handleSave() guards against submitting an empty
+  // serial_device for bluetooth interfaces.
+  let bondedDeviceOptions = $derived(
+    bondedDevices.map((d) => ({
       value: d.mac,
       label: `${d.name} (${d.mac})`,
     })),
-  ]);
+  );
+
+  // Combined error surfaced on the bonded-device FormField. Save-time
+  // validation takes precedence over the network/loader error, since
+  // the operator just acted and that's the more relevant signal.
+  let bondedFieldError = $derived(saveError || bondedError);
+
+  // Hint text for the bonded-device FormField. When the list is empty
+  // and nothing is loading or errored, surface the "pair in Android
+  // Settings first" guidance through the FormField's hint slot so it
+  // gets a stable id and is wired into aria-describedby on the Select.
+  let bondedHint = $derived(
+    !bondedLoading && !bondedError && bondedDevices.length === 0
+      ? 'No paired Bluetooth devices found. Pair your TNC in Android Settings → Bluetooth, then click Refresh.'
+      : 'Pair the TNC in Android Settings → Bluetooth first, then refresh.',
+  );
 
   const modeOptions = [
     { value: 'modem', label: 'Modem' },
@@ -202,6 +220,15 @@
   function openCreate() {
     editing = null;
     form = emptyForm();
+    // The Type select only shows {bluetooth, tcp-client} on Android —
+    // the default `tcp` from emptyForm() would render an invisible
+    // selection and silently submit a server-listen interface if the
+    // operator never touched the field. Pick a visible default for
+    // the platform's actual menu.
+    if (Platform.isAndroid) {
+      form.type = 'bluetooth';
+    }
+    saveError = '';
     // Default AllowTxFromGovernor=true for new tcp-client rows per
     // plan D4. When the operator flips to tcp-client we pre-check
     // the governor-TX checkbox so the common case (outbound TNC for
@@ -211,6 +238,7 @@
 
   function openEdit(row) {
     editing = row;
+    saveError = '';
     form = {
       ...row,
       tcp_port: String(row.tcp_port ?? ''),
@@ -255,15 +283,19 @@
   // Lazy-load bonded devices the first time the operator opens the
   // modal AND selects bluetooth. Re-runs only when the gate
   // conditions flip back to satisfied — operator can clear an error
-  // and click Refresh to retry without remounting.
+  // and click Refresh to retry without remounting. Gated on
+  // Platform.isAndroid: on desktop the GET returns 501 by design, so
+  // we short-circuit with a friendly message instead of letting the
+  // operator stare at "HTTP 501".
   $effect(() => {
-    if (
-      form.type === 'bluetooth' &&
-      modalOpen &&
-      bondedDevices.length === 0 &&
-      !bondedLoading &&
-      !bondedError
-    ) {
+    if (form.type !== 'bluetooth' || !modalOpen) return;
+    if (!Platform.isAndroid) {
+      if (!bondedError) {
+        bondedError = 'Bluetooth interfaces can only be configured from the Android app.';
+      }
+      return;
+    }
+    if (bondedDevices.length === 0 && !bondedLoading && !bondedError) {
       loadBondedDevices();
     }
   });
@@ -303,6 +335,9 @@
   // future name input wires up for free.
   function autofillBtName() {
     if (!form.serial_device) return;
+    // Operator just picked a device — clear any "pick a device first"
+    // validation error so it doesn't linger as visual noise.
+    saveError = '';
     const d = bondedDevices.find((x) => x.mac === form.serial_device);
     if (!d) return;
     const slug = d.name
@@ -365,6 +400,17 @@
   }
 
   function handleSave() {
+    // Client-side guard: chonky-ui's Select doesn't honor per-option
+    // `disabled`, so without this check an operator could leave the
+    // bonded-device picker at its empty placeholder and submit a
+    // bluetooth interface with serial_device=''. The server would
+    // accept it and the supervisor would fail to dial later. Catch
+    // it here and surface the error inline on the FormField.
+    if (form.type === 'bluetooth' && !form.serial_device) {
+      saveError = 'Pick a bonded device before saving.';
+      return;
+    }
+    saveError = '';
     // Mode changes on an existing interface take effect the instant the
     // server restarts the per-interface KISS server — connected peers see
     // routing behavior flip under them. Make the operator confirm it.
@@ -616,23 +662,24 @@
       <FormField
         label="Bonded device"
         id="kiss-bt-device"
-        hint="Pair the TNC in Android Settings → Bluetooth first, then refresh."
-        error={bondedError}
+        hint={bondedHint}
+        error={bondedFieldError}
       >
-        <div class="bt-picker">
-          <Select
-            id="kiss-bt-device"
-            bind:value={form.serial_device}
-            options={bondedDeviceOptions}
-            onchange={autofillBtName}
-          />
-          <Button variant="secondary" onclick={loadBondedDevices} disabled={bondedLoading}>
-            Refresh
-          </Button>
-        </div>
-        {#if !bondedError && !bondedLoading && bondedDevices.length === 0}
-          <span class="bt-empty-hint">No paired Bluetooth devices found. Pair your TNC in Android Settings → Bluetooth, then click Refresh.</span>
-        {/if}
+        {#snippet children(describedBy)}
+          <div class="bt-picker">
+            <Select
+              id="kiss-bt-device"
+              bind:value={form.serial_device}
+              options={bondedDeviceOptions}
+              placeholder={bondedLoading ? 'Loading…' : 'Select a bonded device'}
+              onValueChange={autofillBtName}
+              aria-describedby={describedBy}
+            />
+            <Button variant="secondary" onclick={loadBondedDevices} disabled={bondedLoading}>
+              Refresh
+            </Button>
+          </div>
+        {/snippet}
       </FormField>
     {:else if form.type === 'serial'}
       <FormField
@@ -857,12 +904,5 @@
   .bt-picker :global(input) {
     margin: 0 !important;
     flex: 1 1 auto;
-  }
-  .bt-empty-hint {
-    display: block;
-    margin-top: 6px;
-    font-size: 12px;
-    color: var(--color-text-muted, #888);
-    line-height: 1.4;
   }
 </style>


### PR DESCRIPTION
## Summary

Lets Android-tablet operators add a Bluetooth-paired KISS TNC (Mobilinkd TNC3/TNC4, Kenwood TH-D74/D75, etc.) as a KISS interface. Bytes ride the existing `pkg/kiss` data path via an injected `OpenFunc` — Kotlin holds the `BluetoothSocket`, the existing `SerialSupervisor` consumes the stream identically to a real serial port.

Architecture: new Kotlin `BtSerialAdapter` exposes bonded-device enumeration and RFCOMM byte-relay to the Go child over the platform UDS using five new transport-agnostic proto messages (`SerialOpen`, `SerialOpenAck`, `SerialData`, `SerialClose`, `SerialError`). A new Go-side `pkg/platformsvc/btserial.go` returns an `io.ReadWriteCloser`; Android-build wiring injects it as `SerialConfig.OpenFunc`. Desktop builds are untouched.

- New proto messages on both sides; `SchemaVersion` bumped 1 to 2 with a drift-guard test
- Kotlin `BtSerialAdapter` (worker-thread RFCOMM + per-handle multiplex), `BluetoothFacade` abstraction, `ACTION_BOND_STATE_CHANGED` receiver, BLUETOOTH_CONNECT permission flow via JS bridge
- Go `platformsvc.Client.BondedBtDevices` and `BtSerialOpen` (multiplexed `io.ReadWriteCloser` with per-handle channel registry; drains handles on disconnect/Close)
- `kiss.OpenFunc` exported; build-tagged factory routes MAC-formatted device strings through `platformsvc.BtSerialOpen` on Android, returns nil elsewhere
- `pkg/app/wiring.go` dispatches `KissTypeBluetooth` with forced `BaudRate=0, Mode=ModeTnc`
- `GET /api/kiss/bonded-bt-devices` (501 on non-Android)
- Svelte UI: platform-conditional type select, Bluetooth bonded-device picker, friendly device names in the interface table, permission grant button
- DTO fix: `KissTypeBluetooth` exempt from `BaudRate>0` validation (RFCOMM has no baud)
- Operator handbook page at `docs/handbook/kiss-bluetooth.html`; wiki updates (code-map Kotlin section, system-topology TNC row, new invariant 35 on worker-thread blocking calls)
- Release note for v0.13.6 pre-staged (`cta` style, `#/kiss` deep-link)

## Test plan

Automated:
- [x] `GOWORK=off go build ./...` clean on host and `GOOS=android GOARCH=arm64 CGO_ENABLED=0`
- [x] `go test ./pkg/kiss/ ./pkg/app/ ./pkg/webapi/ ./pkg/webapi/dto/ ./pkg/platformsvc/` all pass
- [x] `go vet` clean on both build tags
- [x] Kotlin `:app:compileDebugKotlin` clean; new `BluetoothFacadeTest` (1) and `BtSerialAdapterTest` (3) pass; new BT cases in `WebAppInterfaceTest` (2) pass
- [x] `npm run build` clean; `npm run test` 215/215 (7 new BT-permission cases + new `Platform.isAndroid` cases)

Hardware (deferred to manual run on the tablet):
- [ ] Pixel 8 + Mobilinkd TNC4 + Baofeng UV-5R -- pair, add interface, TX/RX APRS frames
- [ ] Pixel 6a + Mobilinkd TNC3 + Yaesu FT-65R -- same
- [ ] Samsung A54 + Kenwood TH-D75 (Bluetooth mode) -- same
- [ ] Bond-state lifecycle: unpair the TNC mid-session, confirm the interface flips and re-pairing restores it
- [ ] First-launch permission flow: fresh install, open KISS, confirm the bonded list shows the permission banner before grant and the device list after

## Known deferred follow-ups

- Bond-lost UI state needs a proto-level `permission_denied` flag on `BondedBtDevicesResponse` to distinguish "no devices" from "permission denied"
- `autofillBtName` is dead today (no `form.name` input); enables when interface naming gets a UI
- Pre-existing baseline items not introduced by this branch: 3 unrelated `WebAppInterfaceTest` USB failures, `UsbPttAdapterEnumerateForJsTest.kt` uncompilable, 7 branch-touched files in repo-wide gofmt baseline