### PR TITLE
Android: guaranteed clean shutdown on swipe and hard-kill

### DIFF
--- a/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
@@ -329,6 +329,19 @@ class GraywolfService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? = null
 
+    // Swiping the app from recents removes the Activity but, with
+    // android:stopWithTask unset (default false), the foreground service
+    // keeps running and so would the forked Go backend. Stop ourselves so
+    // onDestroy's full teardown runs (supervisor, Go child SIGTERM, modem,
+    // audio, USB PTT, platform server). A fresh launch then rebuilds the
+    // service -- re-enumerating USB and rebooting the modem -- which is
+    // also exactly what hot-swap recovery needs.
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        Log.i(TAG, "onTaskRemoved: task swiped away, stopping service")
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
+    }
+
     override fun onDestroy() {
         supervisor.stop()
         goListenerReady = false

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
@@ -338,6 +338,11 @@ class GraywolfService : Service() {
     // also exactly what hot-swap recovery needs.
     override fun onTaskRemoved(rootIntent: Intent?) {
         Log.i(TAG, "onTaskRemoved: task swiped away, stopping service")
+        // Mark this as a deliberate stop so the USB_DEVICE_ATTACHED relaunch
+        // caused by our own teardown releasing the radio (the interfaces
+        // re-enumerate ~2s later) is suppressed in MainActivity rather than
+        // silently reviving the station the operator just dismissed.
+        MainActivity.markUserStopped(this)
         stopSelf()
         super.onTaskRemoved(rootIntent)
     }

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
@@ -6,6 +6,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.hardware.usb.UsbManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -34,6 +35,18 @@ class MainActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // If the system auto-relaunched us via USB_DEVICE_ATTACHED right after a
+        // deliberate swipe-stop, that "attach" is the radio's USB interfaces
+        // (CP2102N/C-Media) re-enumerating when our process released them during
+        // teardown -- not a genuine plug-in. Honor the user's intent to stop:
+        // finish without starting the service/backend. A launcher tap (action
+        // MAIN) or a genuine re-plug after the window is NOT suppressed.
+        if (intent?.action == UsbManager.ACTION_USB_DEVICE_ATTACHED &&
+            wasRecentlyStoppedByUser(this)) {
+            Log.i(TAG, "ignoring USB-attach relaunch within stop window; staying stopped")
+            finish()
+            return
+        }
         webView = WebView(this).also {
             it.settings.javaScriptEnabled = true
             it.settings.domStorageEnabled = true
@@ -162,6 +175,9 @@ class MainActivity : Activity() {
     }
 
     private fun startEverything() {
+        // We're committing to running, so clear any prior deliberate-stop marker;
+        // future USB attaches should launch normally.
+        clearUserStopped(this)
         startForegroundService(Intent(this, GraywolfService::class.java))
         val started = System.currentTimeMillis()
         val r = object : Runnable {
@@ -222,7 +238,9 @@ class MainActivity : Activity() {
     }
 
     override fun onDestroy() {
-        webView.destroy()
+        // The USB-attach suppression path finish()es in onCreate before webView
+        // is built, which skips straight here -- guard the lateinit.
+        if (::webView.isInitialized) webView.destroy()
         super.onDestroy()
     }
 
@@ -235,6 +253,14 @@ class MainActivity : Activity() {
         private const val REQ_BT_PERMS = 0x102
         private const val PREFS_NAME = "graywolf-prefs"
         private const val PREF_BATTERY_OPT_REQUESTED = "battery_opt_whitelist_requested_v1"
+        private const val PREF_USER_STOPPED_AT = "user_stopped_at_ms_v1"
+
+        // Window after a deliberate swipe-stop during which a USB_DEVICE_ATTACHED
+        // relaunch is treated as our own teardown re-enumeration (the radio's USB
+        // interfaces detach + re-attach ~2s after the process dies) rather than a
+        // genuine plug-in. Generous enough to cover slow hubs without swallowing a
+        // real re-plug seconds later.
+        private const val STOP_RELAUNCH_SUPPRESS_WINDOW_MS = 15_000L
 
         fun batteryOptWhitelistRequested(ctx: Context): Boolean =
             ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -243,6 +269,24 @@ class MainActivity : Activity() {
         fun markBatteryOptWhitelistRequested(ctx: Context) {
             ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                 .edit().putBoolean(PREF_BATTERY_OPT_REQUESTED, true).apply()
+        }
+
+        // Record the moment the operator deliberately stopped the station (swipe
+        // from recents). Called by GraywolfService.onTaskRemoved before stopSelf.
+        fun markUserStopped(ctx: Context) {
+            ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit().putLong(PREF_USER_STOPPED_AT, System.currentTimeMillis()).apply()
+        }
+
+        fun wasRecentlyStoppedByUser(ctx: Context): Boolean {
+            val at = ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getLong(PREF_USER_STOPPED_AT, 0L)
+            return at != 0L && System.currentTimeMillis() - at < STOP_RELAUNCH_SUPPRESS_WINDOW_MS
+        }
+
+        fun clearUserStopped(ctx: Context) {
+            ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit().remove(PREF_USER_STOPPED_AT).apply()
         }
     }
 }

--- a/cmd/graywolf/main_android.go
+++ b/cmd/graywolf/main_android.go
@@ -60,6 +60,22 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Orphan safety net: if the Android app process dies without the
+	// Service running onDestroy (Force Stop, OOM, OEM killer), nothing
+	// else SIGTERMs us and this Go server would keep iGating to the
+	// internet. watchParentDeath cancels ctx the moment the parent dies
+	// so a.Run unwinds gracefully (closes APRS-IS, flushes DB); the
+	// deadline backstop force-exits if that unwind hangs. (Layer 1 --
+	// GraywolfService.onTaskRemoved -- handles the clean swipe case; this
+	// covers the hard kills onDestroy never sees.)
+	go watchParentDeath(os.Stdin, os.Getppid, time.Second, func() {
+		cancel()
+		time.AfterFunc(5*time.Second, func() {
+			logger.Error("graywolf-android: shutdown deadline exceeded after parent death; forcing exit")
+			os.Exit(0)
+		})
+	})
+
 	a := app.New(cfg, logger)
 
 	cli, err := platformConnect(ctx, logger, os.Getenv("GRAYWOLF_PLATFORM_SOCKET"))

--- a/cmd/graywolf/parentwatch.go
+++ b/cmd/graywolf/parentwatch.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// watchParentDeath blocks until it detects that the parent (Android app)
+// process has died, then invokes onDeath exactly once and returns. It
+// watches two independent signals; whichever fires first wins.
+//
+//   - stdin EOF: ProcessBuilder hands the Go child a stdin pipe whose
+//     write end the JVM holds. When the app process dies (even via
+//     SIGKILL) the kernel closes that fd and stdin.Read returns EOF.
+//     Event-driven, immediate, OEM-independent.
+//   - reparent poll: every pollInterval the current ppid is compared to
+//     the one captured at startup. When the app dies the kernel reparents
+//     the child to init / a subreaper, changing the ppid. Backstops any
+//     case where the stdin pipe behaves unexpectedly.
+func watchParentDeath(stdin io.Reader, ppidFn func() int, pollInterval time.Duration, onDeath func()) {
+	origPpid := ppidFn()
+	done := make(chan struct{})
+	var once sync.Once
+	fire := func(reason string) {
+		once.Do(func() {
+			slog.Warn("graywolf-android: parent death detected", "trigger", reason)
+			onDeath()
+			close(done)
+		})
+	}
+
+	// stdin EOF watcher.
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			if _, err := stdin.Read(buf); err != nil {
+				fire("stdin_eof")
+				return
+			}
+		}
+	}()
+
+	// reparent poll watcher.
+	go func() {
+		t := time.NewTicker(pollInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-t.C:
+				if ppidFn() != origPpid {
+					fire("reparent")
+					return
+				}
+			}
+		}
+	}()
+
+	<-done
+}

--- a/cmd/graywolf/parentwatch_test.go
+++ b/cmd/graywolf/parentwatch_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingReader blocks in Read until release is closed, then returns EOF.
+// Used so the stdin watcher never fires in tests that target the ppid path.
+type blockingReader struct{ release chan struct{} }
+
+func (b *blockingReader) Read(p []byte) (int, error) {
+	<-b.release
+	return 0, io.EOF
+}
+
+func TestWatchParentDeath_StdinEOFFiresOnDeath(t *testing.T) {
+	called := make(chan struct{})
+	onDeath := func() { close(called) }
+
+	// strings.NewReader("") returns (0, io.EOF) on first Read.
+	// Stable ppid + huge poll interval ensure only the stdin path can fire.
+	stablePpid := func() int { return 1234 }
+	go watchParentDeath(strings.NewReader(""), stablePpid, time.Hour, onDeath)
+
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("onDeath was not called on stdin EOF")
+	}
+}
+
+func TestWatchParentDeath_ReparentPollFiresOnDeath(t *testing.T) {
+	called := make(chan struct{})
+	onDeath := func() { close(called) }
+
+	// stdin blocks for the whole test so only the ppid path can fire.
+	br := &blockingReader{release: make(chan struct{})}
+	t.Cleanup(func() { close(br.release) })
+
+	var mu sync.Mutex
+	ppid := 1000 // captured as origPpid on the first call
+	ppidFn := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return ppid
+	}
+
+	go watchParentDeath(br, ppidFn, 5*time.Millisecond, onDeath)
+
+	// Let watchParentDeath capture origPpid, then simulate reparenting.
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	ppid = 1 // reparented to init
+	mu.Unlock()
+
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("onDeath was not called on ppid change")
+	}
+}

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -607,6 +607,19 @@ cannot outlive the app, because no single mechanism covers both cases.
   **unset** (default false) so `onTaskRemoved` is delivered; do NOT set
   `android:stopWithTask="true"` -- the implicit stop is historically flaky
   across OEMs and skips the deterministic log line.
