### PR TITLE
fix(web): disable Android WebView text autosizing

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -39,6 +39,12 @@ html, body, #app {
   font-family: var(--font-mono);
   font-size: 14px;
   line-height: 1.5;
+  /* Disable Android WebView text autosizing ("font boosting"), which
+     inflates text in blocks it deems wider than the viewport. On phones
+     it blew the AX.25 terminal heading up to wrap one word per line.
+     Pin to 100% so all text renders at the CSS-declared size. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 a {


### PR DESCRIPTION
## Bug

Internal tester on a phone: the AX.25 terminal page heading renders
enormous and wraps one word per line ("NEW" / "AX.25" / "SESSION"
stacked), body text also inflated. `.page-header h2` is only 18px in
CSS, so something was scaling it ~2.5x.

## Cause

Android WebView "font boosting" (text autosizing) inflates text in
blocks it considers wider than the viewport. Chromium doesn't do this,
which is why the Playwright screenshot harness never reproduced it --
only real-device WebView.

## Fix

Pin `-webkit-text-size-adjust` / `text-size-adjust` to `100%` on the
root rule so the WebView renders all text at the CSS-declared size.
Global, additive, and safe (only stops the WebView from overriding our
sizes; no effect on Chromium/macOS/Linux/Windows).

## Verification

Builds clean. **On-device verification pending** -- this can't be
reproduced in Chromium/Playwright (no font boosting there), so it needs
a narrow real-WebView device after the next release. Standard,
well-documented fix for this exact symptom.