### PR TITLE
tooling(screenshots): phone screenshots + Play store graphics

### DIFF
--- a/scripts/screenshots/assets.mjs
+++ b/scripts/screenshots/assets.mjs
@@ -62,7 +62,7 @@ const featureHtml = `<!doctype html><html><head><meta charset="utf8">
     <div class="copy">
       <div class="wordmark">Graywolf&nbsp;APRS</div>
       <div class="rule"></div>
-      <div class="tagline">A modern APRS station for your radio. VARA, packet, APRS, and voice.</div>
+      <div class="tagline">A modern APRS stack for your smartphone and tablet</div>
     </div>
   </div>
 </body></html>`;

--- a/scripts/screenshots/assets.mjs
+++ b/scripts/screenshots/assets.mjs
@@ -1,0 +1,79 @@
+// Generate Play Store store-listing graphics from the graywolf brand
+// assets: the 512x512 app icon and the 1024x500 feature graphic. Renders
+// the wolf SVG in chromium (crisp vector output) and screenshots at the
+// exact required dimensions. Output to scratch/ss-work/assets/.
+//
+// Run: node scripts/screenshots/assets.mjs   (from repo root)
+
+import { chromium } from 'playwright';
+import { readFileSync, mkdirSync } from 'node:fs';
+import process from 'node:process';
+
+const OUT = process.env.GW_ASSET_OUT || 'scratch/ss-work/assets';
+mkdirSync(OUT, { recursive: true });
+
+// Inline the wolf SVG so there are no file:// load races. Strip the XML
+// prolog so it embeds cleanly inside HTML.
+const wolfSvg = readFileSync('web/src/assets/graywolf.svg', 'utf8')
+  .replace(/<\?xml[^>]*\?>/, '')
+  .trim();
+
+const AMBER = '#ffaa00';
+const INK = '#111111';
+const MUTED = '#666666';
+
+async function shoot(page, html, w, h, file) {
+  await page.setViewportSize({ width: w, height: h });
+  await page.setContent(html, { waitUntil: 'networkidle' });
+  await page.screenshot({ path: `${OUT}/${file}`, clip: { x: 0, y: 0, width: w, height: h } });
+  console.log(`wrote ${OUT}/${file} (${w}x${h})`);
+}
+
+// 512x512 app icon: wolf centered on white, sized to ~62% of the square
+// so Play's corner mask never clips it.
+const iconHtml = `<!doctype html><html><head><meta charset="utf8">
+<style>
+  html,body{margin:0;padding:0}
+  .canvas{width:512px;height:512px;background:#ffffff;display:flex;
+    align-items:center;justify-content:center}
+  .logo{height:340px;width:auto;display:block}
+  .logo svg{height:340px;width:auto}
+</style></head><body>
+  <div class="canvas"><div class="logo">${wolfSvg}</div></div>
+</body></html>`;
+
+// 1024x500 feature graphic: white field, wolf on the left, wordmark +
+// tagline on the right, amber rule under the wordmark to echo the app's
+// primary accent.
+const featureHtml = `<!doctype html><html><head><meta charset="utf8">
+<style>
+  html,body{margin:0;padding:0}
+  .fg{width:1024px;height:500px;background:#ffffff;display:flex;
+    align-items:center;gap:64px;padding:0 80px;box-sizing:border-box;
+    font-family:"JetBrains Mono","SFMono-Regular",Menlo,Consolas,monospace}
+  .fg .logo svg{height:300px;width:auto;display:block}
+  .copy{display:flex;flex-direction:column;gap:14px}
+  .wordmark{font-size:84px;font-weight:700;color:${INK};letter-spacing:-2px;line-height:1}
+  .rule{width:120px;height:8px;background:${AMBER};border-radius:4px}
+  .tagline{font-size:30px;color:${MUTED};line-height:1.3;max-width:520px}
+</style></head><body>
+  <div class="fg">
+    <div class="logo">${wolfSvg}</div>
+    <div class="copy">
+      <div class="wordmark">Graywolf&nbsp;APRS</div>
+      <div class="rule"></div>
+      <div class="tagline">A modern APRS station for your radio. VARA, packet, APRS, and voice.</div>
+    </div>
+  </div>
+</body></html>`;
+
+async function main() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ deviceScaleFactor: 1 });
+  await shoot(page, iconHtml, 512, 512, 'icon-512.png');
+  await shoot(page, featureHtml, 1024, 500, 'feature-1024x500.png');
+  await browser.close();
+  console.log('\nDone. Play store graphics in', OUT);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/screenshots/run.sh
+++ b/scripts/screenshots/run.sh
@@ -51,9 +51,22 @@ for i in $(seq 1 30); do
   sleep 1
 done
 
