### PR TITLE
Add -demo mode and drive the Play Store screenshot harness with it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ SWAGGER_UI_VENDOR := $(DOCS_HANDBOOK)/vendor/swagger-ui
 # api-client-check guards catch.
 GENERATED_SPEC_FILES := $(DOCS_GEN_DIR)/swagger.json $(DOCS_GEN_DIR)/swagger.yaml $(WEB_DIR)/src/api/generated/api.d.ts
 
-.PHONY: all build release test bench clean clean-web distclean check fmt lint doc run-bench proto go-build go-test go-fuzz web graywolf graywolf-quick version bump-minor bump-point bump-beta handbook-sync handbook-sync-ssh docs docs-api-html docs-check docs-lint api-client api-client-check flareschema install-hooks
+.PHONY: all build release test bench clean clean-web distclean check fmt lint doc run-bench proto go-build go-test go-fuzz web graywolf graywolf-quick version bump-minor bump-point bump-beta handbook-sync handbook-sync-ssh docs docs-api-html docs-check docs-lint api-client api-client-check flareschema install-hooks android-screenshots android-screenshots-seed
 
 all: release web
 	mkdir -p bin
@@ -227,6 +227,21 @@ bump-beta:
 	git diff --cached --quiet || git commit -m "Beta $(BETA_TAG)"
 	git tag "$(BETA_TAG)"
 	git push $(GIT_REMOTE) && git push $(GIT_REMOTE) "$(BETA_TAG)"
+
+# Android Play Store screenshots. Drives the SPA in Android mode
+# (faked WebView bridge) against a local graywolf seeded with a tablet
+# DB snapshot, capturing PNGs at tablet resolution. Two-step:
+#   make android-screenshots-seed   # pull DBs off the tablet (occasional)
+#   make android-screenshots        # build, launch, capture
+# Output lands in scratch/ss-work/shots/. Seed + output stay in
+# scratch/ (gitignored) because they hold the operator's real station
+# data. First run installs Playwright under scripts/screenshots/.
+android-screenshots-seed:
+	./scripts/screenshots/pull-seed.sh
+
+android-screenshots:
+	@test -d scripts/screenshots/node_modules || ( cd scripts/screenshots && npm install )
+	./scripts/screenshots/run.sh
 
 handbook-sync:
 	rsync -av --delete docs/handbook/ /Volumes/NFS/static-sites/chrissnell.com/software/graywolf

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -62,6 +62,11 @@ type Config struct {
 	// Debug enables debug-level logging (-debug).
 	Debug bool
 
+	// Demo, when true, seeds canned station + dashboard data so a fresh
+	// launch looks like a busy real station. For screenshots and demos
+	// only; pair with -modem "" since there is no real RF. Off by default.
+	Demo bool
+
 	// LogBufferRamdisk forces the logbuffer to land on tmpfs even when
 	// graywolf is not running on an SD-card-backed system
 	// (--logbuffer-ramdisk). Useful for desktop/server operators who

--- a/pkg/app/flags.go
+++ b/pkg/app/flags.go
@@ -51,6 +51,8 @@ func parseFlagsTo(args []string, w io.Writer) (Config, error) {
 		"max time to wait for clean shutdown")
 	fs.StringVar(&cfg.FlacFile, "flac", "", "override audio device with a FLAC file for testing")
 	fs.BoolVar(&cfg.Debug, "debug", false, "enable debug-level logging")
+	fs.BoolVar(&cfg.Demo, "demo", false,
+		"seed canned demo data (stations, counters) for screenshots; use with -modem \"\"")
 	fs.BoolVar(&cfg.LogBufferRamdisk, "logbuffer-ramdisk", false,
 		"force the in-database log buffer onto a ramdisk (tmpfs) regardless of the host's storage type")
 

--- a/pkg/app/flags_test.go
+++ b/pkg/app/flags_test.go
@@ -152,3 +152,20 @@ func TestParseFlagsErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFlags_Demo(t *testing.T) {
+	cfg, err := ParseFlags([]string{"-demo"})
+	if err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if !cfg.Demo {
+		t.Fatal("expected cfg.Demo true with -demo")
+	}
+	cfg2, err := ParseFlags([]string{})
+	if err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if cfg2.Demo {
+		t.Fatal("expected cfg.Demo false by default")
+	}
+}

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -1204,6 +1204,7 @@ func (a *App) wireHTTP(ctx context.Context) error {
 		Version:       a.cfg.Version,
 		MapsCache:     mapsCache,
 		Catalog:       catalog,
+		Demo:          a.cfg.Demo,
 	})
 	if err != nil {
 		return fmt.Errorf("webapi new: %w", err)

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -303,6 +303,7 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 					a.logger.Warn("demo: seed input device failed", "err", err)
 				} else {
 					inDevID = in.ID
+					a.logger.Info("demo: seeded input device", "id", inDevID)
 				}
 			}
 			if outDevID == 0 {
@@ -311,6 +312,7 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 					a.logger.Warn("demo: seed output device failed", "err", err)
 				} else {
 					outDevID = out.ID
+					a.logger.Info("demo: seeded output device", "id", outDevID)
 				}
 			}
 		}

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -289,6 +289,7 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 		}
 		if chs, err := a.store.ListChannels(ctx); err == nil && len(chs) == 0 {
 			ch := &configstore.Channel{
+				ID:        2,
 				Name:      "VHF APRS",
 				ModemType: "afsk",
 				BitRate:   1200,

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -301,6 +301,25 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 				a.logger.Info("demo: seeded channel", "id", ch.ID, "name", ch.Name)
 			}
 		}
