### PR TITLE
feat(igate,digi): auto-save master Enable toggle on flip

### DIFF
--- a/web/src/routes/Digipeater.svelte
+++ b/web/src/routes/Digipeater.svelte
@@ -120,6 +120,13 @@
   });
   let savingConfig = $state(false);
 
+  // Last-persisted config body. The master Enable toggle auto-saves
+  // against this snapshot (see autoSaveEnabled) so flipping it never
+  // commits unsaved edits to the callsign / dedupe fields. Seeded on
+  // load and refreshed after every successful save.
+  let savedConfig = $state(/** @type {null | object} */ (null));
+  let enableSaving = $state(false);
+
   let fromCh = $derived(lookupChannel(parseInt(form.from_channel, 10)));
   let toCh = $derived(lookupChannel(parseInt(form.to_channel, 10)));
   // Backing-diff inline warning: when bridging from one backing kind
@@ -256,6 +263,11 @@
       my_call: storedMyCall,
       dedupe_window_seconds: String(data.dedupe_window_seconds || DEFAULT_DEDUPE_SECONDS),
     };
+    savedConfig = {
+      enabled: config.enabled,
+      my_call: storedMyCall,
+      dedupe_window_seconds: parseInt(config.dedupe_window_seconds, 10),
+    };
     // Derive the radio-group state from the loaded value: a stored
     // empty string means "inherit from station callsign"; non-empty
     // means the operator set an explicit override (and we want to
@@ -289,11 +301,13 @@
     }
     savingConfig = true;
     try {
-      await api.put('/digipeater', {
+      const body = {
         enabled: config.enabled,
         my_call: myCallForSave,
         dedupe_window_seconds: seconds,
-      });
+      };
+      await api.put('/digipeater', body);
+      savedConfig = body;
       // Mirror the saved value back into the form so the input shows
       // the canonicalized (trimmed / uppercased) string.
       config.my_call = myCallForSave;
@@ -321,6 +335,29 @@
     if (!stationCallsignMissing || config.enabled) return;
     if (e.key === ' ' || e.key === 'Enter') {
       e.preventDefault();
+    }
+  }
+
+  // Master Enable toggle auto-save. Flipping Enable persists immediately
+  // — only the enabled bit, merged onto the last-saved snapshot, so an
+  // in-progress callsign-override or dedupe edit is NOT committed. The
+  // station-callsign guard above already prevents the flip (and thus
+  // this handler firing) when the callsign is missing.
+  async function autoSaveEnabled(next) {
+    // Absorb the programmatic revert (next already matches saved) and
+    // guard against re-entrancy while a save is in flight.
+    if (!savedConfig || next === savedConfig.enabled || enableSaving) return;
+    enableSaving = true;
+    try {
+      const body = { ...savedConfig, enabled: next };
+      await api.put('/digipeater', body);
+      savedConfig = body;
+      toasts.success(next ? 'Digipeater enabled' : 'Digipeater disabled');
+    } catch (err) {
+      config.enabled = savedConfig.enabled;
+      toasts.error(err.message || 'Failed to update Digipeater');
+    } finally {
+      enableSaving = false;
     }
   }
 
@@ -456,6 +493,7 @@
       aria-describedby={stationCallsignMissing ? 'digi-station-banner' : undefined}
       onclick={handleEnableToggleClick}
       onkeydown={handleEnableToggleKeydown}
+      onCheckedChange={autoSaveEnabled}
     />
     <div style="margin-top: 12px;">
       <FormField label="Callsign" id="digi-call-mode"

--- a/web/src/routes/Igate.svelte
+++ b/web/src/routes/Igate.svelte
@@ -28,6 +28,13 @@
   });
   let loading = $state(false);
 
+  // Last-persisted config body. The master Enable toggle auto-saves
+  // against this snapshot (see autoSaveEnabled) so flipping it never
+  // commits unsaved edits to the other fields. Seeded on load and
+  // refreshed after every successful save.
+  let savedConfig = $state(/** @type {null | object} */ (null));
+  let enableSaving = $state(false);
+
   // Station callsign (read-only on this page). Loaded alongside the
   // iGate config; failure is non-fatal — we treat a failed load as
   // "missing" so the banner renders and the toggle is aria-disabled,
@@ -277,6 +284,7 @@
           software_name: data.software_name,
           software_version: data.software_version,
         };
+        savedConfig = buildBody();
         filters = await api.get('/igate/filters') || [];
       })(),
     ]);
@@ -306,31 +314,36 @@
     return true;
   }
 
