### PR TITLE
Android Play Store pipeline: Phase 4 (signed release on tag pushes)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,9 +1,10 @@
 name: Android
 
 # PR / push:main: build an unsigned debug APK and upload as an artifact.
-# Tag pushes (v*) will additionally trigger the release-sign job in
-# Phase 4 of the Android Play Store pipeline plan
-# (docs/superpowers/plans/2026-05-21-android-play-store-pipeline.md).
+# Tag pushes (v*): also build a release-signed AAB + APK and attach them
+# to the GitHub Release (which goreleaser/release.yml creates in parallel).
+# Phase 5 of the plan will add a step that auto-uploads the AAB to the
+# Play Internal Testing track.
 
 on:
   push:
@@ -21,7 +22,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  # write required so the release-sign job can attach the signed AAB
+  # + APK to the GH Release that goreleaser creates on tag push.
+  contents: write
 
 jobs:
   build:
@@ -138,3 +141,146 @@ jobs:
           name: graywolf-debug-apk
           path: android/app/build/outputs/apk/debug/app-debug.apk
           retention-days: 7
+
+  # ------------------------------------------------------------------
+  # release-sign — only on v* tag pushes. Builds a release-signed
+  # AAB (for Play upload) and APK (for sideload / GH Release), then
+  # attaches both to the GH Release that goreleaser created via the
+  # parallel release.yml workflow. needs:build ensures the cheap
+  # PR-style build passed first; we never try to sign something the
+  # debug path already showed is broken.
+  # ------------------------------------------------------------------
+  release-sign:
+    name: Release sign (AAB + APK)
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: web
+        run: |
+          npm ci
+          npm install @rollup/rollup-linux-x64-gnu
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Set up Rust + Android targets
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,x86_64-linux-android
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Separate key from the build job so the release-sign cache
+          # doesn't churn on every PR push; share the prefix so the
+          # restore-keys fallback can still warm-start from build's cache.
+          key: android-release
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked --version ^4
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: '28.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: 'platforms;android-36 build-tools;36.0.0 ndk;27.2.12479018'
+
+      - name: Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-release-${{ hashFiles('android/**/*.gradle*', 'android/**/gradle-wrapper.properties') }}
+          restore-keys: gradle-release-
+
+      - name: Build signed AAB and APK
+        working-directory: android
+        env:
+          GRAYWOLF_KEYSTORE_BASE64: ${{ secrets.GRAYWOLF_KEYSTORE_BASE64 }}
+          GRAYWOLF_KEYSTORE_PASSWORD: ${{ secrets.GRAYWOLF_KEYSTORE_PASSWORD }}
+          GRAYWOLF_KEY_ALIAS: ${{ secrets.GRAYWOLF_KEY_ALIAS }}
+          GRAYWOLF_KEY_PASSWORD: ${{ secrets.GRAYWOLF_KEY_PASSWORD }}
+        # --info kept (matches the build job) so any go/cargo failure
+        # in this signed path lands a real error message in the log,
+        # not just Gradle's wrapped exit-code-1 message.
+        run: ./gradlew :app:bundleRelease :app:assembleRelease --no-daemon --stacktrace --info
+
+      - name: Stage release artifacts
+        id: stage
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          mkdir -p staging
+          cp android/app/build/outputs/bundle/release/app-release.aab "staging/graywolf-${version}.aab"
+          cp android/app/build/outputs/apk/release/app-release.apk     "staging/graywolf-${version}.apk"
+          ls -la staging/
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify APK signature matches the upload keystore
+        run: |
+          set -euo pipefail
+          v="${{ steps.stage.outputs.version }}"
+          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --print-certs \
+            "staging/graywolf-${v}.apk" \
+            | grep -E "SHA-256 digest|Signer #1 certificate"
+
+      - name: Upload signed AAB + APK to the GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # release.yml runs in parallel and creates the GH Release via
+        # goreleaser. There's a race: this job can finish staging before
+        # goreleaser has created the release. Retry briefly (every 30s
+        # for up to 3 min) to absorb that — well under the 5-7 min the
+        # goreleaser path takes.
+        run: |
+          set -euo pipefail
+          v="${{ steps.stage.outputs.version }}"
+          for i in 1 2 3 4 5 6; do
+            if gh release upload "${GITHUB_REF_NAME}" \
+                 "staging/graywolf-${v}.aab" \
+                 "staging/graywolf-${v}.apk" \
+                 --clobber; then
+              echo "uploaded on attempt $i"
+              exit 0
+            fi
+            echo "Release ${GITHUB_REF_NAME} not yet available, retrying ($i/6)..."
+            sleep 30
+          done
+          echo "::error::Release ${GITHUB_REF_NAME} never appeared; check goreleaser job."
+          exit 1
+
+      - name: Upload signed AAB as workflow artifact (manual fallback)
+        uses: actions/upload-artifact@v5
+        with:
+          name: graywolf-release-aab
+          path: staging/graywolf-*.aab
+          retention-days: 30


### PR DESCRIPTION
Phase 4 of `docs/superpowers/plans/2026-05-21-android-play-store-pipeline.md`.
Builds on Phase 1 (signingConfig) + Phase 3 (build workflow) which
shipped in PRs #163 and #164.

## Summary

- New `release-sign` job in `.github/workflows/android.yml`. Fires
  only on `v*` tag pushes; `needs: build` so the unsigned debug
  sanity-check passes first.
- Builds a signed AAB + APK via `:app:bundleRelease :app:assembleRelease`
  with the four `GRAYWOLF_*` secrets injected as env.
- Verifies the APK signature in the log (`apksigner --print-certs`)
  so you can compare against the upload-keystore SHA-256 in
  1Password.
- Attaches the signed AAB + APK to the GH Release that goreleaser
  creates in parallel. 30s × 6 retry loop absorbs the goreleaser race.
- Also uploads the AAB as a 30-day workflow artifact (manual
  fallback if the release upload ever fails).
- Bumps `permissions: contents: write` (the release upload requires it).

## Test plan

- [ ] PR's `build` job passes (this is just a CI-syntax sanity check;
      the release-sign job only fires on tags, not PRs)
- [ ] After merge, cut a test release via `make bump-point`
- [ ] Confirm `release-sign` job goes green within ~10 min
- [ ] Confirm `graywolf-<ver>.aab` and `graywolf-<ver>.apk` appear on
      the GH Release page alongside goreleaser's outputs
- [ ] Confirm the apksigner SHA-256 in the log matches the 1Password
      keystore fingerprint
- [ ] Download AAB and upload to Play Console Internal Testing manually
      (Phase 5 PR automates this step)