+		if bcns, err := a.store.ListBeacons(ctx); err == nil && len(bcns) == 0 {
+			b := &configstore.Beacon{
+				Type:        "position",
+				Channel:     2,
+				Callsign:    "NW5W-8",
+				Enabled:     true,
+				UseGps:      false,
+				Latitude:    40.47624,
+				Longitude:   -111.84587,
+				SymbolTable: "/",
+				Symbol:      "-",
+				Comment:     "Graywolf demo station",
+			}
+			if err := a.store.CreateBeacon(ctx, b); err != nil {
+				a.logger.Warn("demo: seed beacon failed", "err", err)
+			} else {
+				a.logger.Info("demo: seeded fixed-position beacon", "id", b.ID, "callsign", b.Callsign)
+			}
+		}
 	}
 
 	if plCfg != nil && plCfg.Enabled && a.cfg.HistoryDBPath != "" {

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -280,9 +280,12 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 	// so the dashboard and Channels page render populated. Only seeds when
 	// empty so re-launching against a populated demo DB is idempotent.
 	if a.cfg.Demo {
-		if cfgs, err := a.store.GetStationConfig(ctx); err != nil || cfgs.Callsign == "" {
-			_ = a.store.UpsertStationConfig(ctx, configstore.StationConfig{Callsign: "NW5W-8"})
-			a.logger.Info("demo: seeded station callsign", "callsign", "NW5W-8")
+		if cfgs, err := a.store.GetStationConfig(ctx); err == nil && cfgs.Callsign == "" {
+			if err := a.store.UpsertStationConfig(ctx, configstore.StationConfig{Callsign: "NW5W-8"}); err != nil {
+				a.logger.Warn("demo: seed callsign failed", "err", err)
+			} else {
+				a.logger.Info("demo: seeded station callsign", "callsign", "NW5W-8")
+			}
 		}
 		if chs, err := a.store.ListChannels(ctx); err == nil && len(chs) == 0 {
 			ch := &configstore.Channel{
@@ -295,7 +298,7 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 			if err := a.store.CreateChannel(ctx, ch); err != nil {
 				a.logger.Warn("demo: seed channel failed", "err", err)
 			} else {
-				a.logger.Info("demo: seeded channel", "name", ch.Name)
+				a.logger.Info("demo: seeded channel", "id", ch.ID, "name", ch.Name)
 			}
 		}
 	}
@@ -313,12 +316,14 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 	}
 
 	if a.cfg.Demo {
-		a.stationCache.Update(demoseed.Stations())
-		for _, e := range demoseed.Packets() {
+		stations := demoseed.Stations()
+		packets := demoseed.Packets()
+		a.stationCache.Update(stations)
+		for _, e := range packets {
 			a.plog.Record(e)
 		}
 		a.logger.Info("demo: seeded station cache + packet log",
-			"stations", len(demoseed.Stations()), "packets", len(demoseed.Packets()))
+			"stations", len(stations), "packets", len(packets))
 	}
 
 	// --- Modem bridge (construction; Start happens later) --------------

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -563,13 +563,14 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 	// inserts when the conversation table is empty.
 	if a.cfg.Demo && a.msgStore != nil {
 		if rollup, err := a.msgStore.ConversationRollup(ctx, 1); err == nil && len(rollup) == 0 {
-			for _, m := range demoseed.Messages() {
-				mm := m
+			msgs := demoseed.Messages()
+			for _, m := range msgs {
+				mm := m // copy to avoid taking the address of the loop variable
 				if err := a.msgStore.Insert(ctx, &mm); err != nil {
 					a.logger.Warn("demo: seed message failed", "err", err)
 				}
 			}
-			a.logger.Info("demo: seeded messages", "count", len(demoseed.Messages()))
+			a.logger.Info("demo: seeded messages", "count", len(msgs))
 		}
 	}
 

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -287,6 +287,33 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 				a.logger.Info("demo: seeded station callsign", "callsign", "NW5W-8")
 			}
 		}
+		var inDevID, outDevID uint32
+		if devs, err := a.store.ListAudioDevices(ctx); err == nil {
+			for _, d := range devs {
+				if inDevID == 0 && d.Direction == "input" {
+					inDevID = d.ID
+				}
+				if outDevID == 0 && d.Direction == "output" {
+					outDevID = d.ID
+				}
+			}
+			if inDevID == 0 {
+				in := &configstore.AudioDevice{Name: "Default Input", Direction: "input", SourceType: "soundcard", SourcePath: "demo-default", SampleRate: 48000, Channels: 1, Format: "s16le"}
+				if err := a.store.CreateAudioDevice(ctx, in); err != nil {
+					a.logger.Warn("demo: seed input device failed", "err", err)
+				} else {
+					inDevID = in.ID
+				}
+			}
+			if outDevID == 0 {
+				out := &configstore.AudioDevice{Name: "Default Output", Direction: "output", SourceType: "soundcard", SourcePath: "demo-default", SampleRate: 48000, Channels: 1, Format: "s16le"}
+				if err := a.store.CreateAudioDevice(ctx, out); err != nil {
+					a.logger.Warn("demo: seed output device failed", "err", err)
+				} else {
+					outDevID = out.ID
+				}
+			}
+		}
 		if chs, err := a.store.ListChannels(ctx); err == nil && len(chs) == 0 {
 			ch := &configstore.Channel{
 				ID:        2,
@@ -296,6 +323,10 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 				MarkFreq:  1200,
 				SpaceFreq: 2200,
 			}
+			if inDevID != 0 {
+				ch.InputDeviceID = &inDevID
+			}
+			ch.OutputDeviceID = outDevID
 			if err := a.store.CreateChannel(ctx, ch); err != nil {
 				a.logger.Warn("demo: seed channel failed", "err", err)
 			} else {

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -24,6 +24,7 @@ import (
 	"github.com/chrissnell/graywolf/pkg/beacon"
 	"github.com/chrissnell/graywolf/pkg/callsign"
 	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/demoseed"
 	"github.com/chrissnell/graywolf/pkg/digipeater"
 	"github.com/chrissnell/graywolf/pkg/gps"
 	"github.com/chrissnell/graywolf/pkg/historydb"
@@ -275,6 +276,30 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 		}
 	}
 
+	// Demo mode: ensure the config DB has a station callsign + a channel
+	// so the dashboard and Channels page render populated. Only seeds when
+	// empty so re-launching against a populated demo DB is idempotent.
+	if a.cfg.Demo {
+		if cfgs, err := a.store.GetStationConfig(ctx); err != nil || cfgs.Callsign == "" {
+			_ = a.store.UpsertStationConfig(ctx, configstore.StationConfig{Callsign: "NW5W-8"})
+			a.logger.Info("demo: seeded station callsign", "callsign", "NW5W-8")
+		}
+		if chs, err := a.store.ListChannels(ctx); err == nil && len(chs) == 0 {
+			ch := &configstore.Channel{
+				Name:      "VHF APRS",
+				ModemType: "afsk",
+				BitRate:   1200,
+				MarkFreq:  1200,
+				SpaceFreq: 2200,
+			}
+			if err := a.store.CreateChannel(ctx, ch); err != nil {
+				a.logger.Warn("demo: seed channel failed", "err", err)
+			} else {
+				a.logger.Info("demo: seeded channel", "name", ch.Name)
+			}
+		}
+	}
+
 	if plCfg != nil && plCfg.Enabled && a.cfg.HistoryDBPath != "" {
 		hdb, err := historydb.Open(a.cfg.HistoryDBPath)
 		if err != nil {
@@ -285,6 +310,15 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 				a.logger.Warn("failed to hydrate from history db", "err", err)
 			}
 		}
+	}
+
+	if a.cfg.Demo {
+		a.stationCache.Update(demoseed.Stations())
+		for _, e := range demoseed.Packets() {
+			a.plog.Record(e)
+		}
+		a.logger.Info("demo: seeded station cache + packet log",
+			"stations", len(demoseed.Stations()), "packets", len(demoseed.Packets()))
 	}
 
 	// --- Modem bridge (construction; Start happens later) --------------

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -558,6 +558,21 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 		return err
 	}
 
