### PR TITLE
refactor: collapse cfg.Platform and platformSchemaVersion duplicates

### DIFF
--- a/cmd/graywolf/android_config.go
+++ b/cmd/graywolf/android_config.go
@@ -60,7 +60,6 @@ func configFromEnv() (app.Config, error) {
 		ModemSocketPath: modemSock,
 		HTTPAddr:        listen,
 		BearerToken:     token,
-		Platform:        os.Getenv("GRAYWOLF_PLATFORM"),
 		ShutdownTimeout: 10 * time.Second,
 	}
 	return cfg, nil

--- a/cmd/graywolf/android_config_test.go
+++ b/cmd/graywolf/android_config_test.go
@@ -18,9 +18,6 @@ func TestConfigFromEnv_AllSet(t *testing.T) {
 	if cfg.BearerToken != "tok-abc" {
 		t.Fatalf("BearerToken = %q want tok-abc", cfg.BearerToken)
 	}
-	if cfg.Platform != "android" {
-		t.Fatalf("Platform = %q want android", cfg.Platform)
-	}
 	if cfg.ModemSocketPath != "/tmp/modem.sock" {
 		t.Fatalf("ModemSocketPath = %q", cfg.ModemSocketPath)
 	}
@@ -52,7 +49,6 @@ var andEnvKeys = []string{
 	"GRAYWOLF_PLATFORM_SOCKET",
 	"GRAYWOLF_LISTEN",
 	"GRAYWOLF_LISTEN_TOKEN",
-	"GRAYWOLF_PLATFORM",
 }
 
 func clearEnv(t *testing.T, keys ...string) {
@@ -70,6 +66,5 @@ func happyEnv() map[string]string {
 		"GRAYWOLF_PLATFORM_SOCKET": "@/tmp/platform.sock",
 		"GRAYWOLF_LISTEN":          "127.0.0.1:8080",
 		"GRAYWOLF_LISTEN_TOKEN":    "tok-abc",
-		"GRAYWOLF_PLATFORM":        "android",
 	}
 }

--- a/cmd/graywolf/main_android.go
+++ b/cmd/graywolf/main_android.go
@@ -24,12 +24,6 @@ import (
 	"github.com/chrissnell/graywolf/pkg/platformsvc"
 )
 
-// platformSchemaVersion mirrors the pkg/platformsvc package constant so
-// the wire-schema version is a single source of truth across the Go
-// binary and the Kotlin PlatformServer. Drift between this and Kotlin's
-// `schemaVersion` is caught by pkg/platformsvc/schema_version_test.go.
-const platformSchemaVersion = platformsvc.SchemaVersion
-
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
@@ -100,7 +94,7 @@ func platformConnect(ctx context.Context, logger *slog.Logger, sockPath string) 
 	}
 	helloCtx, helloCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer helloCancel()
