### PR TITLE
Fix adding mycall to digipeater path

### DIFF
--- a/pkg/digipeater/digipeater.go
+++ b/pkg/digipeater/digipeater.go
@@ -488,17 +488,16 @@ func applyMatch(clone *ax25.Frame, slot int, r Rule, mycall ax25.Address) (strin
 			entry.Repeated = true
 		}
 		clone.Path[slot] = entry
-		if r.AliasType == "trace" {
-			// Insert mycall just before the alias slot so the packet
-			// carries an audit trail. Only if there's room.
-			if len(clone.Path) < ax25.MaxRepeaters && mycall.Call != "" {
-				inserted := ax25.Address{Call: mycall.Call, SSID: mycall.SSID, Repeated: true}
-				newPath := make([]ax25.Address, 0, len(clone.Path)+1)
-				newPath = append(newPath, clone.Path[:slot]...)
-				newPath = append(newPath, inserted)
-				newPath = append(newPath, clone.Path[slot:]...)
-				clone.Path = newPath
-			}
+		// Insert mycall just before the alias slot so downstream
+		// listeners can trace the actual digi chain (APRS New-N
+		// paradigm). Only if there's room.
+		if len(clone.Path) < ax25.MaxRepeaters && mycall.Call != "" {
+			inserted := ax25.Address{Call: mycall.Call, SSID: mycall.SSID, Repeated: true}
+			newPath := make([]ax25.Address, 0, len(clone.Path)+1)
+			newPath = append(newPath, clone.Path[:slot]...)
+			newPath = append(newPath, inserted)
+			newPath = append(newPath, clone.Path[slot:]...)
+			clone.Path = newPath
 		}
 		return r.AliasType + " " + entry.String(), true
 	}

--- a/pkg/digipeater/digipeater_test.go
+++ b/pkg/digipeater/digipeater_test.go
@@ -69,7 +69,8 @@ func TestWIDEnNDecrementing(t *testing.T) {
 	}}
 	d, sink := newTestDigi(t, rules, "N0CAL-1")
 
-	// WIDE2-2 → should become WIDE2-1 (SSID decremented, not yet consumed).
+	// WIDE2-2 → mycall* should be inserted and WIDE2 decremented to
+	// WIDE2-1 (not yet consumed). Per APRS New-N paradigm.
 	rx := buildFrame(t, "KK6ABC", "APRS", []string{"WIDE2-2"}, "test")
 	if !d.Handle(context.Background(), 1, rx, ingress.Modem()) {
 		t.Fatalf("expected digi to repeat WIDE2-2")
@@ -78,10 +79,13 @@ func TestWIDEnNDecrementing(t *testing.T) {
 	if cap == nil {
 		t.Fatalf("no tx captured")
 	}
-	if len(cap.Frame.Path) != 1 {
-		t.Fatalf("path len %d", len(cap.Frame.Path))
+	if len(cap.Frame.Path) != 2 {
+		t.Fatalf("expected inserted mycall: %v", cap.Frame.Path)
 	}
-	slot := cap.Frame.Path[0]
+	if cap.Frame.Path[0].Call != "N0CAL" || cap.Frame.Path[0].SSID != 1 || !cap.Frame.Path[0].Repeated {
+		t.Fatalf("mycall not inserted first+repeated: %+v", cap.Frame.Path[0])
+	}
+	slot := cap.Frame.Path[1]
 	if slot.Call != "WIDE2" || slot.SSID != 1 || slot.Repeated {
 		t.Fatalf("expected WIDE2-1 unconsumed, got %s repeated=%v", slot.String(), slot.Repeated)
 	}
@@ -102,7 +106,14 @@ func TestWIDE1_1Consumed(t *testing.T) {
 	if !d.Handle(context.Background(), 1, rx, ingress.Modem()) {
 		t.Fatalf("expected repeat")
 	}
-	slot := sink.Last().Frame.Path[0]
+	cap := sink.Last()
+	if len(cap.Frame.Path) != 2 {
+		t.Fatalf("expected inserted mycall: %v", cap.Frame.Path)
+	}
+	if cap.Frame.Path[0].Call != "N0CAL" || !cap.Frame.Path[0].Repeated {
+		t.Fatalf("mycall not inserted first+repeated: %+v", cap.Frame.Path[0])
+	}
+	slot := cap.Frame.Path[1]
 	if !slot.Repeated || slot.SSID != 0 {
 		t.Fatalf("WIDE1-1 should be consumed (H=1, SSID=0): %+v", slot)
 	}


### PR DESCRIPTION
## Summary

Digipeated frames were missing the station callsign in the AX.25 path. WIDEn-N matches decremented the SSID and marked the slot used, but never inserted `mycall*` ahead of the alias -- so downstream listeners had no way to see which digi handled the frame. Only the `trace` alias type inserted mycall; `widen` did not. iGated frames were unaffected (third-party header path is built separately in `pkg/igate`).

## Fix

In `pkg/digipeater/digipeater.go` `applyMatch`, lift the mycall-insertion block out of the `if r.AliasType == "trace"` guard so it runs for `widen` too. The two alias types now produce identical path mutations, matching the APRS New-N paradigm and what direwolf does by default.

`WIDE2-2` heard at `KK6ABC` via `MYCALL-1` previously became:
`KK6ABC>APRS,WIDE2-1:...`
After this change:
`KK6ABC>APRS,MYCALL-1*,WIDE2-1:...`

## Disclosure:

This code was written entirely by Claude AI. I did not test it nor do I know what this code is actually doing. Feel free to update or reject all together if its wrong!