+	// Demo mode: seed a canned DM conversation so the Messages screen
+	// renders a real-looking thread for screenshots. Idempotent: only
+	// inserts when the conversation table is empty.
+	if a.cfg.Demo && a.msgStore != nil {
+		if rollup, err := a.msgStore.ConversationRollup(ctx, 1); err == nil && len(rollup) == 0 {
+			for _, m := range demoseed.Messages() {
+				mm := m
+				if err := a.msgStore.Insert(ctx, &mm); err != nil {
+					a.logger.Warn("demo: seed message failed", "err", err)
+				}
+			}
+			a.logger.Info("demo: seeded messages", "count", len(demoseed.Messages()))
+		}
+	}
+
 	// --- Actions service ----------------------------------------------
 	// Runs after messages so the reply adapter can ride messages.Service
 	// (msg-id allocation, outbound view, retry ladder). The classifier

--- a/pkg/demoseed/demoseed.go
+++ b/pkg/demoseed/demoseed.go
@@ -1,0 +1,156 @@
+// Package demoseed holds canned data used by graywolf's -demo mode.
+// It exists so a fresh launch can look like a busy real Salt Lake-metro
+// APRS station for screenshots and demo recordings, without depending on
+// a real device DB or live RF. All data here is public APRS information
+// (callsigns + positions broadcast over the air), captured from a real
+// tablet and filtered to a Salt Lake bounding box.
+package demoseed
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/packetlog"
+	"github.com/chrissnell/graywolf/pkg/stationcache"
+)
+
+// station is the compact internal form of a canned demo station; Stations()
+// expands it into a stationcache.CacheEntry with a fresh timestamp.
+type station struct {
+	callsign string
+	lat, lon float64
+	symbol   [2]byte
+	isObject bool
+	speed    float64 // knots; 0 for fixed
+	course   int     // degrees; 0 when not moving
+	comment  string
+}
+
+// slcStations is the curated set captured from a real tablet RF session,
+// filtered to lat 40.4-41.0 / lon -112.3 to -111.6. NW5W-8 is the home
+// station running graywolf.
+var slcStations = []station{
+	{"446.25HRM", 40.51717, -112.01383, [2]byte{0x2F, 0x72}, true, 0, 0, "T118 -5 NetSun9pm n7mvc.org"},
+	{"AC7H-2", 40.83733, -111.87767, [2]byte{0x2F, 0x3E}, false, 0, 327, ""},
+	{"AG7LY-7", 40.76183, -112.02483, [2]byte{0x2F, 0x6B}, false, 0, 1, ""},
+	{"K7SRB", 40.63417, -111.90867, [2]byte{0x5C, 0x4B}, false, 0, 0, ""},
+	{"K7TX-10", 40.42350, -111.83450, [2]byte{0x53, 0x23}, false, 0, 0, "APRS Digi & iGate"},
+	{"K7UHP", 40.92200, -111.89433, [2]byte{0x2F, 0x5F}, false, 0, 0, "K7UHP Centerville Shop"},
+	{"KB0STG-9", 40.49117, -111.99150, [2]byte{0x2F, 0x39}, false, 15, 181, "146.52 or 446.25- 100hz"},
+	{"KD7OUT", 40.72950, -111.96817, [2]byte{0x2F, 0x3E}, false, 0, 173, ""},
+	{"KF6RAL-6", 40.73417, -112.21083, [2]byte{0x2F, 0x5F}, false, 0, 0, "Tooele WX"},
+	{"KI7NNK-9", 40.57317, -111.84083, [2]byte{0x5C, 0x6B}, false, 30, 272, ""},
+	{"KJ6APX-6", 40.72067, -112.05017, [2]byte{0x2F, 0x3E}, false, 18, 239, ""},
+	{"KK7GBE-7", 40.77000, -112.00600, [2]byte{0x2F, 0x6B}, false, 62, 287, ""},
+	{"KK7ZSV-14", 40.52583, -111.84167, [2]byte{0x2F, 0x22}, false, 0, 0, "146.540MHz Hefe's Flyer"},
+	{"KM7GAN-1", 40.64900, -111.86717, [2]byte{0x2F, 0x3E}, false, 0, 93, ""},
+	{"NW5W-8", 40.47624, -111.84587, [2]byte{0x2F, 0x3C}, false, 0, 0, "Graywolf"},
+	{"W1UTE-10", 40.54300, -112.02967, [2]byte{0x2F, 0x2D}, false, 0, 0, "Raspberry Pi, Dire Wolf, Xastir"},
+	{"W7SAR-8", 40.66467, -112.02100, [2]byte{0x5C, 0x6B}, false, 0, 11, "Search and Rescue"},
+}
+
+// Stations returns the canned demo stations as cache entries with
+// timestamps stamped to now (offset by a few minutes so they look
+// freshly heard but distinct). They are stamped at call time because
+// stationcache.QueryBBox filters by a now-relative cutoff; stale
+// timestamps would make them invisible on the map.
+func Stations() []stationcache.CacheEntry {
+	now := time.Now()
+	out := make([]stationcache.CacheEntry, 0, len(slcStations))
+	for i, s := range slcStations {
+		key := "stn:" + s.callsign
+		if s.isObject {
+			key = "obj:" + s.callsign
+		}
+		out = append(out, stationcache.CacheEntry{
+			Key:       key,
+			IsObject:  s.isObject,
+			Callsign:  s.callsign,
+			Lat:       s.lat,
+			Lon:       s.lon,
+			HasPos:    true,
+			Speed:     s.speed,
+			Course:    s.course,
+			HasCourse: s.course != 0,
+			Symbol:    s.symbol,
+			Via:       "rf",
+			Path:      []string{},
+			Direction: "RX",
+			Channel:   2,
+			Comment:   s.comment,
+			// Spread across the last ~12 minutes so "last heard" varies.
+			Timestamp: now.Add(-time.Duration(i) * 42 * time.Second),
+		})
+	}
+	return out
+}
+
+// Counters is the canned dashboard status used by /api/status in demo mode.
+type Counters struct {
+	UptimeSeconds int64
+	RxFrames      uint64
+	TxFrames      uint64
+	RxBadFCS      uint64
+	IgateGated    uint64
+	IgateDownlink uint64
+	AudioPeakDBFS float32
+	AudioRmsDBFS  float32
+}
+
+// StatusCounters returns plausible "active station" dashboard values.
+// ~2 days uptime with ~4250 RX frames (roughly 2100 packets/day, a
+// believable rate for a busy metro APRS receiver). TX/iGate are bogus
+// but plausible.
+func StatusCounters() Counters {
+	return Counters{
+		UptimeSeconds: 2*24*3600 + 3*3600 + 41*60, // ~2d 3h 41m
+		RxFrames:      4253,
+		TxFrames:      188,
+		RxBadFCS:      37,
+		IgateGated:    3914,
+		IgateDownlink: 12,
+		AudioPeakDBFS: -12.0,
+		AudioRmsDBFS:  -24.0,
+	}
+}
+
+// aprsCoord formats decimal degrees into the APRS DMM string used in
+// position packets, e.g. 40.47624,-111.84587 -> "4028.57N/11150.75W".
+func aprsCoord(lat, lon float64) string {
+	latHemi, lonHemi := "N", "W"
+	if lat < 0 {
+		lat, latHemi = -lat, "S"
+	}
+	if lon < 0 {
+		lon = -lon
+	} else {
+		lonHemi = "E"
+	}
+	latDeg := int(lat)
+	latMin := (lat - float64(latDeg)) * 60
+	lonDeg := int(lon)
+	lonMin := (lon - float64(lonDeg)) * 60
+	return fmt.Sprintf("%02d%05.2f%s/%03d%05.2f%s", latDeg, latMin, latHemi, lonDeg, lonMin, lonHemi)
+}
+
+// Packets returns canned packet-log entries derived from the demo
+// stations, so the dashboard's recent-packets panel renders real-looking
+// traffic instead of "Waiting for packets...". Timestamps are stamped to
+// now at call time (same reasoning as Stations).
+func Packets() []packetlog.Entry {
+	now := time.Now()
+	out := make([]packetlog.Entry, 0, len(slcStations))
+	for i, s := range slcStations {
+		display := fmt.Sprintf("%s>APDW17,WIDE1-1:!%s#%s",
+			s.callsign, aprsCoord(s.lat, s.lon), s.comment)
+		out = append(out, packetlog.Entry{
+			Timestamp: now.Add(-time.Duration(i) * 37 * time.Second),
+			Channel:   2,
+			Direction: packetlog.DirRX,
+			Source:    "modem",
+			Display:   display,
+			Type:      "position",
+		})
+	}
+	return out
+}