-	resp, err := cli.Hello(helloCtx, platformSchemaVersion)
+	resp, err := cli.Hello(helloCtx, platformsvc.SchemaVersion)
 	if err != nil {
 		_ = cli.Close()
 		return nil, fmt.Errorf("hello: %w", err)
@@ -108,10 +102,10 @@ func platformConnect(ctx context.Context, logger *slog.Logger, sockPath string) 
 	logger.Info("platformsvc: connected",
 		"server_version", resp.GetServerVersion(),
 		"schema_version", resp.GetSchemaVersion())
-	if resp.GetSchemaVersion() != platformSchemaVersion {
+	if resp.GetSchemaVersion() != platformsvc.SchemaVersion {
 		_ = cli.Close()
 		return nil, fmt.Errorf("schema mismatch: client=%d server=%d",
-			platformSchemaVersion, resp.GetSchemaVersion())
+			platformsvc.SchemaVersion, resp.GetSchemaVersion())
 	}
 	return cli, nil
 }

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -88,12 +88,6 @@ type Config struct {
 	// child process).
 	ModemSocketPath string
 
-	// Platform is "android" on Android builds, "" elsewhere. Wiring
-	// uses it to gate components that don't make sense on Android
-	// (updatescheck, native serial PTT). Set by main_android.go from
-	// the GRAYWOLF_PLATFORM env var.
-	Platform string
-
 	// BearerToken, if non-empty, gates every HTTP and WebSocket
 	// request behind webauth.BearerAuthMiddleware. Set by
 	// main_android.go from the GRAYWOLF_LISTEN_TOKEN env var (the

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -37,6 +37,7 @@ import (
 	"github.com/chrissnell/graywolf/pkg/metrics"
 	"github.com/chrissnell/graywolf/pkg/modembridge"
 	"github.com/chrissnell/graywolf/pkg/packetlog"
+	"github.com/chrissnell/graywolf/pkg/platform"
 	"github.com/chrissnell/graywolf/pkg/pttdevice"
 	"github.com/chrissnell/graywolf/pkg/remoteactions"
 	"github.com/chrissnell/graywolf/pkg/stationcache"
@@ -207,7 +208,7 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 	// write amplification; Android internal storage doesn't share that
 	// constraint and a disabled history db wipes the live map on every
 	// process restart -- a confusing failure mode for the operator.
-	if plCfg == nil && a.cfg.Platform == "android" && a.cfg.HistoryDBPath != "" {
+	if plCfg == nil && platform.Kind == "android" && a.cfg.HistoryDBPath != "" {
 		seeded := &configstore.PositionLogConfig{
 			Enabled: true,
 			DBPath:  a.cfg.HistoryDBPath,
@@ -230,7 +231,7 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 	// already being decoded, which is a confusing failure mode.
 	// Operator can still rename / delete via the SPA; subsequent
 	// boots respect the persisted state.
-	if a.cfg.Platform == "android" {
+	if platform.Kind == "android" {
 		if devs, err := a.store.ListAudioDevices(ctx); err == nil && len(devs) == 0 {
 			// One input row + one output row. AudioPump (Kotlin)
 			// captures from the system default mic and renders to
@@ -1267,7 +1268,7 @@ func (a *App) wireHTTP(ctx context.Context) error {
 	// Skipped on Android: Play Store handles upgrades there; an
 	// in-process GitHub poll has no purpose and would generate
 	// unwanted background traffic.
-	if a.cfg.Platform != "android" {
+	if platform.Kind != "android" {
 		a.updatesChecker = updatescheck.NewChecker(
 			a.cfg.Version,
 			a.store,


### PR DESCRIPTION
## Summary

Two scoped, mechanical cleanups that close cross-site footguns:

1. **wiring.go gates** — three `a.cfg.Platform == "android"` checks now key off `pkg/platform.Kind`, the established build-tagged single source of truth (mirrored by Kotlin `Platform.kind` and JS `Platform.kind`). With no other reader, `app.Config.Platform`, its `os.Getenv("GRAYWOLF_PLATFORM")` assignment, and the corresponding test assertion are removed. The Kotlin side still exports the env var; the Go side just stops reading it.

2. **platformSchemaVersion alias** — deleted from `cmd/graywolf/main_android.go`; the three Android entrypoint references now use `platformsvc.SchemaVersion` directly.

## Why issue 2 matters

The platformsvc wire-schema version historically lived in three places: the Go const in `pkg/platformsvc`, the Kotlin `GraywolfService` field, and a local Go alias in `main_android.go`. The drift-guard test compares only the first two. A previous v1→v2 bump missed the third site; a freshly-installed APK ANR'd on boot with `ERROR_SCHEMA_MISMATCH: server 2 client 1` and the Go child never signaled readiness, costing a real-tablet debug cycle.

Dropping the alias makes drift structurally impossible — there is no third constant to forget to bump, and the existing drift-guard test remains sufficient (Go == Kotlin, and the Android entry now reads the Go const directly).

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./pkg/app/... ./pkg/platform/... ./pkg/platformsvc/... ./cmd/graywolf/...` — all green
- [x] `GOWORK=off go vet ./...` — clean
- [x] `GOOS=linux GOARCH=arm64 CGO_ENABLED=0 GOWORK=off go vet -tags android ./cmd/graywolf/... ./pkg/app/... ./pkg/platform/...` — clean (full `go build -tags android` link fails locally on missing CGO/NDK; not a code regression)
- [ ] On-device APK verification (operator)