+  // Build the PUT body explicitly from form state — do NOT spread
+  // `form`. The iGate PUT decoder uses DisallowUnknownFields (Phase
+  // 3B), so an unexpected `callsign`/`passcode` key would return 400.
+  // Shared by handleSave and the savedConfig seed so the auto-save
+  // snapshot shape can't drift from the explicit-save shape.
+  function buildBody() {
+    return {
+      enabled: form.enabled,
+      server: form.server,
+      port: parseInt(form.port),
+      server_filter: form.server_filter,
+      tx_channel: parseInt(form.tx_channel),
+      simulation_mode: form.simulation_mode,
+      gate_rf_to_is: form.gate_rf_to_is,
+      gate_is_to_rf: form.gate_is_to_rf,
+      rf_channel: form.rf_channel,
+      max_msg_hops: form.max_msg_hops,
+      software_name: form.software_name,
+      software_version: form.software_version,
+    };
+  }
+
   async function handleSave(e) {
     e.preventDefault();
     if (!validateConfig()) return;
     loading = true;
     try {
-      // Build the save body explicitly — do NOT spread `form`. The
-      // iGate PUT decoder uses DisallowUnknownFields (Phase 3B), so an
-      // unexpected `callsign`/`passcode` key would return 400 even
-      // though both were removed from the form state above. Being
-      // explicit also makes future DTO drift a compile-time concern.
-      const body = {
-        enabled: form.enabled,
-        server: form.server,
-        port: parseInt(form.port),
-        server_filter: form.server_filter,
-        tx_channel: parseInt(form.tx_channel),
-        simulation_mode: form.simulation_mode,
-        gate_rf_to_is: form.gate_rf_to_is,
-        gate_is_to_rf: form.gate_is_to_rf,
-        rf_channel: form.rf_channel,
-        max_msg_hops: form.max_msg_hops,
-        software_name: form.software_name,
-        software_version: form.software_version,
-      };
+      const body = buildBody();
       await api.put('/igate/config', body);
+      savedConfig = body;
       toasts.success('iGate config saved');
       refreshChannels();
     } catch (err) {
@@ -360,6 +373,37 @@
     if (!stationCallsignMissing || form.enabled) return;
     if (e.key === ' ' || e.key === 'Enter') {
       e.preventDefault();
+    }
+  }
+
+  // Master Enable toggle auto-save. Flipping Enable persists immediately
+  // — only the enabled bit, merged onto the last-saved snapshot, so
+  // unsaved edits to the other fields are NOT committed. The
+  // station-callsign guard above already prevents the flip (and thus
+  // this handler firing) when the callsign is missing.
+  async function autoSaveEnabled(next) {
+    // Absorb the programmatic revert (next already matches saved) and
+    // guard against re-entrancy while a save is in flight.
+    if (!savedConfig || next === savedConfig.enabled || enableSaving) return;
+    // Preserve the disabled-Save safety: never auto-enable onto a
+    // non-TX-capable channel. Disabling is always allowed.
+    if (next && txBlock) {
+      form.enabled = savedConfig.enabled;
+      toasts.error(`Cannot enable iGate: TX channel not TX-capable — ${txBlock.reason}.`);
+      return;
+    }
+    enableSaving = true;
+    try {
+      const body = { ...savedConfig, enabled: next };
+      await api.put('/igate/config', body);
+      savedConfig = body;
+      toasts.success(next ? 'iGate enabled' : 'iGate disabled');
+      refreshChannels();
+    } catch (err) {
+      form.enabled = savedConfig.enabled;
+      toasts.error(err.message || 'Failed to update iGate');
+    } finally {
+      enableSaving = false;
     }
   }
 
@@ -525,6 +569,7 @@
         aria-describedby={stationCallsignMissing ? 'igate-station-banner' : undefined}
         onclick={handleEnableToggleClick}
         onkeydown={handleEnableToggleKeydown}
+        onCheckedChange={autoSaveEnabled}
       />
       <div style="margin-top: 16px;">
         <FormField label="APRS-IS Server" id="ig-server">


### PR DESCRIPTION
## Problem

On the **iGate** and **Digipeater** settings pages, the master **Enable** toggle was a bound form field that only persisted when you clicked **Save**. Flipping it and navigating to another tab discarded the change on unmount; returning re-ran `onMount`, which reloaded `enabled: false` from the API. The toggle appeared to "not stick." This is platform-independent (surfaced on an Android tablet).

## Change

Wire the chonky `Toggle`'s `onCheckedChange` to an `autoSaveEnabled` handler that persists immediately:

- Saves **only the enabled bit**, merged onto a `savedConfig` snapshot of the last-persisted body — so an in-progress edit to a sibling field (server/port/TX channel/filter; callsign/dedupe) is **not** silently committed. Those fields keep their own Save button.
- Toasts on success; on API error, **reverts** the toggle to the saved value.
- The snapshot is seeded on load and refreshed after every successful explicit Save *and* auto-save.

### Guards preserved

- **Station callsign missing:** the existing `onclick`/`onkeydown` `preventDefault` blocks the flip *before* `onCheckedChange` fires — unchanged.
- **iGate TX channel not TX-capable:** `autoSaveEnabled` refuses an auto-**enable** while `txBlock` is active (revert + toast), mirroring today's disabled-Save behavior. Disabling is always allowed.
- A no-op/`enableSaving` guard absorbs the programmatic revert and prevents re-entrancy, so reverting `checked` can't loop.

Backend is unchanged; the PUT triggers the existing iGate hot-reload (invariant #28) the same way Save did.

## Scope

Frontend only, two files: `web/src/routes/Igate.svelte`, `web/src/routes/Digipeater.svelte`.

## Verification

- `vite build` clean.
- `npm test` — 232/232 pass.
- Manual on-device check still recommended: flip Enable, switch tabs, return → stays on, with an enabled/disabled toast per flip.