### PR TITLE
feat(android): hide Actions from the Android UI

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -67,6 +67,10 @@
     const r = { ...baseRoutes };
     delete r['/agw'];
     delete r['/login'];
+    // Actions command-handlers exec shell scripts, which Android's W^X
+    // sandbox forbids; the tab is hidden in the sidebar and the route
+    // is dropped so a stray hash nav can't render a dead surface.
+    delete r['/actions'];
     return r;
   })();
 

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -9,10 +9,15 @@
   import { Platform } from '../lib/platform.js';
   import logoUrl from '../assets/graywolf.svg';
 
-  // Surfaces deferred or unsupported on Android. PTT lands in phase 5;
-  // Simulation is a desktop dev-mode tool. Hidden from the sidebar so
-  // operators don't tap into a non-functional surface.
-  const HIDDEN_ON_ANDROID = new Set(['/simulation', '/agw', '/login']);
+  // Surfaces deferred or unsupported on Android. Hidden from the
+  // sidebar so operators don't tap into a non-functional surface:
+  //   /simulation - dev-mode tool, not for Android operators
+  //   /agw        - AGWPE TCP server, not wired on Android
+  //   /login      - Android authenticates via the per-launch bearer token
+  //   /actions    - command-handler Actions exec shell scripts, which
+  //                 Android's W^X sandbox forbids; webhook handlers
+  //                 would work but aren't worth a partial UI for launch
+  const HIDDEN_ON_ANDROID = new Set(['/simulation', '/agw', '/login', '/actions']);
 
   // Main-function entries get an icon and render in a single
   // unsubheadered top section. Inline SVGs cover the cases chonky-ui's
@@ -45,6 +50,14 @@
     { path: '/simulation', label: 'Simulation' },
     { path: '/callsign', label: 'Station Callsign' },
   ];
+  // mainItems carries the icon'd top section; it's filtered by the
+  // same HIDDEN_ON_ANDROID set as the settings group so an entry like
+  // /actions disappears from both places on Android.
+  const visibleMainItems = $derived(
+    Platform.kind === 'android'
+      ? mainItems.filter(it => !HIDDEN_ON_ANDROID.has(it.path))
+      : mainItems,
+  );
   const navGroups = $derived([
     {
       label: 'Settings',
@@ -138,7 +151,7 @@
 
 {#snippet navItems()}
   <ul class="nav-list main-list">
-    {#each mainItems as item}
+    {#each visibleMainItems as item}
       {@const unread = item.badge ? badgeCount(item.badge) : 0}
       <li>
         <a


### PR DESCRIPTION
Actions command-handlers run operator scripts via os/exec, which
Android's W^X sandbox forbids. Hide the feature on Android (UI only,
per request).

## Changes

- Add `/actions` to `HIDDEN_ON_ANDROID` in `Sidebar.svelte`.
- Filter `mainItems` by that set (it previously only filtered the
  settings group, so the icon'd Actions entry would have stayed).
- Drop `/actions` from the SPA route map on Android in `App.svelte`,
  matching how `/agw` and `/login` are handled.

Backend Actions runner is intentionally untouched -- harmless on a
fresh Android install (no configured Actions to run). Webhook-type
Actions would technically work on Android but supporting a
webhook-only surface isn't worth the partial UI for launch.

## Test plan

- [ ] On Android build: Actions absent from sidebar main section
- [ ] On Android build: navigating to #/actions renders nothing/404,
      not a dead Actions page
- [ ] On macOS/Linux/Windows builds: Actions still present and working
- [ ] Ships in the next release (0.13.7) to reach the Play build