-echo "==> Capturing screenshots"
+echo "==> Capturing tablet screenshots"
 GW_SCREENSHOT_BASE="http://127.0.0.1:$PORT" \
 GW_SCREENSHOT_OUT="$OUT" \
   node scripts/screenshots/shoot.mjs
 
-echo "==> Done. Screenshots in $OUT/"
+echo "==> Capturing phone screenshots"
+GW_SCREENSHOT_BASE="http://127.0.0.1:$PORT" \
+GW_SCREENSHOT_MODE=phone \
+GW_SCREENSHOT_OUT="${OUT}-phone" \
+  node scripts/screenshots/shoot.mjs
+
+echo "==> Generating store graphics (icon + feature)"
+GW_ASSET_OUT="$(dirname "$OUT")/assets" \
+  node scripts/screenshots/assets.mjs
+
+echo "==> Done."
+echo "    tablet screenshots: $OUT/"
+echo "    phone screenshots:  ${OUT}-phone/"
+echo "    store graphics:     $(dirname "$OUT")/assets/"

--- a/scripts/screenshots/shoot.mjs
+++ b/scripts/screenshots/shoot.mjs
@@ -24,11 +24,19 @@ import { mkdir } from 'node:fs/promises';
 import process from 'node:process';
 
 const BASE = process.env.GW_SCREENSHOT_BASE || 'http://127.0.0.1:8088';
-const OUT = process.env.GW_SCREENSHOT_OUT || 'scratch/ss-work/shots';
-// Tablet portrait-ish landscape. The test device reports 1280x800;
-// Play accepts tablet screenshots at this size.
-const WIDTH = 1280;
-const HEIGHT = 800;
+// GW_SCREENSHOT_MODE=phone shoots a narrow portrait viewport so the SPA
+// renders its mobile layout (sidebar collapses to the top bar); anything
+// else shoots the 1280x800 tablet layout. Play wants both phone and
+// 7"/10" tablet screenshots, so the harness runs once per mode.
+const PHONE = process.env.GW_SCREENSHOT_MODE === 'phone';
+const OUT = process.env.GW_SCREENSHOT_OUT ||
+  (PHONE ? 'scratch/ss-work/shots-phone' : 'scratch/ss-work/shots');
+// Phone: a Pixel-5-class profile -- 393x851 CSS px (narrow enough to
+// trigger the mobile layout) at dsf 2.75 renders 1080x2340 PNGs, within
+// Play's phone limits. Tablet: 1280x800 (the test device's resolution).
+const WIDTH = PHONE ? 393 : 1280;
+const HEIGHT = PHONE ? 851 : 800;
+const DSF = PHONE ? 2.75 : 2;
 const USER = 'admin';
 const PASS = 'screenshot-admin-pw';
 
@@ -64,7 +72,9 @@ async function main() {
   const browser = await chromium.launch();
   const context = await browser.newContext({
     viewport: { width: WIDTH, height: HEIGHT },
-    deviceScaleFactor: 2,
+    deviceScaleFactor: DSF,
+    isMobile: PHONE,
+    hasTouch: PHONE,
     baseURL: BASE,
   });
   const page = await context.newPage();


### PR DESCRIPTION
Extends the screenshot harness to produce the remaining Play listing
assets, all in one `make android-screenshots` run.

## What's new

- **Phone screenshots** — `shoot.mjs` `GW_SCREENSHOT_MODE=phone` uses a
  Pixel-5-class 393x851 / dsf 2.75 portrait viewport (`isMobile`) so the
  SPA renders its mobile top-bar layout. Output to `shots-phone/`.
- **App icon (512x512)** + **feature graphic (1024x500)** — new
  `assets.mjs` renders the wolf SVG in chromium on the brand white field
  with the monospace wordmark + amber accent rule.
- `run.sh` now runs three passes: tablet, phone, store graphics.

## Output (all under `scratch/ss-work/`, gitignored)

```
shots/         tablet screenshots (1280x800)
shots-phone/   phone screenshots (1080x2340)
assets/        icon-512.png, feature-1024x500.png
```

## Verified

- Phone dashboard renders the mobile layout with demo counters
  (4253 RX / 188 TX / 3914 iGated / 51h41m uptime) + scrolling SLC
  packet log.
- Phone map zooms to the Salt Lake metro with the demo stations.
- Icon + feature graphic are exact dimensions, crisp.

## Test plan

- [x] `make android-screenshots` produces tablet + phone + graphics
- [ ] Reviewer eyeballs a phone shot + the feature graphic