### PR TITLE
Beacons: add Object beacon type to the UI

### DIFF
--- a/docs/handbook/beacons.html
+++ b/docs/handbook/beacons.html
@@ -225,6 +225,60 @@
       </div>
     </div>
 
+    <h2>Objects</h2>
+
+    <p>
+      An <strong>object</strong> beacon transmits a named item (a repeater,
+      a hospital, an event site) on behalf of someone else. The packet
+      carries both the object name and your station callsign as the
+      transmitting source, so APRS clients like aprs.fi display it as
+      <em>NAME (via YOUR-CALL)</em> &mdash; making it clear who is
+      injecting the object onto the network.
+    </p>
+
+    <p>
+      Use an object beacon (rather than the <code>Override station
+      callsign</code> checkbox on a Position beacon) whenever the item
+      you are beaconing is not your own station. Overriding the callsign
+      makes the packet look as if that name is a real station on the
+      air, which other operators have no way to attribute back to you.
+    </p>
+
+    <div class="box">
+      <div class="box-body">
+        <table>
+          <thead>
+            <tr><th>Field</th><th>Default</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>object_name</code></td>
+              <td>&mdash;</td>
+              <td>1&ndash;9 character object name shown on APRS maps</td>
+            </tr>
+            <tr>
+              <td><code>latitude</code></td>
+              <td>&mdash;</td>
+              <td>Fixed latitude (decimal degrees, north positive)</td>
+            </tr>
+            <tr>
+              <td><code>longitude</code></td>
+              <td>&mdash;</td>
+              <td>Fixed longitude (decimal degrees, east positive)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <p>
+      Object beacons accept the same <code>Position source</code> choice
+      as Position beacons &mdash; either fixed coordinates or the live
+      GPS fix. Fixed is the common case (the object is somewhere other
+      than your station), but GPS-sourced object positions are
+      supported for moving objects that you want to label by name.
+    </p>
+
     <h2>Symbols</h2>
 
     <p>