--- a/pkg/demoseed/demoseed.go
+++ b/pkg/demoseed/demoseed.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/packetlog"
 	"github.com/chrissnell/graywolf/pkg/stationcache"
 )
@@ -131,6 +132,54 @@ func aprsCoord(lat, lon float64) string {
 	lonDeg := int(lon)
 	lonMin := (lon - float64(lonDeg)) * 60
 	return fmt.Sprintf("%02d%05.2f%s/%03d%05.2f%s", latDeg, latMin, latHemi, lonDeg, lonMin, lonHemi)
+}
+
+// Messages returns a canned DM thread between NW5W-8 and KK7GBE-7 so
+// the Messages screen renders a real-looking conversation for screenshots.
+// Timestamps are stamped to now at call time (same reasoning as Stations).
+func Messages() []configstore.Message {
+	now := time.Now()
+	const (
+		ourCall  = "NW5W-8"
+		peerCall = "KK7GBE-7"
+	)
+	seed := []struct {
+		dir      string
+		text     string
+		ackState string
+		unread   bool
+		age      time.Duration
+	}{
+		{"in", "Good morning! You up for the SLC valley net tonight?", "none", false, 9 * time.Minute},
+		{"out", "Affirmative, QRV 1900 local on 146.520.", "acked", false, 6 * time.Minute},
+		{"in", "Perfect, talk then. 73", "none", false, 2 * time.Minute},
+	}
+	msgs := make([]configstore.Message, 0, len(seed))
+	for _, s := range seed {
+		ts := now.Add(-s.age)
+		from, to := peerCall, ourCall
+		if s.dir == "out" {
+			from, to = ourCall, peerCall
+		}
+		msgs = append(msgs, configstore.Message{
+			Direction:  s.dir,
+			OurCall:    ourCall,
+			PeerCall:   peerCall,
+			FromCall:   from,
+			ToCall:     to,
+			Text:       s.text,
+			AckState:   s.ackState,
+			Source:     "rf",
+			Channel:    2,
+			ThreadKind: "dm",
+			ThreadKey:  peerCall,
+			Kind:       "text",
+			Unread:     s.unread,
+			CreatedAt:  ts,
+			UpdatedAt:  ts,
+		})
+	}
+	return msgs
 }
 
 // Packets returns canned packet-log entries derived from the demo

--- a/pkg/demoseed/demoseed_test.go
+++ b/pkg/demoseed/demoseed_test.go
@@ -1,0 +1,64 @@
+package demoseed
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStations_FreshAndInBox(t *testing.T) {
+	entries := Stations()
+	if len(entries) != 17 {
+		t.Fatalf("want 17 demo stations, got %d", len(entries))
+	}
+	now := time.Now()
+	for _, e := range entries {
+		if e.Callsign == "" {
+			t.Errorf("empty callsign in entry %q", e.Key)
+		}
+		if !e.HasPos {
+			t.Errorf("%s missing position", e.Callsign)
+		}
+		// Fresh: within the last 15 minutes so the map's time-window
+		// query (default 1h) always includes them.
+		if now.Sub(e.Timestamp) > 15*time.Minute {
+			t.Errorf("%s timestamp too old: %v", e.Callsign, e.Timestamp)
+		}
+		// Salt Lake bounding box.
+		if e.Lat < 40.4 || e.Lat > 41.0 || e.Lon < -112.3 || e.Lon > -111.6 {
+			t.Errorf("%s out of SLC box: %f,%f", e.Callsign, e.Lat, e.Lon)
+		}
+	}
+}
+
+func TestStatusCounters_Plausible(t *testing.T) {
+	c := StatusCounters()
+	if c.RxFrames == 0 || c.UptimeSeconds == 0 {
+		t.Fatal("expected non-zero demo counters")
+	}
+}
+
+func TestPackets_Derived(t *testing.T) {
+	pkts := Packets()
+	if len(pkts) != 17 {
+		t.Fatalf("want 17 demo packets, got %d", len(pkts))
+	}
+	now := time.Now()
+	for _, p := range pkts {
+		if p.Display == "" {
+			t.Error("empty packet display line")
+		}
+		if p.Direction != "RX" {
+			t.Errorf("want RX direction, got %q", p.Direction)
+		}
+		if now.Sub(p.Timestamp) > 15*time.Minute {
+			t.Errorf("packet timestamp too old: %v", p.Timestamp)
+		}
+	}
+}
+
+func TestAprsCoord(t *testing.T) {
+	got := aprsCoord(40.47624, -111.84587)
+	if got != "4028.57N/11150.75W" {
+		t.Fatalf("aprsCoord = %q", got)
+	}
+}

--- a/pkg/demoseed/demoseed_test.go
+++ b/pkg/demoseed/demoseed_test.go
@@ -62,3 +62,43 @@ func TestAprsCoord(t *testing.T) {
 		t.Fatalf("aprsCoord = %q", got)
 	}
 }
+
+func TestMessages_Conversation(t *testing.T) {
+	msgs := Messages()
+	if len(msgs) < 3 {
+		t.Fatalf("want >= 3 demo messages, got %d", len(msgs))
+	}
+	now := time.Now()
+	hasIn, hasOut := false, false
+	for _, m := range msgs {
+		if m.OurCall != "NW5W-8" {
+			t.Errorf("OurCall = %q, want NW5W-8", m.OurCall)
+		}
+		if m.Text == "" {
+			t.Error("empty Text in message")
+		}
+		if len(m.Text) > 67 {
+			t.Errorf("Text too long (%d > 67): %q", len(m.Text), m.Text)
+		}
+		if m.ThreadKind != "dm" {
+			t.Errorf("ThreadKind = %q, want dm", m.ThreadKind)
+		}
+		if m.ThreadKey != m.PeerCall {
+			t.Errorf("ThreadKey %q != PeerCall %q", m.ThreadKey, m.PeerCall)
+		}
+		if now.Sub(m.CreatedAt) > 30*time.Minute {
+			t.Errorf("CreatedAt too old: %v", m.CreatedAt)
+		}
+		switch m.Direction {
+		case "in":
+			hasIn = true
+		case "out":
+			hasOut = true
+		default:
+			t.Errorf("unexpected Direction %q", m.Direction)
+		}
+	}
+	if !hasIn || !hasOut {
+		t.Errorf("conversation must contain both 'in' and 'out' messages; hasIn=%v hasOut=%v", hasIn, hasOut)
+	}
+}

