### PR TITLE
ci(android): promote-to-closed beta workflow (Phase 6)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,11 +15,15 @@ on:
   pull_request:
     branches:
       - main
-  # Manual trigger so this workflow can be exercised from a branch PR
-  # (e.g. while it's stacked on another feature branch and the PR's
-  # base isn't main yet). Also useful for re-running on transient
-  # network failures.
+  # Manual trigger. Two uses: (a) re-run the build on transient network
+  # failures, and (b) promote an already-released version to the closed
+  # beta track via the promote-to-closed job (provide `version`).
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Released version to promote to the closed beta track (X.Y.Z, no v). Leave blank for a plain build re-run.'
+        required: false
+        type: string
 
 permissions:
   # write required so the release-sign job can attach the signed AAB
@@ -30,6 +34,9 @@ jobs:
   build:
     name: Build (debug APK)
     runs-on: ubuntu-latest
+    # Skip on workflow_dispatch promote runs -- those only need the
+    # promote-to-closed job, not a fresh APK build.
+    if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -300,3 +307,47 @@ jobs:
           name: graywolf-release-aab
           path: staging/graywolf-*.aab
           retention-days: 30
+
+  # ------------------------------------------------------------------
+  # promote-to-closed — manual (workflow_dispatch) promotion of an
+  # already-released version from Internal to the closed beta track
+  # (graywolf-beta). Keeping this a deliberate human action means a CI
+  # tag never auto-ships to the 15 external beta testers; you choose
+  # which build they get. Run from the Actions tab (or:
+  #   gh workflow run android.yml --field version=X.Y.Z).
+  # ------------------------------------------------------------------
+  promote-to-closed:
+    name: Promote to closed beta (graywolf-beta)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+    steps:
+      - name: Validate version input
+        run: |
+          set -euo pipefail
+          v="${{ github.event.inputs.version }}"
+          if ! printf '%s' "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::version must be X.Y.Z (no leading v); got '$v'"
+            exit 1
+          fi
+
+      - name: Download AAB from the GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p staging
+          gh release download "v${{ github.event.inputs.version }}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'graywolf-*.aab' \
+            --dir staging
+          ls -la staging/
+
+      - name: Promote AAB to the closed beta track
+        if: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        uses: r0adkll/upload-google-play@v1.1.3
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.nw5w.graywolf
+          releaseFiles: staging/graywolf-*.aab
+          track: graywolf-beta
+          status: completed

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -162,6 +162,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
+    # The `secrets` context is not allowed in step-level `if:`, so resolve
+    # "is the Play service account configured?" once into a job-level env
+    # var (env IS allowed in if). Gates the Play-upload step below.
+    env:
+      HAVE_PLAY_SA: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -292,7 +297,7 @@ jobs:
       # only; humans promote to the closed beta track separately, so a
       # CI tag never reaches external testers automatically.
       - name: Upload AAB to Play Internal Testing
-        if: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        if: env.HAVE_PLAY_SA == 'true'
         uses: r0adkll/upload-google-play@v1.1.3
         with:
           serviceAccountJsonPlainText: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -320,6 +325,8 @@ jobs:
     name: Promote to closed beta (graywolf-beta)
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+    env:
+      HAVE_PLAY_SA: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON != '' }}
     steps:
       - name: Validate version input
         run: |
@@ -343,7 +350,7 @@ jobs:
           ls -la staging/
 
       - name: Promote AAB to the closed beta track
-        if: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        if: env.HAVE_PLAY_SA == 'true'
         uses: r0adkll/upload-google-play@v1.1.3
         with:
           serviceAccountJsonPlainText: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
Phase 6: a manual `workflow_dispatch` promotes an already-released AAB
from the Internal track to the closed beta track (`graywolf-beta`).

## Usage
```
gh workflow run android.yml --field version=0.13.8
```
(or the Actions tab "Run workflow" button)

## Design
- Tags auto-upload to **Internal** (Phase 5). Promotion to the closed
  beta is a **deliberate human action** so a CI tag never auto-ships to
  the 15 external testers -- you choose which build graduates.
- `build` job now skips on `workflow_dispatch` (a promote run doesn't
  need a fresh APK).
- Validates the version is `X.Y.Z`, downloads that Release's AAB,
  uploads to `graywolf-beta` with the same gated service-account secret.

## Prerequisites before first use
1. Create the **graywolf-beta** closed track in Play Console + add the
   15 testers (Plan Phase 6 Task 6.1, done by hand).
2. Service-account secret set + propagated (Phase 5 / `make android-play-check`).

## Test plan
- [x] Workflow still parses (PR build job runs)
- [ ] After the closed track exists + secret is live: `gh workflow run`
      lands the chosen version in graywolf-beta