--- a/pkg/beacon/builder.go
+++ b/pkg/beacon/builder.go
@@ -94,7 +94,20 @@ func (s *Scheduler) buildInfo(ctx context.Context, b Config) (string, error) {
 		if b.ObjectName == "" {
 			return "", fmt.Errorf("object beacon missing object_name")
 		}
-		return ObjectInfo(b.ObjectName, true, "", b.Lat, b.Lon, b.SymbolTable, b.SymbolCode, phg, comment), nil
+		lat, lon := b.Lat, b.Lon
+		if b.UseGps {
+			if s.cache == nil {
+				return "", fmt.Errorf("object beacon: use_gps set but no GPS cache configured")
+			}
+			fix, ok := s.cache.Get()
+			if !ok {
+				return "", fmt.Errorf("object beacon: use_gps set but no GPS fix available")
+			}
+			lat, lon = fix.Latitude, fix.Longitude
+		} else if lat == 0 && lon == 0 {
+			return "", fmt.Errorf("object beacon: fixed coordinates are 0/0 (configure lat/lon or enable use_gps)")
+		}
+		return ObjectInfo(b.ObjectName, true, "", lat, lon, b.SymbolTable, b.SymbolCode, phg, comment), nil
 
 	case TypeCustom:
 		if b.CustomInfo == "" {

--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -90,6 +90,7 @@
   // openEdit's Object.assign still covers the full form snapshot and
   // we don't need a parallel lifecycle for the checkbox.
   let form = $state({
+    type: 'position', object_name: '',
     channel: '', callsign: '', callsign_override: false,
     destination: 'APGRWO', path: 'WIDE1-1,WIDE2-1',
     symbol_table: '/', symbol: '-', overlay: '',
@@ -259,6 +260,8 @@
       return;
     }
     editing = null;
+    form.type = 'position';
+    form.object_name = '';
     form.channel = String(channels[0].id);
     form.callsign = '';
     form.callsign_override = false;
@@ -292,6 +295,8 @@
     // Mutate form in place (rather than reassigning) so nested bind:value
     // on the RadioGroup picks up the new value reliably.
     Object.assign(form, row, {
+      type: row.type || 'position',
+      object_name: row.object_name || '',
       channel: String(row.channel),
       callsign: rowCall,
       callsign_override: rowCall !== '',
@@ -333,6 +338,19 @@
     if (!Number.isFinite(channelId) || channelId <= 0) {
       toasts.error('Channel required');
       return;
+    }
+    // Object beacons carry a 1-9 char name in the info field (APRS101).
+    if (form.type === 'object') {
+      const n = (form.object_name || '').trim();
+      if (!n) {
+        toasts.error('Object name required');
+        return;
+      }
+      if (n.length > 9) {
+        toasts.error('Object name must be 9 characters or fewer');
+        return;
+      }
+      form.object_name = n;
     }
     const useGps = form.pos_source === 'gps';
     const latStr = form.latitude.trim();
@@ -407,10 +425,15 @@
     }
   }
 
+  function beaconLabel(row) {
+    if (row.type === 'object' && row.object_name) return row.object_name;
+    return row.callsign || stationCallsign || '(unset)';
+  }
+
   async function handleSendNow(row) {
     try {
       await api.post(`/beacons/${row.id}/send`, {});
-      toasts.success(`Beacon sent: ${row.callsign || stationCallsign || '(unset)'}`);
+      toasts.success(`Beacon sent: ${beaconLabel(row)}`);
     } catch (err) {
       toasts.error(err.message);
     }
@@ -472,7 +495,10 @@
                 <span class="symbol-swatch-overlay">{b.overlay}</span>
               {/if}
             </span>
-            {#if b.callsign}
+            {#if b.type === 'object' && b.object_name}
+              <span class="beacon-callsign">{b.object_name}</span>
+              <span class="beacon-callsign-inherited">via {b.callsign || stationCallsign || '(not set)'}</span>
+            {:else if b.callsign}
               <span class="beacon-callsign">{b.callsign}</span>
             {:else if stationCallsign}
               <span class="beacon-callsign">{stationCallsign}</span>
@@ -483,6 +509,9 @@
           </div>
           <div class="beacon-badges">
             <Badge variant={b.enabled ? 'success' : 'default'}>{b.enabled ? 'Enabled' : 'Disabled'}</Badge>
+            {#if b.type === 'object'}
+              <Badge variant="info">Object</Badge>
+            {/if}
             {#if b.send_to_aprs_is}
               <Badge variant="info">APRS-IS</Badge>
             {/if}
@@ -613,6 +642,24 @@
       <div style="margin-bottom: 12px;">
         <Toggle bind:checked={form.enabled} label="Enabled" />
       </div>
+      <FormField label="Type" id="bcn-type">
+        <RadioGroup bind:value={form.type}>
+          <div class="pos-source-row">
+            <Radio value="position" label="Position" />
+            <Radio value="object" label="Object" />
+          </div>
+        </RadioGroup>
+        <div class="type-hint">
+          <div><strong>Position:</strong> a beacon for a station.</div>
+          <div><strong>Object:</strong> a named item such as a repeater, event site, hospital.</div>
+        </div>
+      </FormField>
+      {#if form.type === 'object'}
+        <FormField label="Object name" id="bcn-objname"
+          hint="1-9 characters. Appears as the object's label on APRS maps.">
+          <Input id="bcn-objname" bind:value={form.object_name} placeholder="Object callsign" maxlength="9" />
+        </FormField>
+      {/if}
       <FormField label="Channel" id="bcn-channel"
         hint="Radio channel this beacon transmits on. Defined on the Channels page.">
         <ChannelListbox
@@ -747,7 +794,7 @@
   <AlertDialog.Content>
     <AlertDialog.Title>Delete Beacon</AlertDialog.Title>
     <AlertDialog.Description>
-      Are you sure you want to delete the beacon for "{deleteTarget?.callsign || stationCallsign || '(unset)'}"? This cannot be undone.
+      Are you sure you want to delete the beacon for "{deleteTarget ? beaconLabel(deleteTarget) : '(unset)'}"? This cannot be undone.
     </AlertDialog.Description>
     <div class="modal-footer">
       <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
@@ -964,6 +1011,15 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
+  }
+  .type-hint {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--color-text-muted, #888);
+    line-height: 1.4;
   }
   .symbol-swatch {
     flex: 0 0 auto;

--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -357,10 +357,11 @@
     const lonStr = form.longitude.trim();
     const lat = latStr === '' ? 0 : parseFloat(latStr);
     const lon = lonStr === '' ? 0 : parseFloat(lonStr);
-    // Convert altitude input to feet for the API
+    // Convert altitude input to feet for the API. Object reports don't
+    // carry altitude (the ObjectInfo encoder has no /A= field), so skip it.
     const altNorm = altInput.replace(',', '.').trim();
     let altFt = null;
-    if (altNorm !== '') {
+    if (form.type !== 'object' && altNorm !== '') {
       const altVal = parseFloat(altNorm);
       if (Number.isNaN(altVal)) {
         altError = 'Altitude must be a number';
@@ -657,7 +658,7 @@
       {#if form.type === 'object'}
         <FormField label="Object name" id="bcn-objname"
           hint="1-9 characters. Appears as the object's label on APRS maps.">
-          <Input id="bcn-objname" bind:value={form.object_name} placeholder="Object callsign" maxlength="9" />
+          <Input id="bcn-objname" bind:value={form.object_name} placeholder="e.g. FIELDDAY" maxlength="9" />
         </FormField>
       {/if}
       <FormField label="Channel" id="bcn-channel"
@@ -670,7 +671,14 @@
           capabilityFilter={txPredicate}
         />
       </FormField>
-      <FormField label="Callsign" id="bcn-call" error={callsignError}>
+      <FormField
+        label={form.type === 'object' ? 'Transmitting station (via)' : 'Callsign'}
+        id="bcn-call"
+        error={callsignError}
+        hint={form.type === 'object'
+          ? "The object is attributed to this station on APRS maps as “NAME (via callsign)”. Leave unchecked to transmit it under your station callsign."
+          : undefined}
+      >
         <div class="callsign-row">
           <Input
             id="bcn-call"
@@ -681,7 +689,7 @@
           />
           <label class="callsign-override-label" for="bcn-call-override">
             <Checkbox id="bcn-call-override" bind:checked={form.callsign_override} />
-            <span>Override station callsign</span>
+            <span>{form.type === 'object' ? 'Use a different callsign' : 'Override station callsign'}</span>
           </label>
         </div>
       </FormField>
@@ -718,7 +726,9 @@
 
     <div class="beacon-form-col">
       <FormField label="Position source" id="bcn-pos-source"
-        hint="Choose whether this beacon's coordinates come from the live GPS fix or from fixed values you enter below.">
+        hint={form.type === 'object'
+          ? "Choose whether this object's coordinates come from the live GPS fix or from fixed values you enter below."
+          : "Choose whether this beacon's coordinates come from the live GPS fix or from fixed values you enter below."}>
         <RadioGroup bind:value={form.pos_source}>
           <div class="pos-source-row">
             <Radio value="gps" label="Use latest fix from GPS" />
@@ -735,19 +745,21 @@
           hint="Decimal degrees, east positive (e.g. -122.4 for San Francisco; 151.2 for Sydney).">
           <Input id="bcn-lon" bind:value={form.longitude} placeholder="-122.4" />
         </FormField>
-        <FormField label="Altitude" id="bcn-alt"
-          hint="Antenna height above sea level in {altUnit}. Optional; leave blank or 0 to omit.">
-          <div class="alt-row">
-            <Input id="bcn-alt" bind:value={altInput} placeholder={altUnit === 'feet' ? '0 ft' : '0 m'}
-              type="text" inputmode="decimal" error={altError} oninput={() => altError = ''} />
-            <div class="unit-toggle" role="group" aria-label="Altitude unit">
-              <button type="button" class="unit-btn" class:unit-active={altUnit === 'feet'}
-                onclick={() => toggleAltUnit('feet')}>ft</button>
-              <button type="button" class="unit-btn" class:unit-active={altUnit === 'meters'}
-                onclick={() => toggleAltUnit('meters')}>m</button>
+        {#if form.type !== 'object'}
+          <FormField label="Altitude" id="bcn-alt"
+            hint="Antenna height above sea level in {altUnit}. Optional; leave blank or 0 to omit.">
+            <div class="alt-row">
+              <Input id="bcn-alt" bind:value={altInput} placeholder={altUnit === 'feet' ? '0 ft' : '0 m'}
+                type="text" inputmode="decimal" error={altError} oninput={() => altError = ''} />
+              <div class="unit-toggle" role="group" aria-label="Altitude unit">
+                <button type="button" class="unit-btn" class:unit-active={altUnit === 'feet'}
+                  onclick={() => toggleAltUnit('feet')}>ft</button>
+                <button type="button" class="unit-btn" class:unit-active={altUnit === 'meters'}
+                  onclick={() => toggleAltUnit('meters')}>m</button>
+              </div>
             </div>
-          </div>
-        </FormField>
+          </FormField>
+        {/if}
       {/if}
       <FormField label="Interval (seconds)" id="bcn-interval">
         <Input id="bcn-interval" bind:value={form.interval} type="number" placeholder="600" />


### PR DESCRIPTION
## Why

Operators who wanted to beacon a named item — a hospital, a repeater, an
event site — had to use the **Override station callsign** checkbox to do
it. That works at the AX.25 source-address layer, so the packet looks
like a brand-new station on aprs.fi instead of an object you injected.
There's no way for other operators to attribute the beacon back to you.

The backend already understood APRS object reports (`pkg/beacon/encoder.go`,
`builder.go`, the DTO, the model — all wired) but the UI never let you
pick this mode. This PR adds that selector.

## What changed

- **New Type radio on the Edit Beacon dialog** — Position (default) or
  Object. Picking Object reveals an **Object name** field (1-9 chars,
  per APRS101). Saved beacons round-trip through the existing DTO and
  configstore columns; no schema changes.
- **Beacon card** now shows the object name as the primary identifier
  with a `via {callsign}` subtitle when the row is an object beacon,
  plus a small **Object** badge. Card layout for position beacons is
  unchanged.
- **Object beacons can use GPS** — same Position source choice as
  Position beacons (fixed coords or live GPS fix). The scheduler's
  `TypeObject` branch now reads from the GPS cache when `use_gps=true`,
  mirroring the position path's behavior and error messages.
- **Handbook** — new **Objects** section under `docs/handbook/beacons.html`
  explaining the `Name (via callsign)` semantics, the GPS option, and
  why operators should pick this over the callsign-override trick.

Sent over the air, an object beacon for `TLRMC` from `KO4BKU-10` now
shows on aprs.fi as `TLRMC (via KO4BKU-10)` — properly attributed.

## Files

- `web/src/routes/Beacons.svelte`
- `pkg/beacon/builder.go`
- `docs/handbook/beacons.html`


## Disclosure
This was written by AI. Feel free to adjust or reject!


<img width="822" height="495" alt="image" src="https://github.com/user-attachments/assets/5a7a34b6-b726-4933-931c-2c420ccf6e91" />

<img width="447" height="397" alt="image" src="https://github.com/user-attachments/assets/fcbf9b70-c948-45d9-9bc3-5132f1de4004" />