--- a/pkg/webapi/catalog.go
+++ b/pkg/webapi/catalog.go
@@ -23,7 +23,7 @@ func (s *Server) registerCatalog(mux *http.ServeMux) {
 func (s *Server) getCatalog(w http.ResponseWriter, r *http.Request) {
 	// Demo mode: no offline-maps backend; return an empty catalog so the SPA shows no error toast.
 	if s.demo {
-		writeJSON(w, http.StatusOK, toCatalogDTO(mapscatalog.Catalog{}))
+		writeJSON(w, http.StatusOK, toCatalogDTO(mapscatalog.Catalog{SchemaVersion: 1}))
 		return
 	}
 	if s.catalog == nil {

--- a/pkg/webapi/catalog.go
+++ b/pkg/webapi/catalog.go
@@ -21,6 +21,11 @@ func (s *Server) registerCatalog(mux *http.ServeMux) {
 // @Security CookieAuth
 // @Router   /maps/catalog [get]
 func (s *Server) getCatalog(w http.ResponseWriter, r *http.Request) {
+	// Demo mode: no offline-maps backend; return an empty catalog so the SPA shows no error toast.
+	if s.demo {
+		writeJSON(w, http.StatusOK, toCatalogDTO(mapscatalog.Catalog{}))
+		return
+	}
 	if s.catalog == nil {
 		serviceUnavailable(w, "maps catalog not initialized")
 		return

--- a/pkg/webapi/catalog_test.go
+++ b/pkg/webapi/catalog_test.go
@@ -55,3 +55,34 @@ func TestGetCatalog_ServiceUnavailable(t *testing.T) {
 		t.Fatalf("status=%d", rec.Code)
 	}
 }
+
+func TestGetCatalog_Demo(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.demo = true
+
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/maps/catalog", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var out dto.Catalog
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.SchemaVersion != 1 {
+		t.Fatalf("expected SchemaVersion=1, got %d", out.SchemaVersion)
+	}
+	if len(out.Countries) != 0 {
+		t.Fatalf("expected empty countries, got %d", len(out.Countries))
+	}
+	if len(out.Provinces) != 0 {
+		t.Fatalf("expected empty provinces, got %d", len(out.Provinces))
+	}
+	if len(out.States) != 0 {
+		t.Fatalf("expected empty states, got %d", len(out.States))
+	}
+}

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -127,6 +127,8 @@ type Server struct {
 	// the handler falls back to pttdevice.Enumerate() natively. See
 	// pkg/webapi/ptt.go for the interface definition.
 	pttDeviceSource PttDeviceSource
+
+	demo bool // true when running in screenshot/demo mode; set from Config.Demo
 }
 
 // ActionsService is the narrow surface the webapi handlers consume
@@ -189,6 +191,9 @@ type Config struct {
 	// /api/maps/catalog handler and slug-validation paths return 503
 	// when nil. Tests inject a Cache pointed at an httptest upstream.
 	Catalog *mapscatalog.Cache
+	// Demo serves canned dashboard counters from /api/status. Set by the
+	// wiring layer from app.Config.Demo. Screenshots/demos only.
+	Demo bool
 }
 
 // NewServer constructs a Server. Store is required; Logger defaults to
@@ -222,6 +227,7 @@ func NewServer(cfg Config) (*Server, error) {
 		mapsAuth:        mapsClient,
 		mapsCache:       cfg.MapsCache,
 		catalog:         cfg.Catalog,
+		demo:            cfg.Demo,
 	}, nil
 }
 

--- a/pkg/webapi/status.go
+++ b/pkg/webapi/status.go
@@ -74,6 +74,7 @@ type StatusChannel struct {
 // @Router   /status [get]
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	if s.demo {
+		// Demo mode: serve canned counters without touching the store or runtime.
 		c := demoseed.StatusCounters()
 		writeJSON(w, http.StatusOK, StatusDTO{
 			UptimeSeconds: c.UptimeSeconds,

--- a/pkg/webapi/status.go
+++ b/pkg/webapi/status.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/chrissnell/graywolf/pkg/demoseed"
 	"github.com/chrissnell/graywolf/pkg/igate"
 	"github.com/chrissnell/graywolf/pkg/modembridge"
 )
@@ -72,6 +73,36 @@ type StatusChannel struct {
 // @Security CookieAuth
 // @Router   /status [get]
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if s.demo {
+		c := demoseed.StatusCounters()
+		writeJSON(w, http.StatusOK, StatusDTO{
+			UptimeSeconds: c.UptimeSeconds,
+			Channels: []StatusChannel{{
+				ID:             2,
+				Name:           "VHF APRS",
+				ModemType:      "afsk",
+				BitRate:        1200,
+				RxFrames:       c.RxFrames,
+				RxBadFCS:       c.RxBadFCS,
+				TxFrames:       c.TxFrames,
+				DcdState:       false,
+				AudioPeak:      c.AudioPeakDBFS,
+				InputDeviceID:  1,
+				DevicePeakDBFS: c.AudioPeakDBFS,
+				DeviceRmsDBFS:  c.AudioRmsDBFS,
+				DeviceClipping: false,
+			}},
+			Igate: &StatusIgateDTO{
+				Connected:  true,
+				Server:     "rotate.aprs2.net:14580",
+				Callsign:   "NW5W-8",
+				Gated:      c.IgateGated,
+				Downlinked: c.IgateDownlink,
+			},
+		})
+		return
+	}
+
 	out := StatusDTO{
 		UptimeSeconds: int64(time.Since(s.startedAt).Seconds()),
 	}

--- a/pkg/webapi/status_test.go
+++ b/pkg/webapi/status_test.go
@@ -138,4 +138,7 @@ func TestHandleStatus_Demo(t *testing.T) {
 	if len(dto.Channels) == 0 || dto.Channels[0].RxFrames == 0 {
 		t.Error("demo should report a channel with non-zero RxFrames")
 	}
+	if dto.Igate == nil {
+		t.Error("demo should report an igate section")
+	}
 }

--- a/pkg/webapi/status_test.go
+++ b/pkg/webapi/status_test.go
@@ -2,6 +2,8 @@ package webapi
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -115,5 +117,25 @@ func TestStatusDTO_WireShape_WithIgate_EmptyLastConnected(t *testing.T) {
 
 	if string(oldBytes) != string(newBytes) {
 		t.Fatalf("wire shape drift with zero LastConnected:\n old: %s\n new: %s", oldBytes, newBytes)
+	}
+}
+
+func TestHandleStatus_Demo(t *testing.T) {
+	srv := &Server{demo: true, startedAt: time.Now()}
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStatus(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var dto StatusDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if dto.UptimeSeconds == 0 {
+		t.Error("demo uptime should be non-zero")
+	}
+	if len(dto.Channels) == 0 || dto.Channels[0].RxFrames == 0 {
+		t.Error("demo should report a channel with non-zero RxFrames")
 	}
 }

--- a/scripts/screenshots/.gitignore
+++ b/scripts/screenshots/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/scripts/screenshots/package-lock.json
+++ b/scripts/screenshots/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "graywolf-android-screenshots",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "graywolf-android-screenshots",
+      "version": "0.0.0",
+      "devDependencies": {
+        "playwright": "^1.49.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/scripts/screenshots/package.json
+++ b/scripts/screenshots/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "graywolf-android-screenshots",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Playwright harness that drives the graywolf SPA in Android mode to capture Play Store screenshots.",
+  "type": "module",
+  "scripts": {
+    "shoot": "node shoot.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.49.0"
+  }
+}

--- a/scripts/screenshots/pull-seed.sh
+++ b/scripts/screenshots/pull-seed.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Pull a snapshot of the connected tablet's graywolf DBs to use as seed
+# data for screenshot generation. Requires a DEBUGGABLE build on the
+# tablet (run-as only works on debug builds) and adb connectivity.
+#
+# Force-stops the app for a consistent snapshot, copies the config +
+# history DBs, checkpoints their WAL into the main file, then relaunches.
+#
+# The pulled DBs land in scratch/screenshots-seed/ (gitignored -- they
+# contain the operator's real callsign, heard-station history, and
+# position data, which must not be committed).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PKG="com.nw5w.graywolf"
+SEED_DIR="scratch/screenshots-seed"
+mkdir -p "$SEED_DIR"
+
+if ! adb shell run-as "$PKG" true 2>/dev/null; then
+  echo "ERROR: run-as $PKG failed -- is a DEBUG build installed and adb connected?" >&2
+  exit 1
+fi
+
+echo "==> Force-stopping $PKG for a consistent snapshot"
+adb shell am force-stop "$PKG"
+sleep 2
+
+echo "==> Pulling DB files"
+for f in \
+  graywolf.db graywolf.db-shm graywolf.db-wal \
+  graywolf-history.db graywolf-history.db-shm graywolf-history.db-wal; do
+  if adb exec-out run-as "$PKG" cat "files/$f" >"$SEED_DIR/$f" 2>/dev/null; then
+    echo "    pulled $f ($(wc -c <"$SEED_DIR/$f") bytes)"
+  else
+    echo "    (skip $f -- not present)"
+    rm -f "$SEED_DIR/$f"
+  fi
+done
+
+echo "==> Checkpointing WAL into the main DB files"
+for db in "$SEED_DIR/graywolf.db" "$SEED_DIR/graywolf-history.db"; do
+  [[ -f "$db" ]] && sqlite3 "$db" "PRAGMA wal_checkpoint(TRUNCATE);" >/dev/null || true
+done
+
+echo "==> Relaunching the app"
+adb shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1 || true
+
+echo "==> Seed ready in $SEED_DIR/"

--- a/scripts/screenshots/run.sh
+++ b/scripts/screenshots/run.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Orchestrates Android Play Store screenshot capture:
+#   1. refresh web/dist so screenshots reflect the current UI
+#   2. build a local graywolf binary (SPA embedded; no Rust modem needed)
+#   3. stage a copy of the seed DBs (originals stay pristine)
+#   4. launch graywolf against the seed on a test port
+#   5. run the Playwright harness (shoot.mjs) in Android mode
+#   6. tear graywolf down
+#
+# Seed DBs come from a real tablet snapshot; refresh them with
+# scripts/screenshots/pull-seed.sh while the tablet is on adb.
+#
+# Run via `make android-screenshots` from the repo root.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PORT="${ANDROID_SS_PORT:-8088}"
+SEED_DIR="scratch/screenshots-seed"
+WORK_DIR="scratch/ss-work"
+BIN="scratch/gw-screenshots"
+OUT="${GW_SCREENSHOT_OUT:-$WORK_DIR/shots}"
+
+if [[ ! -f "$SEED_DIR/graywolf.db" ]]; then
+  echo "ERROR: no seed DB at $SEED_DIR/graywolf.db" >&2
+  echo "Run 'make android-screenshots-seed' with the tablet on adb first." >&2
+  exit 1
+fi
+
+echo "==> Building SPA bundle (vite)"
+( cd web && npx vite build >/dev/null )
+
+echo "==> Building graywolf binary"
+GOWORK=off go build -o "$BIN" ./cmd/graywolf
+
+echo "==> Staging seed DBs into $WORK_DIR"
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR/tiles"
+cp "$SEED_DIR/graywolf.db" "$WORK_DIR/graywolf.db"
+cp "$SEED_DIR/graywolf-history.db" "$WORK_DIR/graywolf-history.db"
+
+echo "==> Launching graywolf on 127.0.0.1:$PORT"
+GRAYWOLF_PLATFORM=desktop "$BIN" \
+  -config "$WORK_DIR/graywolf.db" \
+  -history-db "$WORK_DIR/graywolf-history.db" \
+  -tile-cache-dir "$WORK_DIR/tiles" \
+  -http "127.0.0.1:$PORT" \
+  -modem "" >"$WORK_DIR/gw.log" 2>&1 &
+GW_PID=$!
+# Always kill graywolf on exit, even if the harness fails.
+trap 'kill "$GW_PID" 2>/dev/null || true' EXIT
+
+echo "==> Waiting for HTTP listener"
+for i in $(seq 1 30); do
+  if curl -sf -o /dev/null "http://127.0.0.1:$PORT/api/auth/setup"; then
+    break
+  fi
+  if ! kill -0 "$GW_PID" 2>/dev/null; then
+    echo "ERROR: graywolf exited early; see $WORK_DIR/gw.log" >&2
+    tail -20 "$WORK_DIR/gw.log" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "==> Capturing screenshots"
+GW_SCREENSHOT_BASE="http://127.0.0.1:$PORT" \
+GW_SCREENSHOT_OUT="$OUT" \
+  node scripts/screenshots/shoot.mjs
+
+echo "==> Done. Screenshots in $OUT/"

--- a/scripts/screenshots/run.sh
+++ b/scripts/screenshots/run.sh
@@ -2,13 +2,9 @@
 # Orchestrates Android Play Store screenshot capture:
 #   1. refresh web/dist so screenshots reflect the current UI
 #   2. build a local graywolf binary (SPA embedded; no Rust modem needed)
-#   3. stage a copy of the seed DBs (originals stay pristine)
-#   4. launch graywolf against the seed on a test port
-#   5. run the Playwright harness (shoot.mjs) in Android mode
-#   6. tear graywolf down
-#
-# Seed DBs come from a real tablet snapshot; refresh them with
-# scripts/screenshots/pull-seed.sh while the tablet is on adb.
+#   3. launch graywolf in -demo mode (self-seeding; no tablet DB required)
+#   4. run the Playwright harness (shoot.mjs) in Android mode
+#   5. tear graywolf down
 #
 # Run via `make android-screenshots` from the repo root.
 set -euo pipefail
@@ -17,16 +13,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 PORT="${ANDROID_SS_PORT:-8088}"
-SEED_DIR="scratch/screenshots-seed"
 WORK_DIR="scratch/ss-work"
 BIN="scratch/gw-screenshots"
 OUT="${GW_SCREENSHOT_OUT:-$WORK_DIR/shots}"
-
-if [[ ! -f "$SEED_DIR/graywolf.db" ]]; then
-  echo "ERROR: no seed DB at $SEED_DIR/graywolf.db" >&2
-  echo "Run 'make android-screenshots-seed' with the tablet on adb first." >&2
-  exit 1
-fi
 
 echo "==> Building SPA bundle (vite)"
 ( cd web && npx vite build >/dev/null )
@@ -34,14 +23,12 @@ echo "==> Building SPA bundle (vite)"
 echo "==> Building graywolf binary"
 GOWORK=off go build -o "$BIN" ./cmd/graywolf
 
-echo "==> Staging seed DBs into $WORK_DIR"
+echo "==> Preparing work dir $WORK_DIR"
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR/tiles"
-cp "$SEED_DIR/graywolf.db" "$WORK_DIR/graywolf.db"
-cp "$SEED_DIR/graywolf-history.db" "$WORK_DIR/graywolf-history.db"
 
 echo "==> Launching graywolf on 127.0.0.1:$PORT"
-GRAYWOLF_PLATFORM=desktop "$BIN" \
+GRAYWOLF_PLATFORM=desktop "$BIN" -demo \
   -config "$WORK_DIR/graywolf.db" \
   -history-db "$WORK_DIR/graywolf-history.db" \
   -tile-cache-dir "$WORK_DIR/tiles" \

--- a/scripts/screenshots/shoot.mjs
+++ b/scripts/screenshots/shoot.mjs
@@ -40,8 +40,7 @@ const ROUTES = [
   { hash: '#/map', file: '02-livemap.png', wait: 'canvas, .maplibregl-canvas' },
   { hash: '#/messages', file: '03-messages.png', wait: '.nav-list' },
   { hash: '#/channels', file: '04-channels.png', wait: '.nav-list' },
-  { hash: '#/ptt', file: '05-ptt.png', wait: '.nav-list' },
-  { hash: '#/beacons', file: '06-beacons.png', wait: '.nav-list' },
+  { hash: '#/beacons', file: '05-beacons.png', wait: '.nav-list' },
 ];
 
 const BRIDGE_INIT = () => {
@@ -94,24 +93,18 @@ async function main() {
   }
   console.log(`auth OK (/api/status -> ${statusResp.status()})`);
 
-  // --- Step 2: inject the Android bridge for all future loads ------
+  // --- Step 2: pre-ack release notes via the API -------------------
+  // Pre-ack release notes so the "What's New" popup never appears and
+  // no "Saved" toast pollutes the screenshots. The endpoint acks every
+  // note up to the running version; no body required. Must happen before
+  // the bridge is injected and before any page navigations.
+  const ackResp = await page.request.post('/api/release-notes/ack');
+  console.log(`/release-notes/ack -> ${ackResp.status()}`);
+
+  // --- Step 3: inject the Android bridge for all future loads ------
   await context.addInitScript(BRIDGE_INIT);
 
-  // --- Step 2b: dismiss the "What's New" release-notes popup -------
-  // App.svelte mounts NewsPopup whenever the user has unseen release
-  // notes (tracked server-side). A fresh user has the current build's
-  // note unseen, so the popup covers every page. Clicking "Got it"
-  // acks it server-side, so it stays dismissed for the rest of the run.
-  await page.goto('/#/', { waitUntil: 'networkidle' });
-  await page.waitForTimeout(1000);
-  const gotIt = page.locator('button:has-text("Got it")');
-  if (await gotIt.count()) {
-    await gotIt.first().click();
-    await page.waitForTimeout(500);
-    console.log('dismissed What\'s New popup');
-  }
-
-  // --- Step 3: screenshot each Android-visible route ---------------
+  // --- Step 4: screenshot each Android-visible route ---------------
   for (const route of ROUTES) {
     await page.goto(`/${route.hash}`, { waitUntil: 'networkidle' });
     // The hash-router needs a tick to mount the route component.
@@ -121,8 +114,20 @@ async function main() {
     } catch {
       console.warn(`  (selector ${route.wait} not found for ${route.hash}; shooting anyway)`);
     }
-    // Map tiles + history markers stream in async; give them time.
-    await page.waitForTimeout(route.hash === '#/map' ? 4000 : 1200);
+    if (route.hash === '#/map') {
+      // Wait for at least one station marker to appear so the map has
+      // auto-fitted to the station cluster (first poll ~5-6s). Fall back
+      // gracefully -- warn and shoot rather than aborting the whole run.
+      try {
+        await page.waitForSelector('.gw-station-marker', { timeout: 15000 });
+        // Let the auto-fit fly-to animation settle before shooting.
+        await page.waitForTimeout(1500);
+      } catch {
+        console.warn('  (no station markers appeared on the map; shooting anyway)');
+      }
+    } else {
+      await page.waitForTimeout(1200);
+    }
     const path = `${OUT}/${route.file}`;
     await page.screenshot({ path });
     console.log(`shot ${route.hash} -> ${path}`);

--- a/scripts/screenshots/shoot.mjs
+++ b/scripts/screenshots/shoot.mjs
@@ -1,0 +1,138 @@
+// Drive the graywolf SPA in *Android mode* and capture Play Store
+// screenshots. The Makefile target `android-screenshots` launches a
+// local graywolf seeded with a snapshot of a real station's DBs, then
+// runs this script against it.
+//
+// Why the bridge injection: the SPA decides Android-vs-other-platforms
+// from globalThis.GraywolfWebInterface.getBearerToken() (the Android
+// WebView bridge). A plain browser has no bridge, so the SPA would
+// render the macOS/Linux/Windows UI -- showing surfaces hidden on
+// Android (Actions, AGW, Simulation). We inject a fake bridge via
+// addInitScript so Platform.kind === 'android' and the SPA renders the
+// real Android-filtered UI.
+//
+// Auth wrinkle: injecting the bridge also flips the SPA into bearer-
+// token auth (no /login). The local graywolf has no bearer middleware
+// (that's Android-only), so we instead authenticate with a normal
+// session cookie BEFORE injecting the bridge -- the cookie rides along
+// on every request and the ignored Authorization: Bearer header is
+// harmless. So the order is: create-user/login (no bridge) -> inject
+// bridge -> screenshot.
+
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import process from 'node:process';
+
+const BASE = process.env.GW_SCREENSHOT_BASE || 'http://127.0.0.1:8088';
+const OUT = process.env.GW_SCREENSHOT_OUT || 'scratch/ss-work/shots';
+// Tablet portrait-ish landscape. The test device reports 1280x800;
+// Play accepts tablet screenshots at this size.
+const WIDTH = 1280;
+const HEIGHT = 800;
+const USER = 'admin';
+const PASS = 'screenshot-admin-pw';
+
+// Android-visible routes worth showing on the Play listing, each with a
+// filename and a selector to wait for so we don't shoot a half-rendered
+// page. Keep this list curated -- Play wants 2-8 screenshots.
+const ROUTES = [
+  { hash: '#/', file: '01-dashboard.png', wait: '.nav-list' },
+  { hash: '#/map', file: '02-livemap.png', wait: 'canvas, .maplibregl-canvas' },
+  { hash: '#/messages', file: '03-messages.png', wait: '.nav-list' },
+  { hash: '#/channels', file: '04-channels.png', wait: '.nav-list' },
+  { hash: '#/ptt', file: '05-ptt.png', wait: '.nav-list' },
+  { hash: '#/beacons', file: '06-beacons.png', wait: '.nav-list' },
+];
+
+const BRIDGE_INIT = () => {
+  // Minimal stand-in for the Android WebView's GraywolfWebInterface.
+  // getBearerToken() must return a non-empty string for Platform.kind
+  // to resolve to 'android'. The value is otherwise unused here (the
+  // local server authenticates us by cookie).
+  globalThis.GraywolfWebInterface = {
+    getBearerToken: () => 'screenshot-bridge-token',
+    // listUsbDevices is consulted by the PTT page's device source; an
+    // empty array keeps it from throwing.
+    listUsbDevices: () => '[]',
+    requestUsbPermission: () => {},
+    requestBluetoothPermission: () => {},
+  };
+};
+
+async function main() {
+  await mkdir(OUT, { recursive: true });
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: WIDTH, height: HEIGHT },
+    deviceScaleFactor: 2,
+    baseURL: BASE,
+  });
+  const page = await context.newPage();
+
+  // --- Step 1: authenticate (no bridge yet) ------------------------
+  // Drive auth via the API rather than the two-stage UI form: POST
+  // /auth/setup creates the first user (the seed DB has none) but does
+  // NOT log in, then POST /auth/login sets the graywolf_session cookie.
+  // page.request shares the browser context's cookie jar, so the cookie
+  // is live for subsequent page.goto navigations. Setup is idempotent
+  // enough for our purposes -- if a user already exists it 403s, which
+  // we ignore and proceed straight to login.
+  const setupResp = await page.request.post('/api/auth/setup', {
+    data: { username: USER, password: PASS },
+  });
+  console.log(`/auth/setup -> ${setupResp.status()}`);
+  const loginResp = await page.request.post('/api/auth/login', {
+    data: { username: USER, password: PASS },
+  });
+  if (!loginResp.ok()) {
+    throw new Error(`login failed: ${loginResp.status()} ${await loginResp.text()}`);
+  }
+  const statusResp = await page.request.get('/api/status');
+  if (statusResp.status() === 401) {
+    throw new Error('still unauthenticated after setup/login; aborting');
+  }
+  console.log(`auth OK (/api/status -> ${statusResp.status()})`);
+
+  // --- Step 2: inject the Android bridge for all future loads ------
+  await context.addInitScript(BRIDGE_INIT);
+
+  // --- Step 2b: dismiss the "What's New" release-notes popup -------
+  // App.svelte mounts NewsPopup whenever the user has unseen release
+  // notes (tracked server-side). A fresh user has the current build's
+  // note unseen, so the popup covers every page. Clicking "Got it"
+  // acks it server-side, so it stays dismissed for the rest of the run.
+  await page.goto('/#/', { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1000);
+  const gotIt = page.locator('button:has-text("Got it")');
+  if (await gotIt.count()) {
+    await gotIt.first().click();
+    await page.waitForTimeout(500);
+    console.log('dismissed What\'s New popup');
+  }
+
+  // --- Step 3: screenshot each Android-visible route ---------------
+  for (const route of ROUTES) {
+    await page.goto(`/${route.hash}`, { waitUntil: 'networkidle' });
+    // The hash-router needs a tick to mount the route component.
+    await page.waitForTimeout(800);
+    try {
+      await page.waitForSelector(route.wait, { timeout: 8000 });
+    } catch {
+      console.warn(`  (selector ${route.wait} not found for ${route.hash}; shooting anyway)`);
+    }
+    // Map tiles + history markers stream in async; give them time.
+    await page.waitForTimeout(route.hash === '#/map' ? 4000 : 1200);
+    const path = `${OUT}/${route.file}`;
+    await page.screenshot({ path });
+    console.log(`shot ${route.hash} -> ${path}`);
+  }
+
+  await browser.close();
+  console.log(`\nDone. ${ROUTES.length} screenshots in ${OUT}/`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a `-demo` flag that makes a freshly-launched graywolf look like a busy Salt Lake-metro APRS station, and points the Play Store screenshot harness at it so screenshots no longer depend on a real tablet's database.

When `-demo` is set, graywolf seeds (all guarded, off by default, idempotent):
- 17 curated SLC-metro stations into the station cache + a derived recent-packets log
- Canned `/api/status` dashboard counters (~2d uptime, 4253 RX, etc.)
- Station callsign NW5W-8, a "VHF APRS" channel, a fixed-position beacon at the QTH, and a short DM conversation with KK7GBE-7
- A pair of virtual audio devices bound to the channel so the station reads as operational

New `pkg/demoseed` package holds the canned data (pure data, no I/O); the wiring layer performs the seeding. Nothing touches real hardware -- pair with `-modem ""`.

## Harness changes (`scripts/screenshots/`)
- Launches graywolf with `-demo` against fresh DBs instead of staging a tablet snapshot (the seed dependency is gone; `pull-seed.sh` is retained for refreshing the curated set later)
- Dropped the PTT screenshot (now 5 shots: dashboard, live map, messages, channels, beacons)
- Pre-acks release notes via the API so the "What's New" popup -- and its stray "Saved" toast -- never appear
- Waits for station markers before capturing the map (the Android-mode planet-view bbox excluded SLC; seeding a fixed position recenters the map onto the cluster)

## Notable detail
The demo channel is bound to virtual audio devices so the dashboard health pills and beacon reachability read green. Because no real soundcard named `demo-default` exists, the demo's *logs* contain harmless `modem: input device not found` retries -- invisible in any screenshot.

## Test Plan
- [ ] `go test ./pkg/demoseed/ ./pkg/app/ ./pkg/webapi/` passes (incl. new `-demo` flag, demoseed, canned status, and demo-catalog tests)
- [ ] `make android-screenshots` builds, launches with `-demo`, and captures 5 clean PNGs
- [ ] Dashboard shows non-zero counters + RX/TX Ready; map shows the SLC cluster; messages shows the DM thread; beacons shows the NW5W-8 beacon with no error badge
