### PR TITLE
Add right-click context menu to map (copy coords / grid, add fixed beacon)

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -209,7 +209,7 @@ and embedded via `go:embed all:dist` -- see [invariant 12](invariants.md).
 | `src/components/` | Reusable: ConfirmDialog, DataTable, FormField, Modal, NewsPopup, PacketLogViewer, PageHeader, ReleaseNoteCard, Sidebar, StationCallsignBanner, SymbolPicker, UpdateAvailableBanner |
 | `src/components/messages/remote_actions/` | Outbound Actions UI: `RemoteActionsDrawer` (zap-icon-anchored thread drawer), `MacroTile` + `MacroEditRow` (fire / edit modes), `FreeFormSender` (ad-hoc `@@<otp>#cmd`), `CredentialsModal` + `EditCredentialModal` + `CredentialPicker` (TOTP secret CRUD), `ReplyBubbleAdornment` (zap-tagged inbound badge). See [`remote-actions.md`](remote-actions.md). |
 | `src/lib/remote_actions/` | Outbound Actions client lib: typed API wrapper, reactive store (Svelte 5 runes singleton), TOTP countdown timer, reply correlation (60s window + status-prefix allowlist), wire-string assembler + send helper that piggy-backs on `POST /api/messages`. |
-| `src/lib/map/` | MapLibre integration (data-store, map-store, layers, sources, popups, APRS icons) |
+| `src/lib/map/` | MapLibre integration (data-store, map-store, layers, sources, popups, APRS icons, right-click `map-context-menu.svelte` — Copy GPS / Copy grid / Add fixed beacon here; the last item deep-links into `Beacons.svelte` via `#/beacons?lat=…&lon=…`, which its `onMount` parses to prefill the create modal) |
 | `src/lib/maps/` | Offline-maps client glue (downloads-store, state-bounds, state-list, state-picker) |
 | `src/lib/settings/` | Reactive prefs stores (units, maps, messages-preferences, theme) |
 | `src/lib/themes/`, `themes/` | Theme registry + static CSS theme files |

--- a/web/src/lib/map/map-context-menu.svelte
+++ b/web/src/lib/map/map-context-menu.svelte
@@ -26,10 +26,11 @@
   // Clamp the menu inside the viewport so it doesn't get cut off when
   // right-clicking near the right or bottom edge. Computed in the effect
   // after the menu mounts (so we can measure its rect); until then it
