### PR TITLE
ci(android): auto-upload AAB to Play Internal (Phase 5)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -278,6 +278,22 @@ jobs:
           echo "::error::Release ${GITHUB_REF_NAME} never appeared; check goreleaser job."
           exit 1
 
+      # Auto-upload the signed AAB to Play Internal Testing. Gated on the
+      # service-account secret so it safely skips (not fails) until the
+      # Google Cloud service account is created and stored as
+      # GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON. Lands in the Internal track
+      # only; humans promote to the closed beta track separately, so a
+      # CI tag never reaches external testers automatically.
+      - name: Upload AAB to Play Internal Testing
+        if: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        uses: r0adkll/upload-google-play@v1.1.3
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.nw5w.graywolf
+          releaseFiles: staging/graywolf-*.aab
+          track: internal
+          status: completed
+
       - name: Upload signed AAB as workflow artifact (manual fallback)
         uses: actions/upload-artifact@v5
         with:


### PR DESCRIPTION
Phase 5: a v* tag push now auto-uploads the signed AAB to the Play
Internal Testing track. After this, \`make bump-point\` is the only
manual step a release needs.

## How it works
- Adds `r0adkll/upload-google-play@v1.1.3` to the `release-sign` job,
  after the GH Release upload.
- `track: internal` only. Promotion to the closed beta track stays a
  deliberate human action, so a CI tag never auto-ships to external
  testers.
- **Gated** on `secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON != ''` — the
  step skips (not fails) until the service account is created and stored,
  so merging this can't break the release pipeline.

## Prerequisite before it does anything
1. Create a Google Cloud service account with the Play Developer API
   enabled, grant it "Manage testing track releases" on
   com.nw5w.graywolf in Play Console (Plan Phase 2 Task 2.5).
2. `gh secret set GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON < service-account.json`
3. The next `v*` tag auto-uploads to Internal.

## Test plan
- [x] CI parses the workflow (the step skips cleanly without the secret)
- [ ] After the secret is added, a tag lands the AAB in Play Internal