### PR TITLE
Android clean shutdown + serialized startup

### DIFF
--- a/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
@@ -30,6 +30,7 @@ import com.nw5w.graywolf.binaries.Supervisor
 import com.nw5w.graywolf.gps.GpsAdapter
 import com.nw5w.graywolf.jni.ModemBridge
 import com.nw5w.graywolf.platformsvc.BtSerialAdapter
+import com.nw5w.graywolf.platformsvc.BindContendedException
 import com.nw5w.graywolf.platformsvc.PlatformServer
 import com.nw5w.graywolf.platformsvc.SystemBluetoothFacade
 import com.nw5w.graywolf.platformsvc.UsbDeviceLister
@@ -93,8 +94,7 @@ class GraywolfService : Service() {
     private fun socketPath(): String =
         File(cacheDir, "graywolf-modem.sock").absolutePath
 
-    private fun platformSocketPath(): String =
-        File(cacheDir, "platform.sock").absolutePath
+    private fun platformSocketPath(): String = platformSocketName(this)
 
     /**
      * Read the active network's DNS server list from ConnectivityManager
@@ -279,11 +279,21 @@ class GraywolfService : Service() {
         // Bring up the Go ↔ Kotlin platform contract before exec'ing the Go child.
         // Phase 2: Hello + GpsFix only; the Go child connects, handshakes, and
         // logs the schema version. Real GpsFix producer is wired in phase 4.
-        platformServer = PlatformServer(
-            socketPath = platformSocketPath(),
-            serverVersion = BuildConfig.VERSION_NAME,
-            schemaVersion = 2,
-        ).also { it.start() }
+        try {
+            platformServer = PlatformServer(
+                socketPath = platformSocketPath(),
+                serverVersion = BuildConfig.VERSION_NAME,
+                schemaVersion = 2,
+            ).also { it.start() }
+        } catch (e: BindContendedException) {
+            // A previous instance still owns the platformsvc socket after the
+            // bounded wait. Don't crash (that would relaunch and re-collide);
+            // bow out and let the surviving instance keep running. The UI-gated
+            // launch path normally prevents reaching here.
+            Log.w(TAG, "platformsvc address owned by another instance; stopping this duplicate", e)
+            stopSelf()
+            return
+        }
         gpsAdapter = GpsAdapter(this, platformServer!!).also { it.start() }
 
         // Bluetooth-classic KISS TNC adapter. Wired AFTER PlatformServer.start()
@@ -374,6 +384,13 @@ class GraywolfService : Service() {
 
     companion object {
         private const val TAG = "GraywolfService"
+
+        // The abstract-namespace socket name PlatformServer binds. Exposed so
+        // MainActivity can probe whether a previous backend is still alive
+        // (connect succeeds) before starting a new one. Must match
+        // platformSocketPath() exactly.
+        fun platformSocketName(ctx: android.content.Context): String =
+            java.io.File(ctx.cacheDir, "platform.sock").absolutePath
         private const val NOTIF_ID = 0x6757
         const val ACTION_STOP = "com.nw5w.graywolf.STOP"
 

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
@@ -36,6 +36,7 @@ import com.nw5w.graywolf.platformsvc.SystemBluetoothFacade
 import com.nw5w.graywolf.platformsvc.UsbDeviceLister
 import com.nw5w.graywolf.usb.UsbPttAdapter
 import java.io.File
+import kotlin.concurrent.thread
 
 class GraywolfService : Service() {
     private val audioPump = AudioPump()
@@ -43,6 +44,9 @@ class GraywolfService : Service() {
     private var goLauncher: GoLauncher? = null
     private var platformServer: PlatformServer? = null
     private var gpsAdapter: GpsAdapter? = null
+    // Worker that runs the blocking audio/USB HAL init off the main thread
+    // (see onCreate). onDestroy joins it before tearing those resources down.
+    @Volatile private var startupThread: Thread? = null
     private var btSerialAdapter: BtSerialAdapter? = null
     private val supervisor = Supervisor(onRestart = ::supervisorRestart)
 
@@ -271,10 +275,26 @@ class GraywolfService : Service() {
         audioTxPump = txPump
         ModemBridge.installAudioTxCallback(txPump)
 
-        // Start TX audio + USB PTT adapter after FGS is active (spec §3.1).
-        txPump.start()
+        // USB PTT adapter init is cheap (stores context, gets the USB service,
+        // registers a receiver) and must precede enumerate(); keep it on the main
+        // thread so onResume's enumerate() never races an uninitialized adapter.
         UsbPttAdapter.init(applicationContext)
-        UsbPttAdapter.enumerate()
+
+        // AudioTrack construction + setPreferredDevice and USB device opens are
+        // synchronous HAL/binder calls that block for seconds when a USB audio
+        // dongle is wedged -- a real failure mode on this hardware, since a churned
+        // hub can wedge a Digirig. On the main thread that ANRs onCreate within 5s
+        // (lessons: feedback_android_usb_open_worker_thread,
+        // feedback_android_audiotxpump_main_thread_anr). Run them off the main
+        // thread: the modem TX/PTT callbacks are already installed above and
+        // tolerate the brief window before this completes (AudioTxPump drops audio
+        // while track is null; UsbPttAdapter re-enumerates when a handle is absent).
+        // These are output-path only -- no ordering dependency on modem boot below.
+        // onDestroy joins this thread (bounded) before tearing the same resources down.
+        startupThread = thread(start = true, isDaemon = true, name = "graywolf-io-init") {
+            txPump.start()
+            UsbPttAdapter.enumerate()
+        }
 
         // Bring up the Go ↔ Kotlin platform contract before exec'ing the Go child.
         // Phase 2: Hello + GpsFix only; the Go child connects, handshakes, and
@@ -360,6 +380,16 @@ class GraywolfService : Service() {
     override fun onDestroy() {
         supervisor.stop()
         goListenerReady = false
+        // The off-main-thread audio/USB init (onCreate) may still be in flight --
+        // wait for it (bounded) before stopping txPump / closing USB handles, so we
+        // don't tear down a half-built AudioTrack or open USB handle. If it's wedged
+        // on the HAL the join times out and teardown proceeds; the daemon thread dies
+        // with the process. The wait runs here, not on input dispatch, so it can't ANR.
+        startupThread?.let {
+            it.interrupt()
+            it.join(2_000)
+        }
+        startupThread = null
         gpsAdapter?.stop()
         gpsAdapter = null
         goLauncher?.stop()

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.hardware.usb.UsbManager
+import android.net.LocalSocket
+import android.net.LocalSocketAddress
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -22,6 +24,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.nw5w.graywolf.webview.WebAppInterface
 import com.nw5w.graywolf.webview.WebBridgeIds
+import java.io.IOException
 
 class MainActivity : Activity() {
     private lateinit var webView: WebView
@@ -178,6 +181,74 @@ class MainActivity : Activity() {
         // We're committing to running, so clear any prior deliberate-stop marker;
         // future USB attaches should launch normally.
         clearUserStopped(this)
+        // Wait for any previous instance to fully exit before starting a new
+        // backend. A live predecessor still answers on the platformsvc socket;
+        // starting now would collide on the bind and (historically) crash-loop,
+        // churning the USB bus. The probe blocks, so it runs on a background
+        // thread; UI updates post back to the main thread.
+        waitForPredecessorThenStart()
+    }
+
+    // Background-threaded probe of the platformsvc abstract socket. While a
+    // predecessor answers, show the waiting page and re-probe every
+    // PROBE_STEP_MS; once it stops answering (or PROBE_TIMEOUT_MS elapses)
+    // start the foreground service and begin the readiness poll.
+    private fun waitForPredecessorThenStart() {
+        val socketName = GraywolfService.platformSocketName(this)
+        Thread({
+            val deadline = System.currentTimeMillis() + PROBE_TIMEOUT_MS
+            var shownWaiting = false
+            while (predecessorAlive(socketName) && System.currentTimeMillis() < deadline) {
+                if (!shownWaiting) {
+                    shownWaiting = true
+                    mainHandler.post { showWaitingPage() }
+                }
+                try {
+                    Thread.sleep(PROBE_STEP_MS)
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    break
+                }
+            }
+            mainHandler.post { startServiceAndAwaitReady() }
+        }, "predecessor-wait").apply { isDaemon = true; start() }
+    }
+
+    // True if a previous backend still accepts connections on the abstract
+    // platformsvc socket. connect() throwing (refused / no such address) means
+    // the address is free.
+    private fun predecessorAlive(socketName: String): Boolean {
+        val s = LocalSocket()
+        return try {
+            s.connect(LocalSocketAddress(socketName, LocalSocketAddress.Namespace.ABSTRACT))
+            true
+        } catch (_: IOException) {
+            false
+        } finally {
+            try { s.close() } catch (_: IOException) { /* ignore */ }
+        }
+    }
+
+    private fun showWaitingPage() {
+        val html = """
+            <!doctype html><html><head><meta name="viewport"
+            content="width=device-width,initial-scale=1">
+            <style>
+              html,body{height:100%;margin:0;background:#0b0d10;color:#cfd6e4;
+                font-family:-apple-system,Roboto,sans-serif;
+                display:flex;align-items:center;justify-content:center}
+              .box{text-align:center;padding:2rem}
+              .t{font-size:1.1rem;margin-bottom:.5rem}
+              .s{font-size:.85rem;color:#8b94a7}
+            </style></head><body><div class="box">
+            <div class="t">Waiting for the previous session to close&hellip;</div>
+            <div class="s">Graywolf is shutting down a prior instance before starting.</div>
+            </div></body></html>
+        """.trimIndent()
+        webView.loadData(html, "text/html", "utf-8")
+    }
+
+    private fun startServiceAndAwaitReady() {
         startForegroundService(Intent(this, GraywolfService::class.java))
         val started = System.currentTimeMillis()
         val r = object : Runnable {
@@ -261,6 +332,13 @@ class MainActivity : Activity() {
         // genuine plug-in. Generous enough to cover slow hubs without swallowing a
         // real re-plug seconds later.
         private const val STOP_RELAUNCH_SUPPRESS_WINDOW_MS = 15_000L
+
+        // Predecessor-exit probe cadence and ceiling. The probe runs off the
+        // main thread; the timeout is a safety valve so a stuck/zombie
+        // predecessor can't block launch forever -- on timeout we start anyway
+        // and PlatformServer.start()'s own bounded retry is the final backstop.
+        private const val PROBE_STEP_MS = 200L
+        private const val PROBE_TIMEOUT_MS = 12_000L
 
         fun batteryOptWhitelistRequested(ctx: Context): Boolean =
             ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/PlatformServer.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/PlatformServer.kt
@@ -28,6 +28,15 @@ import kotlin.concurrent.thread
  * Uses android.net.LocalServerSocket (API 1) with NAMESPACE_FILESYSTEM
  * so the Go side dials the path with net.Dialer{} "unix" unchanged.
  */
+/**
+ * Thrown by PlatformServer.start() when the abstract-namespace address is
+ * still held by a previous instance after the bounded wait. The caller
+ * (GraywolfService.onCreate) treats this as "another instance owns the
+ * station" and stops itself cleanly rather than crashing the process.
+ */
+class BindContendedException(name: String, cause: Throwable) :
+    java.io.IOException("platformsvc address still in use after wait: $name", cause)
+
 class PlatformServer(
     private val socketPath: String,
     private val serverVersion: String,
@@ -111,16 +120,44 @@ class PlatformServer(
      * supports.
      */
     fun start() {
-        // Lesson: feedback_uds_unlink_before_bind. The Service can be
-        // killed/restarted by the OS; the prior socket file lingers.
-        File(socketPath).delete()
-
-        prodListener = LocalServerSocket(socketPath)
+        // The abstract-namespace address frees the instant the holding
+        // process dies, so "Address already in use" means a previous
+        // instance is still tearing down. Wait for it briefly rather than
+        // crashing -- a single bind attempt here is what produced the
+        // relaunch->crash->relaunch loop that churned the USB bus.
+        prodListener = bindWithRetry()
         running = true
         acceptThread = thread(start = true, isDaemon = true, name = "platformsvc-accept") {
             prodAcceptLoop()
         }
         Log.i(TAG, "PlatformServer bound at $socketPath")
+    }
+
+    // Bind, retrying on "Address already in use" until the predecessor frees
+    // the abstract address or BIND_WAIT_MS elapses. Throws BindContendedException
+    // on timeout so the caller can stopSelf() cleanly instead of crashing.
+    private fun bindWithRetry(): LocalServerSocket {
+        val deadline = System.currentTimeMillis() + BIND_WAIT_MS
+        var attempt = 0
+        while (true) {
+            try {
+                return LocalServerSocket(socketPath)
+            } catch (e: IOException) {
+                if (System.currentTimeMillis() >= deadline) {
+                    throw BindContendedException(socketPath, e)
+                }
+                if (attempt == 0) {
+                    Log.w(TAG, "platformsvc address busy; waiting for previous instance to exit")
+                }
+                attempt++
+                try {
+                    Thread.sleep(BIND_RETRY_STEP_MS)
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    throw BindContendedException(socketPath, e)
+                }
+            }
+        }
     }
 
     /**
@@ -311,6 +348,15 @@ class PlatformServer(
 
     companion object {
         private const val TAG = "PlatformServer"
+
+        // Total time start() waits for a predecessor to free the abstract
+        // address before giving up. Kept short because the only main-thread
+        // caller is a START_STICKY restart's onCreate (ANR budget ~5s); the
+        // common case binds on the first attempt. The UI-gated launch path
+        // (MainActivity) already waits off the main thread, so this is only
+        // a backstop.
+        private const val BIND_WAIT_MS = 3_000L
+        private const val BIND_RETRY_STEP_MS = 100L
     }
 }
 

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -630,6 +630,18 @@ cannot outlive the app, because no single mechanism covers both cases.
   detection, stdout carries readiness; different fds, no conflict. The modem
   cdylib is in-process JNI, so it always dies with the app -- no separate
   handling needed.
+- **Single backend, serialized startup:** the platformsvc socket
+  (`<cacheDir>/platform.sock`, Linux abstract namespace) is effectively the
+  station's single-instance lock. A new instance must not start its backend
+  while a previous one is still tearing down. `MainActivity.waitForPredecessorThenStart`
+  probes the socket on a background thread (a live predecessor still accepts a
+  `LocalSocket` connect) and shows a "waiting" page until it is free, then starts
+  the foreground service. `PlatformServer.start()` additionally retries the bind
+  for `BIND_WAIT_MS` and, on timeout, throws `BindContendedException` so
+  `GraywolfService.onCreate` `stopSelf()`s cleanly -- it never lets
+  `Address already in use` crash the process, because that crash relaunches and
+  re-collides, a loop that re-enumerates the USB bus fast enough to wedge devices
+  off a powered hub.
 
 Source: [`../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt),
 [`../../cmd/graywolf/parentwatch.go`](../../cmd/graywolf/parentwatch.go),

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -642,6 +642,15 @@ cannot outlive the app, because no single mechanism covers both cases.
   `Address already in use` crash the process, because that crash relaunches and
   re-collides, a loop that re-enumerates the USB bus fast enough to wedge devices
   off a powered hub.
+- **No blocking HAL calls on the main thread in `onCreate`:** `AudioTxPump.start()`
+  (AudioTrack build + `setPreferredDevice`) and `UsbPttAdapter.enumerate()` (USB
+  device opens) are synchronous HAL/binder calls that block for seconds when a USB
+  audio dongle is wedged, ANR'ing the process within ~5s. `GraywolfService.onCreate`
+  runs them on a `graywolf-io-init` worker thread (the modem TX/PTT callbacks are
+  installed first and tolerate the brief gap); `onDestroy` joins that worker
+  (bounded) before tearing the same resources down. The cheap `UsbPttAdapter.init()`
+  stays on the main thread so `MainActivity.onResume`'s `enumerate()` never races an
+  uninitialized adapter.
 
 Source: [`../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt),
 [`../../cmd/graywolf/parentwatch.go`](../../cmd/graywolf/parentwatch.go),


### PR DESCRIPTION
## Summary

Makes the Android app shut down cleanly, prevents a freshly launched instance
from colliding with one still tearing down, and keeps service startup off the
main thread. Together these stop the relaunch->crash->relaunch loop whose
USB-bus churn could wedge a radio off a powered hub, and stop a wedged USB
audio dongle from ANR'ing startup.

**Clean shutdown (earlier commits):**
- `watchParentDeath` cancels the Go child's app context when the parent dies
  (stdin EOF + reparent poll, with a deadline `os.Exit` backstop).
- `onTaskRemoved` stops the service on a recents swipe.
- A USB-attach auto-relaunch within 15s of a deliberate stop is suppressed.

**Serialized startup:**
- `PlatformServer.start()` retries the abstract-namespace bind for a bounded
  window instead of crashing on `Address already in use`; on timeout it throws
  `BindContendedException`.
- `GraywolfService.onCreate` catches that and `stopSelf()`s the duplicate
  cleanly rather than crashing (covers `START_STICKY` restarts).
- `MainActivity` probes the platformsvc socket on a background thread before
  starting the service, showing a "waiting" page while a predecessor answers.

**No blocking HAL calls on the main thread (onCreate ANR fix):**
- `AudioTxPump.start()` (AudioTrack build + setPreferredDevice) and
  `UsbPttAdapter.enumerate()` (USB opens) block for seconds when a USB audio
  dongle is wedged, ANR'ing onCreate within 5s. They now run on a
  `graywolf-io-init` worker thread; cheap `UsbPttAdapter.init()` stays on main;
  `onDestroy` joins the worker (bounded) before teardown.

## Test Plan

- [x] `:app:compileDebugKotlin` BUILD SUCCESSFUL.
- [x] On-device (T865): clean launch loads UI; swipe + relaunch yields exactly
      one `libgraywolf.so`, no `AndroidRuntime` crash, no `Address already in use`.
- [x] On-device: clean-bus launch (AIOC only) starts with no ANR; AudioTxPump
      and enumerate confirmed running on the worker thread.
- [x] On-device: Digirig hotplug into the running app detected (CP2102 serial +
      CM108 audio/PTT), TX audio routed, no ANR, no crash.

Note: no host-side unit tests for this Android-specific code (no Robolectric);
verification is compile + on-device. `audioPump.start()` (RX) was left on the
main thread to preserve its ordering with `bootModem()`; revisit if a wedged USB
input device ANRs there.