+  - **USB auto-relaunch suppression:** `MainActivity` declares a
+    `USB_DEVICE_ATTACHED` intent-filter so plugging in a radio launches the app.
+    Tearing down on swipe releases the radio's USB interfaces, which physically
+    re-enumerate (~2s later, new bus device numbers) -- indistinguishable from a
+    fresh plug-in, so Android would auto-relaunch and revive the station the
+    operator just dismissed. To prevent that, `onTaskRemoved` records a
+    deliberate-stop timestamp (`MainActivity.markUserStopped`, in `graywolf-prefs`)
+    and `MainActivity.onCreate` `finish()`es immediately if the launch action is
+    `USB_DEVICE_ATTACHED` within `STOP_RELAUNCH_SUPPRESS_WINDOW_MS` (15s) of that
+    stop. A launcher tap (action `MAIN`) or a genuine re-plug after the window is
+    NOT suppressed; the marker is cleared in `startEverything()`. The window
+    (not a one-shot) is required because re-enumeration fires one attach per
+    interface (e.g. CP2102N serial + C-Media audio).
 - **Layer 2 (hard-kill safety net):** `watchParentDeath` in
   `cmd/graywolf/parentwatch.go` cancels the app context when the parent dies,
   via two triggers -- stdin EOF (the JVM holds the write end of the child's

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -589,3 +589,35 @@ blocking work still belongs on a worker thread.
 Source: [`../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt),
 [`../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BluetoothFacade.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BluetoothFacade.kt),
 [`../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/BtSerialAdapter.kt).
+
+### 36. The Android Go child dies with the app (two-layer shutdown)
+
+*Why:* Swiping the app from recents removes the Activity but, with
+`android:stopWithTask` at its default (`false`), the foreground service keeps
+running -- so the forked Go backend would keep iGating/beaconing and the next
+launch shows stale uptime. A hard kill (Force Stop / OOM / OEM killer) can
+orphan the Go child entirely. Two independent layers guarantee the child
+cannot outlive the app, because no single mechanism covers both cases.
+
+*How to apply:*
+- **Layer 1 (clean swipe):** `GraywolfService.onTaskRemoved` calls `stopSelf()`,
+  which runs the existing `onDestroy()` teardown (`supervisor.stop()`,
+  `goLauncher.stop()` -> SIGTERM, `ModemBridge.modemStop()`, audio pumps,
+  `UsbPttAdapter.closeAll()`, `platformServer.stop()`). Keep `stopWithTask`
+  **unset** (default false) so `onTaskRemoved` is delivered; do NOT set
+  `android:stopWithTask="true"` -- the implicit stop is historically flaky
+  across OEMs and skips the deterministic log line.
+- **Layer 2 (hard-kill safety net):** `watchParentDeath` in
+  `cmd/graywolf/parentwatch.go` cancels the app context when the parent dies,
+  via two triggers -- stdin EOF (the JVM holds the write end of the child's
+  stdin pipe; the kernel closes it on app death) and a reparent poll
+  (`os.Getppid()` changes when the child reparents to init). A deadline
+  `os.Exit` backstops a hung unwind. This is separate from the stdout
+  readiness channel ([invariant 13](invariants.md)) -- stdin carries death
+  detection, stdout carries readiness; different fds, no conflict. The modem
+  cdylib is in-process JNI, so it always dies with the app -- no separate
+  handling needed.
+
+Source: [`../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt),
+[`../../cmd/graywolf/parentwatch.go`](../../cmd/graywolf/parentwatch.go),
+[`../../cmd/graywolf/main_android.go`](../../cmd/graywolf/main_android.go).


### PR DESCRIPTION
## Summary

Guarantees the forked Go backend dies whenever the Android app goes away, so the station can never keep iGating/beaconing after the app is dismissed.

- **Layer 1 (clean swipe):** `GraywolfService.onTaskRemoved` -> `stopSelf()`, running the existing `onDestroy()` teardown (supervisor, Go child SIGTERM, modem, audio, USB PTT, platform server).
- **Layer 2 (hard kill / OOM / OEM killer):** new `watchParentDeath` goroutine in `cmd/graywolf/parentwatch.go` cancels the app context when the parent process dies, via stdin EOF (the JVM holds the child's stdin pipe) plus a reparent poll backstop. A deadline `os.Exit` covers a hung unwind.
- **USB auto-relaunch suppression:** swiping releases the radio's USB interfaces, which physically re-enumerate ~2s later; because `MainActivity` declares a `USB_DEVICE_ATTACHED` intent-filter, Android would auto-relaunch and revive the station. `onTaskRemoved` now records a deliberate-stop timestamp and `MainActivity.onCreate` finishes immediately if relaunched by `USB_DEVICE_ATTACHED` within a 15s window. Launcher taps and genuine re-plugs after the window are unaffected.
- Wiki invariant #36 documents the two-layer contract and the USB suppression.

## Test Plan

- [x] `go test ./cmd/graywolf/` -- `watchParentDeath` unit tests cover both triggers (stdin EOF, reparent poll)
- [x] On-device (Samsung T865): swipe -> backend torn down, stays down, no relaunch, no crash
- [x] On-device: USB re-enumeration after swipe is suppressed (logcat `ignoring USB-attach relaunch within stop window`); no Go backend started
- [x] On-device: synthetic `USB_DEVICE_ATTACHED` with stale marker launches normally (genuine plug-in path)
- [x] On-device: `am force-stop` -> Go child gone and stays gone