-  // sits at the raw cursor position. Plain $state, not $derived, because
-  // the effect both reads x/y and writes the clamped result.
-  let adjustedX = $state(x);
-  let adjustedY = $state(y);
+  // sits at the raw cursor position. Seeded with 0 (not x/y) so it isn't
+  // a non-reactive capture of the prop -- the effect below sets the real
+  // value before paint, resetting to raw x/y until the rect is measurable.
+  let adjustedX = $state(0);
+  let adjustedY = $state(0);
   $effect(() => {
     if (!open || !menuEl || typeof window === 'undefined') {
       adjustedX = x;

--- a/web/src/lib/map/map-context-menu.svelte
+++ b/web/src/lib/map/map-context-menu.svelte
@@ -1,12 +1,14 @@
 <script>
   // MapContextMenu: positioned overlay shown on right-click (or long-press)
-  // of the map background. Three items: Copy GPS, Copy grid, Add fixed
-  // beacon here. The parent owns visibility and position; this component
-  // is purely presentational and emits clicks back via the items prop.
+  // of the map background. A muted coordinate header sits at the top, then
+  // the primary "Add fixed beacon here" action, then a copy group. The
+  // parent owns visibility/position and the item model; this component is
+  // purely presentational and emits clicks back via each item's onSelect.
   //
-  // Closing is the parent's responsibility -- pan/zoom listeners live on
-  // the map and are easier to wire there. This component closes itself
-  // on outside-click and Escape, both of which call onclose.
+  // Items are plain objects: { label, icon?, hint?, primary?, disabled?,
+  // onSelect? } or { divider: true } for a separator rule. Closing is the
+  // parent's responsibility for pan/zoom (those listeners live on the map);
+  // this component closes itself on outside-click and Escape via onclose.
 
   import { onDestroy } from 'svelte';
 
@@ -14,6 +16,7 @@
     open = false,
     x = 0,
     y = 0,
+    header = '',
     items = [],
     onclose = () => {},
   } = $props();
@@ -21,13 +24,18 @@
   let menuEl = $state(null);
 
   // Clamp the menu inside the viewport so it doesn't get cut off when
-  // right-clicking near the right or bottom edge. Measured after mount;
-  // until then the menu sits at the raw cursor position. The clamp uses
-  // the menu's own rect, so it adapts to the longest visible item.
-  let adjustedX = $derived(x);
-  let adjustedY = $derived(y);
+  // right-clicking near the right or bottom edge. Computed in the effect
+  // after the menu mounts (so we can measure its rect); until then it
+  // sits at the raw cursor position. Plain $state, not $derived, because
+  // the effect both reads x/y and writes the clamped result.
+  let adjustedX = $state(x);
+  let adjustedY = $state(y);
   $effect(() => {
-    if (!open || !menuEl || typeof window === 'undefined') return;
+    if (!open || !menuEl || typeof window === 'undefined') {
+      adjustedX = x;
+      adjustedY = y;
+      return;
+    }
     const rect = menuEl.getBoundingClientRect();
     const vw = window.innerWidth;
     const vh = window.innerHeight;
@@ -36,8 +44,8 @@
     let ny = y;
     if (nx + rect.width + pad > vw) nx = Math.max(pad, vw - rect.width - pad);
     if (ny + rect.height + pad > vh) ny = Math.max(pad, vh - rect.height - pad);
-    if (nx !== adjustedX) adjustedX = nx;
-    if (ny !== adjustedY) adjustedY = ny;
+    adjustedX = nx;
+    adjustedY = ny;
   });
 
   function onWindowDown(ev) {
@@ -77,20 +85,35 @@
     role="menu"
     style="left: {adjustedX}px; top: {adjustedY}px;"
   >
+    {#if header}
+      <div class="menu-header">{header}</div>
+    {/if}
     {#each items as item}
-      <button
-        type="button"
-        class="menu-item"
-        role="menuitem"
-        disabled={item.disabled}
-        onclick={() => {
-          if (item.disabled) return;
-          onclose();
-          item.onSelect?.();
-        }}
-      >
-        {item.label}
-      </button>
+      {#if item.divider}
+        <div class="menu-divider" role="separator"></div>
+      {:else}
+        {@const IconCmp = item.icon}
+        <button
+          type="button"
+          class="menu-item"
+          class:menu-item--primary={item.primary}
+          role="menuitem"
+          disabled={item.disabled}
+          onclick={() => {
+            if (item.disabled) return;
+            onclose();
+            item.onSelect?.();
+          }}
+        >
+          {#if IconCmp}
+            <span class="menu-icon"><IconCmp size={14} strokeWidth={2} /></span>
+          {/if}
+          <span class="menu-label">{item.label}</span>
+          {#if item.hint}
+            <span class="menu-hint">{item.hint}</span>
+          {/if}
+        </button>
+      {/if}
     {/each}
   </div>
 {/if}
@@ -99,19 +122,33 @@
   .map-context-menu {
     position: fixed;
     z-index: 80;
-    min-width: 200px;
+    min-width: 184px;
     padding: 4px;
     background: var(--map-overlay-bg);
     color: var(--map-overlay-fg);
     border: 1px solid var(--map-overlay-border);
-    border-radius: 6px;
+    border-radius: 8px;
     box-shadow: var(--map-overlay-shadow);
     font-family: var(--font-mono);
     font-size: 13px;
     user-select: none;
   }
+  .menu-header {
+    padding: 5px 10px 6px;
+    font-size: 12px;
+    line-height: 1.2;
+    color: var(--map-overlay-muted);
+    white-space: nowrap;
+  }
+  .menu-divider {
+    height: 1px;
+    margin: 4px 6px;
+    background: var(--map-overlay-border);
+  }
   .menu-item {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 8px;
     width: 100%;
     padding: 6px 10px;
     border: none;
@@ -120,14 +157,40 @@
     text-align: left;
     font: inherit;
     cursor: pointer;
-    border-radius: 4px;
+    border-radius: 5px;
     white-space: nowrap;
+  }
+  .menu-icon {
+    display: inline-flex;
+    flex: 0 0 auto;
+    color: var(--map-overlay-muted);
+  }
+  .menu-item--primary .menu-icon {
+    color: var(--color-primary);
+  }
+  .menu-label {
+    flex: 1 1 auto;
+  }
+  .menu-hint {
+    flex: 0 0 auto;
+    padding-left: 8px;
+    font-size: 12px;
+    color: var(--map-overlay-muted);
   }
   .menu-item:hover:not(:disabled),
   .menu-item:focus-visible:not(:disabled) {
-    background: var(--color-surface-hover, rgba(255, 255, 255, 0.08));
+    /* Tint toward text color so the hover shows in both light and dark
+       themes (the bare white-alpha fallback vanishes on light surfaces). */
+    background: var(
+      --color-surface-hover,
+      color-mix(in srgb, var(--color-text) 9%, transparent)
+    );
     color: var(--color-text);
     outline: none;
+  }
+  .menu-item:hover:not(:disabled) .menu-hint,
+  .menu-item:focus-visible:not(:disabled) .menu-hint {
+    color: var(--color-text);
   }
   .menu-item:disabled {
     opacity: 0.5;

--- a/web/src/lib/map/map-context-menu.svelte
+++ b/web/src/lib/map/map-context-menu.svelte
@@ -1,0 +1,136 @@
+<script>
+  // MapContextMenu: positioned overlay shown on right-click (or long-press)
+  // of the map background. Three items: Copy GPS, Copy grid, Add fixed
+  // beacon here. The parent owns visibility and position; this component
+  // is purely presentational and emits clicks back via the items prop.
+  //
+  // Closing is the parent's responsibility -- pan/zoom listeners live on
+  // the map and are easier to wire there. This component closes itself
+  // on outside-click and Escape, both of which call onclose.
+
+  import { onDestroy } from 'svelte';
+
+  let {
+    open = false,
+    x = 0,
+    y = 0,
+    items = [],
+    onclose = () => {},
+  } = $props();
+
+  let menuEl = $state(null);
+
+  // Clamp the menu inside the viewport so it doesn't get cut off when
+  // right-clicking near the right or bottom edge. Measured after mount;
+  // until then the menu sits at the raw cursor position. The clamp uses
+  // the menu's own rect, so it adapts to the longest visible item.
+  let adjustedX = $derived(x);
+  let adjustedY = $derived(y);
+  $effect(() => {
+    if (!open || !menuEl || typeof window === 'undefined') return;
+    const rect = menuEl.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const pad = 8;
+    let nx = x;
+    let ny = y;
+    if (nx + rect.width + pad > vw) nx = Math.max(pad, vw - rect.width - pad);
+    if (ny + rect.height + pad > vh) ny = Math.max(pad, vh - rect.height - pad);
+    if (nx !== adjustedX) adjustedX = nx;
+    if (ny !== adjustedY) adjustedY = ny;
+  });
+
+  function onWindowDown(ev) {
+    if (!open) return;
+    if (menuEl && menuEl.contains(ev.target)) return;
+    onclose();
+  }
+  function onKeyDown(ev) {
+    if (!open) return;
+    if (ev.key === 'Escape') onclose();
+  }
+  $effect(() => {
+    if (typeof window === 'undefined') return;
+    if (!open) return;
+    // pointerdown (rather than click) so the menu closes on the same
+    // physical event that initiates a new map click/drag -- waiting for
+    // 'click' lets a drag start with the menu still painted.
+    window.addEventListener('pointerdown', onWindowDown, true);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('pointerdown', onWindowDown, true);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  });
+
+  onDestroy(() => {
+    if (typeof window === 'undefined') return;
+    window.removeEventListener('pointerdown', onWindowDown, true);
+    window.removeEventListener('keydown', onKeyDown);
+  });
+</script>
+
+{#if open}
+  <div
+    bind:this={menuEl}
+    class="map-context-menu"
+    role="menu"
+    style="left: {adjustedX}px; top: {adjustedY}px;"
+  >
+    {#each items as item}
+      <button
+        type="button"
+        class="menu-item"
+        role="menuitem"
+        disabled={item.disabled}
+        onclick={() => {
+          if (item.disabled) return;
+          onclose();
+          item.onSelect?.();
+        }}
+      >
+        {item.label}
+      </button>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .map-context-menu {
+    position: fixed;
+    z-index: 80;
+    min-width: 200px;
+    padding: 4px;
+    background: var(--map-overlay-bg);
+    color: var(--map-overlay-fg);
+    border: 1px solid var(--map-overlay-border);
+    border-radius: 6px;
+    box-shadow: var(--map-overlay-shadow);
+    font-family: var(--font-mono);
+    font-size: 13px;
+    user-select: none;
+  }
+  .menu-item {
+    display: block;
+    width: 100%;
+    padding: 6px 10px;
+    border: none;
+    background: transparent;
+    color: inherit;
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
+    border-radius: 4px;
+    white-space: nowrap;
+  }
+  .menu-item:hover:not(:disabled),
+  .menu-item:focus-visible:not(:disabled) {
+    background: var(--color-surface-hover, rgba(255, 255, 255, 0.08));
+    color: var(--color-text);
+    outline: none;
+  }
+  .menu-item:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -190,6 +190,35 @@
   // now owns channel freshness; this page just subscribes.
   startChannelsStore();
 
+  // Parse ?lat=…&lon=… from the hash route. svelte-spa-router doesn't
+  // hand us the query string directly; the conventional pattern is to
+  // pull it off window.location.hash. Returns nulls when either field
+  // is missing or unparseable, so the caller can short-circuit.
+  function parseLatLonFromHash() {
+    if (typeof window === 'undefined') return { lat: null, lon: null };
+    const h = window.location.hash || '';
+    const qIdx = h.indexOf('?');
+    if (qIdx < 0) return { lat: null, lon: null };
+    const params = new URLSearchParams(h.slice(qIdx + 1));
+    const lat = parseFloat(params.get('lat'));
+    const lon = parseFloat(params.get('lon'));
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+      return { lat: null, lon: null };
+    }
+    return { lat, lon };
+  }
+
+  // Strip query params from the hash without triggering a route nav, so
+  // a reload doesn't re-open the modal. replaceState keeps history clean.
+  function clearLatLonFromHash() {
+    if (typeof window === 'undefined') return;
+    const h = window.location.hash || '';
+    const qIdx = h.indexOf('?');
+    if (qIdx < 0) return;
+    const clean = h.slice(0, qIdx);
+    window.history.replaceState(null, '', window.location.pathname + window.location.search + clean);
+  }
+
   onMount(async () => {
     beacons = await api.get('/beacons') || [];
     const sb = await api.get('/smart-beacon');
@@ -209,6 +238,18 @@
       stationCallsign = (st && st.callsign) || '';
     } catch {
       stationCallsign = '';
+    }
+    // Deep-link entry from the map context menu's "Add fixed beacon
+    // here" item: open the create modal with pos_source=fixed and the
+    // clicked coordinates prefilled. Done after the channels store has
+    // been kicked above so openCreate() finds a default channel.
+    const { lat, lon } = parseLatLonFromHash();
+    if (lat != null && lon != null) {
+      clearLatLonFromHash();
+      openCreate();
+      form.pos_source = 'fixed';
+      form.latitude = String(lat);
+      form.longitude = String(lon);
     }
   });
 

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -22,6 +22,8 @@
   import { toMaidenhead } from '../lib/map/maidenhead.js';
   import { fmtLat, fmtLon, timeAgo } from '../lib/map/popup-helpers.js';
   import { toasts } from '../lib/stores.js';
+  import MapPinPlus from 'lucide-svelte/icons/map-pin-plus';
+  import Copy from 'lucide-svelte/icons/copy';
 
   // Values are seconds (data store wants ms; multiplied at dispatch).
   const TIMERANGES_S = [
@@ -97,6 +99,11 @@
       toasts.error('Clipboard unavailable');
     }
   }
+  // Hemispheric coords shown once in the menu header; the copy items
+  // carry short labels so the menu stays narrow.
+  function ctxMenuHeader() {
+    return `${fmtLat(ctxMenu.lat)} ${fmtLon(ctxMenu.lon)}`;
+  }
   function ctxMenuItems() {
     const { lat, lon } = ctxMenu;
     const coords = `${fmtLat(lat)} ${fmtLon(lon)}`;
@@ -107,22 +114,29 @@
     const grid = toMaidenhead(lat, lon);
     return [
       {
-        label: 'Add fixed beacon here…',
+        label: 'Add fixed beacon here',
+        icon: MapPinPlus,
+        primary: true,
         onSelect: () => {
           const q = `lat=${lat.toFixed(6)}&lon=${lon.toFixed(6)}`;
           window.location.hash = `#/beacons?${q}`;
         },
       },
+      { divider: true },
       {
-        label: `Copy coordinates (${coords})`,
+        label: 'Copy coordinates',
+        icon: Copy,
         onSelect: () => copyToClipboard(coords, 'Coordinates'),
       },
       {
-        label: `Copy decimal coordinates (${decimal})`,
+        label: 'Copy decimal',
+        icon: Copy,
         onSelect: () => copyToClipboard(decimal, 'Decimal coordinates'),
       },
       {
-        label: `Copy grid square (${grid})`,
+        label: 'Copy grid',
+        icon: Copy,
+        hint: grid,
         onSelect: () => copyToClipboard(grid, 'Grid square'),
       },
     ];
@@ -631,6 +645,7 @@
     open={ctxMenu.open}
     x={ctxMenu.x}
     y={ctxMenu.y}
+    header={ctxMenu.open ? ctxMenuHeader() : ''}
     items={ctxMenu.open ? ctxMenuItems() : []}
     onclose={closeCtxMenu}
   />

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -9,6 +9,7 @@
   import maplibregl from 'maplibre-gl';
   import MaplibreMap from '../lib/map/maplibre-map.svelte';
   import InfoPanel from '../lib/map/info-panel.svelte';
+  import MapContextMenu from '../lib/map/map-context-menu.svelte';
   import { createDataStore } from '../lib/map/data-store.svelte.js';
   import { mountStationsLayer } from '../lib/map/layers/stations.js';
   import { mountTrailsLayer } from '../lib/map/layers/trails.js';
@@ -20,6 +21,7 @@
   import { mapState, MY_POSITION_ZOOM } from '../lib/map/map-store.svelte.js';
   import { toMaidenhead } from '../lib/map/maidenhead.js';
   import { fmtLat, fmtLon, timeAgo } from '../lib/map/popup-helpers.js';
+  import { toasts } from '../lib/stores.js';
 
   // Values are seconds (data store wants ms; multiplied at dispatch).
   const TIMERANGES_S = [
@@ -79,6 +81,44 @@
   let timerangeSec = $state(Math.floor(dataStore.timerangeMs / 1000));
   let coordText = $state('');
   let zoomLevel = $state(null);
+
+  // Right-click context menu (background only — station markers keep
+  // their own left-click popup). The menu is positioned in viewport
+  // coords; the map listener supplies them on contextmenu.
+  let ctxMenu = $state({ open: false, x: 0, y: 0, lat: 0, lon: 0 });
+  function closeCtxMenu() {
+    ctxMenu.open = false;
+  }
+  async function copyToClipboard(text, label) {
+    try {
+      await navigator.clipboard.writeText(text);
+      toasts.success(`${label} copied`);
+    } catch {
+      toasts.error('Clipboard unavailable');
+    }
+  }
+  function ctxMenuItems() {
+    const { lat, lon } = ctxMenu;
+    const coords = `${fmtLat(lat)} ${fmtLon(lon)}`;
+    const grid = toMaidenhead(lat, lon);
+    return [
+      {
+        label: `Copy coordinates (${coords})`,
+        onSelect: () => copyToClipboard(coords, 'Coordinates'),
+      },
+      {
+        label: `Copy grid square (${grid})`,
+        onSelect: () => copyToClipboard(grid, 'Grid square'),
+      },
+      {
+        label: 'Add fixed beacon here…',
+        onSelect: () => {
+          const q = `lat=${lat.toFixed(6)}&lon=${lon.toFixed(6)}`;
+          window.location.hash = `#/beacons?${q}`;
+        },
+      },
+    ];
+  }
 
   // Tick once a second so "5s ago" stays accurate without hammering the
   // status-bar derived state from elsewhere.
@@ -252,6 +292,38 @@
     // is fine without an explicit rAF gate.
     map.on('mousemove', (e) => updateCoordText(e.lngLat));
     map.on('mouseout', () => (coordText = ''));
+
+    // Right-click background → open context menu. Bail when the click
+    // landed on a station marker (or any DOM child of one): markers own
+    // a left-click popup and we don't want to fight that surface.
+    map.on('contextmenu', (e) => {
+      const target = e.originalEvent?.target;
+      if (target && target.closest && target.closest('.gw-station-marker')) {
+        return;
+      }
+      e.preventDefault?.();
+      e.originalEvent?.preventDefault?.();
+      // position:fixed menu wants viewport coords, not canvas-relative
+      // (which is what e.point gives us). originalEvent.clientX/Y is the
+      // right surface, with a fallback to e.point in the unlikely case
+      // where the synthetic event lacks an originalEvent.
+      const oe = e.originalEvent;
+      const vx = oe?.clientX ?? e.point.x;
+      const vy = oe?.clientY ?? e.point.y;
+      ctxMenu = {
+        open: true,
+        x: vx,
+        y: vy,
+        lat: e.lngLat.lat,
+        lon: e.lngLat.lng,
+      };
+      // Suppress hover overlays while the menu is up.
+      closePopup();
+      hoverPathLayer?.clear();
+    });
+    // Any camera change closes the menu — its anchor lat/lon would drift.
+    map.on('movestart', closeCtxMenu);
+    map.on('zoomstart', closeCtxMenu);
 
     dataStore.start();
   }
@@ -546,6 +618,14 @@
       {#if coordText}{coordText} &middot; {/if}z {zoomLevel?.toFixed(1) ?? ''}
     </div>
   {/if}
+
+  <MapContextMenu
+    open={ctxMenu.open}
+    x={ctxMenu.x}
+    y={ctxMenu.y}
+    items={ctxMenu.open ? ctxMenuItems() : []}
+    onclose={closeCtxMenu}
+  />
 
   <!-- Status bar (bottom-center; legacy placement so it doesn't sit
        under the sidebar on narrow desktop windows). -->

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -100,22 +100,30 @@
   function ctxMenuItems() {
     const { lat, lon } = ctxMenu;
     const coords = `${fmtLat(lat)} ${fmtLon(lon)}`;
+    // Signed-decimal form -- the shape paste targets like Google Maps,
+    // OpenStreetMap, and most spreadsheets expect. 5 decimal places is
+    // ~1 m of precision, enough for any APRS use.
+    const decimal = `${lat.toFixed(5)}, ${lon.toFixed(5)}`;
     const grid = toMaidenhead(lat, lon);
     return [
-      {
-        label: `Copy coordinates (${coords})`,
-        onSelect: () => copyToClipboard(coords, 'Coordinates'),
-      },
-      {
-        label: `Copy grid square (${grid})`,
-        onSelect: () => copyToClipboard(grid, 'Grid square'),
-      },
       {
         label: 'Add fixed beacon here…',
         onSelect: () => {
           const q = `lat=${lat.toFixed(6)}&lon=${lon.toFixed(6)}`;
           window.location.hash = `#/beacons?${q}`;
         },
+      },
+      {
+        label: `Copy coordinates (${coords})`,
+        onSelect: () => copyToClipboard(coords, 'Coordinates'),
+      },
+      {
+        label: `Copy decimal coordinates (${decimal})`,
+        onSelect: () => copyToClipboard(decimal, 'Decimal coordinates'),
+      },
+      {
+        label: `Copy grid square (${grid})`,
+        onSelect: () => copyToClipboard(grid, 'Grid square'),
       },
     ];
   }


### PR DESCRIPTION
## Summary

Adds a right-click (desktop) / long-press (mobile) context menu to the LiveMap background with four actions:

- **Add fixed beacon here…** — navigates to `#/beacons?lat=…&lon=…`; the Beacons page parses those params, opens the create modal, and prefills `pos_source=fixed` + lat/lon
- **Copy coordinates** — hemispheric form (`37.47246°N 86.28855°W`), the shape the rest of the map UI already uses
- **Copy decimal coordinates** — signed decimal (`37.47246, -86.28855`), the shape Google Maps / OpenStreetMap / spreadsheets expect
- **Copy grid square** — Maidenhead locator (`EM67ll`)

The menu only opens on the map background. Right-clicks on station markers are filtered via `closest('.gw-station-marker')` so they don't fight the existing left-click station popup.

## Why

Right-clicking a point on a map and grabbing its coordinates is a baseline expectation users bring from Google Maps / Apple Maps / etc. The "add fixed beacon here" item is the high-value variant: setting up a fixed-position beacon previously meant copying coords from somewhere, navigating to the Beacons page, opening the modal, switching the position source, and pasting them in. This collapses that flow to one click — which is why it sits at the top of the menu, directly under the cursor.

Mobile is covered by MapLibre's built-in long-press → contextmenu synthesis. The same handler fires from a touch-and-hold, no second code path.

## What changed

- **New**: `web/src/lib/map/map-context-menu.svelte` — positioned overlay themed with the existing `--map-overlay-*` tokens. Closes on outside-click (pointerdown), Escape, and (via the parent) `movestart`/`zoomstart`. Clamps inside the viewport so it doesn't get cut off near the edges.
- `web/src/routes/LiveMapV2.svelte` — wires `map.on('contextmenu', …)` inside `onMapReady`. Uses `originalEvent.clientX/Y` (viewport coords) since the menu is `position: fixed`; falls back to `e.point` if needed.
- `web/src/routes/Beacons.svelte` — `onMount` peeks at `window.location.hash` for `?lat=…&lon=…`, strips them via `history.replaceState` (so a reload doesn't re-open the modal), then opens the create modal with values prefilled.
- `docs/wiki/code-map.md` — updated the Web UI row to mention the new component and the deep-link contract.


## Disclosure
This was written by AI. Feel free to adjust or reject!

<img width="1069" height="759" alt="image" src="https://github.com/user-attachments/assets/0bfe0499-1db8-436a-84df-b341faa9f95c" />