### PR TITLE
test(logbuffer): de-flake concurrent-chains component assertion

### DIFF
--- a/pkg/logbuffer/integration_test.go
+++ b/pkg/logbuffer/integration_test.go
@@ -102,9 +102,10 @@ func TestConcurrentChainsShareThrottleAndStayBounded(t *testing.T) {
 	wg.Wait()
 
 	// Bound check: same shape as TestEndToEndBurstStaysBounded but
-	// across N concurrent producers. If the throttle counter were
-	// per-chain, MaintenanceEvery would only fire on whichever chain
-	// hit the threshold first and the count would blow past the bound.
+	// across N concurrent producers. This is the real proof that the
+	// throttle counter is shared: if it were per-chain, MaintenanceEvery
+	// would only fire on whichever chain hit the threshold first and the
+	// count would blow past the bound.
 	var count int64
 	if err := db.gorm.Raw("SELECT COUNT(*) FROM logs").Scan(&count).Error; err != nil {
 		t.Fatalf("count: %v", err)
@@ -116,8 +117,18 @@ func TestConcurrentChainsShareThrottleAndStayBounded(t *testing.T) {
 		t.Fatalf("ring under-populated: count=%d, want >=40 (concurrent writes lost?)", count)
 	}
 
-	// Both components must be represented in the survivors — proves
-	// neither chain was starved by the other.
+	// Both chains must route to their own component column. The survivor
+	// set from the concurrent burst above can't prove this: evict() keeps
+	// the globally-newest RingSize rows by id, so whichever chain's
+	// goroutines happened to commit last owns the entire tail — a legal
+	// scheduling outcome, not starvation. Write a short interleaved tail
+	// (shorter than RingSize) so both components are deterministically
+	// present in the survivor window, then assert routing.
+	const tail = 20
+	for i := 0; i < tail; i++ {
+		chainA.Info("tail", "i", i)
+		chainB.Info("tail", "i", i)
+	}
 	var componentsSeen int64
 	if err := db.gorm.Raw("SELECT COUNT(DISTINCT component) FROM logs").Scan(&componentsSeen).Error; err != nil {
 		t.Fatalf("distinct components: %v", err)


### PR DESCRIPTION
`TestConcurrentChainsShareThrottleAndStayBounded` flaked on slow CI
runners (`distinct components = 1, want 2`) -- it blocked an unrelated
PR earlier this session.

## Cause
After a 2000-write concurrent burst through a size-50 eviction ring, the
test asserted both `ptt` and `kiss` components survive. But `evict()`
keeps the globally-newest `RingSize` rows by id, so whichever chain's
goroutines committed last can legally own the entire tail. That's a
scheduling outcome, not starvation -- the assertion was unsound.

## Fix
The burst's `count <= 60` bound check is the real shared-throttle proof
and stays. For the routing assertion, write a short deterministic
interleaved tail (20x chainA+chainB, < RingSize) after the burst so both
components are guaranteed in the survivor window, then assert. Passes
6/6 locally.