### PR TITLE
ci(android): checkout repo in promote job (fastlane needs Gemfile)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -337,6 +337,13 @@ jobs:
     env:
       HAVE_PLAY_SA: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON != '' }}
     steps:
+      # Needed so the Gemfile + fastlane/ are present: setup-ruby's
+      # bundler-cache and `bundle exec fastlane` both require the repo
+      # checked out (the old r0adkll promote didn't, which is why this
+      # was missing).
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Validate version input
         run: |
           set -euo pipefail


### PR DESCRIPTION
The fastlane promote failed with 'Could not locate Gemfile' -- the promote-to-closed job had no Checkout step. The old r0adkll promote didn't need the repo; the fastlane version needs the Gemfile + fastlane/Fastfile. Adds actions/checkout before the Ruby setup.

## Test plan
- [ ] After merge: `gh workflow run android.yml --field version=0.13.8 --field track=alpha` promotes successfully