### PR TITLE
Channel TX test signals: CW callsign ID + tones (remove broken Test Tone)

### DIFF
--- a/docs/superpowers/plans/2026-05-26-channel-cw-id.md
+++ b/docs/superpowers/plans/2026-05-26-channel-cw-id.md
@@ -1,16 +1,16 @@
-# Channel CW ID Implementation Plan
+# Channel TX Test Signals Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Remove the broken audio Test Tone feature and add a per-channel "Send CW ID" button that transmits the station callsign in Morse through the channel's real TX path (key PTT → CW audio → unkey).
+**Goal:** Remove the broken audio Test Tone feature and add a per-channel "Test TX" dropdown menu offering four TX test signals — station callsign in CW, a 1200 Hz tone, a 2400 Hz tone, and a 1200/2400 Hz alternating tone — each transmitted through the channel's real TX path (key PTT → audio → unkey).
 
-**Architecture:** A new `TransmitCwId` IPC message carries `{channel, callsign}` from Go to the Rust modem. A pure Rust `morse` module turns the callsign into i16 PCM samples (hardcoded 20 WPM / 700 Hz, PARIS timing); the modem submits them as a `TxJob` to the existing TX worker, which keys/unkeys PTT automatically — exactly like `handle_transmit_frame`. Go resolves the centralized station callsign and refuses to key the radio on an empty or N0CALL callsign.
+**Architecture:** A new `TransmitTestSignal` IPC message carries `{channel, kind, callsign, freqs, duration…}` from Go to the Rust modem. A pure Rust `txtest` module synthesizes i16 PCM (CW via a Morse encoder, plus steady and alternating tone generators); the modem submits the samples as a `TxJob` to the existing TX worker, which keys/unkeys PTT automatically — exactly like `handle_transmit_frame`. The four UI options map to hardcoded parameter sets in one place in Go. The CW option resolves the centralized station callsign and refuses (422) to key the radio on an empty or N0CALL callsign; the three tones need no callsign.
 
-**Tech Stack:** Rust (graywolf-modem, prost protobuf), Go (webapi + modembridge, protoc-gen-go), Svelte 5 (web UI, chonky-ui), Protocol Buffers IPC.
+**Tech Stack:** Rust (graywolf-modem, prost protobuf), Go (webapi + modembridge, protoc-gen-go), Svelte 5 (web UI, chonky-ui `DropdownMenu`), Protocol Buffers IPC.
 
 **Reference spec:** `docs/superpowers/specs/2026-05-26-channel-cw-id-design.md`
 
-**Branch:** `feature/channel-cw-id` (already created; the design doc commit is its first commit).
+**Branch:** `feature/channel-cw-id` (already created; the design + plan commits are its first commits).
 
 ---
 
@@ -24,7 +24,7 @@
 - **Go tests (webapi + bridge):** `go test ./pkg/webapi/... ./pkg/modembridge/...`
 - **Docs drift check:** `make docs-check`
 
-> Note: `cfg(linux)` Rust cannot fully compile on the dev Mac (see project memory). `cargo test -p graywolf-modem` for the pure `morse` module and host-buildable code works; full-modem on-target verification happens in CI / on-device. Where a step's Rust build is expected to need CI, the step says so.
+> Note: `cfg(linux)` Rust cannot fully compile on the dev Mac (see project memory). `cargo test -p graywolf-modem` for the pure `txtest` module and host-buildable code works; full-modem on-target verification happens in CI / on-device. Where a step's Rust build is expected to need CI, the step says so.
 
 ---
 
@@ -73,8 +73,6 @@ Remove this block from the output-device actions (around line 405):
 
 - [ ] **Step 3: Delete the `testingTone` state declaration**
 
-Find and remove the line declaring `testingTone` (search the file):
-
 Run: `grep -n "testingTone" web/src/routes/AudioDevices.svelte`
 Delete the remaining declaration line (e.g. `let testingTone = $state(null);`). After this, the grep must return nothing.
 
@@ -120,17 +118,7 @@ Expected: no output.
 
 - [ ] **Step 3: Remove the DTO**
 
-In `pkg/webapi/dto/audio_device.go`, delete the `TestToneResponse` type and its doc comment (around line 131):
-
-```go
-// TestToneResponse is the body returned by POST /api/audio-devices/{id}/test-tone
-// ...
-type TestToneResponse struct {
-	Status string `json:"status" example:"ok"`
-}
-```
-
-(Confirm exact field by reading lines 131-136 first.)
+In `pkg/webapi/dto/audio_device.go`, delete the `TestToneResponse` type and its doc comment (around line 131). Read lines 131-136 first to match exactly.
 
 - [ ] **Step 4: Remove the op-id constant**
 
@@ -222,6 +210,7 @@ git commit -m "Remove test tone request path from modem bridge"
 
 **Files:**
 - Modify: `graywolf-modem/src/modem/mod.rs`
+- Modify: `graywolf-modem/src/ipc/proto.rs`
 
 - [ ] **Step 1: Remove the dispatch arm**
 
@@ -304,7 +293,7 @@ Delete the `message PlayTestTone { ... }` block (around line 243-249) and the `m
 - [ ] **Step 3: Regenerate Go bindings**
 
 Run: `make proto`
-Expected: succeeds; `pkg/ipcproto/graywolf.pb.go` no longer contains `PlayTestTone` or `TestToneResult`.
+Expected: succeeds.
 
 Run: `grep -c "PlayTestTone\|TestToneResult" pkg/ipcproto/graywolf.pb.go`
 Expected: `0`.
@@ -312,12 +301,12 @@ Expected: `0`.
 - [ ] **Step 4: Regenerate Rust bindings + build**
 
 Run: `cargo build -p graywolf-modem 2>&1 | tail -20`
-Expected: build proceeds past codegen with no `TestTone`/`PlayTestTone` errors (prost regenerates from the edited proto via build.rs). Defer to CI if the host can't finish a `cfg(linux)` build.
+Expected: build proceeds past codegen with no `TestTone`/`PlayTestTone` errors. Defer to CI if the host can't finish a `cfg(linux)` build.
 
 - [ ] **Step 5: Regenerate docs and API types**
 
 Run: `make docs && cd web && npm run api:generate && cd ..`
-Expected: succeeds. `web/src/api/generated/api.d.ts` no longer references `test-tone`.
+Expected: succeeds.
 
 Run: `grep -rn "test-tone\|TestTone" web/src/api/generated/api.d.ts pkg/webapi/docs/gen/`
 Expected: no output.
@@ -336,25 +325,25 @@ git commit -m "Remove test tone IPC messages and regenerate bindings"
 
 ---
 
-# PART B — Add Channel CW ID
+# PART B — Add Channel TX Test Signals
 
-## Task B1: Pure Rust `morse` module (TDD)
+## Task B1: Pure Rust `txtest` module (TDD)
 
 **Files:**
-- Create: `graywolf-modem/src/morse.rs`
-- Modify: `graywolf-modem/src/lib.rs` (add `pub(crate) mod morse;`)
+- Create: `graywolf-modem/src/txtest.rs`
+- Modify: `graywolf-modem/src/lib.rs` (add `pub(crate) mod txtest;`)
 
 - [ ] **Step 1: Register the module**
 
 In `graywolf-modem/src/lib.rs`, add alongside the other top-level module declarations:
 
 ```rust
-pub(crate) mod morse;
+pub(crate) mod txtest;
 ```
 
 - [ ] **Step 2: Write the failing tests**
 
-Create `graywolf-modem/src/morse.rs` with the test module only first:
+Create `graywolf-modem/src/txtest.rs` with the test module only first:
 
 ```rust
 #[cfg(test)]
@@ -371,7 +360,6 @@ mod tests {
 
     #[test]
     fn encode_inter_character_gap() {
-        // "EE" => dit, 3-unit inter-char gap, dit
         assert_eq!(encode("EE"), vec![on(1), off(3), on(1)]);
     }
 
@@ -387,59 +375,95 @@ mod tests {
         assert_eq!(
             encode("A B"),
             vec![
-                on(1), off(1), on(3),          // A
-                off(7),                         // word gap
-                on(3), off(1), on(1), off(1), on(1), off(1), on(1), // B
+                on(1), off(1), on(3),
+                off(7),
+                on(3), off(1), on(1), off(1), on(1), off(1), on(1),
             ]
         );
     }
 
     #[test]
     fn encode_skips_unknown_chars() {
-        // '@' has no Morse representation; result equals "EE".
         assert_eq!(encode("E@E"), encode("EE"));
     }
 
     #[test]
-    fn synthesize_dit_length_matches_wpm() {
+    fn cw_samples_dit_length_matches_wpm() {
         // 20 WPM at 48 kHz: dit = 1.2/20 s = 60 ms = 2880 samples.
-        let samples = synthesize(&encode("E"), 48_000, 20, 700.0);
-        assert_eq!(samples.len(), 2880);
-        assert!(samples.iter().any(|&s| s != 0), "tone must be non-silent");
+        let s = cw_samples("E", 48_000, 20, 700.0);
+        assert_eq!(s.len(), 2880);
+        assert!(s.iter().any(|&v| v != 0), "tone must be non-silent");
     }
 
     #[test]
-    fn synthesize_empty_is_empty() {
-        assert!(synthesize(&[], 48_000, 20, 700.0).is_empty());
+    fn cw_samples_empty_callsign_is_empty() {
+        assert!(cw_samples("", 48_000, 20, 700.0).is_empty());
+    }
+
+    #[test]
+    fn tone_samples_length_and_nonsilent() {
+        // 3000 ms at 48 kHz = 144000 samples.
+        let s = tone_samples(48_000, 1200.0, 3000);
+        assert_eq!(s.len(), 144_000);
+        assert!(s.iter().any(|&v| v != 0));
+    }
+
+    #[test]
+    fn alternating_samples_length_and_nonsilent() {
+        let s = alternating_samples(48_000, 1200.0, 2400.0, 3000, 200);
+        assert_eq!(s.len(), 144_000);
+        assert!(s.iter().any(|&v| v != 0));
     }
 }
 ```
 
 - [ ] **Step 3: Run tests to verify they fail**
 
-Run: `cargo test -p graywolf-modem morse:: 2>&1 | tail -20`
-Expected: FAIL — `encode`, `synthesize`, `Segment` not found.
+Run: `cargo test -p graywolf-modem txtest:: 2>&1 | tail -20`
+Expected: FAIL — `encode`, `cw_samples`, `tone_samples`, `alternating_samples`, `Segment` not found.
 
 - [ ] **Step 4: Implement the module**
 
-Prepend the implementation above the test module in `graywolf-modem/src/morse.rs`:
+Prepend the implementation above the test module in `graywolf-modem/src/txtest.rs`:
 
 ```rust
-//! Pure CW (Morse) generation for station identification.
+//! Pure TX test-signal generation: CW (Morse) station ID and steady /
+//! alternating test tones.
 //!
-//! No I/O and no audio device — this turns a callsign string into i16 PCM
-//! samples. The modem submits those samples as a normal TxJob, so PTT
-//! keying and play-out reuse the existing TX worker path.
+//! No I/O and no audio device — this turns parameters into i16 PCM samples.
+//! The modem submits the samples as a normal TxJob, so PTT keying and
+//! play-out reuse the existing TX worker path.
 
-/// One keyed or unkeyed span, measured in Morse time units (1 unit = 1 dit).
+const AMP: f32 = 0.6 * 32767.0;
+const RAMP_MS: f32 = 5.0;
+
+/// One keyed or unkeyed CW span, in Morse time units (1 unit = 1 dit).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Segment {
     pub on: bool,
     pub units: u32,
 }
 
-/// Dot/dash pattern for a character, or None when there is no standard
-/// Morse representation (encode skips those).
+fn ramp_samples(sample_rate: u32) -> usize {
+    ((sample_rate as f32) * RAMP_MS / 1000.0) as usize
+}
+
+/// Apply a raised-cosine rise/fall (in place) to suppress edge clicks.
+fn apply_edges(buf: &mut [i16], ramp: usize) {
+    let n = buf.len();
+    let r = ramp.min(n / 2);
+    if r == 0 {
+        return;
+    }
+    for i in 0..r {
+        let env = 0.5 * (1.0 - (std::f32::consts::PI * i as f32 / r as f32).cos());
+        buf[i] = (buf[i] as f32 * env) as i16;
+        buf[n - 1 - i] = (buf[n - 1 - i] as f32 * env) as i16;
+    }
+}
+
+/// Dot/dash pattern for a character, or None when there is no standard Morse
+/// representation (encode skips those).
 fn pattern(c: char) -> Option<&'static str> {
     Some(match c.to_ascii_uppercase() {
         'A' => ".-", 'B' => "-...", 'C' => "-.-.", 'D' => "-..",
@@ -490,54 +514,79 @@ pub fn encode(text: &str) -> Vec<Segment> {
     out
 }
 
-/// Synthesize keyed segments to i16 PCM at `sample_rate`. `wpm` sets dit
-/// length via PARIS timing (dit = 1.2 / wpm seconds); `tone_hz` is the
-/// sidetone. Keyed spans get a 5 ms raised-cosine rise/fall to suppress key
-/// clicks; unkeyed spans are silence.
-pub fn synthesize(segments: &[Segment], sample_rate: u32, wpm: u32, tone_hz: f32) -> Vec<i16> {
+/// CW: encode `callsign` and render the on/off-keyed sidetone at `wpm`
+/// (PARIS timing) and `tone_hz`, with raised-cosine edges on each keyed span.
+/// Returns empty if the callsign has no renderable characters.
+pub fn cw_samples(callsign: &str, sample_rate: u32, wpm: u32, tone_hz: f32) -> Vec<i16> {
+    let segments = encode(callsign);
     let wpm = wpm.max(1);
-    let dit_samples = ((sample_rate as f64) * 1.2 / (wpm as f64)).round() as usize;
-    let total: usize = segments.iter().map(|s| dit_samples * s.units as usize).sum();
-    let mut out = Vec::with_capacity(total);
-    const AMP: f32 = 0.6 * 32767.0;
-    let ramp = ((sample_rate as f32) * 0.005) as usize; // 5 ms
+    let dit = ((sample_rate as f64) * 1.2 / wpm as f64).round() as usize;
+    let ramp = ramp_samples(sample_rate);
     let w = 2.0 * std::f32::consts::PI * tone_hz / sample_rate as f32;
-    for seg in segments {
-        let n = dit_samples * seg.units as usize;
+    let mut out: Vec<i16> = Vec::new();
+    for seg in &segments {
+        let n = dit * seg.units as usize;
         if !seg.on {
             out.extend(std::iter::repeat(0i16).take(n));
             continue;
         }
-        let r = ramp.min(n / 2);
+        let start = out.len();
         for i in 0..n {
-            let env = if r > 0 && i < r {
-                0.5 * (1.0 - (std::f32::consts::PI * i as f32 / r as f32).cos())
-            } else if r > 0 && i >= n - r {
-                0.5 * (1.0 - (std::f32::consts::PI * (n - 1 - i) as f32 / r as f32).cos())
-            } else {
-                1.0
-            };
-            let s = (w * i as f32).sin() * AMP * env;
-            out.push(s as i16);
+            out.push(((w * i as f32).sin() * AMP) as i16);
         }
+        let end = out.len();
+        apply_edges(&mut out[start..end], ramp);
     }
+    out
+}
+
+/// Steady sine of `freq_hz` for `duration_ms`, with edge ramps.
+pub fn tone_samples(sample_rate: u32, freq_hz: f32, duration_ms: u32) -> Vec<i16> {
+    let n = (sample_rate as u64 * duration_ms as u64 / 1000) as usize;
+    let w = 2.0 * std::f32::consts::PI * freq_hz / sample_rate as f32;
+    let mut out: Vec<i16> = (0..n).map(|i| ((w * i as f32).sin() * AMP) as i16).collect();
+    apply_edges(&mut out, ramp_samples(sample_rate));
+    out
+}
+
+/// Alternating tone: switch between `freq_a` and `freq_b` every `period_ms`
+/// for `duration_ms`. Phase-continuous (a running phase accumulator) so the
+/// frequency switches don't click; raised-cosine ramps on the outer edges.
+pub fn alternating_samples(
+    sample_rate: u32,
+    freq_a: f32,
+    freq_b: f32,
+    duration_ms: u32,
+    period_ms: u32,
+) -> Vec<i16> {
+    let n = (sample_rate as u64 * duration_ms as u64 / 1000) as usize;
+    let per = ((sample_rate as u64 * period_ms.max(1) as u64 / 1000) as usize).max(1);
+    let mut out: Vec<i16> = Vec::with_capacity(n);
+    let mut phase = 0.0f32;
+    let two_pi = 2.0 * std::f32::consts::PI;
+    for i in 0..n {
+        let f = if (i / per) % 2 == 0 { freq_a } else { freq_b };
+        phase += two_pi * f / sample_rate as f32;
+        out.push((phase.sin() * AMP) as i16);
+    }
+    apply_edges(&mut out, ramp_samples(sample_rate));
     out
 }
 ```
 
 - [ ] **Step 5: Run tests to verify they pass**
 
-Run: `cargo test -p graywolf-modem morse:: 2>&1 | tail -20`
-Expected: all 7 tests PASS.
+Run: `cargo test -p graywolf-modem txtest:: 2>&1 | tail -20`
+Expected: all 9 tests PASS.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add graywolf-modem/src/morse.rs graywolf-modem/src/lib.rs
-git commit -m "Add pure CW (Morse) sample-generation module"
+git add graywolf-modem/src/txtest.rs graywolf-modem/src/lib.rs
+git commit -m "Add pure TX test-signal module (CW, steady tone, alternating tone)"
 ```
 
-## Task B2: Add the CW ID IPC messages and regenerate bindings
+## Task B2: Add the TX test-signal IPC messages and regenerate bindings
 
 **Files:**
 - Modify: `proto/graywolf.proto`
@@ -546,16 +595,16 @@ git commit -m "Add pure CW (Morse) sample-generation module"
 
 - [ ] **Step 1: Add oneof entries**
 
-In `proto/graywolf.proto`, inside `oneof payload`, add to the Rust→Go group (use field **9**, the next free RX id):
+In `proto/graywolf.proto`, inside `oneof payload`, add to the Rust→Go group (field **9**, the next free RX id):
 
 ```proto
-    CwIdResult cw_id_result = 9;
+    TestSignalResult test_signal_result = 9;
 ```
 
-and to the Go→Rust group (use field **22**, the next free TX id):
+and to the Go→Rust group (field **22**, the next free TX id):
 
 ```proto
-    TransmitCwId transmit_cw_id = 22;
+    TransmitTestSignal transmit_test_signal = 22;
 ```
 
 - [ ] **Step 2: Add message definitions**
@@ -563,19 +612,26 @@ and to the Go→Rust group (use field **22**, the next free TX id):
 Add near the other audio/PTT messages:
 
 ```proto
-// Go -> Rust: transmit the station callsign as CW (Morse) for ID / TX
-// self-test. Callsign is already resolved and uppercased by Go.
-message TransmitCwId {
-  uint32 request_id = 1;        // echoed back in CwIdResult
-  uint32 channel = 2;           // selects output device + PTT driver
-  string callsign = 3;
+// Go -> Rust: transmit a TX test signal on a channel. kind selects the
+// generator: 0 = station callsign in CW, 1 = steady tone, 2 = alternating
+// tone. Go fills the relevant parameters; the modem is a pure renderer.
+message TransmitTestSignal {
+  uint32 request_id = 1;     // echoed back in TestSignalResult
+  uint32 channel = 2;        // selects output device + PTT driver
+  uint32 kind = 3;           // 0=CW callsign, 1=steady tone, 2=alternating
+  string callsign = 4;       // kind 0; already resolved + uppercased by Go
+  uint32 cw_wpm = 5;         // kind 0
+  uint32 freq_a_hz = 6;      // CW sidetone (0) / tone (1) / tone A (2)
+  uint32 freq_b_hz = 7;      // tone B (kind 2)
+  uint32 duration_ms = 8;    // kinds 1, 2
+  uint32 alt_period_ms = 9;  // kind 2: ms per tone before switching
 }
 
-// Result of a CW ID transmission attempt (submission to the TX worker).
-message CwIdResult {
+// Result of a TX test-signal submission to the TX worker.
+message TestSignalResult {
   uint32 request_id = 1;
   bool success = 2;
-  string error = 3;             // empty on success
+  string error = 3;          // empty on success
 }
 ```
 
@@ -584,25 +640,25 @@ message CwIdResult {
 Run: `make proto`
 Expected: succeeds.
 
-Run: `grep -c "TransmitCwId\|CwIdResult" pkg/ipcproto/graywolf.pb.go`
-Expected: non-zero (types generated).
+Run: `grep -c "TransmitTestSignal\|TestSignalResult" pkg/ipcproto/graywolf.pb.go`
+Expected: non-zero.
 
 - [ ] **Step 4: Add the Rust proto.rs helper**
 
-In `graywolf-modem/src/ipc/proto.rs`, add a constructor mirroring the others (next to where `test_tone_result` used to be):
+In `graywolf-modem/src/ipc/proto.rs`, add a constructor mirroring the others:
 
 ```rust
-    pub fn cw_id_result(r: CwIdResult) -> Self {
-        Self { payload: Some(ipc_message::Payload::CwIdResult(r)) }
+    pub fn test_signal_result(r: TestSignalResult) -> Self {
+        Self { payload: Some(ipc_message::Payload::TestSignalResult(r)) }
     }
 ```
 
-Ensure `CwIdResult` is imported in that file's `use` block (mirror how the other result types are imported).
+Ensure `TestSignalResult` is imported in that file's `use` block (mirror the other result types).
 
 - [ ] **Step 5: Build Rust to regenerate prost bindings**
 
 Run: `cargo build -p graywolf-modem 2>&1 | tail -20`
-Expected: codegen succeeds; `CwIdResult` / `TransmitCwId` resolve. (`cw_id_result` is unused until Task B3 — a dead-code warning is acceptable here.)
+Expected: codegen succeeds; `TestSignalResult` / `TransmitTestSignal` resolve. (`test_signal_result` is unused until Task B3 — a dead-code warning is acceptable here.)
 
 - [ ] **Step 6: Verify Go compiles**
 
@@ -613,43 +669,40 @@ Expected: PASS.
 
 ```bash
 git add proto/graywolf.proto pkg/ipcproto/graywolf.pb.go graywolf-modem/src/ipc/proto.rs
-git commit -m "Add TransmitCwId and CwIdResult IPC messages"
+git commit -m "Add TransmitTestSignal and TestSignalResult IPC messages"
 ```
 
-## Task B3: Rust modem CW ID handler
+## Task B3: Rust modem test-signal handler
 
 **Files:**
 - Modify: `graywolf-modem/src/modem/mod.rs`
 
 - [ ] **Step 1: Import the new result type**
 
-In the `use crate::ipc::proto::{...}` block (around line 29), add `CwIdResult` to the imported names.
+In the `use crate::ipc::proto::{...}` block (around line 29), add `TestSignalResult` to the imported names.
 
 - [ ] **Step 2: Add the dispatch arm**
 
 In the inbound-payload `match` (near the `Some(Payload::TransmitFrame(tf))` arm, around line 338), add:
 
 ```rust
-            Some(Payload::TransmitCwId(req)) => {
-                self.handle_transmit_cw_id(req);
+            Some(Payload::TransmitTestSignal(req)) => {
+                self.handle_transmit_test_signal(req);
             }
 ```
 
-- [ ] **Step 3: Add `CwIdResult` to the inbound-ignore list**
+- [ ] **Step 3: Add `TestSignalResult` to the inbound-ignore list**
 
-In the ignore arm (the `|`-chain of Rust→Go types, around line 353), add `| Some(Payload::CwIdResult(_))`.
+In the ignore arm (the `|`-chain of Rust→Go types, around line 353), add `| Some(Payload::TestSignalResult(_))`.
 
 - [ ] **Step 4: Implement the handler**
 
-Add this method to the same `impl` block that holds `handle_transmit_frame` (place it right after `handle_transmit_frame`, before the closing `}` of the impl). It mirrors `handle_transmit_frame`'s channel/audio-config resolution, but builds samples from the `morse` module and replies with a `CwIdResult`:
+Add this method to the same `impl` block that holds `handle_transmit_frame` (place it right after `handle_transmit_frame`). It mirrors that method's channel/audio-config resolution, picks the generator by `kind`, applies gain, submits a `TxJob`, and replies with `TestSignalResult`:
 
 ```rust
-    fn handle_transmit_cw_id(&mut self, req: crate::ipc::proto::TransmitCwId) {
-        const CW_WPM: u32 = 20;
-        const CW_TONE_HZ: f32 = 700.0;
-
-        let reply = |success: bool, error: String| {
-            let _ = self.handle.send(&IpcMessage::cw_id_result(crate::ipc::proto::CwIdResult {
+    fn handle_transmit_test_signal(&mut self, req: crate::ipc::proto::TransmitTestSignal) {
+        let reply = |handle: &IpcHandle, success: bool, error: String| {
+            let _ = handle.send(&IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
                 request_id: req.request_id,
                 success,
                 error,
@@ -666,24 +719,41 @@ Add this method to the same `impl` block that holds `handle_transmit_frame` (pla
         let ccfg = match self.channel_configs.get(&req.channel) {
             Some(c) => c.clone(),
             None => {
-                reply(false, format!("unknown channel {}", req.channel));
+                reply(&self.handle, false, format!("unknown channel {}", req.channel));
                 return;
             }
         };
         let acfg = match self.audio_configs.get(&ccfg.output_device_id) {
             Some(a) => a.clone(),
             None => {
-                reply(false, format!("no audio config for output device {}", ccfg.output_device_id));
+                reply(&self.handle, false, format!("no audio config for output device {}", ccfg.output_device_id));
                 return;
             }
         };
 
-        let segments = crate::morse::encode(&req.callsign);
-        if segments.is_empty() {
-            reply(false, "callsign produced no CW symbols".to_string());
-            return;
-        }
-        let mut samples = crate::morse::synthesize(&segments, acfg.sample_rate, CW_WPM, CW_TONE_HZ);
+        let sr = acfg.sample_rate;
+        let mut samples = match req.kind {
+            0 => {
+                let s = crate::txtest::cw_samples(&req.callsign, sr, req.cw_wpm.max(1), req.freq_a_hz as f32);
+                if s.is_empty() {
+                    reply(&self.handle, false, "callsign produced no CW symbols".to_string());
+                    return;
+                }
+                s
+            }
+            1 => crate::txtest::tone_samples(sr, req.freq_a_hz as f32, req.duration_ms),
+            2 => crate::txtest::alternating_samples(
+                sr,
+                req.freq_a_hz as f32,
+                req.freq_b_hz as f32,
+                req.duration_ms,
+                req.alt_period_ms,
+            ),
+            other => {
+                reply(&self.handle, false, format!("unknown test signal kind {}", other));
+                return;
+            }
+        };
 
         // Apply output device gain, matching handle_transmit_frame.
         if let Some(gain_atom) = self.gain_atoms.get(&ccfg.output_device_id) {
@@ -700,11 +770,11 @@ Add this method to the same `impl` block that holds `handle_transmit_frame` (pla
         let job = tx_worker::TxJob {
             channel: req.channel,
             samples,
-            sample_rate: acfg.sample_rate,
+            sample_rate: sr,
             output_device_id: ccfg.output_device_id,
             sink_config: audio::soundcard::SoundcardOutputConfig {
                 device_name: acfg.device_name.clone(),
-                sample_rate: acfg.sample_rate,
+                sample_rate: sr,
                 channels: acfg.channels,
                 audio_channel: ccfg.output_channel,
             },
@@ -713,31 +783,36 @@ Add this method to the same `impl` block that holds `handle_transmit_frame` (pla
         match self.tx_worker.transmit(job) {
             Ok(()) => {
                 *self.tx_frames.entry(req.channel).or_default() += 1;
-                reply(true, String::new());
+                reply(&self.handle, true, String::new());
             }
-            Err(e) => reply(false, e),
+            Err(e) => reply(&self.handle, false, e),
         }
     }
 ```
 
-> Note: `channel_configs`/`audio_configs` are cloned here (rather than borrowed) so the later `&mut self` calls (`apply_ptt_config`, `tx_worker.transmit`, `tx_frames`) don't conflict with the immutable borrow. If `ChannelConfig`/`AudioConfig` are not `Clone`, read their definitions and copy out only the fields used above (`output_device_id`, `output_channel`, `sample_rate`, `device_name`, `channels`) into locals before the mutable calls.
+> Note: `channel_configs`/`audio_configs` are cloned so the later `&mut self`
+> calls don't conflict with the immutable borrow. If `ChannelConfig`/`AudioConfig`
+> are not `Clone`, read their definitions and copy out only the fields used
+> (`output_device_id`, `output_channel`, `sample_rate`, `device_name`,
+> `channels`) into locals before the mutable calls. The `reply` closure takes
+> `&self.handle` explicitly to avoid capturing `self`.
 
 - [ ] **Step 5: Verify (compile-check; CI for full target)**
 
 Run: `cargo build -p graywolf-modem 2>&1 | tail -30`
-Expected: compiles, or fails only on unrelated `cfg(linux)`-only code. No errors mentioning `handle_transmit_cw_id`, `morse`, `CwIdResult`, or `TransmitCwId`. If the host can't finish, note it; CI is the gate.
+Expected: compiles, or fails only on unrelated `cfg(linux)`-only code. No errors mentioning `handle_transmit_test_signal`, `txtest`, `TestSignalResult`, or `TransmitTestSignal`. If the host can't finish, note it; CI is the gate.
 
-Run: `cargo test -p graywolf-modem morse:: 2>&1 | tail -5`
-Expected: morse tests still PASS.
+Run: `cargo test -p graywolf-modem txtest:: 2>&1 | tail -5`
+Expected: txtest tests still PASS.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add graywolf-modem/src/modem/mod.rs
-git commit -m "Handle TransmitCwId in the modem: synthesize CW and submit a TxJob"
+git commit -m "Handle TransmitTestSignal in the modem: render CW/tone and submit a TxJob"
 ```
 
-## Task B4: Go bridge `TransmitCwID`
+## Task B4: Go bridge `TransmitTestSignal`
 
 **Files:**
 - Modify: `pkg/modembridge/requests.go`
@@ -750,40 +825,60 @@ git commit -m "Handle TransmitCwId in the modem: synthesize CW and submit a TxJo
 In `pkg/modembridge/bridge.go`, add the field next to the other dispatchers:
 
 ```go
-	cwDispatcher *dispatcher[*pb.CwIdResult]
+	testSignalDispatcher *dispatcher[*pb.TestSignalResult]
 ```
 
 and in `New`, next to the other dispatcher inits:
 
 ```go
-		cwDispatcher: newDispatcher[*pb.CwIdResult](),
+		testSignalDispatcher: newDispatcher[*pb.TestSignalResult](),
 ```
 
-- [ ] **Step 2: Add the `TransmitCwID` method**
+- [ ] **Step 2: Add the params type and `TransmitTestSignal` method**
 
 In `pkg/modembridge/requests.go`, add (mirrors the former `PlayTestTone` pattern):
 
 ```go
-// TransmitCwID asks the Rust modem to transmit the given callsign as CW
-// (Morse) on the named channel and waits for the submission result. The
-// modem keys PTT, plays the CW audio, and unkeys via the TX worker.
-func (b *Bridge) TransmitCwID(ctx context.Context, channel uint32, callsign string) error {
+// TestSignalParams describes one TX test signal. Kind: 0=CW callsign,
+// 1=steady tone, 2=alternating tone. Unused fields for a given kind are
+// ignored by the modem.
+type TestSignalParams struct {
+	Channel     uint32
+	Kind        uint32
+	Callsign    string
+	CwWpm       uint32
+	FreqAHz     uint32
+	FreqBHz     uint32
+	DurationMs  uint32
+	AltPeriodMs uint32
+}
+
+// TransmitTestSignal asks the Rust modem to transmit a TX test signal on a
+// channel and waits for the submission result. The modem keys PTT, plays the
+// audio, and unkeys via the TX worker.
+func (b *Bridge) TransmitTestSignal(ctx context.Context, p TestSignalParams) error {
 	if b.State() != StateRunning {
 		return errors.New("modembridge: not in RUNNING state")
 	}
 
-	reqID, ch := b.cwDispatcher.Register()
-	defer b.cwDispatcher.Cancel(reqID)
+	reqID, ch := b.testSignalDispatcher.Register()
+	defer b.testSignalDispatcher.Cancel(reqID)
 
-	msg := &pb.IpcMessage{Payload: &pb.IpcMessage_TransmitCwId{
-		TransmitCwId: &pb.TransmitCwId{
-			RequestId: reqID,
-			Channel:   channel,
-			Callsign:  callsign,
+	msg := &pb.IpcMessage{Payload: &pb.IpcMessage_TransmitTestSignal{
+		TransmitTestSignal: &pb.TransmitTestSignal{
+			RequestId:   reqID,
+			Channel:     p.Channel,
+			Kind:        p.Kind,
+			Callsign:    p.Callsign,
+			CwWpm:       p.CwWpm,
+			FreqAHz:     p.FreqAHz,
+			FreqBHz:     p.FreqBHz,
+			DurationMs:  p.DurationMs,
+			AltPeriodMs: p.AltPeriodMs,
 		},
 	}}
 	if err := b.sendIPC(msg); err != nil {
-		return fmt.Errorf("send TransmitCwId: %w", err)
+		return fmt.Errorf("send TransmitTestSignal: %w", err)
 	}
 
 	timer := time.NewTimer(5 * time.Second)
@@ -794,40 +889,48 @@ func (b *Bridge) TransmitCwID(ctx context.Context, channel uint32, callsign stri
 			return errBridgeStopped
 		}
 		if !resp.Success {
-			return fmt.Errorf("CW ID failed: %s", resp.Error)
+			return fmt.Errorf("test signal failed: %s", resp.Error)
 		}
 		return nil
 	case <-timer.C:
-		return errors.New("modembridge: CW ID timeout")
+		return errors.New("modembridge: test signal timeout")
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 }
 
-func (b *Bridge) dispatchCwIdResponse(r *pb.CwIdResult) {
-	b.cwDispatcher.Deliver(r.RequestId, r)
+func (b *Bridge) dispatchTestSignalResponse(r *pb.TestSignalResult) {
+	b.testSignalDispatcher.Deliver(r.RequestId, r)
 }
 ```
+
+> Verify the generated Go field names against `pkg/ipcproto/graywolf.pb.go`
+> after `make proto` — protoc-gen-go names `cw_wpm` → `CwWpm`, `freq_a_hz` →
+> `FreqAHz`, `alt_period_ms` → `AltPeriodMs`, `transmit_test_signal` →
+> `IpcMessage_TransmitTestSignal` / field `TransmitTestSignal`. Adjust if the
+> generated names differ.
 
 - [ ] **Step 3: Add the session dispatch case**
 
 In `pkg/modembridge/session.go`, in the inbound `switch`, add:
 
 ```go
-	case *pb.IpcMessage_CwIdResult:
-		b.dispatchCwIdResponse(p.CwIdResult)
+	case *pb.IpcMessage_TestSignalResult:
+		b.dispatchTestSignalResponse(p.TestSignalResult)
 ```
 
 - [ ] **Step 4: Add the stop-test coverage**
 
 In `pkg/modembridge/bridge_stop_test.go`, mirror the existing dispatcher patterns. Read the file first, then:
 
-- Add a test-case entry that calls `b.TransmitCwID(context.Background(), 0, "N0CALL")` and asserts it unblocks with `errBridgeStopped` (mirror the former `PlayTestTone` entry shape).
-- Add `"cw": adaptPbCwIdResult(cwCh),` to the channel map and declare `cwCh` like the others.
+- Add a test-case entry that calls
+  `b.TransmitTestSignal(context.Background(), modembridge.TestSignalParams{Channel: 0, Kind: 1, FreqAHz: 1200, DurationMs: 100})`
+  (use the package-internal form — no `modembridge.` prefix since the test is in-package; check the file's package clause) and asserts it unblocks with `errBridgeStopped` (mirror the former `PlayTestTone` entry shape).
+- Add `"testsignal": adaptPbTestSignalResult(testSignalCh),` to the channel map and declare `testSignalCh` like the others.
 - Add the adapter:
 
 ```go
-func adaptPbCwIdResult(c <-chan *pb.CwIdResult) <-chan any {
+func adaptPbTestSignalResult(c <-chan *pb.TestSignalResult) <-chan any {
 	out := make(chan any)
 	go func() {
 		defer close(out)
@@ -850,16 +953,16 @@ Expected: PASS.
 
 ```bash
 git add pkg/modembridge/
-git commit -m "Add TransmitCwID request path to modem bridge"
+git commit -m "Add TransmitTestSignal request path to modem bridge"
 ```
 
-## Task B5: Go webapi `POST /api/channels/{id}/cw-id`
+## Task B5: Go webapi `POST /api/channels/{id}/test-tx`
 
 **Files:**
 - Modify: `pkg/webapi/channels.go`
-- Modify: `pkg/webapi/dto/` (add `CwIdResponse` — put it in the channels DTO file; find it via grep below)
+- Modify: `pkg/webapi/dto/` (channels DTO file — find via grep)
 - Modify: `pkg/webapi/docs/op_ids.go`
-- Test: `pkg/webapi/channels_cw_id_test.go` (create)
+- Test: `pkg/webapi/channels_test_tx_test.go` (create)
 
 - [ ] **Step 1: Locate the channels DTO file**
 
@@ -867,8 +970,14 @@ Run: `grep -rln "ChannelResponse\|BeaconSendResponse" pkg/webapi/dto/`
 Use the file that holds channel-related DTOs (likely `pkg/webapi/dto/channel.go`). Add there:
 
 ```go
-// CwIdResponse is the body returned by POST /api/channels/{id}/cw-id.
-type CwIdResponse struct {
+// TestSignalRequest is the body for POST /api/channels/{id}/test-tx.
+// Signal is one of: "cw", "tone1200", "tone2400", "alt".
+type TestSignalRequest struct {
+	Signal string `json:"signal" example:"cw"`
+}
+
+// TestSignalResponse is the body returned by POST /api/channels/{id}/test-tx.
+type TestSignalResponse struct {
 	Status string `json:"status" example:"sent"`
 }
 ```
@@ -878,7 +987,7 @@ type CwIdResponse struct {
 In `pkg/webapi/docs/op_ids.go`, near `OpManualPtt`/`OpSendBeacon`, add:
 
 ```go
-	OpSendCwID = "sendCwId"
+	OpSendTestSignal = "sendTestSignal"
 ```
 
 - [ ] **Step 3: Register the route**
@@ -886,29 +995,44 @@ In `pkg/webapi/docs/op_ids.go`, near `OpManualPtt`/`OpSendBeacon`, add:
 In `pkg/webapi/channels.go`, in `registerChannels`, add after the `ptt` route:
 
 ```go
-	mux.HandleFunc("POST /api/channels/{id}/cw-id", s.sendCwID)
+	mux.HandleFunc("POST /api/channels/{id}/test-tx", s.sendTestSignal)
 ```
 
 - [ ] **Step 4: Write the handler**
 
-In `pkg/webapi/channels.go`, add (mirrors `manualPtt` + the beacon refusal mapping). Ensure imports include `errors` and `github.com/chrissnell/graywolf/pkg/callsign`:
+In `pkg/webapi/channels.go`, add (mirrors `manualPtt` + the beacon refusal mapping). Ensure imports include `errors` and `github.com/chrissnell/graywolf/pkg/callsign` and `github.com/chrissnell/graywolf/pkg/modembridge`:
 
 ```go
-// sendCwID transmits the station callsign as CW (Morse) on a channel. It
-// refuses to key the radio when the station callsign is empty or N0CALL,
-// and when the channel is not TX-capable.
+// CW / tone recipe constants — the single source of the hardcoded test-signal
+// parameters. The four UI options map to these.
+const (
+	cwTestWpm       = 20
+	cwTestToneHz    = 700
+	toneTestDurMs   = 3000
+	altTestPeriodMs = 200
+	toneTestLowHz   = 1200
+	toneTestHighHz  = 2400
+)
+
+// sendTestSignal transmits a TX test signal (CW callsign or a tone) on a
+// channel. The "cw" signal refuses to key the radio when the station callsign
+// is empty or N0CALL; tone signals need no callsign. All signals require a
+// TX-capable channel.
 //
-// @Summary  Send CW ID (station callsign in Morse) on a channel
+// @Summary  Send a TX test signal (CW callsign or tone) on a channel
 // @Tags     Channels
-// @ID       sendCwId
+// @ID       sendTestSignal
+// @Accept   json
 // @Produce  json
 // @Param    id path int true "Channel ID"
-// @Success  200 {object} dto.CwIdResponse
+// @Param    body body dto.TestSignalRequest true "Signal to send"
+// @Success  200 {object} dto.TestSignalResponse
+// @Failure  400 {object} webtypes.ErrorResponse
 // @Failure  409 {object} webtypes.ErrorResponse
 // @Failure  422 {object} webtypes.ErrorResponse
 // @Failure  503 {object} webtypes.ErrorResponse
-// @Router   /channels/{id}/cw-id [post]
-func (s *Server) sendCwID(w http.ResponseWriter, r *http.Request) {
+// @Router   /channels/{id}/test-tx [post]
+func (s *Server) sendTestSignal(w http.ResponseWriter, r *http.Request) {
 	id, err := parseID(r.PathValue("id"))
 	if err != nil {
 		badRequest(w, "invalid channel id")
@@ -919,16 +1043,47 @@ func (s *Server) sendCwID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	call, err := s.store.ResolveStationCallsign(r.Context())
-	if err != nil {
-		switch {
-		case errors.Is(err, callsign.ErrCallsignEmpty):
-			writeJSON(w, http.StatusUnprocessableEntity, webtypes.ErrorResponse{Error: "set your station callsign before sending CW ID"})
-		case errors.Is(err, callsign.ErrCallsignN0Call):
-			writeJSON(w, http.StatusUnprocessableEntity, webtypes.ErrorResponse{Error: "station callsign is still N0CALL; set a real callsign before sending CW ID"})
-		default:
-			s.internalError(w, r, "resolve station callsign", err)
+	var req dto.TestSignalRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		badRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	params := modembridge.TestSignalParams{Channel: id}
+	switch req.Signal {
+	case "cw":
+		call, err := s.store.ResolveStationCallsign(r.Context())
+		if err != nil {
+			switch {
+			case errors.Is(err, callsign.ErrCallsignEmpty):
+				writeJSON(w, http.StatusUnprocessableEntity, webtypes.ErrorResponse{Error: "set your station callsign before sending CW ID"})
+			case errors.Is(err, callsign.ErrCallsignN0Call):
+				writeJSON(w, http.StatusUnprocessableEntity, webtypes.ErrorResponse{Error: "station callsign is still N0CALL; set a real callsign before sending CW ID"})
+			default:
+				s.internalError(w, r, "resolve station callsign", err)
+			}
+			return
 		}
+		params.Kind = 0
+		params.Callsign = call
+		params.CwWpm = cwTestWpm
+		params.FreqAHz = cwTestToneHz
+	case "tone1200":
+		params.Kind = 1
+		params.FreqAHz = toneTestLowHz
+		params.DurationMs = toneTestDurMs
+	case "tone2400":
+		params.Kind = 1
+		params.FreqAHz = toneTestHighHz
+		params.DurationMs = toneTestDurMs
+	case "alt":
+		params.Kind = 2
+		params.FreqAHz = toneTestLowHz
+		params.FreqBHz = toneTestHighHz
+		params.DurationMs = toneTestDurMs
+		params.AltPeriodMs = altTestPeriodMs
+	default:
+		badRequest(w, "unknown signal: "+req.Signal)
 		return
 	}
 
@@ -937,32 +1092,39 @@ func (s *Server) sendCwID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.bridge.TransmitCwID(r.Context(), id, call); err != nil {
+	if err := s.bridge.TransmitTestSignal(r.Context(), params); err != nil {
 		writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: err.Error()})
 		return
 	}
 
-	writeJSON(w, http.StatusOK, dto.CwIdResponse{Status: "sent"})
+	writeJSON(w, http.StatusOK, dto.TestSignalResponse{Status: "sent"})
 }
 ```
 
-> Verify the exact import path/alias for `webtypes` and `dto` at the top of `channels.go` and match them (they are already used by sibling handlers in this file).
+> Verify the exact import aliases for `webtypes`, `dto`, and `modembridge` at
+> the top of `channels.go` and match them (sibling handlers already use
+> `webtypes` and `dto`; confirm whether `modembridge` is already imported and
+> under what name). Confirm `s.bridge` has type `*modembridge.Bridge` (the
+> `manualPtt` handler calls `s.bridge.ManualPttWithWatchdog`, so the field
+> exists).
 
 - [ ] **Step 5: Write the test**
 
-Create `pkg/webapi/channels_cw_id_test.go`. Read an existing webapi test (e.g. `pkg/webapi/beacons_send_test.go`) first to copy the exact server-construction/test harness helpers used in this package (store setup, bridge stub, request helper). Then assert these cases:
+Create `pkg/webapi/channels_test_tx_test.go`. Read `pkg/webapi/beacons_send_test.go` first to copy the exact server-construction / store / bridge-stub harness this package uses. Then assert:
 
-- Empty station callsign → `422`.
-- N0CALL station callsign → `422`.
-- Non-TX channel → `409`.
-- Valid callsign + TX-capable channel + bridge stub returning nil → `200` with `{"status":"sent"}`.
+- `cw` with empty station callsign → `422`.
+- `cw` with N0CALL station callsign → `422`.
+- unknown signal (e.g. `{"signal":"bogus"}`) → `400`.
+- non-TX channel (any valid signal) → `409`.
+- `tone1200` on a TX-capable channel with the bridge stub returning nil → `200` and body `{"status":"sent"}`.
+- (Optional but cheap) `cw` with a valid station callsign + TX channel → `200`, and assert the stub received `Kind==0`, `Callsign` non-empty, `FreqAHz==700`.
 
-Use the package's existing patterns for stubbing `s.bridge.TransmitCwID` (e.g. an interface stub or fake bridge already present). If the bridge field is a concrete `*modembridge.Bridge`, follow how `manualPtt`/beacon tests inject a fake — replicate that mechanism rather than inventing a new one.
+Use the package's existing mechanism for stubbing the bridge (interface stub / fake). If `s.bridge` is a concrete `*modembridge.Bridge`, replicate exactly how `manualPtt`/beacon tests inject a fake rather than inventing a new mechanism. If the harness only supports a real bridge in `StateRunning`, follow the beacon-send test's approach for driving `TransmitTestSignal` to a deterministic result.
 
 - [ ] **Step 6: Run the test**
 
-Run: `go test ./pkg/webapi/ -run CwId -v`
-Expected: PASS (all four cases).
+Run: `go test ./pkg/webapi/ -run TestSignal -v`
+Expected: PASS (all cases).
 
 - [ ] **Step 7: Full webapi build + test**
 
@@ -972,8 +1134,8 @@ Expected: PASS.
 - [ ] **Step 8: Commit**
 
 ```bash
-git add pkg/webapi/channels.go pkg/webapi/dto/ pkg/webapi/docs/op_ids.go pkg/webapi/channels_cw_id_test.go
-git commit -m "Add channel CW ID REST endpoint with callsign and TX-capability guards"
+git add pkg/webapi/channels.go pkg/webapi/dto/ pkg/webapi/docs/op_ids.go pkg/webapi/channels_test_tx_test.go
+git commit -m "Add channel TX test-signal REST endpoint with callsign and TX-capability guards"
 ```
 
 ## Task B6: Regenerate docs and API types
@@ -988,7 +1150,7 @@ Expected: succeeds.
 
 - [ ] **Step 2: Verify the new endpoint is present**
 
-Run: `grep -rn "cw-id\|sendCwId" pkg/webapi/docs/gen/swagger.json web/src/api/generated/api.d.ts`
+Run: `grep -rn "test-tx\|sendTestSignal" pkg/webapi/docs/gen/swagger.json web/src/api/generated/api.d.ts`
 Expected: matches in both.
 
 - [ ] **Step 3: Docs drift check**
@@ -1000,62 +1162,99 @@ Expected: no drift.
 
 ```bash
 git add pkg/webapi/docs/gen web/src/api/generated/api.d.ts
-git commit -m "Regenerate API docs and types for CW ID endpoint"
+git commit -m "Regenerate API docs and types for TX test-signal endpoint"
 ```
 
-## Task B7: Frontend "Send CW ID" button
+## Task B7: Frontend "Test TX" dropdown menu
 
 **Files:**
 - Modify: `web/src/routes/channels/ChannelRow.svelte`
 
-The click handler runs inline in `ChannelRow` (with local in-flight state), matching how `AudioDevices.svelte` handled Test Tone. The button is gated by the same TX-capability condition the PTT indicator uses: `!isKissOnly && channel.output_device_id && channel.output_device_id !== 0`.
+The click handlers run inline in `ChannelRow` (with a single local in-flight
+flag), matching how `AudioDevices.svelte` handled Test Tone. The menu is gated
+by the same TX-capability condition the PTT indicator uses:
+`!isKissOnly && channel.output_device_id && channel.output_device_id !== 0`.
 
-- [ ] **Step 1: Add the API + toast imports and local state**
+- [ ] **Step 1: Add imports, state, and the send function**
 
-In the `<script>` block of `ChannelRow.svelte`, add to imports:
+In the `<script>` block of `ChannelRow.svelte`, add `DropdownMenu` to the chonky-ui import (it already imports `{ Badge, Button }`):
+
+```javascript
+  import { Badge, Button, DropdownMenu } from '@chrissnell/chonky-ui';
+```
+
+Add to the imports:
 
 ```javascript
   import { api } from '../../lib/api.js';
   import { toasts } from '../../lib/stores.js';
 ```
 
-> Verify the relative depth: `ChannelRow.svelte` is in `web/src/routes/channels/`, so `lib` is two levels up (`../../lib/...`). Confirm against how `channelBacking.js` is imported (`../../lib/...`) at the top of the file.
+> Verify the relative depth: `ChannelRow.svelte` is in `web/src/routes/channels/`,
+> so `lib` is two levels up. Confirm against the existing `../../lib/channelBacking.js`
+> import at the top of the file.
 
 After the `$props()` line, add:
 
 ```javascript
-  let sendingCwId = $state(false);
+  let sendingSignal = $state(false);
 
-  async function sendCwId() {
-    sendingCwId = true;
+  const SIGNAL_LABELS = {
+    cw: 'Send callsign in CW',
+    tone1200: 'Send 1200 Hz tone',
+    tone2400: 'Send 2400 Hz tone',
+    alt: 'Send 1200/2400 Hz alternating tone',
+  };
+
+  async function sendTestSignal(signal) {
+    sendingSignal = true;
     try {
-      await api.post(`/channels/${channel.id}/cw-id`);
-      toasts.success(`Sent CW ID on "${channel.name}"`);
+      await api.post(`/channels/${channel.id}/test-tx`, { signal });
+      toasts.success(`Sent "${SIGNAL_LABELS[signal]}" on "${channel.name}"`);
     } catch (err) {
-      toasts.error(`CW ID failed: ${err.message}`);
+      toasts.error(`Test TX failed: ${err.message}`);
     } finally {
-      sendingCwId = false;
+      sendingSignal = false;
     }
   }
 ```
 
-> Confirm the channel display field name (`channel.name`) by checking how the row already renders the channel title; use whatever field that markup uses.
+> Confirm the channel display field (`channel.name`) and the `api.post(url, body)`
+> signature against `web/src/lib/api.js` and an existing caller (e.g.
+> `AudioDevices.svelte` calls `api.post('/audio-devices/${id}/test-tone')` with
+> no body; check how a body is passed elsewhere — `grep -n "api.post" web/src`).
+> Adjust the call to the project's actual `api.post` body convention.
 
-- [ ] **Step 2: Add the button to the action row**
+- [ ] **Step 2: Add the menu to the action row**
 
-In the action row that currently holds Edit/Delete (around line 139), add the CW ID button before Edit, gated on TX capability:
+In the action row that currently holds Edit/Delete (around line 139), add the dropdown before Edit, gated on TX capability:
 
 ```svelte
   {#if !isKissOnly && channel.output_device_id && channel.output_device_id !== 0}
-    <Button variant="ghost" onclick={sendCwId} disabled={sendingCwId}>
-      {sendingCwId ? 'Sending…' : 'Send CW ID'}
-    </Button>
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        <Button variant="ghost" disabled={sendingSignal}>
+          {sendingSignal ? 'Sending…' : 'Test TX ▾'}
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item onSelect={() => sendTestSignal('cw')}>Send callsign in CW</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => sendTestSignal('tone1200')}>Send 1200 Hz tone</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => sendTestSignal('tone2400')}>Send 2400 Hz tone</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => sendTestSignal('alt')}>Send 1200/2400 Hz alternating tone</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
   {/if}
   <Button variant="ghost" onclick={() => onEdit?.(channel)}>Edit</Button>
   <Button variant="danger" onclick={() => onDelete?.(channel)}>Delete</Button>
 ```
 
-(Keep the existing Edit/Delete buttons; only add the guarded CW ID button.)
+> The `DropdownMenu` compound API (`Root` / `Trigger` / `Content` / `Item`
+> with `onSelect`+`disabled`) is confirmed from chonky-ui's type definitions.
+> If `Trigger` does not accept a nested `<Button>` cleanly (some trigger
+> components render their own button), check
+> `node_modules/@chrissnell/chonky-ui/dist/components/DropdownMenu/DropdownMenuTrigger.svelte`
+> and adapt (e.g. apply the trigger's `class` to style it as a button).
 
 - [ ] **Step 3: Build the frontend**
 
@@ -1064,13 +1263,16 @@ Expected: build succeeds.
 
 - [ ] **Step 4: Manual verification (record result)**
 
-Run the app and confirm: the "Send CW ID" button appears only on modem-backed TX channels (not on KISS-only or RX-only rows); clicking a TX channel shows a success toast (or a clear error toast if no station callsign is set). Note the observed result in the task checklist.
+Run the app and confirm: the "Test TX" menu appears only on modem-backed TX
+channels (not on KISS-only or RX-only rows); the four items are present;
+choosing a tone shows a success toast; choosing "Send callsign in CW" with no
+station callsign set shows a clear error toast. Note the observed result.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add web/src/routes/channels/ChannelRow.svelte
-git commit -m "Add Send CW ID button to TX-capable channel rows"
+git commit -m "Add Test TX dropdown menu to TX-capable channel rows"
 ```
 
 ## Task B8: Update the wiki
@@ -1081,24 +1283,28 @@ git commit -m "Add Send CW ID button to TX-capable channel rows"
 
 - [ ] **Step 1: Update code-map**
 
-In `docs/wiki/code-map.md`: remove any Test Tone / `playTestTone` / `play_test_tone` references; add the new `POST /api/channels/{id}/cw-id` endpoint (handler `sendCwID` in `pkg/webapi/channels.go`), the `graywolf-modem/src/morse.rs` module, and the `TransmitCwId`/`CwIdResult` IPC messages. Keep it to navigation-level pointers, not internals.
+In `docs/wiki/code-map.md`: remove any Test Tone / `playTestTone` / `play_test_tone` references; add the new `POST /api/channels/{id}/test-tx` endpoint (handler `sendTestSignal` in `pkg/webapi/channels.go`), the `graywolf-modem/src/txtest.rs` module, and the `TransmitTestSignal`/`TestSignalResult` IPC messages. Navigation-level pointers only.
 
 - [ ] **Step 2: Update invariants**
 
-In `docs/wiki/invariants.md`, add an invariant:
+In `docs/wiki/invariants.md`, add:
 
-> **CW ID never keys the radio with an empty or N0CALL callsign.** `POST /api/channels/{id}/cw-id` resolves the station callsign via `Store.ResolveStationCallsign` and returns 422 before any IPC if it is empty or N0CALL.
+> **The CW test signal never keys the radio with an empty or N0CALL callsign.**
+> `POST /api/channels/{id}/test-tx` with `signal=cw` resolves the station
+> callsign via `Store.ResolveStationCallsign` and returns 422 before any IPC if
+> it is empty or N0CALL. The tone signals (`tone1200`, `tone2400`, `alt`) do not
+> use the callsign.
 
 - [ ] **Step 3: Verify references**
 
 Run: `grep -rn "test tone\|Test Tone\|test-tone\|playTestTone" docs/wiki/`
-Expected: no output (all Test Tone mentions removed from the wiki).
+Expected: no output.
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add docs/wiki/code-map.md docs/wiki/invariants.md
-git commit -m "Update wiki for channel CW ID; drop test tone references"
+git commit -m "Update wiki for channel TX test signals; drop test tone references"
 ```
 
 ---
@@ -1106,16 +1312,33 @@ git commit -m "Update wiki for channel CW ID; drop test tone references"
 ## Final verification (whole feature)
 
 - [ ] **Go:** `go build ./... && go test ./pkg/webapi/... ./pkg/modembridge/... ./pkg/ipcproto/...` → PASS
-- [ ] **Rust (host-buildable parts):** `cargo test -p graywolf-modem morse::` → PASS; `cargo build -p graywolf-modem` → no CW/test-tone errors (full `cfg(linux)` build via CI)
+- [ ] **Rust (host-buildable parts):** `cargo test -p graywolf-modem txtest::` → PASS; `cargo build -p graywolf-modem` → no test-signal/test-tone errors (full `cfg(linux)` build via CI)
 - [ ] **Frontend:** `cd web && npm run build` → PASS
 - [ ] **Docs:** `make docs-check` → no drift
 - [ ] **No stragglers:** `grep -rn "test_tone\|TestTone\|test-tone\|playTestTone\|PlayTestTone" pkg/ graywolf-modem/src/ web/src/ proto/ docs/wiki/` → no output
-- [ ] **On-device (CI build + radio):** confirm clicking "Send CW ID" keys PTT and the callsign is audible/decodable in Morse on a second radio, and that an unset callsign yields a clear refusal.
+- [ ] **On-device (CI build + radio):** each menu item keys PTT and transmits the expected signal (callsign decodable in Morse; steady 1200/2400 tones; audible warble for alternating), all verifiable on a second radio; CW with an unset callsign yields a clear refusal.
 
 ---
 
 ## Self-review notes (author)
 
-- **Spec coverage:** Part A removes Test Tone across all six layers named in the spec (UI, webapi, bridge, proto, Rust handler, regen). Part B covers the IPC messages, Rust `morse` + handler, Go bridge, webapi endpoint with all three refusal guards + success, frontend button gated by TX capability, and wiki updates — matching the spec's architecture and testing sections.
-- **Type consistency:** Go `TransmitCwID`/`pb.TransmitCwId`/`pb.CwIdResult`/`OpSendCwID`/`dto.CwIdResponse`; Rust `morse::encode`/`morse::synthesize`/`Segment`/`handle_transmit_cw_id`/`IpcMessage::cw_id_result`; proto field ids 9 (RX) and 22 (TX) are the next free numbers after the Part A removals; frontend `sendCwId`/`sendingCwId`. Names are used identically across tasks.
-- **No placeholders:** every code step shows complete code; verification steps give exact commands and expected output. Cross-file uncertainties (DTO file location, test harness shape, `webtypes` alias, Clone-ability of config structs, import depth) are flagged with a grep/read-first instruction rather than guessed.
+- **Spec coverage:** Part A removes Test Tone across all six layers. Part B
+  covers the `TransmitTestSignal`/`TestSignalResult` IPC, the `txtest` Rust
+  module (CW + tone + alternating) and handler dispatching on `kind`, the Go
+  bridge `TransmitTestSignal` + `TestSignalParams`, the webapi endpoint with the
+  four hardcoded recipes and all guards (CW callsign 422, unknown signal 400,
+  non-TX 409, success 200), the chonky-ui `DropdownMenu` frontend gated by TX
+  capability, and wiki updates — matching the revised spec.
+- **Type consistency:** Go `TransmitTestSignal`/`TestSignalParams`/
+  `pb.TransmitTestSignal`/`pb.TestSignalResult`/`OpSendTestSignal`/
+  `dto.TestSignalRequest`/`dto.TestSignalResponse`; Rust `txtest::encode`/
+  `cw_samples`/`tone_samples`/`alternating_samples`/`Segment`/
+  `handle_transmit_test_signal`/`IpcMessage::test_signal_result`; proto fields 9
+  (RX) and 22 (TX); `kind` values 0/1/2 are used identically in proto comments,
+  the Rust match, and the Go recipe switch; frontend signal ids
+  `cw`/`tone1200`/`tone2400`/`alt` match the Go handler switch exactly.
+- **No placeholders:** every code step shows complete code; verification steps
+  give exact commands and expected output. Cross-file uncertainties (DTO file
+  location, generated Go field names, `api.post` body convention, `Clone`-ability
+  of config structs, `DropdownMenu.Trigger` nesting, import depth/aliases) are
+  flagged with grep/read-first instructions rather than guessed.

--- a/docs/superpowers/plans/2026-05-26-channel-cw-id.md
+++ b/docs/superpowers/plans/2026-05-26-channel-cw-id.md
@@ -1,0 +1,1121 @@
+# Channel CW ID Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the broken audio Test Tone feature and add a per-channel "Send CW ID" button that transmits the station callsign in Morse through the channel's real TX path (key PTT → CW audio → unkey).
+
+**Architecture:** A new `TransmitCwId` IPC message carries `{channel, callsign}` from Go to the Rust modem. A pure Rust `morse` module turns the callsign into i16 PCM samples (hardcoded 20 WPM / 700 Hz, PARIS timing); the modem submits them as a `TxJob` to the existing TX worker, which keys/unkeys PTT automatically — exactly like `handle_transmit_frame`. Go resolves the centralized station callsign and refuses to key the radio on an empty or N0CALL callsign.
+
+**Tech Stack:** Rust (graywolf-modem, prost protobuf), Go (webapi + modembridge, protoc-gen-go), Svelte 5 (web UI, chonky-ui), Protocol Buffers IPC.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-26-channel-cw-id-design.md`
+
+**Branch:** `feature/channel-cw-id` (already created; the design doc commit is its first commit).
+
+---
+
+## Build / regen reference (used by multiple tasks)
+
+- **Regenerate Go protobuf bindings:** `make proto`
+- **Regenerate OpenAPI spec:** `make docs`
+- **Regenerate frontend API types:** `cd web && npm run api:generate`
+- **Rust bindings** regenerate automatically on `cargo build` (graywolf-modem/build.rs runs prost on `proto/graywolf.proto`).
+- **Rust tests:** `cargo test -p graywolf-modem`
+- **Go tests (webapi + bridge):** `go test ./pkg/webapi/... ./pkg/modembridge/...`
+- **Docs drift check:** `make docs-check`
+
+> Note: `cfg(linux)` Rust cannot fully compile on the dev Mac (see project memory). `cargo test -p graywolf-modem` for the pure `morse` module and host-buildable code works; full-modem on-target verification happens in CI / on-device. Where a step's Rust build is expected to need CI, the step says so.
+
+---
+
+# PART A — Remove Test Tone
+
+Order matters: remove every consumer of the `PlayTestTone` / `TestToneResult` proto types **before** deleting them from the `.proto`, otherwise regeneration breaks the build.
+
+## Task A1: Remove Test Tone from the Audio Interfaces UI
+
+**Files:**
+- Modify: `web/src/routes/AudioDevices.svelte`
+
+- [ ] **Step 1: Delete the `playTestTone` function**
+
+Remove this block (around line 66):
+
+```javascript
+  async function playTestTone(dev) {
+    testingTone = dev.id;
+    try {
+      await api.post(`/audio-devices/${dev.id}/test-tone`);
+      toasts.success(`Test tone played on "${dev.name}"`);
+    } catch (err) {
+      toasts.error(`Test tone failed: ${err.message}`);
+    } finally {
+      testingTone = null;
+    }
+  }
+```
+
+- [ ] **Step 2: Delete the Test Tone button**
+
+Remove this block from the output-device actions (around line 405):
+
+```svelte
+          {#if dev.direction === 'output'}
+            <Button
+              variant="ghost"
+              onclick={() => playTestTone(dev)}
+              disabled={testingTone === dev.id}
+            >
+              {testingTone === dev.id ? 'Playing...' : 'Test Tone'}
+            </Button>
+          {/if}
+```
+
+- [ ] **Step 3: Delete the `testingTone` state declaration**
+
+Find and remove the line declaring `testingTone` (search the file):
+
+Run: `grep -n "testingTone" web/src/routes/AudioDevices.svelte`
+Delete the remaining declaration line (e.g. `let testingTone = $state(null);`). After this, the grep must return nothing.
+
+- [ ] **Step 4: Verify no references remain and the file builds**
+
+Run: `grep -rn "testingTone\|test-tone\|Test Tone\|playTestTone" web/src/routes/AudioDevices.svelte`
+Expected: no output.
+
+Run: `cd web && npm run build`
+Expected: build succeeds (no reference errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/routes/AudioDevices.svelte
+git commit -m "Remove broken test tone button from audio interfaces UI"
+```
+
+## Task A2: Remove the Test Tone Go webapi handler
+
+**Files:**
+- Modify: `pkg/webapi/audio_devices.go`
+- Modify: `pkg/webapi/dto/audio_device.go`
+- Modify: `pkg/webapi/docs/op_ids.go`
+- Modify: `pkg/webapi/audio_devices_test.go`
+
+- [ ] **Step 1: Remove the route registration**
+
+In `pkg/webapi/audio_devices.go`, delete the line:
+
+```go
+	mux.HandleFunc("POST /api/audio-devices/{id}/test-tone", s.playTestTone)
+```
+
+Also update the package/registration comment at the top of the file (line ~14) that lists `/{id}/test-tone` among the routes — remove `test-tone` from that list.
+
+- [ ] **Step 2: Remove the `playTestTone` handler**
+
+Delete the entire `playTestTone` method (the func starting around line 284, including its `// @...` swagger annotation block starting around line 267).
+
+Run: `grep -n "playTestTone\|PlayTestTone\|test tone\|test-tone" pkg/webapi/audio_devices.go`
+Expected: no output.
+
+- [ ] **Step 3: Remove the DTO**
+
+In `pkg/webapi/dto/audio_device.go`, delete the `TestToneResponse` type and its doc comment (around line 131):
+
+```go
+// TestToneResponse is the body returned by POST /api/audio-devices/{id}/test-tone
+// ...
+type TestToneResponse struct {
+	Status string `json:"status" example:"ok"`
+}
+```
+
+(Confirm exact field by reading lines 131-136 first.)
+
+- [ ] **Step 4: Remove the op-id constant**
+
+In `pkg/webapi/docs/op_ids.go`, delete the line:
+
+```go
+	OpPlayTestTone              = "playTestTone"
+```
+
+- [ ] **Step 5: Remove test references**
+
+Run: `grep -n "TestTone\|test-tone\|playTestTone\|PlayTestTone" pkg/webapi/audio_devices_test.go`
+Delete any test functions or assertions that exercise the test-tone route/handler/DTO. Remove whole test funcs, do not skip them.
+
+- [ ] **Step 6: Verify the package compiles and tests pass**
+
+Run: `go build ./pkg/webapi/... && go test ./pkg/webapi/...`
+Expected: PASS. (`pb.PlayTestTone` types still exist at this point — only Go webapi references are gone.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/webapi/audio_devices.go pkg/webapi/dto/audio_device.go pkg/webapi/docs/op_ids.go pkg/webapi/audio_devices_test.go
+git commit -m "Remove test tone REST endpoint and DTO"
+```
+
+## Task A3: Remove Test Tone from the Go modem bridge
+
+**Files:**
+- Modify: `pkg/modembridge/requests.go`
+- Modify: `pkg/modembridge/bridge.go`
+- Modify: `pkg/modembridge/session.go`
+- Modify: `pkg/modembridge/bridge_stop_test.go`
+
+- [ ] **Step 1: Remove the `PlayTestTone` method**
+
+In `pkg/modembridge/requests.go`, delete the entire `PlayTestTone` method (starts around line 86, ends at its closing brace before `dispatchEnumResponse`).
+
+- [ ] **Step 2: Remove the tone dispatch hook**
+
+In `pkg/modembridge/requests.go`, delete:
+
+```go
+func (b *Bridge) dispatchToneResponse(r *pb.TestToneResult) {
+	b.toneDispatcher.Deliver(r.RequestId, r)
+}
+```
+
+- [ ] **Step 3: Remove the dispatcher field and its init**
+
+In `pkg/modembridge/bridge.go`, delete the struct field:
+
+```go
+	toneDispatcher *dispatcher[*pb.TestToneResult]
+```
+
+and the init line in `New`:
+
+```go
+		toneDispatcher: newDispatcher[*pb.TestToneResult](),
+```
+
+- [ ] **Step 4: Remove the session dispatch case**
+
+In `pkg/modembridge/session.go`, delete:
+
+```go
+	case *pb.IpcMessage_TestToneResult:
+		b.dispatchToneResponse(p.TestToneResult)
+```
+
+- [ ] **Step 5: Remove the stop-test case**
+
+In `pkg/modembridge/bridge_stop_test.go`, delete the `PlayTestTone` test-case entry (around line 43-46), the `"tone": adaptPbTestToneResult(toneCh),` map entry (line ~100), the `adaptPbTestToneResult` helper (line ~127), and the standalone assertion (lines ~168-169). Read the file first to remove cleanly; remove whole entries, do not skip.
+
+- [ ] **Step 6: Verify the package compiles and tests pass**
+
+Run: `go build ./pkg/modembridge/... && go test ./pkg/modembridge/...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/modembridge/
+git commit -m "Remove test tone request path from modem bridge"
+```
+
+## Task A4: Remove Test Tone from the Rust modem
+
+**Files:**
+- Modify: `graywolf-modem/src/modem/mod.rs`
+
+- [ ] **Step 1: Remove the dispatch arm**
+
+In `graywolf-modem/src/modem/mod.rs`, delete (around line 322):
+
+```rust
+            Some(Payload::PlayTestTone(req)) => {
+                self.handle_play_test_tone(req);
+            }
+```
+
+- [ ] **Step 2: Remove `TestToneResult` from the inbound-ignore list**
+
+In the match arm that ignores Rust→Go message types (around line 353-360), remove the `| Some(Payload::TestToneResult(_))` term. Leave the rest of the `|`-chain valid.
+
+- [ ] **Step 3: Remove the handler**
+
+Delete the entire `fn handle_play_test_tone(...)` method (around line 774-793).
+
+- [ ] **Step 4: Remove the blocking implementation**
+
+Delete the entire `fn play_test_tone_blocking(...)` free function (around line 2213 through its closing brace ~2390). Read the surrounding lines first to find the exact end.
+
+- [ ] **Step 5: Remove the import**
+
+In the `use ...proto::{... TestToneResult ...}` import (around line 29), remove `TestToneResult`.
+
+- [ ] **Step 6: Remove the proto.rs helper**
+
+In `graywolf-modem/src/ipc/proto.rs`, delete:
+
+```rust
+    pub fn test_tone_result(r: TestToneResult) -> Self {
+        Self { payload: Some(ipc_message::Payload::TestToneResult(r)) }
+    }
+```
+
+and any now-unused `TestToneResult` import in that file.
+
+- [ ] **Step 7: Verify (compile-check; may require CI for full target)**
+
+Run: `cargo build -p graywolf-modem 2>&1 | tail -30`
+Expected: compiles, OR fails only on known `cfg(linux)`-only modules unrelated to test tone. There must be **no** errors mentioning `test_tone`, `TestTone`, or `play_test_tone`. If the dev host can't complete the build, note it and rely on CI; the grep in Step 8 is the local gate.
+
+- [ ] **Step 8: Verify no references remain**
+
+Run: `grep -rn "test_tone\|TestTone\|play_test_tone\|PlayTestTone" graywolf-modem/src/`
+Expected: no output.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add graywolf-modem/src/
+git commit -m "Remove test tone handler from Rust modem"
+```
+
+## Task A5: Delete the Test Tone proto messages and regenerate
+
+**Files:**
+- Modify: `proto/graywolf.proto`
+- Regenerate: `pkg/ipcproto/graywolf.pb.go`, `graywolf-modem` prost bindings, `pkg/webapi/docs/gen/*`, `web/src/api/generated/api.d.ts`
+
+- [ ] **Step 1: Remove the oneof entries**
+
+In `proto/graywolf.proto`, delete these two lines from the `oneof payload` block:
+
+```proto
+    TestToneResult test_tone_result = 6;
+```
+```proto
+    PlayTestTone play_test_tone = 18;
+```
+
+Do **not** renumber other fields and do **not** reuse 6 or 18 later (Part B uses fresh numbers 9 and 22).
+
+- [ ] **Step 2: Remove the message definitions**
+
+Delete the `message PlayTestTone { ... }` block (around line 243-249) and the `message TestToneResult { ... }` block (around line 252-256), including their comments.
+
+- [ ] **Step 3: Regenerate Go bindings**
+
+Run: `make proto`
+Expected: succeeds; `pkg/ipcproto/graywolf.pb.go` no longer contains `PlayTestTone` or `TestToneResult`.
+
+Run: `grep -c "PlayTestTone\|TestToneResult" pkg/ipcproto/graywolf.pb.go`
+Expected: `0`.
+
+- [ ] **Step 4: Regenerate Rust bindings + build**
+
+Run: `cargo build -p graywolf-modem 2>&1 | tail -20`
+Expected: build proceeds past codegen with no `TestTone`/`PlayTestTone` errors (prost regenerates from the edited proto via build.rs). Defer to CI if the host can't finish a `cfg(linux)` build.
+
+- [ ] **Step 5: Regenerate docs and API types**
+
+Run: `make docs && cd web && npm run api:generate && cd ..`
+Expected: succeeds. `web/src/api/generated/api.d.ts` no longer references `test-tone`.
+
+Run: `grep -rn "test-tone\|TestTone" web/src/api/generated/api.d.ts pkg/webapi/docs/gen/`
+Expected: no output.
+
+- [ ] **Step 6: Full Go build + test**
+
+Run: `go build ./... && go test ./pkg/webapi/... ./pkg/modembridge/... ./pkg/ipcproto/...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add proto/graywolf.proto pkg/ipcproto/graywolf.pb.go pkg/webapi/docs/gen web/src/api/generated/api.d.ts
+git commit -m "Remove test tone IPC messages and regenerate bindings"
+```
+
+---
+
+# PART B — Add Channel CW ID
+
+## Task B1: Pure Rust `morse` module (TDD)
+
+**Files:**
+- Create: `graywolf-modem/src/morse.rs`
+- Modify: `graywolf-modem/src/lib.rs` (add `pub(crate) mod morse;`)
+
+- [ ] **Step 1: Register the module**
+
+In `graywolf-modem/src/lib.rs`, add alongside the other top-level module declarations:
+
+```rust
+pub(crate) mod morse;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `graywolf-modem/src/morse.rs` with the test module only first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn on(units: u32) -> Segment { Segment { on: true, units } }
+    fn off(units: u32) -> Segment { Segment { on: false, units } }
+
+    #[test]
+    fn encode_single_dit() {
+        assert_eq!(encode("E"), vec![on(1)]);
+    }
+
+    #[test]
+    fn encode_inter_character_gap() {
+        // "EE" => dit, 3-unit inter-char gap, dit
+        assert_eq!(encode("EE"), vec![on(1), off(3), on(1)]);
+    }
+
+    #[test]
+    fn encode_dah_and_intra_gaps() {
+        // "K" = -.-  => dah, gap, dit, gap, dah
+        assert_eq!(encode("K"), vec![on(3), off(1), on(1), off(1), on(3)]);
+    }
+
+    #[test]
+    fn encode_word_gap() {
+        // "A B": A=.- ; word gap 7 ; B=-...
+        assert_eq!(
+            encode("A B"),
+            vec![
+                on(1), off(1), on(3),          // A
+                off(7),                         // word gap
+                on(3), off(1), on(1), off(1), on(1), off(1), on(1), // B
+            ]
+        );
+    }
+
+    #[test]
+    fn encode_skips_unknown_chars() {
+        // '@' has no Morse representation; result equals "EE".
+        assert_eq!(encode("E@E"), encode("EE"));
+    }
+
+    #[test]
+    fn synthesize_dit_length_matches_wpm() {
+        // 20 WPM at 48 kHz: dit = 1.2/20 s = 60 ms = 2880 samples.
+        let samples = synthesize(&encode("E"), 48_000, 20, 700.0);
+        assert_eq!(samples.len(), 2880);
+        assert!(samples.iter().any(|&s| s != 0), "tone must be non-silent");
+    }
+
+    #[test]
+    fn synthesize_empty_is_empty() {
+        assert!(synthesize(&[], 48_000, 20, 700.0).is_empty());
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test -p graywolf-modem morse:: 2>&1 | tail -20`
+Expected: FAIL — `encode`, `synthesize`, `Segment` not found.
+
+- [ ] **Step 4: Implement the module**
+
+Prepend the implementation above the test module in `graywolf-modem/src/morse.rs`:
+
+```rust
+//! Pure CW (Morse) generation for station identification.
+//!
+//! No I/O and no audio device — this turns a callsign string into i16 PCM
+//! samples. The modem submits those samples as a normal TxJob, so PTT
+//! keying and play-out reuse the existing TX worker path.
+
+/// One keyed or unkeyed span, measured in Morse time units (1 unit = 1 dit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Segment {
+    pub on: bool,
+    pub units: u32,
+}
+
+/// Dot/dash pattern for a character, or None when there is no standard
+/// Morse representation (encode skips those).
+fn pattern(c: char) -> Option<&'static str> {
+    Some(match c.to_ascii_uppercase() {
+        'A' => ".-", 'B' => "-...", 'C' => "-.-.", 'D' => "-..",
+        'E' => ".", 'F' => "..-.", 'G' => "--.", 'H' => "....",
+        'I' => "..", 'J' => ".---", 'K' => "-.-", 'L' => ".-..",
+        'M' => "--", 'N' => "-.", 'O' => "---", 'P' => ".--.",
+        'Q' => "--.-", 'R' => ".-.", 'S' => "...", 'T' => "-",
+        'U' => "..-", 'V' => "...-", 'W' => ".--", 'X' => "-..-",
+        'Y' => "-.--", 'Z' => "--..",
+        '0' => "-----", '1' => ".----", '2' => "..---", '3' => "...--",
+        '4' => "....-", '5' => ".....", '6' => "-....", '7' => "--...",
+        '8' => "---..", '9' => "----.",
+        '/' => "-..-.", '-' => "-....-", '.' => ".-.-.-", ',' => "--..--",
+        '?' => "..--..",
+        _ => return None,
+    })
+}
+
+/// Encode text into keyed/unkeyed segments with standard Morse timing:
+/// dit=1, dah=3, intra-character gap=1, inter-character gap=3, word gap=7
+/// (in dit units). No leading/trailing gaps. Unknown characters are skipped.
+pub fn encode(text: &str) -> Vec<Segment> {
+    let mut out: Vec<Segment> = Vec::new();
+    let mut prev_was_char = false;
+    for raw in text.chars() {
+        if raw == ' ' {
+            if prev_was_char {
+                out.push(Segment { on: false, units: 7 });
+                prev_was_char = false;
+            }
+            continue;
+        }
+        let pat = match pattern(raw) {
+            Some(p) => p,
+            None => continue,
+        };
+        if prev_was_char {
+            out.push(Segment { on: false, units: 3 });
+        }
+        for (i, el) in pat.chars().enumerate() {
+            if i > 0 {
+                out.push(Segment { on: false, units: 1 });
+            }
+            out.push(Segment { on: true, units: if el == '-' { 3 } else { 1 } });
+        }
+        prev_was_char = true;
+    }
+    out
+}
+
+/// Synthesize keyed segments to i16 PCM at `sample_rate`. `wpm` sets dit
+/// length via PARIS timing (dit = 1.2 / wpm seconds); `tone_hz` is the
+/// sidetone. Keyed spans get a 5 ms raised-cosine rise/fall to suppress key
+/// clicks; unkeyed spans are silence.
+pub fn synthesize(segments: &[Segment], sample_rate: u32, wpm: u32, tone_hz: f32) -> Vec<i16> {
+    let wpm = wpm.max(1);
+    let dit_samples = ((sample_rate as f64) * 1.2 / (wpm as f64)).round() as usize;
+    let total: usize = segments.iter().map(|s| dit_samples * s.units as usize).sum();
+    let mut out = Vec::with_capacity(total);
+    const AMP: f32 = 0.6 * 32767.0;
+    let ramp = ((sample_rate as f32) * 0.005) as usize; // 5 ms
+    let w = 2.0 * std::f32::consts::PI * tone_hz / sample_rate as f32;
+    for seg in segments {
+        let n = dit_samples * seg.units as usize;
+        if !seg.on {
+            out.extend(std::iter::repeat(0i16).take(n));
+            continue;
+        }
+        let r = ramp.min(n / 2);
+        for i in 0..n {
+            let env = if r > 0 && i < r {
+                0.5 * (1.0 - (std::f32::consts::PI * i as f32 / r as f32).cos())
+            } else if r > 0 && i >= n - r {
+                0.5 * (1.0 - (std::f32::consts::PI * (n - 1 - i) as f32 / r as f32).cos())
+            } else {
+                1.0
+            };
+            let s = (w * i as f32).sin() * AMP * env;
+            out.push(s as i16);
+        }
+    }
+    out
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p graywolf-modem morse:: 2>&1 | tail -20`
+Expected: all 7 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add graywolf-modem/src/morse.rs graywolf-modem/src/lib.rs
+git commit -m "Add pure CW (Morse) sample-generation module"
+```
+
+## Task B2: Add the CW ID IPC messages and regenerate bindings
+
+**Files:**
+- Modify: `proto/graywolf.proto`
+- Modify: `graywolf-modem/src/ipc/proto.rs`
+- Regenerate: `pkg/ipcproto/graywolf.pb.go`, prost bindings
+
+- [ ] **Step 1: Add oneof entries**
+
+In `proto/graywolf.proto`, inside `oneof payload`, add to the Rust→Go group (use field **9**, the next free RX id):
+
+```proto
+    CwIdResult cw_id_result = 9;
+```
+
+and to the Go→Rust group (use field **22**, the next free TX id):
+
+```proto
+    TransmitCwId transmit_cw_id = 22;
+```
+
+- [ ] **Step 2: Add message definitions**
+
+Add near the other audio/PTT messages:
+
+```proto
+// Go -> Rust: transmit the station callsign as CW (Morse) for ID / TX
+// self-test. Callsign is already resolved and uppercased by Go.
+message TransmitCwId {
+  uint32 request_id = 1;        // echoed back in CwIdResult
+  uint32 channel = 2;           // selects output device + PTT driver
+  string callsign = 3;
+}
+
+// Result of a CW ID transmission attempt (submission to the TX worker).
+message CwIdResult {
+  uint32 request_id = 1;
+  bool success = 2;
+  string error = 3;             // empty on success
+}
+```
+
+- [ ] **Step 3: Regenerate Go bindings**
+
+Run: `make proto`
+Expected: succeeds.
+
+Run: `grep -c "TransmitCwId\|CwIdResult" pkg/ipcproto/graywolf.pb.go`
+Expected: non-zero (types generated).
+
+- [ ] **Step 4: Add the Rust proto.rs helper**
+
+In `graywolf-modem/src/ipc/proto.rs`, add a constructor mirroring the others (next to where `test_tone_result` used to be):
+
+```rust
+    pub fn cw_id_result(r: CwIdResult) -> Self {
+        Self { payload: Some(ipc_message::Payload::CwIdResult(r)) }
+    }
+```
+
+Ensure `CwIdResult` is imported in that file's `use` block (mirror how the other result types are imported).
+
+- [ ] **Step 5: Build Rust to regenerate prost bindings**
+
+Run: `cargo build -p graywolf-modem 2>&1 | tail -20`
+Expected: codegen succeeds; `CwIdResult` / `TransmitCwId` resolve. (`cw_id_result` is unused until Task B3 — a dead-code warning is acceptable here.)
+
+- [ ] **Step 6: Verify Go compiles**
+
+Run: `go build ./pkg/ipcproto/...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add proto/graywolf.proto pkg/ipcproto/graywolf.pb.go graywolf-modem/src/ipc/proto.rs
+git commit -m "Add TransmitCwId and CwIdResult IPC messages"
+```
+
+## Task B3: Rust modem CW ID handler
+
+**Files:**
+- Modify: `graywolf-modem/src/modem/mod.rs`
+
+- [ ] **Step 1: Import the new result type**
+
+In the `use crate::ipc::proto::{...}` block (around line 29), add `CwIdResult` to the imported names.
+
+- [ ] **Step 2: Add the dispatch arm**
+
+In the inbound-payload `match` (near the `Some(Payload::TransmitFrame(tf))` arm, around line 338), add:
+
+```rust
+            Some(Payload::TransmitCwId(req)) => {
+                self.handle_transmit_cw_id(req);
+            }
+```
+
+- [ ] **Step 3: Add `CwIdResult` to the inbound-ignore list**
+
+In the ignore arm (the `|`-chain of Rust→Go types, around line 353), add `| Some(Payload::CwIdResult(_))`.
+
+- [ ] **Step 4: Implement the handler**
+
+Add this method to the same `impl` block that holds `handle_transmit_frame` (place it right after `handle_transmit_frame`, before the closing `}` of the impl). It mirrors `handle_transmit_frame`'s channel/audio-config resolution, but builds samples from the `morse` module and replies with a `CwIdResult`:
+
+```rust
+    fn handle_transmit_cw_id(&mut self, req: crate::ipc::proto::TransmitCwId) {
+        const CW_WPM: u32 = 20;
+        const CW_TONE_HZ: f32 = 700.0;
+
+        let reply = |success: bool, error: String| {
+            let _ = self.handle.send(&IpcMessage::cw_id_result(crate::ipc::proto::CwIdResult {
+                request_id: req.request_id,
+                success,
+                error,
+            }));
+        };
+
+        // Lazy rigctld retry, same as handle_transmit_frame.
+        if self.ptt_rigctld_pending.contains(&req.channel) {
+            if let Some(cfg) = self.ptt_cfgs.get(&req.channel).cloned() {
+                self.apply_ptt_config(cfg);
+            }
+        }
+
+        let ccfg = match self.channel_configs.get(&req.channel) {
+            Some(c) => c.clone(),
+            None => {
+                reply(false, format!("unknown channel {}", req.channel));
+                return;
+            }
+        };
+        let acfg = match self.audio_configs.get(&ccfg.output_device_id) {
+            Some(a) => a.clone(),
+            None => {
+                reply(false, format!("no audio config for output device {}", ccfg.output_device_id));
+                return;
+            }
+        };
+
+        let segments = crate::morse::encode(&req.callsign);
+        if segments.is_empty() {
+            reply(false, "callsign produced no CW symbols".to_string());
+            return;
+        }
+        let mut samples = crate::morse::synthesize(&segments, acfg.sample_rate, CW_WPM, CW_TONE_HZ);
+
+        // Apply output device gain, matching handle_transmit_frame.
+        if let Some(gain_atom) = self.gain_atoms.get(&ccfg.output_device_id) {
+            let gain_db = f32::from_bits(gain_atom.load(std::sync::atomic::Ordering::Relaxed));
+            if gain_db.abs() > f32::EPSILON {
+                let gain_linear = 10f32.powf(gain_db / 20.0);
+                for s in samples.iter_mut() {
+                    let amplified = (*s as f32) * gain_linear;
+                    *s = amplified.clamp(-32767.0, 32767.0) as i16;
+                }
+            }
+        }
+
+        let job = tx_worker::TxJob {
+            channel: req.channel,
+            samples,
+            sample_rate: acfg.sample_rate,
+            output_device_id: ccfg.output_device_id,
+            sink_config: audio::soundcard::SoundcardOutputConfig {
+                device_name: acfg.device_name.clone(),
+                sample_rate: acfg.sample_rate,
+                channels: acfg.channels,
+                audio_channel: ccfg.output_channel,
+            },
+        };
+
+        match self.tx_worker.transmit(job) {
+            Ok(()) => {
+                *self.tx_frames.entry(req.channel).or_default() += 1;
+                reply(true, String::new());
+            }
+            Err(e) => reply(false, e),
+        }
+    }
+```
+
+> Note: `channel_configs`/`audio_configs` are cloned here (rather than borrowed) so the later `&mut self` calls (`apply_ptt_config`, `tx_worker.transmit`, `tx_frames`) don't conflict with the immutable borrow. If `ChannelConfig`/`AudioConfig` are not `Clone`, read their definitions and copy out only the fields used above (`output_device_id`, `output_channel`, `sample_rate`, `device_name`, `channels`) into locals before the mutable calls.
+
+- [ ] **Step 5: Verify (compile-check; CI for full target)**
+
+Run: `cargo build -p graywolf-modem 2>&1 | tail -30`
+Expected: compiles, or fails only on unrelated `cfg(linux)`-only code. No errors mentioning `handle_transmit_cw_id`, `morse`, `CwIdResult`, or `TransmitCwId`. If the host can't finish, note it; CI is the gate.
+
+Run: `cargo test -p graywolf-modem morse:: 2>&1 | tail -5`
+Expected: morse tests still PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add graywolf-modem/src/modem/mod.rs
+git commit -m "Handle TransmitCwId in the modem: synthesize CW and submit a TxJob"
+```
+
+## Task B4: Go bridge `TransmitCwID`
+
+**Files:**
+- Modify: `pkg/modembridge/requests.go`
+- Modify: `pkg/modembridge/bridge.go`
+- Modify: `pkg/modembridge/session.go`
+- Modify: `pkg/modembridge/bridge_stop_test.go`
+
+- [ ] **Step 1: Add the dispatcher field + init**
+
+In `pkg/modembridge/bridge.go`, add the field next to the other dispatchers:
+
+```go
+	cwDispatcher *dispatcher[*pb.CwIdResult]
+```
+
+and in `New`, next to the other dispatcher inits:
+
+```go
+		cwDispatcher: newDispatcher[*pb.CwIdResult](),
+```
+
+- [ ] **Step 2: Add the `TransmitCwID` method**
+
+In `pkg/modembridge/requests.go`, add (mirrors the former `PlayTestTone` pattern):
+
+```go
+// TransmitCwID asks the Rust modem to transmit the given callsign as CW
+// (Morse) on the named channel and waits for the submission result. The
+// modem keys PTT, plays the CW audio, and unkeys via the TX worker.
+func (b *Bridge) TransmitCwID(ctx context.Context, channel uint32, callsign string) error {
+	if b.State() != StateRunning {
+		return errors.New("modembridge: not in RUNNING state")
+	}
+
+	reqID, ch := b.cwDispatcher.Register()
+	defer b.cwDispatcher.Cancel(reqID)
+
+	msg := &pb.IpcMessage{Payload: &pb.IpcMessage_TransmitCwId{
+		TransmitCwId: &pb.TransmitCwId{
+			RequestId: reqID,
+			Channel:   channel,
+			Callsign:  callsign,
+		},
+	}}
+	if err := b.sendIPC(msg); err != nil {
+		return fmt.Errorf("send TransmitCwId: %w", err)
+	}
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case resp := <-ch:
+		if resp == nil {
+			return errBridgeStopped
+		}
+		if !resp.Success {
+			return fmt.Errorf("CW ID failed: %s", resp.Error)
+		}
+		return nil
+	case <-timer.C:
+		return errors.New("modembridge: CW ID timeout")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (b *Bridge) dispatchCwIdResponse(r *pb.CwIdResult) {
+	b.cwDispatcher.Deliver(r.RequestId, r)
+}
+```
+
+- [ ] **Step 3: Add the session dispatch case**
+
+In `pkg/modembridge/session.go`, in the inbound `switch`, add:
+
+```go
+	case *pb.IpcMessage_CwIdResult:
+		b.dispatchCwIdResponse(p.CwIdResult)
+```
+
+- [ ] **Step 4: Add the stop-test coverage**
+
+In `pkg/modembridge/bridge_stop_test.go`, mirror the existing dispatcher patterns. Read the file first, then:
+
+- Add a test-case entry that calls `b.TransmitCwID(context.Background(), 0, "N0CALL")` and asserts it unblocks with `errBridgeStopped` (mirror the former `PlayTestTone` entry shape).
+- Add `"cw": adaptPbCwIdResult(cwCh),` to the channel map and declare `cwCh` like the others.
+- Add the adapter:
+
+```go
+func adaptPbCwIdResult(c <-chan *pb.CwIdResult) <-chan any {
+	out := make(chan any)
+	go func() {
+		defer close(out)
+		for v := range c {
+			out <- v
+		}
+	}()
+	return out
+}
+```
+
+(Match the exact structure of the sibling adapters already in the file.)
+
+- [ ] **Step 5: Verify build + tests**
+
+Run: `go build ./pkg/modembridge/... && go test ./pkg/modembridge/...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/modembridge/
+git commit -m "Add TransmitCwID request path to modem bridge"
+```
+
+## Task B5: Go webapi `POST /api/channels/{id}/cw-id`
+
+**Files:**
+- Modify: `pkg/webapi/channels.go`
+- Modify: `pkg/webapi/dto/` (add `CwIdResponse` — put it in the channels DTO file; find it via grep below)
+- Modify: `pkg/webapi/docs/op_ids.go`
+- Test: `pkg/webapi/channels_cw_id_test.go` (create)
+
+- [ ] **Step 1: Locate the channels DTO file**
+
+Run: `grep -rln "ChannelResponse\|BeaconSendResponse" pkg/webapi/dto/`
+Use the file that holds channel-related DTOs (likely `pkg/webapi/dto/channel.go`). Add there:
+
+```go
+// CwIdResponse is the body returned by POST /api/channels/{id}/cw-id.
+type CwIdResponse struct {
+	Status string `json:"status" example:"sent"`
+}
+```
+
+- [ ] **Step 2: Add the op-id constant**
+
+In `pkg/webapi/docs/op_ids.go`, near `OpManualPtt`/`OpSendBeacon`, add:
+
+```go
+	OpSendCwID = "sendCwId"
+```
+
+- [ ] **Step 3: Register the route**
+
+In `pkg/webapi/channels.go`, in `registerChannels`, add after the `ptt` route:
+
+```go
+	mux.HandleFunc("POST /api/channels/{id}/cw-id", s.sendCwID)
+```
+
+- [ ] **Step 4: Write the handler**
+
+In `pkg/webapi/channels.go`, add (mirrors `manualPtt` + the beacon refusal mapping). Ensure imports include `errors` and `github.com/chrissnell/graywolf/pkg/callsign`:
+
+```go
+// sendCwID transmits the station callsign as CW (Morse) on a channel. It
+// refuses to key the radio when the station callsign is empty or N0CALL,
+// and when the channel is not TX-capable.
+//
+// @Summary  Send CW ID (station callsign in Morse) on a channel
+// @Tags     Channels
+// @ID       sendCwId
+// @Produce  json
+// @Param    id path int true "Channel ID"
+// @Success  200 {object} dto.CwIdResponse
+// @Failure  409 {object} webtypes.ErrorResponse
+// @Failure  422 {object} webtypes.ErrorResponse
+// @Failure  503 {object} webtypes.ErrorResponse
+// @Router   /channels/{id}/cw-id [post]
+func (s *Server) sendCwID(w http.ResponseWriter, r *http.Request) {
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid channel id")
+		return
+	}
+	if s.bridge == nil {
+		writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: "bridge not available"})
+		return
+	}
+
+	call, err := s.store.ResolveStationCallsign(r.Context())
+	if err != nil {
+		switch {
+		case errors.Is(err, callsign.ErrCallsignEmpty):
+			writeJSON(w, http.StatusUnprocessableEntity, webtypes.ErrorResponse{Error: "set your station callsign before sending CW ID"})
+		case errors.Is(err, callsign.ErrCallsignN0Call):
+			writeJSON(w, http.StatusUnprocessableEntity, webtypes.ErrorResponse{Error: "station callsign is still N0CALL; set a real callsign before sending CW ID"})
+		default:
+			s.internalError(w, r, "resolve station callsign", err)
+		}
+		return
+	}
+
+	if err := s.requireTxCapableChannel(r.Context(), "channel", id); err != nil {
+		writeJSON(w, http.StatusConflict, webtypes.ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	if err := s.bridge.TransmitCwID(r.Context(), id, call); err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, dto.CwIdResponse{Status: "sent"})
+}
+```
+
+> Verify the exact import path/alias for `webtypes` and `dto` at the top of `channels.go` and match them (they are already used by sibling handlers in this file).
+
+- [ ] **Step 5: Write the test**
+
+Create `pkg/webapi/channels_cw_id_test.go`. Read an existing webapi test (e.g. `pkg/webapi/beacons_send_test.go`) first to copy the exact server-construction/test harness helpers used in this package (store setup, bridge stub, request helper). Then assert these cases:
+
+- Empty station callsign → `422`.
+- N0CALL station callsign → `422`.
+- Non-TX channel → `409`.
+- Valid callsign + TX-capable channel + bridge stub returning nil → `200` with `{"status":"sent"}`.
+
+Use the package's existing patterns for stubbing `s.bridge.TransmitCwID` (e.g. an interface stub or fake bridge already present). If the bridge field is a concrete `*modembridge.Bridge`, follow how `manualPtt`/beacon tests inject a fake — replicate that mechanism rather than inventing a new one.
+
+- [ ] **Step 6: Run the test**
+
+Run: `go test ./pkg/webapi/ -run CwId -v`
+Expected: PASS (all four cases).
+
+- [ ] **Step 7: Full webapi build + test**
+
+Run: `go build ./pkg/webapi/... && go test ./pkg/webapi/...`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pkg/webapi/channels.go pkg/webapi/dto/ pkg/webapi/docs/op_ids.go pkg/webapi/channels_cw_id_test.go
+git commit -m "Add channel CW ID REST endpoint with callsign and TX-capability guards"
+```
+
+## Task B6: Regenerate docs and API types
+
+**Files:**
+- Regenerate: `pkg/webapi/docs/gen/*`, `web/src/api/generated/api.d.ts`
+
+- [ ] **Step 1: Regenerate**
+
+Run: `make docs && cd web && npm run api:generate && cd ..`
+Expected: succeeds.
+
+- [ ] **Step 2: Verify the new endpoint is present**
+
+Run: `grep -rn "cw-id\|sendCwId" pkg/webapi/docs/gen/swagger.json web/src/api/generated/api.d.ts`
+Expected: matches in both.
+
+- [ ] **Step 3: Docs drift check**
+
+Run: `make docs-check`
+Expected: no drift.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/webapi/docs/gen web/src/api/generated/api.d.ts
+git commit -m "Regenerate API docs and types for CW ID endpoint"
+```
+
+## Task B7: Frontend "Send CW ID" button
+
+**Files:**
+- Modify: `web/src/routes/channels/ChannelRow.svelte`
+
+The click handler runs inline in `ChannelRow` (with local in-flight state), matching how `AudioDevices.svelte` handled Test Tone. The button is gated by the same TX-capability condition the PTT indicator uses: `!isKissOnly && channel.output_device_id && channel.output_device_id !== 0`.
+
+- [ ] **Step 1: Add the API + toast imports and local state**
+
+In the `<script>` block of `ChannelRow.svelte`, add to imports:
+
+```javascript
+  import { api } from '../../lib/api.js';
+  import { toasts } from '../../lib/stores.js';
+```
+
+> Verify the relative depth: `ChannelRow.svelte` is in `web/src/routes/channels/`, so `lib` is two levels up (`../../lib/...`). Confirm against how `channelBacking.js` is imported (`../../lib/...`) at the top of the file.
+
+After the `$props()` line, add:
+
+```javascript
+  let sendingCwId = $state(false);
+
+  async function sendCwId() {
+    sendingCwId = true;
+    try {
+      await api.post(`/channels/${channel.id}/cw-id`);
+      toasts.success(`Sent CW ID on "${channel.name}"`);
+    } catch (err) {
+      toasts.error(`CW ID failed: ${err.message}`);
+    } finally {
+      sendingCwId = false;
+    }
+  }
+```
+
+> Confirm the channel display field name (`channel.name`) by checking how the row already renders the channel title; use whatever field that markup uses.
+
+- [ ] **Step 2: Add the button to the action row**
+
+In the action row that currently holds Edit/Delete (around line 139), add the CW ID button before Edit, gated on TX capability:
+
+```svelte
+  {#if !isKissOnly && channel.output_device_id && channel.output_device_id !== 0}
+    <Button variant="ghost" onclick={sendCwId} disabled={sendingCwId}>
+      {sendingCwId ? 'Sending…' : 'Send CW ID'}
+    </Button>
+  {/if}
+  <Button variant="ghost" onclick={() => onEdit?.(channel)}>Edit</Button>
+  <Button variant="danger" onclick={() => onDelete?.(channel)}>Delete</Button>
+```
+
+(Keep the existing Edit/Delete buttons; only add the guarded CW ID button.)
+
+- [ ] **Step 3: Build the frontend**
+
+Run: `cd web && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Manual verification (record result)**
+
+Run the app and confirm: the "Send CW ID" button appears only on modem-backed TX channels (not on KISS-only or RX-only rows); clicking a TX channel shows a success toast (or a clear error toast if no station callsign is set). Note the observed result in the task checklist.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/routes/channels/ChannelRow.svelte
+git commit -m "Add Send CW ID button to TX-capable channel rows"
+```
+
+## Task B8: Update the wiki
+
+**Files:**
+- Modify: `docs/wiki/code-map.md`
+- Modify: `docs/wiki/invariants.md`
+
+- [ ] **Step 1: Update code-map**
+
+In `docs/wiki/code-map.md`: remove any Test Tone / `playTestTone` / `play_test_tone` references; add the new `POST /api/channels/{id}/cw-id` endpoint (handler `sendCwID` in `pkg/webapi/channels.go`), the `graywolf-modem/src/morse.rs` module, and the `TransmitCwId`/`CwIdResult` IPC messages. Keep it to navigation-level pointers, not internals.
+
+- [ ] **Step 2: Update invariants**
+
+In `docs/wiki/invariants.md`, add an invariant:
+
+> **CW ID never keys the radio with an empty or N0CALL callsign.** `POST /api/channels/{id}/cw-id` resolves the station callsign via `Store.ResolveStationCallsign` and returns 422 before any IPC if it is empty or N0CALL.
+
+- [ ] **Step 3: Verify references**
+
+Run: `grep -rn "test tone\|Test Tone\|test-tone\|playTestTone" docs/wiki/`
+Expected: no output (all Test Tone mentions removed from the wiki).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/wiki/code-map.md docs/wiki/invariants.md
+git commit -m "Update wiki for channel CW ID; drop test tone references"
+```
+
+---
+
+## Final verification (whole feature)
+
+- [ ] **Go:** `go build ./... && go test ./pkg/webapi/... ./pkg/modembridge/... ./pkg/ipcproto/...` → PASS
+- [ ] **Rust (host-buildable parts):** `cargo test -p graywolf-modem morse::` → PASS; `cargo build -p graywolf-modem` → no CW/test-tone errors (full `cfg(linux)` build via CI)
+- [ ] **Frontend:** `cd web && npm run build` → PASS
+- [ ] **Docs:** `make docs-check` → no drift
+- [ ] **No stragglers:** `grep -rn "test_tone\|TestTone\|test-tone\|playTestTone\|PlayTestTone" pkg/ graywolf-modem/src/ web/src/ proto/ docs/wiki/` → no output
+- [ ] **On-device (CI build + radio):** confirm clicking "Send CW ID" keys PTT and the callsign is audible/decodable in Morse on a second radio, and that an unset callsign yields a clear refusal.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** Part A removes Test Tone across all six layers named in the spec (UI, webapi, bridge, proto, Rust handler, regen). Part B covers the IPC messages, Rust `morse` + handler, Go bridge, webapi endpoint with all three refusal guards + success, frontend button gated by TX capability, and wiki updates — matching the spec's architecture and testing sections.
+- **Type consistency:** Go `TransmitCwID`/`pb.TransmitCwId`/`pb.CwIdResult`/`OpSendCwID`/`dto.CwIdResponse`; Rust `morse::encode`/`morse::synthesize`/`Segment`/`handle_transmit_cw_id`/`IpcMessage::cw_id_result`; proto field ids 9 (RX) and 22 (TX) are the next free numbers after the Part A removals; frontend `sendCwId`/`sendingCwId`. Names are used identically across tasks.
+- **No placeholders:** every code step shows complete code; verification steps give exact commands and expected output. Cross-file uncertainties (DTO file location, test harness shape, `webtypes` alias, Clone-ability of config structs, import depth) are flagged with a grep/read-first instruction rather than guessed.

--- a/docs/superpowers/specs/2026-05-26-channel-cw-id-design.md
+++ b/docs/superpowers/specs/2026-05-26-channel-cw-id-design.md
@@ -1,4 +1,4 @@
-# Channel CW ID — Design
+# Channel TX Test Signals — Design
 
 **Date:** 2026-05-26
 **Status:** Approved for planning
@@ -13,25 +13,41 @@ Two related changes:
    because opening the output stream while capture is active returns "device no
    longer available." It is a soundcard toy that does not exercise the radio.
 
-2. **Add a per-channel "Send CW ID" button** that transmits the station
-   callsign in Morse through the channel's real TX path: key PTT → play
-   on/off-keyed CW audio → unkey. This is a genuine end-to-end TX self-test
-   (PTT keying + audio routing + deviation, all verifiable by ear on a second
-   radio) and doubles as legal station identification.
+2. **Add a per-channel "Test TX" dropdown menu** that transmits a chosen test
+   signal through the channel's real TX path: key PTT → play audio → unkey.
+   This is a genuine end-to-end TX self-test (PTT keying + audio routing +
+   deviation, all verifiable by ear or meter on a second radio). The CW option
+   doubles as legal station identification.
+
+   The menu offers four options:
+   - **Send callsign in CW** — the station callsign in Morse (~20 WPM, 700 Hz).
+   - **Send 1200 Hz tone** — a steady 1200 Hz tone for 3 seconds.
+   - **Send 2400 Hz tone** — a steady 2400 Hz tone for 3 seconds.
+   - **Send 1200/2400 Hz alternating tone** — alternating between the two for
+     3 seconds.
 
 This effectively moves the "test transmit" concept from Audio Interfaces (where
 PTT/TX has no meaning) up to Channels (where it does).
 
 ## Decisions (from brainstorming)
 
-- **Scope:** Manual button only. No automatic/periodic CW ID timer.
-- **CW parameters:** Hardcoded defaults — ~20 WPM, ~700 Hz sidetone, PARIS
-  timing. No UI, no config schema.
-- **Callsign source:** `Store.ResolveStationCallsign(ctx)` (the centralized
-  station callsign). If empty or N0CALL, refuse with a clear error and never
-  key the radio. N0CALL must never reach the air.
-- **Button placement:** A per-channel action in `ChannelRow.svelte`, alongside
-  Edit/Delete. Disabled/hidden for non-TX-capable channels.
+- **Scope:** Manual menu only. No automatic/periodic timers.
+- **UI:** A "Test TX" button on each channel row opens a chonky-ui
+  `DropdownMenu` with the four options. Shown only for TX-capable channels.
+- **CW parameters:** Hardcoded — 20 WPM, 700 Hz sidetone, PARIS timing.
+- **Tone parameters:** Hardcoded — 3 second duration; alternating tone switches
+  every 200 ms (≈2.5 Hz warble). 1200 Hz and 2400 Hz are the two tone
+  frequencies (1200 is the Bell 202 mark tone; the pair exercises AFSK-style
+  deviation).
+- **Callsign source / guard:** the CW option resolves
+  `Store.ResolveStationCallsign(ctx)` (the centralized station callsign) and
+  refuses (HTTP 422) with a clear error if it is empty or N0CALL — N0CALL must
+  never reach the air. The three tone options do **not** require a callsign and
+  work regardless of station-callsign state.
+- **Where the "recipes" live:** the four UI options map to hardcoded parameter
+  sets in one place in Go (the webapi handler). The Rust modem is a pure
+  renderer keyed by a numeric `kind` + parameters — no hardcoded frequencies or
+  durations buried in Rust.
 
 ## Architecture
 
@@ -58,100 +74,138 @@ Delete the entire chain:
 
 Regenerate API types (`web/src/api/generated/api.d.ts`) and Swagger docs.
 
-### Part 2 — Channel CW ID
+### Part 2 — Channel TX test signals
 
 Reuses the existing TX worker, which already keys PTT → submits samples →
 drains → unkeys per channel via `TxJob { samples: Vec<i16>, sample_rate }`
-(`graywolf-modem/src/modem/tx_worker.rs`). CW is just a different way to
-generate those samples.
-
-**Approach A (chosen):** dedicated IPC message; the modem owns CW synthesis.
+(`graywolf-modem/src/modem/tx_worker.rs`). Every test signal is just a
+different way to *generate* those samples.
 
 #### IPC
 
-- New `TransmitCwId { request_id, channel, callsign }` request message.
-- New `CwIdResult { request_id, success, error }` result message (mirrors
-  `TestToneResult`).
-- Added to the `.proto`, regenerated into `graywolf.pb.go` and `proto.rs`.
+A single request message carries a numeric `kind` plus parameters; Go fills in
+the hardcoded values per UI option. Using a plain `uint32 kind` (not a proto
+enum) avoids prost enum-prefix-naming fragility.
+
+```proto
+// Go -> Rust: transmit a TX test signal on a channel. kind selects the
+// generator: 0 = station callsign in CW, 1 = steady tone, 2 = alternating
+// tone. Go fills the relevant parameters; the modem is a pure renderer.
+message TransmitTestSignal {
+  uint32 request_id = 1;   // echoed back in TestSignalResult
+  uint32 channel = 2;      // selects output device + PTT driver
+  uint32 kind = 3;         // 0=CW callsign, 1=steady tone, 2=alternating
+  string callsign = 4;     // kind 0; already resolved + uppercased by Go
+  uint32 cw_wpm = 5;       // kind 0
+  uint32 freq_a_hz = 6;    // CW sidetone (kind 0) / tone (kind 1) / tone A (kind 2)
+  uint32 freq_b_hz = 7;    // tone B (kind 2)
+  uint32 duration_ms = 8;  // kinds 1, 2
+  uint32 alt_period_ms = 9;// kind 2: ms per tone before switching
+}
+
+message TestSignalResult {
+  uint32 request_id = 1;
+  bool success = 2;
+  string error = 3;        // empty on success
+}
+```
+
+Oneof field numbers: `TestSignalResult` takes RX id **9** (next free after the
+Test Tone removal frees 6); `TransmitTestSignal` takes TX id **22** (next free
+after 21).
 
 #### Rust modem
 
-- New pure `morse` module:
-  - `encode(callsign: &str) -> Vec<Symbol>` where `Symbol` ∈ {Dit, Dah,
-    intra-char gap, inter-char gap, word gap}. Unknown characters are skipped.
-  - `synthesize(symbols, sample_rate, wpm, tone_hz) -> Vec<i16>` using PARIS
-    timing (dit = 1.2 / wpm seconds), a ~700 Hz sine gated on for key-down with
-    short rise/fall ramps to avoid key clicks.
-  - Both pure and unit-tested (timing lengths, symbol mapping, empty/invalid
-    input).
-- `handle_transmit_cw_id(req)`: build samples via the `morse` module, submit a
-  `TxJob` to the TX worker for `req.channel`, reply with `CwIdResult`. PTT
-  key/unkey is handled by the worker. Errors (no TX device/driver for the
-  channel, worker failure) map to `success: false` with a message.
-- New `Some(Payload::TransmitCwId(..))` match arm; `CwIdResult` added to the
-  inbound-ignore list.
+A pure `txtest` module (no I/O), unit-tested:
+- `encode(&str) -> Vec<Segment>` — Morse symbol/timing encoder (skips unknown
+  characters).
+- `cw_samples(callsign, sample_rate, wpm, tone_hz) -> Vec<i16>` — encode +
+  synthesize the on/off-keyed sidetone (PARIS timing, raised-cosine edges).
+- `tone_samples(sample_rate, freq_hz, duration_ms) -> Vec<i16>` — steady sine
+  with edge ramps.
+- `alternating_samples(sample_rate, freq_a, freq_b, duration_ms, period_ms) ->
+  Vec<i16>` — phase-continuous frequency switching (no click at the switch),
+  with outer edge ramps.
 
-#### Go bridge
-
-- `TransmitCwID(ctx, channel uint32, callsign string) error` in
-  `pkg/modembridge/requests.go`, mirroring the request/dispatcher pattern of
-  the existing typed requests; a `cwIdDispatcher` in `bridge.go` and dispatch
-  in `session.go`; a `bridge_stop_test.go` case so it unblocks on stop.
+`handle_transmit_test_signal` resolves channel + audio config exactly like
+`handle_transmit_frame`, picks the generator by `kind`, applies output gain,
+submits a `TxJob` to the TX worker, and replies with `TestSignalResult`. PTT
+key/unkey is handled by the worker.
 
 #### Go webapi
 
-- `POST /api/channels/{id}/cw-id`:
-  1. Parse channel ID.
-  2. `ResolveStationCallsign` → on empty/N0CALL, `422` with a clear message
-     ("set your station callsign before sending CW ID").
-  3. `requireTxCapableChannel` → on failure, `409`/`422` consistent with the
-     beacon-send path.
-  4. `bridge.TransmitCwID` → on failure, `503`/`500` as appropriate.
-  5. `200 { "status": "sent" }`.
-- New DTO `CwIdResponse { Status string }` in `pkg/webapi/dto`.
-- Op-id entry; Swagger annotations; regenerated docs + `api.d.ts`.
+`POST /api/channels/{id}/test-tx` with body `{ "signal": "<id>" }` where
+`<id>` ∈ `cw | tone1200 | tone2400 | alt`. The handler:
+1. Parses channel ID and the signal id (unknown id → 400).
+2. For `cw` only: `ResolveStationCallsign` → 422 on empty/N0CALL.
+3. `requireTxCapableChannel` → 409 on failure.
+4. Maps the signal id to a hardcoded `modembridge.TestSignalParams`
+   (kind + frequencies + duration + period + callsign/wpm) and calls
+   `bridge.TransmitTestSignal` → 503 on failure.
+5. `200 { "status": "sent" }`.
+
+The four recipes (the single source of the hardcoded values):
+
+| signal      | kind | callsign | wpm | freq_a | freq_b | duration | alt_period |
+|-------------|------|----------|-----|--------|--------|----------|------------|
+| `cw`        | 0    | resolved | 20  | 700    | —      | —        | —          |
+| `tone1200`  | 1    | —        | —   | 1200   | —      | 3000 ms  | —          |
+| `tone2400`  | 1    | —        | —   | 2400   | —      | 3000 ms  | —          |
+| `alt`       | 2    | —        | —   | 1200   | 2400   | 3000 ms  | 200 ms     |
+
+#### Go bridge
+
+`TransmitTestSignal(ctx, params TestSignalParams) error`, mirroring the
+existing typed request/dispatcher pattern; a dispatcher in `bridge.go`, dispatch
+in `session.go`, and a `bridge_stop_test.go` case so it unblocks on stop.
 
 #### Frontend
 
-- In `web/src/routes/channels/ChannelRow.svelte`, add a "Send CW ID" `Button`
-  (ghost variant) in the action row next to Edit/Delete. Show only for
-  TX-capable channels (same condition that gates the RX/TX badge / PTT
-  indicator — modem-backed channel with an output device). On click, `POST` the
-  endpoint; success → toast "Sent CW ID on \"<channel>\""; failure → error
-  toast with the server message. Disable the button while in flight.
+In `web/src/routes/channels/ChannelRow.svelte`, replace the Edit/Delete-only
+action row with a chonky-ui `DropdownMenu` ("Test TX ▾" trigger) holding four
+`DropdownMenu.Item`s, shown only for TX-capable channels (same condition that
+gates the RX/TX badge / PTT indicator: modem-backed channel with an output
+device). Each item `POST`s `/channels/{id}/test-tx` with its signal id. One
+in-flight flag disables the trigger while a signal is transmitting. Success →
+toast; failure → error toast with the server message (e.g. the CW
+callsign-missing 422).
 
 ### Wiki maintenance
 
-- `docs/wiki/code-map.md`: record the new `/api/channels/{id}/cw-id` endpoint
-  and the `morse` modem module; remove Test Tone references.
-- `docs/wiki/invariants.md`: add "CW ID never keys the radio with an empty or
-  N0CALL callsign."
+- `docs/wiki/code-map.md`: record the new `/api/channels/{id}/test-tx` endpoint,
+  the `txtest` modem module, and the `TransmitTestSignal`/`TestSignalResult`
+  IPC messages. Remove Test Tone references.
+- `docs/wiki/invariants.md`: add "the CW test signal never keys the radio with
+  an empty or N0CALL callsign."
 
 ## Error handling
 
-- Empty/N0CALL callsign → refuse before any IPC; nothing is keyed.
-- Non-TX channel → refuse before any IPC.
-- Modem-side failure (no driver/sink, submit error) → `CwIdResult.success =
-  false`; the TX worker's existing sequencing guarantees PTT is released on
+- CW with empty/N0CALL callsign → refuse before any IPC (422); nothing keyed.
+- Unknown signal id → 400 before any IPC.
+- Non-TX channel → 409 before any IPC.
+- Modem-side failure (no driver/sink, submit error) → `TestSignalResult.success
+  = false`; the TX worker's existing sequencing guarantees PTT is released on
   submit failure (no stuck-keyed radio).
 
 ## Testing
 
-- **Rust:** unit tests for `morse::encode` (symbol mapping, unknown-char skip)
-  and `morse::synthesize` (sample-count vs. WPM timing, non-empty output,
-  ramping). A handler test that a `TransmitCwId` with no registered
-  driver/sink yields `success: false`.
-- **Go:** webapi tests for the three refusal paths (empty callsign, N0CALL,
-  non-TX channel) and the success path (bridge stub returns nil). Bridge
-  stop-test case for `TransmitCwID`.
-- **Frontend:** button visibility gating by TX capability; success/error toast
-  on stubbed responses.
+- **Rust:** unit tests for `encode` (symbol mapping, unknown-char skip, gaps),
+  `cw_samples` (length vs WPM, non-empty), `tone_samples` (length vs duration,
+  non-silent), `alternating_samples` (length, non-silent). Handler test that an
+  unknown channel yields `success: false`.
+- **Go:** webapi tests for refusal paths (CW empty callsign → 422, CW N0CALL →
+  422, unknown signal → 400, non-TX channel → 409) and success paths (each of
+  the four signals with a bridge stub returning nil → 200). Bridge stop-test
+  case for `TransmitTestSignal`.
+- **Frontend:** menu visibility gating by TX capability; each item posts the
+  right signal id; success/error toast on stubbed responses.
 - **Removal:** confirm the Test Tone route/handler/DTO/UI are gone and tests
   referencing them are removed, not skipped.
 
 ## Out of scope (YAGNI)
 
 - Automatic/periodic station ID timer.
-- Configurable WPM / tone frequency.
+- Configurable WPM / tone frequency / duration in the UI or config schema.
 - Per-channel callsign override (uses the station callsign).
 - Any CW receive/decode.
+- Tone frequencies beyond the three fixed options.

--- a/docs/superpowers/specs/2026-05-26-channel-cw-id-design.md
+++ b/docs/superpowers/specs/2026-05-26-channel-cw-id-design.md
@@ -1,0 +1,157 @@
+# Channel CW ID — Design
+
+**Date:** 2026-05-26
+**Status:** Approved for planning
+
+## Summary
+
+Two related changes:
+
+1. **Remove the broken Test Tone feature** from Audio Interfaces. It plays a
+   1 kHz tone straight to the cpal output device — it never keys PTT (so a real
+   radio transmits nothing) and it fails on shared input/output dongles (AIOC)
+   because opening the output stream while capture is active returns "device no
+   longer available." It is a soundcard toy that does not exercise the radio.
+
+2. **Add a per-channel "Send CW ID" button** that transmits the station
+   callsign in Morse through the channel's real TX path: key PTT → play
+   on/off-keyed CW audio → unkey. This is a genuine end-to-end TX self-test
+   (PTT keying + audio routing + deviation, all verifiable by ear on a second
+   radio) and doubles as legal station identification.
+
+This effectively moves the "test transmit" concept from Audio Interfaces (where
+PTT/TX has no meaning) up to Channels (where it does).
+
+## Decisions (from brainstorming)
+
+- **Scope:** Manual button only. No automatic/periodic CW ID timer.
+- **CW parameters:** Hardcoded defaults — ~20 WPM, ~700 Hz sidetone, PARIS
+  timing. No UI, no config schema.
+- **Callsign source:** `Store.ResolveStationCallsign(ctx)` (the centralized
+  station callsign). If empty or N0CALL, refuse with a clear error and never
+  key the radio. N0CALL must never reach the air.
+- **Button placement:** A per-channel action in `ChannelRow.svelte`, alongside
+  Edit/Delete. Disabled/hidden for non-TX-capable channels.
+
+## Architecture
+
+### Part 1 — Remove Test Tone
+
+Delete the entire chain:
+
+- **Frontend:** `playTestTone()` + the Test Tone button and its state in
+  `web/src/routes/AudioDevices.svelte`.
+- **Go webapi:** the `POST /api/audio-devices/{id}/test-tone` route + the
+  `playTestTone` handler in `pkg/webapi/audio_devices.go`; `TestToneResponse`
+  in `pkg/webapi/dto/audio_device.go`; the op-id entry in
+  `pkg/webapi/docs/op_ids.go`; related assertions in
+  `pkg/webapi/audio_devices_test.go`.
+- **Bridge:** `PlayTestTone` in `pkg/modembridge/requests.go`; the tone
+  dispatcher + `TestToneResult` dispatch in `bridge.go` / `session.go`; the
+  `PlayTestTone` case in `bridge_stop_test.go` and its adapter.
+- **IPC proto:** the `PlayTestTone` and `TestToneResult` messages in the
+  `.proto`, with regenerated `pkg/ipcproto/graywolf.pb.go` and
+  `graywolf-modem/src/ipc/proto.rs`.
+- **Rust modem:** `play_test_tone_blocking`, `handle_play_test_tone`, the
+  `Some(Payload::PlayTestTone(..))` match arm, and the `TestToneResult` arm in
+  the inbound-ignore list in `graywolf-modem/src/modem/mod.rs`.
+
+Regenerate API types (`web/src/api/generated/api.d.ts`) and Swagger docs.
+
+### Part 2 — Channel CW ID
+
+Reuses the existing TX worker, which already keys PTT → submits samples →
+drains → unkeys per channel via `TxJob { samples: Vec<i16>, sample_rate }`
+(`graywolf-modem/src/modem/tx_worker.rs`). CW is just a different way to
+generate those samples.
+
+**Approach A (chosen):** dedicated IPC message; the modem owns CW synthesis.
+
+#### IPC
+
+- New `TransmitCwId { request_id, channel, callsign }` request message.
+- New `CwIdResult { request_id, success, error }` result message (mirrors
+  `TestToneResult`).
+- Added to the `.proto`, regenerated into `graywolf.pb.go` and `proto.rs`.
+
+#### Rust modem
+
+- New pure `morse` module:
+  - `encode(callsign: &str) -> Vec<Symbol>` where `Symbol` ∈ {Dit, Dah,
+    intra-char gap, inter-char gap, word gap}. Unknown characters are skipped.
+  - `synthesize(symbols, sample_rate, wpm, tone_hz) -> Vec<i16>` using PARIS
+    timing (dit = 1.2 / wpm seconds), a ~700 Hz sine gated on for key-down with
+    short rise/fall ramps to avoid key clicks.
+  - Both pure and unit-tested (timing lengths, symbol mapping, empty/invalid
+    input).
+- `handle_transmit_cw_id(req)`: build samples via the `morse` module, submit a
+  `TxJob` to the TX worker for `req.channel`, reply with `CwIdResult`. PTT
+  key/unkey is handled by the worker. Errors (no TX device/driver for the
+  channel, worker failure) map to `success: false` with a message.
+- New `Some(Payload::TransmitCwId(..))` match arm; `CwIdResult` added to the
+  inbound-ignore list.
+
+#### Go bridge
+
+- `TransmitCwID(ctx, channel uint32, callsign string) error` in
+  `pkg/modembridge/requests.go`, mirroring the request/dispatcher pattern of
+  the existing typed requests; a `cwIdDispatcher` in `bridge.go` and dispatch
+  in `session.go`; a `bridge_stop_test.go` case so it unblocks on stop.
+
+#### Go webapi
+
+- `POST /api/channels/{id}/cw-id`:
+  1. Parse channel ID.
+  2. `ResolveStationCallsign` → on empty/N0CALL, `422` with a clear message
+     ("set your station callsign before sending CW ID").
+  3. `requireTxCapableChannel` → on failure, `409`/`422` consistent with the
+     beacon-send path.
+  4. `bridge.TransmitCwID` → on failure, `503`/`500` as appropriate.
+  5. `200 { "status": "sent" }`.
+- New DTO `CwIdResponse { Status string }` in `pkg/webapi/dto`.
+- Op-id entry; Swagger annotations; regenerated docs + `api.d.ts`.
+
+#### Frontend
+
+- In `web/src/routes/channels/ChannelRow.svelte`, add a "Send CW ID" `Button`
+  (ghost variant) in the action row next to Edit/Delete. Show only for
+  TX-capable channels (same condition that gates the RX/TX badge / PTT
+  indicator — modem-backed channel with an output device). On click, `POST` the
+  endpoint; success → toast "Sent CW ID on \"<channel>\""; failure → error
+  toast with the server message. Disable the button while in flight.
+
+### Wiki maintenance
+
+- `docs/wiki/code-map.md`: record the new `/api/channels/{id}/cw-id` endpoint
+  and the `morse` modem module; remove Test Tone references.
+- `docs/wiki/invariants.md`: add "CW ID never keys the radio with an empty or
+  N0CALL callsign."
+
+## Error handling
+
+- Empty/N0CALL callsign → refuse before any IPC; nothing is keyed.
+- Non-TX channel → refuse before any IPC.
+- Modem-side failure (no driver/sink, submit error) → `CwIdResult.success =
+  false`; the TX worker's existing sequencing guarantees PTT is released on
+  submit failure (no stuck-keyed radio).
+
+## Testing
+
+- **Rust:** unit tests for `morse::encode` (symbol mapping, unknown-char skip)
+  and `morse::synthesize` (sample-count vs. WPM timing, non-empty output,
+  ramping). A handler test that a `TransmitCwId` with no registered
+  driver/sink yields `success: false`.
+- **Go:** webapi tests for the three refusal paths (empty callsign, N0CALL,
+  non-TX channel) and the success path (bridge stub returns nil). Bridge
+  stop-test case for `TransmitCwID`.
+- **Frontend:** button visibility gating by TX capability; success/error toast
+  on stubbed responses.
+- **Removal:** confirm the Test Tone route/handler/DTO/UI are gone and tests
+  referencing them are removed, not skipped.
+
+## Out of scope (YAGNI)
+
+- Automatic/periodic station ID timer.
+- Configurable WPM / tone frequency.
+- Per-channel callsign override (uses the station callsign).
+- Any CW receive/decode.

--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -32,8 +32,9 @@ Crate name: `graywolf-demod`. Binary: `graywolf-modem`. Source:
 | FLAC test vector playback | `audio/flac.rs` |
 | Stdin raw i16 PCM | `audio/stdin_raw.rs` |
 | SDR UDP audio bridge | `sdr/mod.rs` |
-| Modem orchestration | `modem/mod.rs` |
+| Modem orchestration + `TransmitTestSignal` / `TestSignalResult` IPC handler (`handle_transmit_test_signal`) | `modem/mod.rs` |
 | TX worker thread (owns sinks + PTT) | `modem/tx_worker.rs` |
+| CW / tone PCM synthesis for TX test signals | `txtest.rs` |
 | PTT method enum + factory | `tx/ptt.rs` |
 | Serial RTS/DTR PTT (Unix `ioctl(TIOCMSET)`) | `tx/ptt_unix.rs` |
 | Serial PTT (Windows `EscapeCommFunction`) | `tx/ptt_win.rs` |
@@ -65,7 +66,7 @@ Crate name: `graywolf-demod`. Binary: `graywolf-modem`. Source:
 | `app` (USB serial source) | Build-tag dispatch for the USB serial device source (Android vs. stub) | `pkg/app/usbserialsource_android.go`, `pkg/app/usbserialsource_default.go` |
 | `agw` | AGWPE TCP server (direwolf-compatible subset: R/G/g/k/K/m/X/x/y/Y/V) | `server.go`, `protocol.go` |
 | `ipcproto` | Generated Go bindings for `proto/graywolf.proto` | `graywolf.pb.go` (regen via `make proto`) |
-| `modembridge` | Supervises Rust modem child + IPC state machine + dispatcher + status cache + DCD publisher | `bridge.go`, `supervisor.go`, `ipc_unix.go`, `ipc_windows.go`, `dispatcher.go`, `session.go`, `status_cache.go` |
+| `modembridge` | Supervises Rust modem child + IPC state machine + dispatcher + status cache + DCD publisher. `Bridge.TransmitTestSignal` sends the `TransmitTestSignal` IPC message and returns a `TestSignalResult`. | `bridge.go`, `supervisor.go`, `ipc_unix.go`, `ipc_windows.go`, `dispatcher.go`, `session.go`, `status_cache.go` |
 | `txgovernor` | Centralized TX gate: per-channel rate limits, dedup, priority queue | `governor.go`, `pqueue.go`, `sink.go` |
 
 See [`../handbook/kiss.html`](../handbook/kiss.html), [`../handbook/agwpe.html`](../handbook/agwpe.html), [`../handbook/remote-kiss-tnc.html`](../handbook/remote-kiss-tnc.html).
@@ -149,6 +150,14 @@ The split is enforced by [invariant 9](invariants.md).
 | UI | `web/src/routes/Channels.svelte` shows mode selector + badge; `web/src/routes/MessagesSettings.svelte` shows messages TX-channel selector filtered to non-packet channels. |
 
 See [invariant 23](invariants.md) for the TX-gating contract.
+
+### Channel TX test signal
+
+| Surface | Where |
+|---|---|
+| REST endpoint | `pkg/webapi/channels.go` -- `sendTestSignal` handles `POST /api/channels/{id}/test-tx`; validates callsign before IPC (see [invariant 39](invariants.md)). |
+| Go bridge call | `pkg/modembridge` -- `Bridge.TransmitTestSignal` sends the `TransmitTestSignal` proto message and returns `TestSignalResult`. |
+| Rust handler | `graywolf-modem/src/modem/mod.rs` -- `handle_transmit_test_signal` dispatches to `graywolf-modem/src/txtest.rs` for PCM synthesis. |
 
 ## Go service: web
 

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -734,3 +734,16 @@ that could conflict.
 Source: [`../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbDeviceArbiter.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbDeviceArbiter.kt),
 [`../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/UsbSerialFacade.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/platformsvc/UsbSerialFacade.kt),
 [`../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/usb/UsbPttAdapter.kt).
+
+### 39. The CW test signal never keys the radio with an empty or N0CALL callsign
+
+`POST /api/channels/{id}/test-tx` with `signal=cw` resolves the station
+callsign via `Store.ResolveStationCallsign` and returns 422 before any IPC if
+it is empty or N0CALL. The tone signals (`tone1200`, `tone2400`, `alt`) do not
+use the callsign.
+
+*Why:* A CW ID that transmits nothing (or the literal string "N0CALL") gives
+no useful identification and violates the intent of the feature.
+
+Source: [`../../pkg/webapi/channels.go`](../../pkg/webapi/channels.go)
+(`sendTestSignal`).

--- a/graywolf-modem/src/ipc/proto.rs
+++ b/graywolf-modem/src/ipc/proto.rs
@@ -29,6 +29,9 @@ impl IpcMessage {
     pub fn input_level_scan_result(r: InputLevelScanResult) -> Self {
         Self { payload: Some(ipc_message::Payload::InputLevelScanResult(r)) }
     }
+    pub fn test_signal_result(r: TestSignalResult) -> Self {
+        Self { payload: Some(ipc_message::Payload::TestSignalResult(r)) }
+    }
 }
 
 #[cfg(test)]

--- a/graywolf-modem/src/ipc/proto.rs
+++ b/graywolf-modem/src/ipc/proto.rs
@@ -23,9 +23,6 @@ impl IpcMessage {
     pub fn audio_device_list(l: AudioDeviceList) -> Self {
         Self { payload: Some(ipc_message::Payload::AudioDeviceList(l)) }
     }
-    pub fn test_tone_result(r: TestToneResult) -> Self {
-        Self { payload: Some(ipc_message::Payload::TestToneResult(r)) }
-    }
     pub fn device_level_update(u: DeviceLevelUpdate) -> Self {
         Self { payload: Some(ipc_message::Payload::DeviceLevelUpdate(u)) }
     }

--- a/graywolf-modem/src/lib.rs
+++ b/graywolf-modem/src/lib.rs
@@ -94,6 +94,7 @@ pub mod modem_9600;
 pub mod fx25;
 pub mod il2p;
 pub mod tx;
+pub(crate) mod txtest;
 // CM108 HID PTT and USB topology enumeration depend on hidapi / nusb,
 // which require host-OS facilities (libudev / IOKit / SetupAPI) that
 // aren't present on Android. The Android target uses different audio

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -355,8 +355,6 @@ impl Modem {
             | Some(Payload::InputLevelScanResult(_)) => {
                 // Rust → Go only; ignore if echoed back.
             }
-            // Proto variants removed in A5; no-op until then.
-            Some(Payload::PlayTestTone(_)) | Some(Payload::TestToneResult(_)) => {}
             None => {}
         }
         false

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -1062,6 +1062,14 @@ impl Modem {
 
     /// Render a TX test signal (CW callsign, steady tone, or alternating tones)
     /// and submit it to the TX worker, mirroring handle_transmit_frame's pattern.
+    /// Send a TestSignalResult reply to Go. Borrows only `self.handle`, so it
+    /// composes with the surrounding `&mut self` work in the handler below.
+    fn reply_test_signal(&self, request_id: u32, success: bool, error: String) {
+        let _ = self.handle.send(&IpcMessage::test_signal_result(
+            crate::ipc::proto::TestSignalResult { request_id, success, error },
+        ));
+    }
+
     fn handle_transmit_test_signal(&mut self, req: crate::ipc::proto::TransmitTestSignal) {
         // Lazy rigctld retry, same as handle_transmit_frame.
         if self.ptt_rigctld_pending.contains(&req.channel) {
@@ -1070,33 +1078,25 @@ impl Modem {
             }
         }
 
-        let (output_device_id, output_channel) =
-            match self.channel_configs.get(&req.channel) {
-                Some(c) => (c.output_device_id, c.output_channel),
-                None => {
-                    let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
-                        request_id: req.request_id,
-                        success: false,
-                        error: format!("unknown channel {}", req.channel),
-                    });
-                    let _ = self.handle.send(&msg);
-                    return;
-                }
-            };
+        let (output_device_id, output_channel) = match self.channel_configs.get(&req.channel) {
+            Some(c) => (c.output_device_id, c.output_channel),
+            None => {
+                self.reply_test_signal(req.request_id, false, format!("unknown channel {}", req.channel));
+                return;
+            }
+        };
 
-        let (device_name, sample_rate, channels) =
-            match self.audio_configs.get(&output_device_id) {
-                Some(a) => (a.device_name.clone(), a.sample_rate, a.channels),
-                None => {
-                    let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
-                        request_id: req.request_id,
-                        success: false,
-                        error: format!("no audio config for output device {}", output_device_id),
-                    });
-                    let _ = self.handle.send(&msg);
-                    return;
-                }
-            };
+        let (device_name, sample_rate, channels) = match self.audio_configs.get(&output_device_id) {
+            Some(a) => (a.device_name.clone(), a.sample_rate, a.channels),
+            None => {
+                self.reply_test_signal(
+                    req.request_id,
+                    false,
+                    format!("no audio config for output device {}", output_device_id),
+                );
+                return;
+            }
+        };
 
         let mut samples = match req.kind {
             0 => {
@@ -1107,12 +1107,7 @@ impl Modem {
                     req.freq_a_hz as f32,
                 );
                 if s.is_empty() {
-                    let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
-                        request_id: req.request_id,
-                        success: false,
-                        error: "callsign produced no CW symbols".to_string(),
-                    });
-                    let _ = self.handle.send(&msg);
+                    self.reply_test_signal(req.request_id, false, "callsign produced no CW symbols".to_string());
                     return;
                 }
                 s
@@ -1126,17 +1121,13 @@ impl Modem {
                 req.alt_period_ms,
             ),
             other => {
-                let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
-                    request_id: req.request_id,
-                    success: false,
-                    error: format!("unknown test signal kind {}", other),
-                });
-                let _ = self.handle.send(&msg);
+                self.reply_test_signal(req.request_id, false, format!("unknown test signal kind {}", other));
                 return;
             }
         };
 
-        // Apply output device gain, matching handle_transmit_frame.
+        // Apply output device gain, matching handle_transmit_frame. Live level
+        // metering / DeviceLevelUpdate is intentionally omitted for test signals.
         if let Some(gain_atom) = self.gain_atoms.get(&output_device_id) {
             let gain_db = f32::from_bits(gain_atom.load(std::sync::atomic::Ordering::Relaxed));
             if gain_db.abs() > f32::EPSILON {
@@ -1164,21 +1155,9 @@ impl Modem {
         match self.tx_worker.transmit(job) {
             Ok(()) => {
                 *self.tx_frames.entry(req.channel).or_default() += 1;
-                let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
-                    request_id: req.request_id,
-                    success: true,
-                    error: String::new(),
-                });
-                let _ = self.handle.send(&msg);
+                self.reply_test_signal(req.request_id, true, String::new());
             }
-            Err(e) => {
-                let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
-                    request_id: req.request_id,
-                    success: false,
-                    error: e,
-                });
-                let _ = self.handle.send(&msg);
-            }
+            Err(e) => self.reply_test_signal(req.request_id, false, e),
         }
     }
 }

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -26,8 +26,7 @@ use crate::hdlc::DecodedFrame;
 use crate::ipc::proto::{
     ipc_message::Payload, AudioDeviceInfo, AudioDeviceKind, AudioDeviceList, ConfigureChannel,
     ConfigurePtt, DcdChange, DeviceLevelUpdate, EnumerateAudioDevices, InputDeviceLevel,
-    InputLevelScanResult, IpcMessage, ReceivedFrame, ScanInputLevels, StatusUpdate, TestToneResult,
-    TransmitFrame,
+    InputLevelScanResult, IpcMessage, ReceivedFrame, ScanInputLevels, StatusUpdate, TransmitFrame,
 };
 use crate::ipc::server::{IpcHandle, IpcInbound};
 use crate::modem_9600::Demod9600;
@@ -319,9 +318,6 @@ impl Modem {
             Some(Payload::EnumerateAudioDevices(req)) => {
                 self.handle_enumerate_devices(req);
             }
-            Some(Payload::PlayTestTone(req)) => {
-                self.handle_play_test_tone(req);
-            }
             Some(Payload::ScanInputLevels(req)) => {
                 self.handle_scan_input_levels(req);
             }
@@ -355,11 +351,12 @@ impl Modem {
             | Some(Payload::StatusUpdate(_))
             | Some(Payload::ModemReady(_))
             | Some(Payload::AudioDeviceList(_))
-            | Some(Payload::TestToneResult(_))
             | Some(Payload::DeviceLevelUpdate(_))
             | Some(Payload::InputLevelScanResult(_)) => {
                 // Rust → Go only; ignore if echoed back.
             }
+            // Proto variants removed in A5; no-op until then.
+            Some(Payload::PlayTestTone(_)) | Some(Payload::TestToneResult(_)) => {}
             None => {}
         }
         false
@@ -766,27 +763,6 @@ impl Modem {
                     request_id: req.request_id,
                     devices: results,
                 });
-                let _ = handle.send(&msg);
-            })
-            .ok();
-    }
-
-    fn handle_play_test_tone(&self, req: crate::ipc::proto::PlayTestTone) {
-        let device_id = req.device_id;
-        let gain_atom = self.gain_atoms
-            .get(&device_id)
-            .cloned()
-            .unwrap_or_else(|| Arc::new(AtomicU32::new(0f32.to_bits())));
-        let handle = self.handle.clone();
-        let cached_device = self.output_devices.get(&device_id).cloned();
-        let cached_config = self.output_configs_cache.get(&device_id).copied();
-        std::thread::Builder::new()
-            .name("test-tone".into())
-            .spawn(move || {
-                let result = play_test_tone_blocking(
-                    &req, &handle, device_id, &gain_atom, cached_device, cached_config,
-                );
-                let msg = IpcMessage::test_tone_result(result);
                 let _ = handle.send(&msg);
             })
             .ok();
@@ -2208,186 +2184,6 @@ fn now_ns() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos() as u64)
         .unwrap_or(0)
-}
-
-fn play_test_tone_blocking(
-    req: &crate::ipc::proto::PlayTestTone,
-    handle: &IpcHandle,
-    device_id: u32,
-    gain_atom: &Arc<AtomicU32>,
-    cached_device: Option<cpal::Device>,
-    cached_config: Option<(u16, cpal::SampleFormat)>,
-) -> TestToneResult {
-    use cpal::traits::{DeviceTrait, StreamTrait};
-    use std::sync::atomic::{AtomicBool, AtomicU64};
-
-    // Resolve the cpal Device + channel count for the test tone.
-    //
-    // The cpal supported_output_configs() call fails with "device no
-    // longer available" when called while another stream (input
-    // capture) is already active on the same hardware (e.g. AIOC's
-    // shared input/output PCM). For that reason we prefer the
-    // pre-negotiated channel count cached at start_audio time, when
-    // the device was idle and queryable. Falls back to runtime
-    // negotiation only when no cached config exists (e.g. fresh
-    // ConfigureAudio for a device that hadn't been part of any
-    // channel yet).
-    let sample_rate = if req.sample_rate > 0 { req.sample_rate } else { 48000 };
-    let preferred_ch = req.channels.max(1) as u16;
-
-    fn resolve_fresh(name: &str) -> Result<cpal::Device, String> {
-        use cpal::traits::HostTrait;
-        let host = cpal::default_host();
-        let devs = host.output_devices()
-            .map_err(|e| format!("enumerate output devices: {}", e))?;
-        audio::soundcard::find_device_by_id(devs, name)
-            .ok_or_else(|| format!("output device not found: {}", name))
-    }
-
-    let device = match cached_device {
-        Some(d) => d,
-        None => match resolve_fresh(&req.device_name) {
-            Ok(d) => d,
-            Err(e) => return TestToneResult {
-                request_id: req.request_id,
-                success: false,
-                error: e,
-            },
-        },
-    };
-
-    let channels = match cached_config {
-        Some((ch, _fmt)) => ch,
-        None => {
-            // No cached config -- either device wasn't pre-resolved
-            // (legacy path) or pre-negotiation failed at start_audio.
-            // Fall back to a live supported_output_configs probe;
-            // this is the path that fails when the device is busy,
-            // but it is also the only path that can recover for
-            // configurations the cache doesn't cover.
-            match audio::soundcard::negotiate_channels(
-                &device,
-                sample_rate,
-                preferred_ch,
-                "output",
-                |d| d.supported_output_configs(),
-            ) {
-                Ok(c) => c,
-                Err(e) => return TestToneResult {
-                    request_id: req.request_id,
-                    success: false,
-                    error: e,
-                },
-            }
-        }
-    };
-
-    let config = cpal::StreamConfig {
-        channels,
-        sample_rate,
-        buffer_size: cpal::BufferSize::Default,
-    };
-
-    let tone_freq = 1000.0_f64;
-    let amplitude = 0.5_f64; // -6 dBFS
-    let duration_samples = (sample_rate as u64) * 3 / 2; // 1.5 seconds
-    let phase_inc = tone_freq * 2.0 * std::f64::consts::PI / sample_rate as f64;
-
-    let phase_counter = Arc::new(AtomicU64::new(0));
-    let done = Arc::new(AtomicBool::new(false));
-
-    let pc = phase_counter.clone();
-    let d = done.clone();
-    let ch = channels as usize;
-    let dur = duration_samples;
-    let ga = gain_atom.clone();
-
-    let stream = match device.build_output_stream(
-        &config,
-        move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-            let gain_db = f32::from_bits(ga.load(Ordering::Relaxed));
-            let gain_linear = if gain_db.abs() > f32::EPSILON {
-                10f32.powf(gain_db / 20.0)
-            } else {
-                1.0
-            };
-            for frame in data.chunks_mut(ch) {
-                let sample_idx = pc.fetch_add(1, Ordering::Relaxed);
-                let raw = if sample_idx < dur {
-                    (sample_idx as f64 * phase_inc).sin() * amplitude
-                } else {
-                    d.store(true, Ordering::Relaxed);
-                    0.0
-                };
-                let gained = (raw as f32) * gain_linear;
-                let out = gained.clamp(-1.0, 1.0);
-                for s in frame.iter_mut() {
-                    *s = out;
-                }
-            }
-        },
-        move |e| eprintln!("graywolf-modem: test tone stream error: {}", e),
-        None,
-    ) {
-        Ok(s) => s,
-        Err(e) => {
-            return TestToneResult {
-                request_id: req.request_id,
-                success: false,
-                error: format!("build output stream: {}", e),
-            };
-        }
-    };
-
-    if let Err(e) = stream.play() {
-        return TestToneResult {
-            request_id: req.request_id,
-            success: false,
-            error: format!("play stream: {}", e),
-        };
-    }
-
-    // Wait for tone to finish, emitting level updates at ~5 Hz
-    while !done.load(Ordering::Relaxed) {
-        let gain_db = f32::from_bits(gain_atom.load(Ordering::Relaxed));
-        let gain_linear = 10f32.powf(gain_db / 20.0);
-        let effective_amp = (amplitude as f32) * gain_linear;
-        let peak_dbfs = if effective_amp > 0.0 {
-            (20.0 * effective_amp.log10()).clamp(-60.0, 0.0)
-        } else {
-            -60.0
-        };
-        let rms_dbfs = if effective_amp > 0.0 {
-            // RMS of sine = peak / sqrt(2), i.e. -3.01 dB below peak
-            (peak_dbfs - 3.01).max(-60.0)
-        } else {
-            -60.0
-        };
-        let _ = handle.send(&IpcMessage::device_level_update(DeviceLevelUpdate {
-            device_id,
-            peak_dbfs,
-            rms_dbfs,
-            clipping: effective_amp > 1.0,
-        }));
-        std::thread::sleep(Duration::from_millis(200));
-    }
-
-    // Final silent level after tone ends
-    let _ = handle.send(&IpcMessage::device_level_update(DeviceLevelUpdate {
-        device_id,
-        peak_dbfs: -60.0,
-        rms_dbfs: -60.0,
-        clipping: false,
-    }));
-
-    std::thread::sleep(Duration::from_millis(100));
-    drop(stream);
-
-    TestToneResult {
-        request_id: req.request_id,
-        success: true,
-        error: String::new(),
-    }
 }
 
 #[cfg(test)]

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -346,9 +346,8 @@ impl Modem {
                 self.graceful_shutdown();
                 return true;
             }
-            Some(Payload::TransmitTestSignal(_req)) => {
-                // Handled in B3; stub to satisfy exhaustive match.
-                eprintln!("graywolf-modem: TransmitTestSignal not yet implemented");
+            Some(Payload::TransmitTestSignal(req)) => {
+                self.handle_transmit_test_signal(req);
             }
             Some(Payload::ReceivedFrame(_))
             | Some(Payload::DcdChange(_))
@@ -1059,6 +1058,128 @@ impl Modem {
             return;
         }
         *self.tx_frames.entry(tf.channel).or_default() += 1;
+    }
+
+    /// Render a TX test signal (CW callsign, steady tone, or alternating tones)
+    /// and submit it to the TX worker, mirroring handle_transmit_frame's pattern.
+    fn handle_transmit_test_signal(&mut self, req: crate::ipc::proto::TransmitTestSignal) {
+        // Lazy rigctld retry, same as handle_transmit_frame.
+        if self.ptt_rigctld_pending.contains(&req.channel) {
+            if let Some(cfg) = self.ptt_cfgs.get(&req.channel).cloned() {
+                self.apply_ptt_config(cfg);
+            }
+        }
+
+        let (output_device_id, output_channel) =
+            match self.channel_configs.get(&req.channel) {
+                Some(c) => (c.output_device_id, c.output_channel),
+                None => {
+                    let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
+                        request_id: req.request_id,
+                        success: false,
+                        error: format!("unknown channel {}", req.channel),
+                    });
+                    let _ = self.handle.send(&msg);
+                    return;
+                }
+            };
+
+        let (device_name, sample_rate, channels) =
+            match self.audio_configs.get(&output_device_id) {
+                Some(a) => (a.device_name.clone(), a.sample_rate, a.channels),
+                None => {
+                    let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
+                        request_id: req.request_id,
+                        success: false,
+                        error: format!("no audio config for output device {}", output_device_id),
+                    });
+                    let _ = self.handle.send(&msg);
+                    return;
+                }
+            };
+
+        let mut samples = match req.kind {
+            0 => {
+                let s = crate::txtest::cw_samples(
+                    &req.callsign,
+                    sample_rate,
+                    req.cw_wpm.max(1),
+                    req.freq_a_hz as f32,
+                );
+                if s.is_empty() {
+                    let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
+                        request_id: req.request_id,
+                        success: false,
+                        error: "callsign produced no CW symbols".to_string(),
+                    });
+                    let _ = self.handle.send(&msg);
+                    return;
+                }
+                s
+            }
+            1 => crate::txtest::tone_samples(sample_rate, req.freq_a_hz as f32, req.duration_ms),
+            2 => crate::txtest::alternating_samples(
+                sample_rate,
+                req.freq_a_hz as f32,
+                req.freq_b_hz as f32,
+                req.duration_ms,
+                req.alt_period_ms,
+            ),
+            other => {
+                let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
+                    request_id: req.request_id,
+                    success: false,
+                    error: format!("unknown test signal kind {}", other),
+                });
+                let _ = self.handle.send(&msg);
+                return;
+            }
+        };
+
+        // Apply output device gain, matching handle_transmit_frame.
+        if let Some(gain_atom) = self.gain_atoms.get(&output_device_id) {
+            let gain_db = f32::from_bits(gain_atom.load(std::sync::atomic::Ordering::Relaxed));
+            if gain_db.abs() > f32::EPSILON {
+                let gain_linear = 10f32.powf(gain_db / 20.0);
+                for s in samples.iter_mut() {
+                    let amplified = (*s as f32) * gain_linear;
+                    *s = amplified.clamp(-32767.0, 32767.0) as i16;
+                }
+            }
+        }
+
+        let job = tx_worker::TxJob {
+            channel: req.channel,
+            samples,
+            sample_rate,
+            output_device_id,
+            sink_config: audio::soundcard::SoundcardOutputConfig {
+                device_name,
+                sample_rate,
+                channels,
+                audio_channel: output_channel,
+            },
+        };
+
+        match self.tx_worker.transmit(job) {
+            Ok(()) => {
+                *self.tx_frames.entry(req.channel).or_default() += 1;
+                let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
+                    request_id: req.request_id,
+                    success: true,
+                    error: String::new(),
+                });
+                let _ = self.handle.send(&msg);
+            }
+            Err(e) => {
+                let msg = IpcMessage::test_signal_result(crate::ipc::proto::TestSignalResult {
+                    request_id: req.request_id,
+                    success: false,
+                    error: e,
+                });
+                let _ = self.handle.send(&msg);
+            }
+        }
     }
 }
 

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -346,13 +346,18 @@ impl Modem {
                 self.graceful_shutdown();
                 return true;
             }
+            Some(Payload::TransmitTestSignal(_req)) => {
+                // Handled in B3; stub to satisfy exhaustive match.
+                eprintln!("graywolf-modem: TransmitTestSignal not yet implemented");
+            }
             Some(Payload::ReceivedFrame(_))
             | Some(Payload::DcdChange(_))
             | Some(Payload::StatusUpdate(_))
             | Some(Payload::ModemReady(_))
             | Some(Payload::AudioDeviceList(_))
             | Some(Payload::DeviceLevelUpdate(_))
-            | Some(Payload::InputLevelScanResult(_)) => {
+            | Some(Payload::InputLevelScanResult(_))
+            | Some(Payload::TestSignalResult(_)) => {
                 // Rust → Go only; ignore if echoed back.
             }
             None => {}

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -158,14 +158,14 @@ pub struct Modem {
 
     // Pre-resolved cpal output device handles, keyed by device_id.
     // Populated in start_audio() before input streams open and reused
-    // by both the TX worker and test-tone playback. On Linux/ALSA,
+    // by the TX worker for all transmit playback. On Linux/ALSA,
     // cpal's device enumeration fails once a capture stream holds the
     // hardware, so these must be resolved while the device is idle.
     output_devices: HashMap<u32, cpal::Device>,
 
     // Pre-negotiated output stream params (channels + sample_format),
-    // cached at start_audio time when the device is idle. The test-
-    // tone path uses these to avoid calling supported_output_configs()
+    // cached at start_audio time when the device is idle. The TX
+    // path uses these to avoid calling supported_output_configs()
     // on a device cpal has lost the ability to enumerate (e.g. while a
     // capture stream is active on the same AIOC hardware, or after a
     // USB-EMI hub event invalidates the cached handle).
@@ -382,10 +382,10 @@ impl Modem {
         }
 
         // Pre-resolve output devices before opening input streams.
-        // This lets the TX worker and test-tone path use cached Device
-        // handles without enumerating at transmit time. Also pre-
-        // negotiate channel count + sample format while the device is
-        // idle, so later test-tone clicks don't have to call
+        // This lets the TX worker use cached Device handles without
+        // enumerating at transmit time. Also pre-negotiate channel
+        // count + sample format while the device is idle, so later
+        // transmits don't have to call
         // supported_output_configs() (which fails once an input capture
         // stream holds the same hardware).
         self.output_devices.clear();
@@ -418,7 +418,7 @@ impl Modem {
                             self.output_configs_cache.insert(dev_id, (ch, f));
                         } else {
                             eprintln!(
-                                "graywolf-modem: failed to pre-negotiate output configs for device_id={} ({}); test-tone may fail later if device gets busy",
+                                "graywolf-modem: failed to pre-negotiate output configs for device_id={} ({}); TX may fail later if device gets busy",
                                 dev_id, acfg.device_name
                             );
                         }

--- a/graywolf-modem/src/txtest.rs
+++ b/graywolf-modem/src/txtest.rs
@@ -137,7 +137,8 @@ pub fn alternating_samples(
     let two_pi = 2.0 * std::f32::consts::PI;
     for i in 0..n {
         let f = if (i / per) % 2 == 0 { freq_a } else { freq_b };
-        phase += two_pi * f / sample_rate as f32;
+        // Wrap to keep f32 phase precise over long durations.
+        phase = (phase + two_pi * f / sample_rate as f32) % two_pi;
         out.push((phase.sin() * AMP) as i16);
     }
     apply_edges(&mut out, ramp_samples(sample_rate));
@@ -211,5 +212,22 @@ mod tests {
         let s = alternating_samples(48_000, 1200.0, 2400.0, 3000, 200);
         assert_eq!(s.len(), 144_000);
         assert!(s.iter().any(|&v| v != 0));
+    }
+
+    #[test]
+    fn alternating_samples_actually_alternates_frequency() {
+        // 200 ms period at 48 kHz = 9600 samples/block. Block 0 renders
+        // freq_a (1200 Hz), block 1 renders freq_b (2400 Hz). The higher
+        // tone must show clearly more zero crossings than the lower one.
+        let s = alternating_samples(48_000, 1200.0, 2400.0, 3000, 200);
+        let per = 9600usize;
+        let zero_crossings =
+            |w: &[i16]| w.windows(2).filter(|p| (p[0] >= 0) != (p[1] >= 0)).count();
+        let lo = zero_crossings(&s[0..per]);
+        let hi = zero_crossings(&s[per..2 * per]);
+        assert!(
+            hi > lo * 3 / 2,
+            "freq_b block ({hi} crossings) should clearly exceed freq_a block ({lo})"
+        );
     }
 }

--- a/graywolf-modem/src/txtest.rs
+++ b/graywolf-modem/src/txtest.rs
@@ -98,7 +98,7 @@ pub fn cw_samples(callsign: &str, sample_rate: u32, wpm: u32, tone_hz: f32) -> V
     for seg in &segments {
         let n = dit * seg.units as usize;
         if !seg.on {
-            out.extend(std::iter::repeat(0i16).take(n));
+            out.extend(std::iter::repeat_n(0i16, n));
             continue;
         }
         let start = out.len();
@@ -136,7 +136,7 @@ pub fn alternating_samples(
     let mut phase = 0.0f32;
     let two_pi = 2.0 * std::f32::consts::PI;
     for i in 0..n {
-        let f = if (i / per) % 2 == 0 { freq_a } else { freq_b };
+        let f = if (i / per).is_multiple_of(2) { freq_a } else { freq_b };
         // Wrap to keep f32 phase precise over long durations.
         phase = (phase + two_pi * f / sample_rate as f32) % two_pi;
         out.push((phase.sin() * AMP) as i16);

--- a/graywolf-modem/src/txtest.rs
+++ b/graywolf-modem/src/txtest.rs
@@ -1,0 +1,215 @@
+//! Pure TX test-signal generation: CW (Morse) station ID and steady /
+//! alternating test tones.
+//!
+//! No I/O and no audio device — this turns parameters into i16 PCM samples.
+//! The modem submits the samples as a normal TxJob, so PTT keying and
+//! play-out reuse the existing TX worker path.
+
+const AMP: f32 = 0.6 * 32767.0;
+const RAMP_MS: f32 = 5.0;
+
+/// One keyed or unkeyed CW span, in Morse time units (1 unit = 1 dit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Segment {
+    pub on: bool,
+    pub units: u32,
+}
+
+fn ramp_samples(sample_rate: u32) -> usize {
+    ((sample_rate as f32) * RAMP_MS / 1000.0) as usize
+}
+
+/// Apply a raised-cosine rise/fall (in place) to suppress edge clicks.
+fn apply_edges(buf: &mut [i16], ramp: usize) {
+    let n = buf.len();
+    let r = ramp.min(n / 2);
+    if r == 0 {
+        return;
+    }
+    for i in 0..r {
+        let env = 0.5 * (1.0 - (std::f32::consts::PI * i as f32 / r as f32).cos());
+        buf[i] = (buf[i] as f32 * env) as i16;
+        buf[n - 1 - i] = (buf[n - 1 - i] as f32 * env) as i16;
+    }
+}
+
+/// Dot/dash pattern for a character, or None when there is no standard Morse
+/// representation (encode skips those).
+fn pattern(c: char) -> Option<&'static str> {
+    Some(match c.to_ascii_uppercase() {
+        'A' => ".-", 'B' => "-...", 'C' => "-.-.", 'D' => "-..",
+        'E' => ".", 'F' => "..-.", 'G' => "--.", 'H' => "....",
+        'I' => "..", 'J' => ".---", 'K' => "-.-", 'L' => ".-..",
+        'M' => "--", 'N' => "-.", 'O' => "---", 'P' => ".--.",
+        'Q' => "--.-", 'R' => ".-.", 'S' => "...", 'T' => "-",
+        'U' => "..-", 'V' => "...-", 'W' => ".--", 'X' => "-..-",
+        'Y' => "-.--", 'Z' => "--..",
+        '0' => "-----", '1' => ".----", '2' => "..---", '3' => "...--",
+        '4' => "....-", '5' => ".....", '6' => "-....", '7' => "--...",
+        '8' => "---..", '9' => "----.",
+        '/' => "-..-.", '-' => "-....-", '.' => ".-.-.-", ',' => "--..--",
+        '?' => "..--..",
+        _ => return None,
+    })
+}
+
+/// Encode text into keyed/unkeyed segments with standard Morse timing:
+/// dit=1, dah=3, intra-character gap=1, inter-character gap=3, word gap=7
+/// (in dit units). No leading/trailing gaps. Unknown characters are skipped.
+pub fn encode(text: &str) -> Vec<Segment> {
+    let mut out: Vec<Segment> = Vec::new();
+    let mut prev_was_char = false;
+    for raw in text.chars() {
+        if raw == ' ' {
+            if prev_was_char {
+                out.push(Segment { on: false, units: 7 });
+                prev_was_char = false;
+            }
+            continue;
+        }
+        let pat = match pattern(raw) {
+            Some(p) => p,
+            None => continue,
+        };
+        if prev_was_char {
+            out.push(Segment { on: false, units: 3 });
+        }
+        for (i, el) in pat.chars().enumerate() {
+            if i > 0 {
+                out.push(Segment { on: false, units: 1 });
+            }
+            out.push(Segment { on: true, units: if el == '-' { 3 } else { 1 } });
+        }
+        prev_was_char = true;
+    }
+    out
+}
+
+/// CW: encode `callsign` and render the on/off-keyed sidetone at `wpm`
+/// (PARIS timing) and `tone_hz`, with raised-cosine edges on each keyed span.
+/// Returns empty if the callsign has no renderable characters.
+pub fn cw_samples(callsign: &str, sample_rate: u32, wpm: u32, tone_hz: f32) -> Vec<i16> {
+    let segments = encode(callsign);
+    let wpm = wpm.max(1);
+    let dit = ((sample_rate as f64) * 1.2 / wpm as f64).round() as usize;
+    let ramp = ramp_samples(sample_rate);
+    let w = 2.0 * std::f32::consts::PI * tone_hz / sample_rate as f32;
+    let mut out: Vec<i16> = Vec::new();
+    for seg in &segments {
+        let n = dit * seg.units as usize;
+        if !seg.on {
+            out.extend(std::iter::repeat(0i16).take(n));
+            continue;
+        }
+        let start = out.len();
+        for i in 0..n {
+            out.push(((w * i as f32).sin() * AMP) as i16);
+        }
+        let end = out.len();
+        apply_edges(&mut out[start..end], ramp);
+    }
+    out
+}
+
+/// Steady sine of `freq_hz` for `duration_ms`, with edge ramps.
+pub fn tone_samples(sample_rate: u32, freq_hz: f32, duration_ms: u32) -> Vec<i16> {
+    let n = (sample_rate as u64 * duration_ms as u64 / 1000) as usize;
+    let w = 2.0 * std::f32::consts::PI * freq_hz / sample_rate as f32;
+    let mut out: Vec<i16> = (0..n).map(|i| ((w * i as f32).sin() * AMP) as i16).collect();
+    apply_edges(&mut out, ramp_samples(sample_rate));
+    out
+}
+
+/// Alternating tone: switch between `freq_a` and `freq_b` every `period_ms`
+/// for `duration_ms`. Phase-continuous (a running phase accumulator) so the
+/// frequency switches don't click; raised-cosine ramps on the outer edges.
+pub fn alternating_samples(
+    sample_rate: u32,
+    freq_a: f32,
+    freq_b: f32,
+    duration_ms: u32,
+    period_ms: u32,
+) -> Vec<i16> {
+    let n = (sample_rate as u64 * duration_ms as u64 / 1000) as usize;
+    let per = ((sample_rate as u64 * period_ms.max(1) as u64 / 1000) as usize).max(1);
+    let mut out: Vec<i16> = Vec::with_capacity(n);
+    let mut phase = 0.0f32;
+    let two_pi = 2.0 * std::f32::consts::PI;
+    for i in 0..n {
+        let f = if (i / per) % 2 == 0 { freq_a } else { freq_b };
+        phase += two_pi * f / sample_rate as f32;
+        out.push((phase.sin() * AMP) as i16);
+    }
+    apply_edges(&mut out, ramp_samples(sample_rate));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn on(units: u32) -> Segment { Segment { on: true, units } }
+    fn off(units: u32) -> Segment { Segment { on: false, units } }
+
+    #[test]
+    fn encode_single_dit() {
+        assert_eq!(encode("E"), vec![on(1)]);
+    }
+
+    #[test]
+    fn encode_inter_character_gap() {
+        assert_eq!(encode("EE"), vec![on(1), off(3), on(1)]);
+    }
+
+    #[test]
+    fn encode_dah_and_intra_gaps() {
+        // "K" = -.-  => dah, gap, dit, gap, dah
+        assert_eq!(encode("K"), vec![on(3), off(1), on(1), off(1), on(3)]);
+    }
+
+    #[test]
+    fn encode_word_gap() {
+        // "A B": A=.- ; word gap 7 ; B=-...
+        assert_eq!(
+            encode("A B"),
+            vec![
+                on(1), off(1), on(3),
+                off(7),
+                on(3), off(1), on(1), off(1), on(1), off(1), on(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn encode_skips_unknown_chars() {
+        assert_eq!(encode("E@E"), encode("EE"));
+    }
+
+    #[test]
+    fn cw_samples_dit_length_matches_wpm() {
+        // 20 WPM at 48 kHz: dit = 1.2/20 s = 60 ms = 2880 samples.
+        let s = cw_samples("E", 48_000, 20, 700.0);
+        assert_eq!(s.len(), 2880);
+        assert!(s.iter().any(|&v| v != 0), "tone must be non-silent");
+    }
+
+    #[test]
+    fn cw_samples_empty_callsign_is_empty() {
+        assert!(cw_samples("", 48_000, 20, 700.0).is_empty());
+    }
+
+    #[test]
+    fn tone_samples_length_and_nonsilent() {
+        // 3000 ms at 48 kHz = 144000 samples.
+        let s = tone_samples(48_000, 1200.0, 3000);
+        assert_eq!(s.len(), 144_000);
+        assert!(s.iter().any(|&v| v != 0));
+    }
+
+    #[test]
+    fn alternating_samples_length_and_nonsilent() {
+        let s = alternating_samples(48_000, 1200.0, 2400.0, 3000, 200);
+        assert_eq!(s.len(), 144_000);
+        assert!(s.iter().any(|&v| v != 0));
+    }
+}

--- a/pkg/ipcproto/graywolf.pb.go
+++ b/pkg/ipcproto/graywolf.pb.go
@@ -87,7 +87,6 @@ type IpcMessage struct {
 	//	*IpcMessage_StatusUpdate
 	//	*IpcMessage_ModemReady
 	//	*IpcMessage_AudioDeviceList
-	//	*IpcMessage_TestToneResult
 	//	*IpcMessage_DeviceLevelUpdate
 	//	*IpcMessage_InputLevelScanResult
 	//	*IpcMessage_TransmitFrame
@@ -98,7 +97,6 @@ type IpcMessage struct {
 	//	*IpcMessage_StopAudio
 	//	*IpcMessage_Shutdown
 	//	*IpcMessage_EnumerateAudioDevices
-	//	*IpcMessage_PlayTestTone
 	//	*IpcMessage_SetDeviceGain
 	//	*IpcMessage_ScanInputLevels
 	//	*IpcMessage_ManualPtt
@@ -184,15 +182,6 @@ func (x *IpcMessage) GetAudioDeviceList() *AudioDeviceList {
 	if x != nil {
 		if x, ok := x.Payload.(*IpcMessage_AudioDeviceList); ok {
 			return x.AudioDeviceList
-		}
-	}
-	return nil
-}
-
-func (x *IpcMessage) GetTestToneResult() *TestToneResult {
-	if x != nil {
-		if x, ok := x.Payload.(*IpcMessage_TestToneResult); ok {
-			return x.TestToneResult
 		}
 	}
 	return nil
@@ -288,15 +277,6 @@ func (x *IpcMessage) GetEnumerateAudioDevices() *EnumerateAudioDevices {
 	return nil
 }
 
-func (x *IpcMessage) GetPlayTestTone() *PlayTestTone {
-	if x != nil {
-		if x, ok := x.Payload.(*IpcMessage_PlayTestTone); ok {
-			return x.PlayTestTone
-		}
-	}
-	return nil
-}
-
 func (x *IpcMessage) GetSetDeviceGain() *SetDeviceGain {
 	if x != nil {
 		if x, ok := x.Payload.(*IpcMessage_SetDeviceGain); ok {
@@ -349,10 +329,6 @@ type IpcMessage_AudioDeviceList struct {
 	AudioDeviceList *AudioDeviceList `protobuf:"bytes,5,opt,name=audio_device_list,json=audioDeviceList,proto3,oneof"`
 }
 
-type IpcMessage_TestToneResult struct {
-	TestToneResult *TestToneResult `protobuf:"bytes,6,opt,name=test_tone_result,json=testToneResult,proto3,oneof"`
-}
-
 type IpcMessage_DeviceLevelUpdate struct {
 	DeviceLevelUpdate *DeviceLevelUpdate `protobuf:"bytes,7,opt,name=device_level_update,json=deviceLevelUpdate,proto3,oneof"`
 }
@@ -394,10 +370,6 @@ type IpcMessage_EnumerateAudioDevices struct {
 	EnumerateAudioDevices *EnumerateAudioDevices `protobuf:"bytes,17,opt,name=enumerate_audio_devices,json=enumerateAudioDevices,proto3,oneof"`
 }
 
-type IpcMessage_PlayTestTone struct {
-	PlayTestTone *PlayTestTone `protobuf:"bytes,18,opt,name=play_test_tone,json=playTestTone,proto3,oneof"`
-}
-
 type IpcMessage_SetDeviceGain struct {
 	SetDeviceGain *SetDeviceGain `protobuf:"bytes,19,opt,name=set_device_gain,json=setDeviceGain,proto3,oneof"`
 }
@@ -420,8 +392,6 @@ func (*IpcMessage_ModemReady) isIpcMessage_Payload() {}
 
 func (*IpcMessage_AudioDeviceList) isIpcMessage_Payload() {}
 
-func (*IpcMessage_TestToneResult) isIpcMessage_Payload() {}
-
 func (*IpcMessage_DeviceLevelUpdate) isIpcMessage_Payload() {}
 
 func (*IpcMessage_InputLevelScanResult) isIpcMessage_Payload() {}
@@ -441,8 +411,6 @@ func (*IpcMessage_StopAudio) isIpcMessage_Payload() {}
 func (*IpcMessage_Shutdown) isIpcMessage_Payload() {}
 
 func (*IpcMessage_EnumerateAudioDevices) isIpcMessage_Payload() {}
-
-func (*IpcMessage_PlayTestTone) isIpcMessage_Payload() {}
 
 func (*IpcMessage_SetDeviceGain) isIpcMessage_Payload() {}
 
@@ -1699,144 +1667,6 @@ func (x *EnumerateAudioDevices) GetIncludeOutput() bool {
 	return false
 }
 
-// Request a brief test tone on an output device.
-type PlayTestTone struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RequestId     uint32                 `protobuf:"varint,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`   // echoed back in TestToneResult
-	DeviceName    string                 `protobuf:"bytes,2,opt,name=device_name,json=deviceName,proto3" json:"device_name,omitempty"` // cpal output device name
-	SampleRate    uint32                 `protobuf:"varint,3,opt,name=sample_rate,json=sampleRate,proto3" json:"sample_rate,omitempty"`
-	Channels      uint32                 `protobuf:"varint,4,opt,name=channels,proto3" json:"channels,omitempty"`
-	DeviceId      uint32                 `protobuf:"varint,5,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"` // configstore ID for gain lookup and level metering
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PlayTestTone) Reset() {
-	*x = PlayTestTone{}
-	mi := &file_graywolf_proto_msgTypes[15]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PlayTestTone) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PlayTestTone) ProtoMessage() {}
-
-func (x *PlayTestTone) ProtoReflect() protoreflect.Message {
-	mi := &file_graywolf_proto_msgTypes[15]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PlayTestTone.ProtoReflect.Descriptor instead.
-func (*PlayTestTone) Descriptor() ([]byte, []int) {
-	return file_graywolf_proto_rawDescGZIP(), []int{15}
-}
-
-func (x *PlayTestTone) GetRequestId() uint32 {
-	if x != nil {
-		return x.RequestId
-	}
-	return 0
-}
-
-func (x *PlayTestTone) GetDeviceName() string {
-	if x != nil {
-		return x.DeviceName
-	}
-	return ""
-}
-
-func (x *PlayTestTone) GetSampleRate() uint32 {
-	if x != nil {
-		return x.SampleRate
-	}
-	return 0
-}
-
-func (x *PlayTestTone) GetChannels() uint32 {
-	if x != nil {
-		return x.Channels
-	}
-	return 0
-}
-
-func (x *PlayTestTone) GetDeviceId() uint32 {
-	if x != nil {
-		return x.DeviceId
-	}
-	return 0
-}
-
-// Result of a test tone attempt.
-type TestToneResult struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RequestId     uint32                 `protobuf:"varint,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
-	Success       bool                   `protobuf:"varint,2,opt,name=success,proto3" json:"success,omitempty"`
-	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"` // empty on success
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *TestToneResult) Reset() {
-	*x = TestToneResult{}
-	mi := &file_graywolf_proto_msgTypes[16]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *TestToneResult) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*TestToneResult) ProtoMessage() {}
-
-func (x *TestToneResult) ProtoReflect() protoreflect.Message {
-	mi := &file_graywolf_proto_msgTypes[16]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use TestToneResult.ProtoReflect.Descriptor instead.
-func (*TestToneResult) Descriptor() ([]byte, []int) {
-	return file_graywolf_proto_rawDescGZIP(), []int{16}
-}
-
-func (x *TestToneResult) GetRequestId() uint32 {
-	if x != nil {
-		return x.RequestId
-	}
-	return 0
-}
-
-func (x *TestToneResult) GetSuccess() bool {
-	if x != nil {
-		return x.Success
-	}
-	return false
-}
-
-func (x *TestToneResult) GetError() string {
-	if x != nil {
-		return x.Error
-	}
-	return ""
-}
-
 // Set software gain for an audio device (live update, no restart).
 type SetDeviceGain struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1848,7 +1678,7 @@ type SetDeviceGain struct {
 
 func (x *SetDeviceGain) Reset() {
 	*x = SetDeviceGain{}
-	mi := &file_graywolf_proto_msgTypes[17]
+	mi := &file_graywolf_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1860,7 +1690,7 @@ func (x *SetDeviceGain) String() string {
 func (*SetDeviceGain) ProtoMessage() {}
 
 func (x *SetDeviceGain) ProtoReflect() protoreflect.Message {
-	mi := &file_graywolf_proto_msgTypes[17]
+	mi := &file_graywolf_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1873,7 +1703,7 @@ func (x *SetDeviceGain) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetDeviceGain.ProtoReflect.Descriptor instead.
 func (*SetDeviceGain) Descriptor() ([]byte, []int) {
-	return file_graywolf_proto_rawDescGZIP(), []int{17}
+	return file_graywolf_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *SetDeviceGain) GetDeviceId() uint32 {
@@ -1903,7 +1733,7 @@ type DeviceLevelUpdate struct {
 
 func (x *DeviceLevelUpdate) Reset() {
 	*x = DeviceLevelUpdate{}
-	mi := &file_graywolf_proto_msgTypes[18]
+	mi := &file_graywolf_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1915,7 +1745,7 @@ func (x *DeviceLevelUpdate) String() string {
 func (*DeviceLevelUpdate) ProtoMessage() {}
 
 func (x *DeviceLevelUpdate) ProtoReflect() protoreflect.Message {
-	mi := &file_graywolf_proto_msgTypes[18]
+	mi := &file_graywolf_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1928,7 +1758,7 @@ func (x *DeviceLevelUpdate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceLevelUpdate.ProtoReflect.Descriptor instead.
 func (*DeviceLevelUpdate) Descriptor() ([]byte, []int) {
-	return file_graywolf_proto_rawDescGZIP(), []int{18}
+	return file_graywolf_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *DeviceLevelUpdate) GetDeviceId() uint32 {
@@ -1970,7 +1800,7 @@ type ScanInputLevels struct {
 
 func (x *ScanInputLevels) Reset() {
 	*x = ScanInputLevels{}
-	mi := &file_graywolf_proto_msgTypes[19]
+	mi := &file_graywolf_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1982,7 +1812,7 @@ func (x *ScanInputLevels) String() string {
 func (*ScanInputLevels) ProtoMessage() {}
 
 func (x *ScanInputLevels) ProtoReflect() protoreflect.Message {
-	mi := &file_graywolf_proto_msgTypes[19]
+	mi := &file_graywolf_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1995,7 +1825,7 @@ func (x *ScanInputLevels) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScanInputLevels.ProtoReflect.Descriptor instead.
 func (*ScanInputLevels) Descriptor() ([]byte, []int) {
-	return file_graywolf_proto_rawDescGZIP(), []int{19}
+	return file_graywolf_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ScanInputLevels) GetRequestId() uint32 {
@@ -2025,7 +1855,7 @@ type ManualPtt struct {
 
 func (x *ManualPtt) Reset() {
 	*x = ManualPtt{}
-	mi := &file_graywolf_proto_msgTypes[20]
+	mi := &file_graywolf_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2037,7 +1867,7 @@ func (x *ManualPtt) String() string {
 func (*ManualPtt) ProtoMessage() {}
 
 func (x *ManualPtt) ProtoReflect() protoreflect.Message {
-	mi := &file_graywolf_proto_msgTypes[20]
+	mi := &file_graywolf_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2050,7 +1880,7 @@ func (x *ManualPtt) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ManualPtt.ProtoReflect.Descriptor instead.
 func (*ManualPtt) Descriptor() ([]byte, []int) {
-	return file_graywolf_proto_rawDescGZIP(), []int{20}
+	return file_graywolf_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ManualPtt) GetChannel() uint32 {
@@ -2078,7 +1908,7 @@ type InputLevelScanResult struct {
 
 func (x *InputLevelScanResult) Reset() {
 	*x = InputLevelScanResult{}
-	mi := &file_graywolf_proto_msgTypes[21]
+	mi := &file_graywolf_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2090,7 +1920,7 @@ func (x *InputLevelScanResult) String() string {
 func (*InputLevelScanResult) ProtoMessage() {}
 
 func (x *InputLevelScanResult) ProtoReflect() protoreflect.Message {
-	mi := &file_graywolf_proto_msgTypes[21]
+	mi := &file_graywolf_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2103,7 +1933,7 @@ func (x *InputLevelScanResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InputLevelScanResult.ProtoReflect.Descriptor instead.
 func (*InputLevelScanResult) Descriptor() ([]byte, []int) {
-	return file_graywolf_proto_rawDescGZIP(), []int{21}
+	return file_graywolf_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *InputLevelScanResult) GetRequestId() uint32 {
@@ -2133,7 +1963,7 @@ type InputDeviceLevel struct {
 
 func (x *InputDeviceLevel) Reset() {
 	*x = InputDeviceLevel{}
-	mi := &file_graywolf_proto_msgTypes[22]
+	mi := &file_graywolf_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2145,7 +1975,7 @@ func (x *InputDeviceLevel) String() string {
 func (*InputDeviceLevel) ProtoMessage() {}
 
 func (x *InputDeviceLevel) ProtoReflect() protoreflect.Message {
-	mi := &file_graywolf_proto_msgTypes[22]
+	mi := &file_graywolf_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2158,7 +1988,7 @@ func (x *InputDeviceLevel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InputDeviceLevel.ProtoReflect.Descriptor instead.
 func (*InputDeviceLevel) Descriptor() ([]byte, []int) {
-	return file_graywolf_proto_rawDescGZIP(), []int{22}
+	return file_graywolf_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *InputDeviceLevel) GetName() string {
@@ -2193,8 +2023,7 @@ var File_graywolf_proto protoreflect.FileDescriptor
 
 const file_graywolf_proto_rawDesc = "" +
 	"\n" +
-	"\x0egraywolf.proto\x12\bgraywolf\"\xcd\n" +
-	"\n" +
+	"\x0egraywolf.proto\x12\bgraywolf\"\xc7\t\n" +
 	"\n" +
 	"IpcMessage\x12@\n" +
 	"\x0ereceived_frame\x18\x01 \x01(\v2\x17.graywolf.ReceivedFrameH\x00R\rreceivedFrame\x124\n" +
@@ -2203,8 +2032,7 @@ const file_graywolf_proto_rawDesc = "" +
 	"\rstatus_update\x18\x03 \x01(\v2\x16.graywolf.StatusUpdateH\x00R\fstatusUpdate\x127\n" +
 	"\vmodem_ready\x18\x04 \x01(\v2\x14.graywolf.ModemReadyH\x00R\n" +
 	"modemReady\x12G\n" +
-	"\x11audio_device_list\x18\x05 \x01(\v2\x19.graywolf.AudioDeviceListH\x00R\x0faudioDeviceList\x12D\n" +
-	"\x10test_tone_result\x18\x06 \x01(\v2\x18.graywolf.TestToneResultH\x00R\x0etestToneResult\x12M\n" +
+	"\x11audio_device_list\x18\x05 \x01(\v2\x19.graywolf.AudioDeviceListH\x00R\x0faudioDeviceList\x12M\n" +
 	"\x13device_level_update\x18\a \x01(\v2\x1b.graywolf.DeviceLevelUpdateH\x00R\x11deviceLevelUpdate\x12W\n" +
 	"\x17input_level_scan_result\x18\b \x01(\v2\x1e.graywolf.InputLevelScanResultH\x00R\x14inputLevelScanResult\x12@\n" +
 	"\x0etransmit_frame\x18\n" +
@@ -2217,8 +2045,7 @@ const file_graywolf_proto_rawDesc = "" +
 	"\n" +
 	"stop_audio\x18\x0f \x01(\v2\x13.graywolf.StopAudioH\x00R\tstopAudio\x120\n" +
 	"\bshutdown\x18\x10 \x01(\v2\x12.graywolf.ShutdownH\x00R\bshutdown\x12Y\n" +
-	"\x17enumerate_audio_devices\x18\x11 \x01(\v2\x1f.graywolf.EnumerateAudioDevicesH\x00R\x15enumerateAudioDevices\x12>\n" +
-	"\x0eplay_test_tone\x18\x12 \x01(\v2\x16.graywolf.PlayTestToneH\x00R\fplayTestTone\x12A\n" +
+	"\x17enumerate_audio_devices\x18\x11 \x01(\v2\x1f.graywolf.EnumerateAudioDevicesH\x00R\x15enumerateAudioDevices\x12A\n" +
 	"\x0fset_device_gain\x18\x13 \x01(\v2\x17.graywolf.SetDeviceGainH\x00R\rsetDeviceGain\x12G\n" +
 	"\x11scan_input_levels\x18\x14 \x01(\v2\x19.graywolf.ScanInputLevelsH\x00R\x0fscanInputLevels\x124\n" +
 	"\n" +
@@ -2346,21 +2173,7 @@ const file_graywolf_proto_rawDesc = "" +
 	"\x15EnumerateAudioDevices\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\rR\trequestId\x12%\n" +
-	"\x0einclude_output\x18\x02 \x01(\bR\rincludeOutput\"\xa8\x01\n" +
-	"\fPlayTestTone\x12\x1d\n" +
-	"\n" +
-	"request_id\x18\x01 \x01(\rR\trequestId\x12\x1f\n" +
-	"\vdevice_name\x18\x02 \x01(\tR\n" +
-	"deviceName\x12\x1f\n" +
-	"\vsample_rate\x18\x03 \x01(\rR\n" +
-	"sampleRate\x12\x1a\n" +
-	"\bchannels\x18\x04 \x01(\rR\bchannels\x12\x1b\n" +
-	"\tdevice_id\x18\x05 \x01(\rR\bdeviceId\"_\n" +
-	"\x0eTestToneResult\x12\x1d\n" +
-	"\n" +
-	"request_id\x18\x01 \x01(\rR\trequestId\x12\x18\n" +
-	"\asuccess\x18\x02 \x01(\bR\asuccess\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\"E\n" +
+	"\x0einclude_output\x18\x02 \x01(\bR\rincludeOutput\"E\n" +
 	"\rSetDeviceGain\x12\x1b\n" +
 	"\tdevice_id\x18\x01 \x01(\rR\bdeviceId\x12\x17\n" +
 	"\again_db\x18\x02 \x01(\x02R\x06gainDb\"\x84\x01\n" +
@@ -2405,7 +2218,7 @@ func file_graywolf_proto_rawDescGZIP() []byte {
 }
 
 var file_graywolf_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_graywolf_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_graywolf_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_graywolf_proto_goTypes = []any{
 	(AudioDeviceKind)(0),          // 0: graywolf.AudioDeviceKind
 	(*IpcMessage)(nil),            // 1: graywolf.IpcMessage
@@ -2423,14 +2236,12 @@ var file_graywolf_proto_goTypes = []any{
 	(*StopAudio)(nil),             // 13: graywolf.StopAudio
 	(*Shutdown)(nil),              // 14: graywolf.Shutdown
 	(*EnumerateAudioDevices)(nil), // 15: graywolf.EnumerateAudioDevices
-	(*PlayTestTone)(nil),          // 16: graywolf.PlayTestTone
-	(*TestToneResult)(nil),        // 17: graywolf.TestToneResult
-	(*SetDeviceGain)(nil),         // 18: graywolf.SetDeviceGain
-	(*DeviceLevelUpdate)(nil),     // 19: graywolf.DeviceLevelUpdate
-	(*ScanInputLevels)(nil),       // 20: graywolf.ScanInputLevels
-	(*ManualPtt)(nil),             // 21: graywolf.ManualPtt
-	(*InputLevelScanResult)(nil),  // 22: graywolf.InputLevelScanResult
-	(*InputDeviceLevel)(nil),      // 23: graywolf.InputDeviceLevel
+	(*SetDeviceGain)(nil),         // 16: graywolf.SetDeviceGain
+	(*DeviceLevelUpdate)(nil),     // 17: graywolf.DeviceLevelUpdate
+	(*ScanInputLevels)(nil),       // 18: graywolf.ScanInputLevels
+	(*ManualPtt)(nil),             // 19: graywolf.ManualPtt
+	(*InputLevelScanResult)(nil),  // 20: graywolf.InputLevelScanResult
+	(*InputDeviceLevel)(nil),      // 21: graywolf.InputDeviceLevel
 }
 var file_graywolf_proto_depIdxs = []int32{
 	2,  // 0: graywolf.IpcMessage.received_frame:type_name -> graywolf.ReceivedFrame
@@ -2438,29 +2249,27 @@ var file_graywolf_proto_depIdxs = []int32{
 	4,  // 2: graywolf.IpcMessage.status_update:type_name -> graywolf.StatusUpdate
 	5,  // 3: graywolf.IpcMessage.modem_ready:type_name -> graywolf.ModemReady
 	6,  // 4: graywolf.IpcMessage.audio_device_list:type_name -> graywolf.AudioDeviceList
-	17, // 5: graywolf.IpcMessage.test_tone_result:type_name -> graywolf.TestToneResult
-	19, // 6: graywolf.IpcMessage.device_level_update:type_name -> graywolf.DeviceLevelUpdate
-	22, // 7: graywolf.IpcMessage.input_level_scan_result:type_name -> graywolf.InputLevelScanResult
-	8,  // 8: graywolf.IpcMessage.transmit_frame:type_name -> graywolf.TransmitFrame
-	9,  // 9: graywolf.IpcMessage.configure_channel:type_name -> graywolf.ConfigureChannel
-	10, // 10: graywolf.IpcMessage.configure_audio:type_name -> graywolf.ConfigureAudio
-	11, // 11: graywolf.IpcMessage.configure_ptt:type_name -> graywolf.ConfigurePtt
-	12, // 12: graywolf.IpcMessage.start_audio:type_name -> graywolf.StartAudio
-	13, // 13: graywolf.IpcMessage.stop_audio:type_name -> graywolf.StopAudio
-	14, // 14: graywolf.IpcMessage.shutdown:type_name -> graywolf.Shutdown
-	15, // 15: graywolf.IpcMessage.enumerate_audio_devices:type_name -> graywolf.EnumerateAudioDevices
-	16, // 16: graywolf.IpcMessage.play_test_tone:type_name -> graywolf.PlayTestTone
-	18, // 17: graywolf.IpcMessage.set_device_gain:type_name -> graywolf.SetDeviceGain
-	20, // 18: graywolf.IpcMessage.scan_input_levels:type_name -> graywolf.ScanInputLevels
-	21, // 19: graywolf.IpcMessage.manual_ptt:type_name -> graywolf.ManualPtt
-	7,  // 20: graywolf.AudioDeviceList.devices:type_name -> graywolf.AudioDeviceInfo
-	0,  // 21: graywolf.AudioDeviceInfo.kind:type_name -> graywolf.AudioDeviceKind
-	23, // 22: graywolf.InputLevelScanResult.devices:type_name -> graywolf.InputDeviceLevel
-	23, // [23:23] is the sub-list for method output_type
-	23, // [23:23] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	17, // 5: graywolf.IpcMessage.device_level_update:type_name -> graywolf.DeviceLevelUpdate
+	20, // 6: graywolf.IpcMessage.input_level_scan_result:type_name -> graywolf.InputLevelScanResult
+	8,  // 7: graywolf.IpcMessage.transmit_frame:type_name -> graywolf.TransmitFrame
+	9,  // 8: graywolf.IpcMessage.configure_channel:type_name -> graywolf.ConfigureChannel
+	10, // 9: graywolf.IpcMessage.configure_audio:type_name -> graywolf.ConfigureAudio
+	11, // 10: graywolf.IpcMessage.configure_ptt:type_name -> graywolf.ConfigurePtt
+	12, // 11: graywolf.IpcMessage.start_audio:type_name -> graywolf.StartAudio
+	13, // 12: graywolf.IpcMessage.stop_audio:type_name -> graywolf.StopAudio
+	14, // 13: graywolf.IpcMessage.shutdown:type_name -> graywolf.Shutdown
+	15, // 14: graywolf.IpcMessage.enumerate_audio_devices:type_name -> graywolf.EnumerateAudioDevices
+	16, // 15: graywolf.IpcMessage.set_device_gain:type_name -> graywolf.SetDeviceGain
+	18, // 16: graywolf.IpcMessage.scan_input_levels:type_name -> graywolf.ScanInputLevels
+	19, // 17: graywolf.IpcMessage.manual_ptt:type_name -> graywolf.ManualPtt
+	7,  // 18: graywolf.AudioDeviceList.devices:type_name -> graywolf.AudioDeviceInfo
+	0,  // 19: graywolf.AudioDeviceInfo.kind:type_name -> graywolf.AudioDeviceKind
+	21, // 20: graywolf.InputLevelScanResult.devices:type_name -> graywolf.InputDeviceLevel
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_graywolf_proto_init() }
@@ -2474,7 +2283,6 @@ func file_graywolf_proto_init() {
 		(*IpcMessage_StatusUpdate)(nil),
 		(*IpcMessage_ModemReady)(nil),
 		(*IpcMessage_AudioDeviceList)(nil),
-		(*IpcMessage_TestToneResult)(nil),
 		(*IpcMessage_DeviceLevelUpdate)(nil),
 		(*IpcMessage_InputLevelScanResult)(nil),
 		(*IpcMessage_TransmitFrame)(nil),
@@ -2485,7 +2293,6 @@ func file_graywolf_proto_init() {
 		(*IpcMessage_StopAudio)(nil),
 		(*IpcMessage_Shutdown)(nil),
 		(*IpcMessage_EnumerateAudioDevices)(nil),
-		(*IpcMessage_PlayTestTone)(nil),
 		(*IpcMessage_SetDeviceGain)(nil),
 		(*IpcMessage_ScanInputLevels)(nil),
 		(*IpcMessage_ManualPtt)(nil),
@@ -2496,7 +2303,7 @@ func file_graywolf_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graywolf_proto_rawDesc), len(file_graywolf_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   23,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/ipcproto/graywolf.pb.go
+++ b/pkg/ipcproto/graywolf.pb.go
@@ -89,6 +89,7 @@ type IpcMessage struct {
 	//	*IpcMessage_AudioDeviceList
 	//	*IpcMessage_DeviceLevelUpdate
 	//	*IpcMessage_InputLevelScanResult
+	//	*IpcMessage_TestSignalResult
 	//	*IpcMessage_TransmitFrame
 	//	*IpcMessage_ConfigureChannel
 	//	*IpcMessage_ConfigureAudio
@@ -100,6 +101,7 @@ type IpcMessage struct {
 	//	*IpcMessage_SetDeviceGain
 	//	*IpcMessage_ScanInputLevels
 	//	*IpcMessage_ManualPtt
+	//	*IpcMessage_TransmitTestSignal
 	Payload       isIpcMessage_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -205,6 +207,15 @@ func (x *IpcMessage) GetInputLevelScanResult() *InputLevelScanResult {
 	return nil
 }
 
+func (x *IpcMessage) GetTestSignalResult() *TestSignalResult {
+	if x != nil {
+		if x, ok := x.Payload.(*IpcMessage_TestSignalResult); ok {
+			return x.TestSignalResult
+		}
+	}
+	return nil
+}
+
 func (x *IpcMessage) GetTransmitFrame() *TransmitFrame {
 	if x != nil {
 		if x, ok := x.Payload.(*IpcMessage_TransmitFrame); ok {
@@ -304,6 +315,15 @@ func (x *IpcMessage) GetManualPtt() *ManualPtt {
 	return nil
 }
 
+func (x *IpcMessage) GetTransmitTestSignal() *TransmitTestSignal {
+	if x != nil {
+		if x, ok := x.Payload.(*IpcMessage_TransmitTestSignal); ok {
+			return x.TransmitTestSignal
+		}
+	}
+	return nil
+}
+
 type isIpcMessage_Payload interface {
 	isIpcMessage_Payload()
 }
@@ -335,6 +355,10 @@ type IpcMessage_DeviceLevelUpdate struct {
 
 type IpcMessage_InputLevelScanResult struct {
 	InputLevelScanResult *InputLevelScanResult `protobuf:"bytes,8,opt,name=input_level_scan_result,json=inputLevelScanResult,proto3,oneof"`
+}
+
+type IpcMessage_TestSignalResult struct {
+	TestSignalResult *TestSignalResult `protobuf:"bytes,9,opt,name=test_signal_result,json=testSignalResult,proto3,oneof"`
 }
 
 type IpcMessage_TransmitFrame struct {
@@ -382,6 +406,10 @@ type IpcMessage_ManualPtt struct {
 	ManualPtt *ManualPtt `protobuf:"bytes,21,opt,name=manual_ptt,json=manualPtt,proto3,oneof"` // Go → Rust: manual PTT toggle for testing
 }
 
+type IpcMessage_TransmitTestSignal struct {
+	TransmitTestSignal *TransmitTestSignal `protobuf:"bytes,22,opt,name=transmit_test_signal,json=transmitTestSignal,proto3,oneof"`
+}
+
 func (*IpcMessage_ReceivedFrame) isIpcMessage_Payload() {}
 
 func (*IpcMessage_DcdChange) isIpcMessage_Payload() {}
@@ -395,6 +423,8 @@ func (*IpcMessage_AudioDeviceList) isIpcMessage_Payload() {}
 func (*IpcMessage_DeviceLevelUpdate) isIpcMessage_Payload() {}
 
 func (*IpcMessage_InputLevelScanResult) isIpcMessage_Payload() {}
+
+func (*IpcMessage_TestSignalResult) isIpcMessage_Payload() {}
 
 func (*IpcMessage_TransmitFrame) isIpcMessage_Payload() {}
 
@@ -417,6 +447,8 @@ func (*IpcMessage_SetDeviceGain) isIpcMessage_Payload() {}
 func (*IpcMessage_ScanInputLevels) isIpcMessage_Payload() {}
 
 func (*IpcMessage_ManualPtt) isIpcMessage_Payload() {}
+
+func (*IpcMessage_TransmitTestSignal) isIpcMessage_Payload() {}
 
 // A successfully decoded AX.25 frame with demodulator metadata.
 type ReceivedFrame struct {
@@ -2019,11 +2051,184 @@ func (x *InputDeviceLevel) GetError() string {
 	return ""
 }
 
+// Go -> Rust: transmit a TX test signal on a channel. kind selects the
+// generator: 0 = station callsign in CW, 1 = steady tone, 2 = alternating
+// tone. Go fills the relevant parameters; the modem is a pure renderer.
+type TransmitTestSignal struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RequestId     uint32                 `protobuf:"varint,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`         // echoed back in TestSignalResult
+	Channel       uint32                 `protobuf:"varint,2,opt,name=channel,proto3" json:"channel,omitempty"`                              // selects output device + PTT driver
+	Kind          uint32                 `protobuf:"varint,3,opt,name=kind,proto3" json:"kind,omitempty"`                                    // 0=CW callsign, 1=steady tone, 2=alternating
+	Callsign      string                 `protobuf:"bytes,4,opt,name=callsign,proto3" json:"callsign,omitempty"`                             // kind 0; already resolved + uppercased by Go
+	CwWpm         uint32                 `protobuf:"varint,5,opt,name=cw_wpm,json=cwWpm,proto3" json:"cw_wpm,omitempty"`                     // kind 0
+	FreqAHz       uint32                 `protobuf:"varint,6,opt,name=freq_a_hz,json=freqAHz,proto3" json:"freq_a_hz,omitempty"`             // CW sidetone (0) / tone (1) / tone A (2)
+	FreqBHz       uint32                 `protobuf:"varint,7,opt,name=freq_b_hz,json=freqBHz,proto3" json:"freq_b_hz,omitempty"`             // tone B (kind 2)
+	DurationMs    uint32                 `protobuf:"varint,8,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`      // kinds 1, 2
+	AltPeriodMs   uint32                 `protobuf:"varint,9,opt,name=alt_period_ms,json=altPeriodMs,proto3" json:"alt_period_ms,omitempty"` // kind 2: ms per tone before switching
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransmitTestSignal) Reset() {
+	*x = TransmitTestSignal{}
+	mi := &file_graywolf_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransmitTestSignal) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransmitTestSignal) ProtoMessage() {}
+
+func (x *TransmitTestSignal) ProtoReflect() protoreflect.Message {
+	mi := &file_graywolf_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransmitTestSignal.ProtoReflect.Descriptor instead.
+func (*TransmitTestSignal) Descriptor() ([]byte, []int) {
+	return file_graywolf_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *TransmitTestSignal) GetRequestId() uint32 {
+	if x != nil {
+		return x.RequestId
+	}
+	return 0
+}
+
+func (x *TransmitTestSignal) GetChannel() uint32 {
+	if x != nil {
+		return x.Channel
+	}
+	return 0
+}
+
+func (x *TransmitTestSignal) GetKind() uint32 {
+	if x != nil {
+		return x.Kind
+	}
+	return 0
+}
+
+func (x *TransmitTestSignal) GetCallsign() string {
+	if x != nil {
+		return x.Callsign
+	}
+	return ""
+}
+
+func (x *TransmitTestSignal) GetCwWpm() uint32 {
+	if x != nil {
+		return x.CwWpm
+	}
+	return 0
+}
+
+func (x *TransmitTestSignal) GetFreqAHz() uint32 {
+	if x != nil {
+		return x.FreqAHz
+	}
+	return 0
+}
+
+func (x *TransmitTestSignal) GetFreqBHz() uint32 {
+	if x != nil {
+		return x.FreqBHz
+	}
+	return 0
+}
+
+func (x *TransmitTestSignal) GetDurationMs() uint32 {
+	if x != nil {
+		return x.DurationMs
+	}
+	return 0
+}
+
+func (x *TransmitTestSignal) GetAltPeriodMs() uint32 {
+	if x != nil {
+		return x.AltPeriodMs
+	}
+	return 0
+}
+
+// Result of a TX test-signal submission to the TX worker.
+type TestSignalResult struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RequestId     uint32                 `protobuf:"varint,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	Success       bool                   `protobuf:"varint,2,opt,name=success,proto3" json:"success,omitempty"`
+	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"` // empty on success
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TestSignalResult) Reset() {
+	*x = TestSignalResult{}
+	mi := &file_graywolf_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TestSignalResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TestSignalResult) ProtoMessage() {}
+
+func (x *TestSignalResult) ProtoReflect() protoreflect.Message {
+	mi := &file_graywolf_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TestSignalResult.ProtoReflect.Descriptor instead.
+func (*TestSignalResult) Descriptor() ([]byte, []int) {
+	return file_graywolf_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *TestSignalResult) GetRequestId() uint32 {
+	if x != nil {
+		return x.RequestId
+	}
+	return 0
+}
+
+func (x *TestSignalResult) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *TestSignalResult) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 var File_graywolf_proto protoreflect.FileDescriptor
 
 const file_graywolf_proto_rawDesc = "" +
 	"\n" +
-	"\x0egraywolf.proto\x12\bgraywolf\"\xc7\t\n" +
+	"\x0egraywolf.proto\x12\bgraywolf\"\xe5\n" +
+	"\n" +
 	"\n" +
 	"IpcMessage\x12@\n" +
 	"\x0ereceived_frame\x18\x01 \x01(\v2\x17.graywolf.ReceivedFrameH\x00R\rreceivedFrame\x124\n" +
@@ -2034,7 +2239,8 @@ const file_graywolf_proto_rawDesc = "" +
 	"modemReady\x12G\n" +
 	"\x11audio_device_list\x18\x05 \x01(\v2\x19.graywolf.AudioDeviceListH\x00R\x0faudioDeviceList\x12M\n" +
 	"\x13device_level_update\x18\a \x01(\v2\x1b.graywolf.DeviceLevelUpdateH\x00R\x11deviceLevelUpdate\x12W\n" +
-	"\x17input_level_scan_result\x18\b \x01(\v2\x1e.graywolf.InputLevelScanResultH\x00R\x14inputLevelScanResult\x12@\n" +
+	"\x17input_level_scan_result\x18\b \x01(\v2\x1e.graywolf.InputLevelScanResultH\x00R\x14inputLevelScanResult\x12J\n" +
+	"\x12test_signal_result\x18\t \x01(\v2\x1a.graywolf.TestSignalResultH\x00R\x10testSignalResult\x12@\n" +
 	"\x0etransmit_frame\x18\n" +
 	" \x01(\v2\x17.graywolf.TransmitFrameH\x00R\rtransmitFrame\x12I\n" +
 	"\x11configure_channel\x18\v \x01(\v2\x1a.graywolf.ConfigureChannelH\x00R\x10configureChannel\x12C\n" +
@@ -2049,7 +2255,8 @@ const file_graywolf_proto_rawDesc = "" +
 	"\x0fset_device_gain\x18\x13 \x01(\v2\x17.graywolf.SetDeviceGainH\x00R\rsetDeviceGain\x12G\n" +
 	"\x11scan_input_levels\x18\x14 \x01(\v2\x19.graywolf.ScanInputLevelsH\x00R\x0fscanInputLevels\x124\n" +
 	"\n" +
-	"manual_ptt\x18\x15 \x01(\v2\x13.graywolf.ManualPttH\x00R\tmanualPttB\t\n" +
+	"manual_ptt\x18\x15 \x01(\v2\x13.graywolf.ManualPttH\x00R\tmanualPtt\x12P\n" +
+	"\x14transmit_test_signal\x18\x16 \x01(\v2\x1c.graywolf.TransmitTestSignalH\x00R\x12transmitTestSignalB\t\n" +
 	"\apayload\"\xb7\x02\n" +
 	"\rReceivedFrame\x12\x18\n" +
 	"\achannel\x18\x01 \x01(\rR\achannel\x12\x18\n" +
@@ -2199,7 +2406,24 @@ const file_graywolf_proto_rawDesc = "" +
 	"\tpeak_dbfs\x18\x02 \x01(\x02R\bpeakDbfs\x12\x1d\n" +
 	"\n" +
 	"has_signal\x18\x03 \x01(\bR\thasSignal\x12\x14\n" +
-	"\x05error\x18\x04 \x01(\tR\x05error*o\n" +
+	"\x05error\x18\x04 \x01(\tR\x05error\"\x91\x02\n" +
+	"\x12TransmitTestSignal\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\x01 \x01(\rR\trequestId\x12\x18\n" +
+	"\achannel\x18\x02 \x01(\rR\achannel\x12\x12\n" +
+	"\x04kind\x18\x03 \x01(\rR\x04kind\x12\x1a\n" +
+	"\bcallsign\x18\x04 \x01(\tR\bcallsign\x12\x15\n" +
+	"\x06cw_wpm\x18\x05 \x01(\rR\x05cwWpm\x12\x1a\n" +
+	"\tfreq_a_hz\x18\x06 \x01(\rR\afreqAHz\x12\x1a\n" +
+	"\tfreq_b_hz\x18\a \x01(\rR\afreqBHz\x12\x1f\n" +
+	"\vduration_ms\x18\b \x01(\rR\n" +
+	"durationMs\x12\"\n" +
+	"\ralt_period_ms\x18\t \x01(\rR\valtPeriodMs\"a\n" +
+	"\x10TestSignalResult\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\x01 \x01(\rR\trequestId\x12\x18\n" +
+	"\asuccess\x18\x02 \x01(\bR\asuccess\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error*o\n" +
 	"\x0fAudioDeviceKind\x12!\n" +
 	"\x1dAUDIO_DEVICE_KIND_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17AUDIO_DEVICE_KIND_INPUT\x10\x01\x12\x1c\n" +
@@ -2218,7 +2442,7 @@ func file_graywolf_proto_rawDescGZIP() []byte {
 }
 
 var file_graywolf_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_graywolf_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_graywolf_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_graywolf_proto_goTypes = []any{
 	(AudioDeviceKind)(0),          // 0: graywolf.AudioDeviceKind
 	(*IpcMessage)(nil),            // 1: graywolf.IpcMessage
@@ -2242,6 +2466,8 @@ var file_graywolf_proto_goTypes = []any{
 	(*ManualPtt)(nil),             // 19: graywolf.ManualPtt
 	(*InputLevelScanResult)(nil),  // 20: graywolf.InputLevelScanResult
 	(*InputDeviceLevel)(nil),      // 21: graywolf.InputDeviceLevel
+	(*TransmitTestSignal)(nil),    // 22: graywolf.TransmitTestSignal
+	(*TestSignalResult)(nil),      // 23: graywolf.TestSignalResult
 }
 var file_graywolf_proto_depIdxs = []int32{
 	2,  // 0: graywolf.IpcMessage.received_frame:type_name -> graywolf.ReceivedFrame
@@ -2251,25 +2477,27 @@ var file_graywolf_proto_depIdxs = []int32{
 	6,  // 4: graywolf.IpcMessage.audio_device_list:type_name -> graywolf.AudioDeviceList
 	17, // 5: graywolf.IpcMessage.device_level_update:type_name -> graywolf.DeviceLevelUpdate
 	20, // 6: graywolf.IpcMessage.input_level_scan_result:type_name -> graywolf.InputLevelScanResult
-	8,  // 7: graywolf.IpcMessage.transmit_frame:type_name -> graywolf.TransmitFrame
-	9,  // 8: graywolf.IpcMessage.configure_channel:type_name -> graywolf.ConfigureChannel
-	10, // 9: graywolf.IpcMessage.configure_audio:type_name -> graywolf.ConfigureAudio
-	11, // 10: graywolf.IpcMessage.configure_ptt:type_name -> graywolf.ConfigurePtt
-	12, // 11: graywolf.IpcMessage.start_audio:type_name -> graywolf.StartAudio
-	13, // 12: graywolf.IpcMessage.stop_audio:type_name -> graywolf.StopAudio
-	14, // 13: graywolf.IpcMessage.shutdown:type_name -> graywolf.Shutdown
-	15, // 14: graywolf.IpcMessage.enumerate_audio_devices:type_name -> graywolf.EnumerateAudioDevices
-	16, // 15: graywolf.IpcMessage.set_device_gain:type_name -> graywolf.SetDeviceGain
-	18, // 16: graywolf.IpcMessage.scan_input_levels:type_name -> graywolf.ScanInputLevels
-	19, // 17: graywolf.IpcMessage.manual_ptt:type_name -> graywolf.ManualPtt
-	7,  // 18: graywolf.AudioDeviceList.devices:type_name -> graywolf.AudioDeviceInfo
-	0,  // 19: graywolf.AudioDeviceInfo.kind:type_name -> graywolf.AudioDeviceKind
-	21, // 20: graywolf.InputLevelScanResult.devices:type_name -> graywolf.InputDeviceLevel
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	23, // 7: graywolf.IpcMessage.test_signal_result:type_name -> graywolf.TestSignalResult
+	8,  // 8: graywolf.IpcMessage.transmit_frame:type_name -> graywolf.TransmitFrame
+	9,  // 9: graywolf.IpcMessage.configure_channel:type_name -> graywolf.ConfigureChannel
+	10, // 10: graywolf.IpcMessage.configure_audio:type_name -> graywolf.ConfigureAudio
+	11, // 11: graywolf.IpcMessage.configure_ptt:type_name -> graywolf.ConfigurePtt
+	12, // 12: graywolf.IpcMessage.start_audio:type_name -> graywolf.StartAudio
+	13, // 13: graywolf.IpcMessage.stop_audio:type_name -> graywolf.StopAudio
+	14, // 14: graywolf.IpcMessage.shutdown:type_name -> graywolf.Shutdown
+	15, // 15: graywolf.IpcMessage.enumerate_audio_devices:type_name -> graywolf.EnumerateAudioDevices
+	16, // 16: graywolf.IpcMessage.set_device_gain:type_name -> graywolf.SetDeviceGain
+	18, // 17: graywolf.IpcMessage.scan_input_levels:type_name -> graywolf.ScanInputLevels
+	19, // 18: graywolf.IpcMessage.manual_ptt:type_name -> graywolf.ManualPtt
+	22, // 19: graywolf.IpcMessage.transmit_test_signal:type_name -> graywolf.TransmitTestSignal
+	7,  // 20: graywolf.AudioDeviceList.devices:type_name -> graywolf.AudioDeviceInfo
+	0,  // 21: graywolf.AudioDeviceInfo.kind:type_name -> graywolf.AudioDeviceKind
+	21, // 22: graywolf.InputLevelScanResult.devices:type_name -> graywolf.InputDeviceLevel
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_graywolf_proto_init() }
@@ -2285,6 +2513,7 @@ func file_graywolf_proto_init() {
 		(*IpcMessage_AudioDeviceList)(nil),
 		(*IpcMessage_DeviceLevelUpdate)(nil),
 		(*IpcMessage_InputLevelScanResult)(nil),
+		(*IpcMessage_TestSignalResult)(nil),
 		(*IpcMessage_TransmitFrame)(nil),
 		(*IpcMessage_ConfigureChannel)(nil),
 		(*IpcMessage_ConfigureAudio)(nil),
@@ -2296,6 +2525,7 @@ func file_graywolf_proto_init() {
 		(*IpcMessage_SetDeviceGain)(nil),
 		(*IpcMessage_ScanInputLevels)(nil),
 		(*IpcMessage_ManualPtt)(nil),
+		(*IpcMessage_TransmitTestSignal)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -2303,7 +2533,7 @@ func file_graywolf_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graywolf_proto_rawDesc), len(file_graywolf_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   21,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/modembridge/bridge.go
+++ b/pkg/modembridge/bridge.go
@@ -5,7 +5,7 @@
 //   - supervisor owns the child process lifecycle and stdout ring buffer.
 //   - ipcLoop owns per-session framing-level send/recv.
 //   - dispatcher correlates request IDs with reply channels for the
-//     three request/response IPC exchanges.
+//     two request/response IPC exchanges.
 //   - dcdPublisher fans out DcdChange events with slow-subscriber drop
 //     accounting.
 //   - statusCache holds per-channel stats and per-device audio levels,
@@ -85,9 +85,8 @@ type Bridge struct {
 	// on every supervise iteration.
 	status *statusCache
 
-	// Three request/response dispatchers, one per IPC exchange kind.
+	// Two request/response dispatchers, one per IPC exchange kind.
 	enumDispatcher *dispatcher[*pb.AudioDeviceList]
-	toneDispatcher *dispatcher[*pb.TestToneResult]
 	scanDispatcher *dispatcher[*pb.InputLevelScanResult]
 
 	// pttWatchdog auto-unkeys channels whose manual PTT has been held
@@ -132,7 +131,6 @@ func New(cfg Config) *Bridge {
 		dcd:            pub,
 		status:         newStatusCache(),
 		enumDispatcher: newDispatcher[*pb.AudioDeviceList](),
-		toneDispatcher: newDispatcher[*pb.TestToneResult](),
 		scanDispatcher: newDispatcher[*pb.InputLevelScanResult](),
 	}
 	// pttWatchdog auto-unkeys channels after 10s of no heartbeat. The
@@ -197,7 +195,6 @@ func (b *Bridge) Stop() {
 // bound to Start/Stop rather than scattered across individual pieces.
 func (b *Bridge) supervise(ctx context.Context) {
 	b.enumDispatcher.Reset()
-	b.toneDispatcher.Reset()
 	b.scanDispatcher.Reset()
 	b.status.Reset()
 	// Cancel any watchdog timers left over from a prior session so a
@@ -223,7 +220,6 @@ func (b *Bridge) supervise(ctx context.Context) {
 // and double-close is impossible.
 func (b *Bridge) closePendingRequests() {
 	b.enumDispatcher.Close()
-	b.toneDispatcher.Close()
 	b.scanDispatcher.Close()
 }
 

--- a/pkg/modembridge/bridge.go
+++ b/pkg/modembridge/bridge.go
@@ -86,8 +86,9 @@ type Bridge struct {
 	status *statusCache
 
 	// Two request/response dispatchers, one per IPC exchange kind.
-	enumDispatcher *dispatcher[*pb.AudioDeviceList]
-	scanDispatcher *dispatcher[*pb.InputLevelScanResult]
+	enumDispatcher       *dispatcher[*pb.AudioDeviceList]
+	scanDispatcher       *dispatcher[*pb.InputLevelScanResult]
+	testSignalDispatcher *dispatcher[*pb.TestSignalResult]
 
 	// pttWatchdog auto-unkeys channels whose manual PTT has been held
 	// longer than 10s without a heartbeat.
@@ -130,8 +131,9 @@ func New(cfg Config) *Bridge {
 		frames:         make(chan *pb.ReceivedFrame, cfg.FrameBufferSize),
 		dcd:            pub,
 		status:         newStatusCache(),
-		enumDispatcher: newDispatcher[*pb.AudioDeviceList](),
-		scanDispatcher: newDispatcher[*pb.InputLevelScanResult](),
+		enumDispatcher:       newDispatcher[*pb.AudioDeviceList](),
+		scanDispatcher:       newDispatcher[*pb.InputLevelScanResult](),
+		testSignalDispatcher: newDispatcher[*pb.TestSignalResult](),
 	}
 	// pttWatchdog auto-unkeys channels after 10s of no heartbeat. The
 	// unkey closure captures b so it can call ManualPtt(ch, false)
@@ -196,6 +198,7 @@ func (b *Bridge) Stop() {
 func (b *Bridge) supervise(ctx context.Context) {
 	b.enumDispatcher.Reset()
 	b.scanDispatcher.Reset()
+	b.testSignalDispatcher.Reset()
 	b.status.Reset()
 	// Cancel any watchdog timers left over from a prior session so a
 	// stale timer can't fire an auto-unkey into a freshly-spawned modem
@@ -221,6 +224,7 @@ func (b *Bridge) supervise(ctx context.Context) {
 func (b *Bridge) closePendingRequests() {
 	b.enumDispatcher.Close()
 	b.scanDispatcher.Close()
+	b.testSignalDispatcher.Close()
 }
 
 // State returns the current supervisor state.

--- a/pkg/modembridge/bridge.go
+++ b/pkg/modembridge/bridge.go
@@ -213,7 +213,7 @@ func (b *Bridge) supervise(ctx context.Context) {
 	b.sup.Run(ctx)
 }
 
-// closePendingRequests closes every reply channel in the three dispatchers
+// closePendingRequests closes every reply channel in the two dispatchers
 // so callers blocked in their per-call select unblock immediately. Must
 // only be invoked from supervise()'s defer chain; at that point the
 // session goroutine has already returned, so no Deliver is in flight

--- a/pkg/modembridge/bridge.go
+++ b/pkg/modembridge/bridge.go
@@ -126,11 +126,11 @@ func New(cfg Config) *Bridge {
 	}
 	pub := newDcdPublisher(cfg.Logger, dcdDropHook)
 	b := &Bridge{
-		cfg:            cfg,
-		logger:         cfg.Logger,
-		frames:         make(chan *pb.ReceivedFrame, cfg.FrameBufferSize),
-		dcd:            pub,
-		status:         newStatusCache(),
+		cfg:                  cfg,
+		logger:               cfg.Logger,
+		frames:               make(chan *pb.ReceivedFrame, cfg.FrameBufferSize),
+		dcd:                  pub,
+		status:               newStatusCache(),
 		enumDispatcher:       newDispatcher[*pb.AudioDeviceList](),
 		scanDispatcher:       newDispatcher[*pb.InputLevelScanResult](),
 		testSignalDispatcher: newDispatcher[*pb.TestSignalResult](),
@@ -364,7 +364,7 @@ func (b *Bridge) GetAllDeviceLevels() map[uint32]*DeviceLevel {
 
 // updateStatusCache and updateDeviceLevelCache are called by dispatchIPC
 // when StatusUpdate / DeviceLevelUpdate messages arrive.
-func (b *Bridge) updateStatusCache(s *pb.StatusUpdate)       { b.status.UpdateStatus(s) }
+func (b *Bridge) updateStatusCache(s *pb.StatusUpdate)           { b.status.UpdateStatus(s) }
 func (b *Bridge) updateDeviceLevelCache(u *pb.DeviceLevelUpdate) { b.status.UpdateDeviceLevel(u) }
 
 // InjectSendFnForTest installs a fake send function so tests can capture

--- a/pkg/modembridge/bridge_stop_test.go
+++ b/pkg/modembridge/bridge_stop_test.go
@@ -39,12 +39,6 @@ func TestBridgeStopCancelsPendingRequests(t *testing.T) {
 				return err
 			},
 		},
-		{
-			name: "PlayTestTone",
-			call: func(b *Bridge) error {
-				return b.PlayTestTone(context.Background(), 0, "fake", 48000, 1)
-			},
-		},
 	}
 
 	for _, tc := range cases {
@@ -89,7 +83,6 @@ func TestBridgeStopClosesDispatchers(t *testing.T) {
 	// Register a pending entry in each dispatcher directly so we can
 	// observe that Close drains them.
 	_, enumCh := b.enumDispatcher.Register()
-	_, toneCh := b.toneDispatcher.Register()
 	_, scanCh := b.scanDispatcher.Register()
 
 	b.closePendingRequests()
@@ -97,7 +90,6 @@ func TestBridgeStopClosesDispatchers(t *testing.T) {
 	// Every waiting channel should receive a zero value (closed channel).
 	for name, ch := range map[string]<-chan any{
 		"enum": adaptPbAudioDeviceList(enumCh),
-		"tone": adaptPbTestToneResult(toneCh),
 		"scan": adaptPbInputLevelScanResult(scanCh),
 	} {
 		select {
@@ -114,17 +106,6 @@ func TestBridgeStopClosesDispatchers(t *testing.T) {
 // The three tiny adapters below widen the typed dispatcher reply channels
 // to <-chan any so the preceding table-driven test can share one select.
 func adaptPbAudioDeviceList(c <-chan *pb.AudioDeviceList) <-chan any {
-	out := make(chan any, 1)
-	go func() {
-		v, ok := <-c
-		if ok {
-			out <- v
-		}
-		close(out)
-	}()
-	return out
-}
-func adaptPbTestToneResult(c <-chan *pb.TestToneResult) <-chan any {
 	out := make(chan any, 1)
 	go func() {
 		v, ok := <-c
@@ -164,8 +145,5 @@ func TestBridgeRegistrationAfterStopRejects(t *testing.T) {
 	}
 	if _, err := b.ScanInputLevels(context.Background()); !errors.Is(err, errBridgeStopped) {
 		t.Errorf("ScanInputLevels err = %v, want errBridgeStopped", err)
-	}
-	if err := b.PlayTestTone(context.Background(), 0, "x", 48000, 1); !errors.Is(err, errBridgeStopped) {
-		t.Errorf("PlayTestTone err = %v, want errBridgeStopped", err)
 	}
 }

--- a/pkg/modembridge/bridge_stop_test.go
+++ b/pkg/modembridge/bridge_stop_test.go
@@ -39,6 +39,14 @@ func TestBridgeStopCancelsPendingRequests(t *testing.T) {
 				return err
 			},
 		},
+		{
+			name: "TransmitTestSignal",
+			call: func(b *Bridge) error {
+				return b.TransmitTestSignal(context.Background(), TestSignalParams{
+					Channel: 0, Kind: 1, FreqAHz: 1200, DurationMs: 100,
+				})
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -84,13 +92,15 @@ func TestBridgeStopClosesDispatchers(t *testing.T) {
 	// observe that Close drains them.
 	_, enumCh := b.enumDispatcher.Register()
 	_, scanCh := b.scanDispatcher.Register()
+	_, testSignalCh := b.testSignalDispatcher.Register()
 
 	b.closePendingRequests()
 
 	// Every waiting channel should receive a zero value (closed channel).
 	for name, ch := range map[string]<-chan any{
-		"enum": adaptPbAudioDeviceList(enumCh),
-		"scan": adaptPbInputLevelScanResult(scanCh),
+		"enum":       adaptPbAudioDeviceList(enumCh),
+		"scan":       adaptPbInputLevelScanResult(scanCh),
+		"testsignal": adaptPbTestSignalResult(testSignalCh),
 	} {
 		select {
 		case v, ok := <-ch:
@@ -127,6 +137,17 @@ func adaptPbInputLevelScanResult(c <-chan *pb.InputLevelScanResult) <-chan any {
 	}()
 	return out
 }
+func adaptPbTestSignalResult(c <-chan *pb.TestSignalResult) <-chan any {
+	out := make(chan any, 1)
+	go func() {
+		v, ok := <-c
+		if ok {
+			out <- v
+		}
+		close(out)
+	}()
+	return out
+}
 
 // TestBridgeRegistrationAfterStopRejects verifies that once
 // closePendingRequests has nil'd the dispatch maps, a caller that forces
@@ -145,5 +166,8 @@ func TestBridgeRegistrationAfterStopRejects(t *testing.T) {
 	}
 	if _, err := b.ScanInputLevels(context.Background()); !errors.Is(err, errBridgeStopped) {
 		t.Errorf("ScanInputLevels err = %v, want errBridgeStopped", err)
+	}
+	if err := b.TransmitTestSignal(context.Background(), TestSignalParams{}); !errors.Is(err, errBridgeStopped) {
+		t.Errorf("TransmitTestSignal err = %v, want errBridgeStopped", err)
 	}
 }

--- a/pkg/modembridge/bridge_stop_test.go
+++ b/pkg/modembridge/bridge_stop_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestBridgeStopCancelsPendingRequests verifies that callers blocked in
-// EnumerateAudioDevices / ScanInputLevels / PlayTestTone are unblocked with
+// EnumerateAudioDevices / ScanInputLevels are unblocked with
 // errBridgeStopped when the supervisor closes their dispatch channels,
 // instead of waiting out the 5s / 30s per-call timeout.
 //
@@ -73,7 +73,7 @@ func TestBridgeStopCancelsPendingRequests(t *testing.T) {
 }
 
 // TestBridgeStopClosesDispatchers verifies that closePendingRequests marks
-// the three dispatchers closed so a caller that races past the
+// the two dispatchers closed so a caller that races past the
 // StateRunning fast-path check sees a closed channel from Register and
 // rejects itself instead of leaking an entry into a dispatcher that will
 // never be drained again.
@@ -103,7 +103,7 @@ func TestBridgeStopClosesDispatchers(t *testing.T) {
 	}
 }
 
-// The three tiny adapters below widen the typed dispatcher reply channels
+// The two tiny adapters below widen the typed dispatcher reply channels
 // to <-chan any so the preceding table-driven test can share one select.
 func adaptPbAudioDeviceList(c <-chan *pb.AudioDeviceList) <-chan any {
 	out := make(chan any, 1)

--- a/pkg/modembridge/requests.go
+++ b/pkg/modembridge/requests.go
@@ -80,48 +80,6 @@ func (b *Bridge) ScanInputLevels(ctx context.Context) ([]InputLevel, error) {
 	}
 }
 
-// PlayTestTone asks the Rust modem to play a test tone on the named output
-// device and waits for the result. Follows the same request/response
-// pattern as EnumerateAudioDevices.
-func (b *Bridge) PlayTestTone(ctx context.Context, deviceID uint32, deviceName string, sampleRate, channels uint32) error {
-	if b.State() != StateRunning {
-		return errors.New("modembridge: not in RUNNING state")
-	}
-
-	reqID, ch := b.toneDispatcher.Register()
-	defer b.toneDispatcher.Cancel(reqID)
-
-	msg := &pb.IpcMessage{Payload: &pb.IpcMessage_PlayTestTone{
-		PlayTestTone: &pb.PlayTestTone{
-			RequestId:  reqID,
-			DeviceName: deviceName,
-			SampleRate: sampleRate,
-			Channels:   channels,
-			DeviceId:   deviceID,
-		},
-	}}
-	if err := b.sendIPC(msg); err != nil {
-		return fmt.Errorf("send PlayTestTone: %w", err)
-	}
-
-	timer := time.NewTimer(5 * time.Second)
-	defer timer.Stop()
-	select {
-	case resp := <-ch:
-		if resp == nil {
-			return errBridgeStopped
-		}
-		if !resp.Success {
-			return fmt.Errorf("test tone failed: %s", resp.Error)
-		}
-		return nil
-	case <-timer.C:
-		return errors.New("modembridge: test tone timeout")
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
 // dispatch hooks invoked by dispatchIPC when the matching response
 // arrives from the modem.
 func (b *Bridge) dispatchEnumResponse(list *pb.AudioDeviceList) {
@@ -129,9 +87,6 @@ func (b *Bridge) dispatchEnumResponse(list *pb.AudioDeviceList) {
 }
 func (b *Bridge) dispatchScanResponse(r *pb.InputLevelScanResult) {
 	b.scanDispatcher.Deliver(r.RequestId, r)
-}
-func (b *Bridge) dispatchToneResponse(r *pb.TestToneResult) {
-	b.toneDispatcher.Deliver(r.RequestId, r)
 }
 
 func convertDeviceList(list *pb.AudioDeviceList) []AvailableDevice {

--- a/pkg/modembridge/requests.go
+++ b/pkg/modembridge/requests.go
@@ -80,6 +80,70 @@ func (b *Bridge) ScanInputLevels(ctx context.Context) ([]InputLevel, error) {
 	}
 }
 
+// TestSignalParams describes one TX test signal. Kind: 0=CW callsign,
+// 1=steady tone, 2=alternating tone. Unused fields for a given kind are
+// ignored by the modem.
+type TestSignalParams struct {
+	Channel     uint32
+	Kind        uint32
+	Callsign    string
+	CwWpm       uint32
+	FreqAHz     uint32
+	FreqBHz     uint32
+	DurationMs  uint32
+	AltPeriodMs uint32
+}
+
+// TransmitTestSignal asks the Rust modem to transmit a TX test signal on a
+// channel and waits for the submission result. The modem keys PTT, plays the
+// audio, and unkeys via the TX worker.
+func (b *Bridge) TransmitTestSignal(ctx context.Context, p TestSignalParams) error {
+	if b.State() != StateRunning {
+		return errors.New("modembridge: not in RUNNING state")
+	}
+
+	reqID, ch := b.testSignalDispatcher.Register()
+	defer b.testSignalDispatcher.Cancel(reqID)
+
+	msg := &pb.IpcMessage{Payload: &pb.IpcMessage_TransmitTestSignal{
+		TransmitTestSignal: &pb.TransmitTestSignal{
+			RequestId:   reqID,
+			Channel:     p.Channel,
+			Kind:        p.Kind,
+			Callsign:    p.Callsign,
+			CwWpm:       p.CwWpm,
+			FreqAHz:     p.FreqAHz,
+			FreqBHz:     p.FreqBHz,
+			DurationMs:  p.DurationMs,
+			AltPeriodMs: p.AltPeriodMs,
+		},
+	}}
+	if err := b.sendIPC(msg); err != nil {
+		return fmt.Errorf("send TransmitTestSignal: %w", err)
+	}
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case resp := <-ch:
+		if resp == nil {
+			return errBridgeStopped
+		}
+		if !resp.Success {
+			return fmt.Errorf("test signal failed: %s", resp.Error)
+		}
+		return nil
+	case <-timer.C:
+		return errors.New("modembridge: test signal timeout")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (b *Bridge) dispatchTestSignalResponse(r *pb.TestSignalResult) {
+	b.testSignalDispatcher.Deliver(r.RequestId, r)
+}
+
 // dispatch hooks invoked by dispatchIPC when the matching response
 // arrives from the modem.
 func (b *Bridge) dispatchEnumResponse(list *pb.AudioDeviceList) {

--- a/pkg/modembridge/requests.go
+++ b/pkg/modembridge/requests.go
@@ -94,9 +94,11 @@ type TestSignalParams struct {
 	AltPeriodMs uint32
 }
 
-// TransmitTestSignal asks the Rust modem to transmit a TX test signal on a
-// channel and waits for the submission result. The modem keys PTT, plays the
-// audio, and unkeys via the TX worker.
+// TransmitTestSignal asks the Rust modem to queue a TX test signal on a
+// channel. It returns once the modem has accepted the job for transmission;
+// PTT keying, audio play-out, and unkey then happen asynchronously on the TX
+// worker thread (so the 5s wait below is for the IPC round-trip, not the
+// signal's duration).
 func (b *Bridge) TransmitTestSignal(ctx context.Context, p TestSignalParams) error {
 	if b.State() != StateRunning {
 		return errors.New("modembridge: not in RUNNING state")
@@ -140,10 +142,6 @@ func (b *Bridge) TransmitTestSignal(ctx context.Context, p TestSignalParams) err
 	}
 }
 
-func (b *Bridge) dispatchTestSignalResponse(r *pb.TestSignalResult) {
-	b.testSignalDispatcher.Deliver(r.RequestId, r)
-}
-
 // dispatch hooks invoked by dispatchIPC when the matching response
 // arrives from the modem.
 func (b *Bridge) dispatchEnumResponse(list *pb.AudioDeviceList) {
@@ -151,6 +149,9 @@ func (b *Bridge) dispatchEnumResponse(list *pb.AudioDeviceList) {
 }
 func (b *Bridge) dispatchScanResponse(r *pb.InputLevelScanResult) {
 	b.scanDispatcher.Deliver(r.RequestId, r)
+}
+func (b *Bridge) dispatchTestSignalResponse(r *pb.TestSignalResult) {
+	b.testSignalDispatcher.Deliver(r.RequestId, r)
 }
 
 func convertDeviceList(list *pb.AudioDeviceList) []AvailableDevice {

--- a/pkg/modembridge/session.go
+++ b/pkg/modembridge/session.go
@@ -128,6 +128,8 @@ func (b *Bridge) dispatchIPC(msg *pb.IpcMessage) {
 		b.updateDeviceLevelCache(p.DeviceLevelUpdate)
 	case *pb.IpcMessage_InputLevelScanResult:
 		b.dispatchScanResponse(p.InputLevelScanResult)
+	case *pb.IpcMessage_TestSignalResult:
+		b.dispatchTestSignalResponse(p.TestSignalResult)
 	default:
 		b.logger.Debug("unhandled ipc message", "type", fmt.Sprintf("%T", p))
 	}

--- a/pkg/modembridge/session.go
+++ b/pkg/modembridge/session.go
@@ -124,8 +124,6 @@ func (b *Bridge) dispatchIPC(msg *pb.IpcMessage) {
 		b.dispatchDcd(p.DcdChange)
 	case *pb.IpcMessage_AudioDeviceList:
 		b.dispatchEnumResponse(p.AudioDeviceList)
-	case *pb.IpcMessage_TestToneResult:
-		b.dispatchToneResponse(p.TestToneResult)
 	case *pb.IpcMessage_DeviceLevelUpdate:
 		b.updateDeviceLevelCache(p.DeviceLevelUpdate)
 	case *pb.IpcMessage_InputLevelScanResult:

--- a/pkg/webapi/audio_devices.go
+++ b/pkg/webapi/audio_devices.go
@@ -321,11 +321,3 @@ func (s *Server) setAudioDeviceGain(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, dto.AudioDeviceFromModel(*dev))
 }
-
-// audioDeviceName picks the cpal device name from an AudioDevice.
-func audioDeviceName(d *configstore.AudioDevice) string {
-	if d.SourcePath != "" {
-		return d.SourcePath
-	}
-	return d.Name
-}

--- a/pkg/webapi/audio_devices.go
+++ b/pkg/webapi/audio_devices.go
@@ -11,9 +11,9 @@ import (
 
 // registerAudioDevices installs the /api/audio-devices route tree on
 // mux using Go 1.22+ method-scoped patterns. Sub-resource routes
-// (/available, /scan-levels, /levels, /{id}/test-tone, /{id}/gain) are
-// registered as method-scoped patterns so mux precedence correctly
-// prefers literal segments over the {id} wildcard.
+// (/available, /scan-levels, /levels, /{id}/gain) are registered as
+// method-scoped patterns so mux precedence correctly prefers literal
+// segments over the {id} wildcard.
 //
 // Operation IDs used in the swag annotation blocks below are frozen
 // against the constants in pkg/webapi/docs/op_ids.go. The
@@ -24,7 +24,6 @@ func (s *Server) registerAudioDevices(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/audio-devices/available", s.listAvailableAudioDevices)
 	mux.HandleFunc("POST /api/audio-devices/scan-levels", s.scanAudioDeviceLevels)
 	mux.HandleFunc("GET /api/audio-devices/levels", s.getAudioDeviceLevels)
-	mux.HandleFunc("POST /api/audio-devices/{id}/test-tone", s.playTestTone)
 	mux.HandleFunc("PUT /api/audio-devices/{id}/gain", s.setAudioDeviceGain)
 	mux.HandleFunc("GET /api/audio-devices/{id}", s.getAudioDevice)
 	mux.HandleFunc("PUT /api/audio-devices/{id}", s.updateAudioDevice)
@@ -262,50 +261,6 @@ func (s *Server) getAudioDeviceLevels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, s.bridge.GetAllDeviceLevels())
-}
-
-// playTestTone plays a 1 kHz test tone on the specified output device
-// for a fixed duration. Fails with 400 if the device is an input
-// device, 404 if the device id is unknown, 503 if the bridge is not
-// wired, and 500 if the bridge IPC call fails.
-//
-// @Summary  Play test tone on audio device
-// @Tags     audio-devices
-// @ID       playTestTone
-// @Produce  json
-// @Param    id  path     int true "Audio device id"
-// @Success  200 {object} dto.TestToneResponse
-// @Failure  400 {object} webtypes.ErrorResponse
-// @Failure  404 {object} webtypes.ErrorResponse
-// @Failure  500 {object} webtypes.ErrorResponse
-// @Failure  503 {object} webtypes.ErrorResponse
-// @Security CookieAuth
-// @Router   /audio-devices/{id}/test-tone [post]
-func (s *Server) playTestTone(w http.ResponseWriter, r *http.Request) {
-	id, err := parseID(r.PathValue("id"))
-	if err != nil {
-		badRequest(w, "invalid id")
-		return
-	}
-	if s.bridge == nil {
-		writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: "bridge not available"})
-		return
-	}
-	dev, err := s.store.GetAudioDevice(r.Context(), id)
-	if err != nil {
-		writeJSON(w, http.StatusNotFound, webtypes.ErrorResponse{Error: "device not found"})
-		return
-	}
-	if dev.Direction != "output" {
-		badRequest(w, "test tone only supported on output devices")
-		return
-	}
-	deviceName := audioDeviceName(dev)
-	if err := s.bridge.PlayTestTone(r.Context(), id, deviceName, dev.SampleRate, dev.Channels); err != nil {
-		s.internalError(w, r, "play test tone", err)
-		return
-	}
-	writeJSON(w, http.StatusOK, dto.TestToneResponse{Status: "ok"})
 }
 
 // setAudioDeviceGain updates the software gain for a device and pushes

--- a/pkg/webapi/audio_devices_test.go
+++ b/pkg/webapi/audio_devices_test.go
@@ -295,40 +295,6 @@ func TestAudioDeviceSetGain_OutOfRange(t *testing.T) {
 	}
 }
 
-// TestAudioDeviceTestTone_RejectsInputDevice guards the new playTestTone
-// handler name: input devices can't play tones.
-func TestAudioDeviceTestTone_RejectsInputDevice(t *testing.T) {
-	srv, _ := newTestServer(t)
-	mux := http.NewServeMux()
-	srv.RegisterRoutes(mux)
-
-	// Seeded device id=1 is direction=input.
-	req := httptest.NewRequest(http.MethodPost, "/api/audio-devices/1/test-tone", nil)
-	rec := httptest.NewRecorder()
-	mux.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
-	}
-}
-
-// TestAudioDeviceTestTone_MissingDevice returns 404 rather than 500
-// even though the bridge is not running in tests — the store lookup
-// fails first.
-func TestAudioDeviceTestTone_MissingDevice(t *testing.T) {
-	srv, _ := newTestServer(t)
-	mux := http.NewServeMux()
-	srv.RegisterRoutes(mux)
-
-	req := httptest.NewRequest(http.MethodPost, "/api/audio-devices/9999/test-tone", nil)
-	rec := httptest.NewRecorder()
-	mux.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
-	}
-}
-
 // TestAudioDeviceGetLevels_NilBridgeReturnsEmptyObject verifies the
 // levels endpoint renders an empty object when the bridge is nil —
 // matching the pre-refactor behavior ("{}") so the UI's meter

--- a/pkg/webapi/channels.go
+++ b/pkg/webapi/channels.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/chrissnell/graywolf/pkg/callsign"
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/kiss"
 	"github.com/chrissnell/graywolf/pkg/modembridge"
@@ -31,6 +32,7 @@ func (s *Server) registerChannels(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/channels/{id}/stats", s.getChannelStats)
 	mux.HandleFunc("GET /api/channels/{id}/referrers", s.getChannelReferrers)
 	mux.HandleFunc("POST /api/channels/{id}/ptt", s.manualPtt)
+	mux.HandleFunc("POST /api/channels/{id}/test-tx", s.sendTestSignal)
 }
 
 // listChannels returns every configured channel.
@@ -618,6 +620,103 @@ func (s *Server) getChannelStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	notFound(w)
+}
+
+// CW / tone recipe constants — the single source of the hardcoded test-signal
+// parameters. The four UI options map to these.
+const (
+	cwTestWpm       = 20
+	cwTestToneHz    = 700
+	toneTestDurMs   = 3000
+	altTestPeriodMs = 200
+	toneTestLowHz   = 1200
+	toneTestHighHz  = 2400
+)
+
+// sendTestSignal transmits a TX test signal (CW callsign or a tone) on a
+// channel. The "cw" signal refuses to key the radio when the station callsign
+// is empty or N0CALL; tone signals need no callsign. All signals require a
+// TX-capable channel.
+//
+// @Summary  Send a TX test signal (CW callsign or tone) on a channel
+// @Tags     Channels
+// @ID       sendTestSignal
+// @Accept   json
+// @Produce  json
+// @Param    id path int true "Channel ID"
+// @Param    body body dto.TestSignalRequest true "Signal to send"
+// @Success  200 {object} dto.TestSignalResponse
+// @Failure  400 {object} webtypes.ErrorResponse
+// @Failure  409 {object} webtypes.ErrorResponse
+// @Failure  422 {object} webtypes.ErrorResponse
+// @Failure  503 {object} webtypes.ErrorResponse
+// @Router   /channels/{id}/test-tx [post]
+func (s *Server) sendTestSignal(w http.ResponseWriter, r *http.Request) {
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid channel id")
+		return
+	}
+	if s.bridge == nil {
+		writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: "bridge not available"})
+		return
+	}
+
+	var req dto.TestSignalRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		badRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	params := modembridge.TestSignalParams{Channel: id}
+	switch req.Signal {
+	case "cw":
+		call, err := s.store.ResolveStationCallsign(r.Context())
+		if err != nil {
+			switch {
+			case errors.Is(err, callsign.ErrCallsignEmpty):
+				writeJSON(w, http.StatusUnprocessableEntity, webtypes.ErrorResponse{Error: "set your station callsign before sending CW ID"})
+			case errors.Is(err, callsign.ErrCallsignN0Call):
+				writeJSON(w, http.StatusUnprocessableEntity, webtypes.ErrorResponse{Error: "station callsign is still N0CALL; set a real callsign before sending CW ID"})
+			default:
+				s.internalError(w, r, "resolve station callsign", err)
+			}
+			return
+		}
+		params.Kind = 0
+		params.Callsign = call
+		params.CwWpm = cwTestWpm
+		params.FreqAHz = cwTestToneHz
+	case "tone1200":
+		params.Kind = 1
+		params.FreqAHz = toneTestLowHz
+		params.DurationMs = toneTestDurMs
+	case "tone2400":
+		params.Kind = 1
+		params.FreqAHz = toneTestHighHz
+		params.DurationMs = toneTestDurMs
+	case "alt":
+		params.Kind = 2
+		params.FreqAHz = toneTestLowHz
+		params.FreqBHz = toneTestHighHz
+		params.DurationMs = toneTestDurMs
+		params.AltPeriodMs = altTestPeriodMs
+	default:
+		badRequest(w, "unknown signal: "+req.Signal)
+		return
+	}
+
+	if err := s.requireTxCapableChannel(r.Context(), "channel", id); err != nil {
+		writeJSON(w, http.StatusConflict, webtypes.ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	if err := s.bridge.TransmitTestSignal(r.Context(), params); err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, dto.TestSignalResponse{Status: "sent"})
 }
 
 // manualPtt keys or unkeys the radio on the given channel for SPA testing.

--- a/pkg/webapi/channels.go
+++ b/pkg/webapi/channels.go
@@ -639,7 +639,7 @@ const (
 // TX-capable channel.
 //
 // @Summary  Send a TX test signal (CW callsign or tone) on a channel
-// @Tags     Channels
+// @Tags     channels
 // @ID       sendTestSignal
 // @Accept   json
 // @Produce  json
@@ -650,6 +650,7 @@ const (
 // @Failure  409 {object} webtypes.ErrorResponse
 // @Failure  422 {object} webtypes.ErrorResponse
 // @Failure  503 {object} webtypes.ErrorResponse
+// @Security CookieAuth
 // @Router   /channels/{id}/test-tx [post]
 func (s *Server) sendTestSignal(w http.ResponseWriter, r *http.Request) {
 	id, err := parseID(r.PathValue("id"))
@@ -683,20 +684,20 @@ func (s *Server) sendTestSignal(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-		params.Kind = 0
+		params.Kind = 0 // CW callsign
 		params.Callsign = call
 		params.CwWpm = cwTestWpm
 		params.FreqAHz = cwTestToneHz
 	case "tone1200":
-		params.Kind = 1
+		params.Kind = 1 // steady tone
 		params.FreqAHz = toneTestLowHz
 		params.DurationMs = toneTestDurMs
 	case "tone2400":
-		params.Kind = 1
+		params.Kind = 1 // steady tone
 		params.FreqAHz = toneTestHighHz
 		params.DurationMs = toneTestDurMs
 	case "alt":
-		params.Kind = 2
+		params.Kind = 2 // alternating tone
 		params.FreqAHz = toneTestLowHz
 		params.FreqBHz = toneTestHighHz
 		params.DurationMs = toneTestDurMs

--- a/pkg/webapi/channels_test_tx_test.go
+++ b/pkg/webapi/channels_test_tx_test.go
@@ -1,0 +1,168 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/webtypes"
+)
+
+// seedNonTxChannel creates a channel with an input device but no output device
+// (OutputDeviceID == 0), which makes it non-TX-capable per computeTxCapability.
+func seedNonTxChannel(t *testing.T, srv *Server) uint32 {
+	t.Helper()
+	ctx := context.Background()
+	// Re-use the existing input device (id 1, direction=input).
+	ch := &configstore.Channel{
+		Name:           "rx-only",
+		InputDeviceID:  configstore.U32Ptr(1),
+		OutputDeviceID: 0, // no output — not TX-capable
+		ModemType:      "afsk",
+		BitRate:        1200,
+		MarkFreq:       1200,
+		SpaceFreq:      2200,
+		Profile:        "A",
+		NumSlicers:     1,
+		FixBits:        "none",
+	}
+	if err := srv.store.CreateChannel(ctx, ch); err != nil {
+		t.Fatalf("seedNonTxChannel: %v", err)
+	}
+	return ch.ID
+}
+
+// postTestSignal issues POST /api/channels/{id}/test-tx with the given signal
+// string and returns the recorder.
+func postTestSignal(t *testing.T, mux *http.ServeMux, channelID uint32, signal string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := `{"signal":"` + signal + `"}`
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/channels/"+strconv.FormatUint(uint64(channelID), 10)+"/test-tx",
+		strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestSendTestSignal_CWEmptyCallsign verifies that the "cw" signal returns
+// 422 when no station callsign has been set (the store returns ErrCallsignEmpty).
+// newTestServer seeds no StationConfig row, so GetStationConfig returns a
+// zero-value struct with Callsign == "" → ResolveStationCallsign returns
+// ErrCallsignEmpty.
+func TestSendTestSignal_CWEmptyCallsign(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	// Seed channel id is 1 (TX-capable) from newTestServer.
+	rec := postTestSignal(t, mux, 1, "cw")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var er webtypes.ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&er); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(er.Error, "callsign") {
+		t.Errorf("error body = %q; want mention of callsign", er.Error)
+	}
+}
+
+// TestSendTestSignal_CWN0CallCallsign verifies that the "cw" signal returns
+// 422 when the station callsign is N0CALL.
+func TestSendTestSignal_CWN0CallCallsign(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	if err := srv.store.UpsertStationConfig(context.Background(), configstore.StationConfig{
+		Callsign: "N0CALL",
+	}); err != nil {
+		t.Fatalf("UpsertStationConfig: %v", err)
+	}
+
+	rec := postTestSignal(t, mux, 1, "cw")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var er webtypes.ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&er); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(er.Error, "N0CALL") {
+		t.Errorf("error body = %q; want mention of N0CALL", er.Error)
+	}
+}
+
+// TestSendTestSignal_UnknownSignal verifies that an unknown signal value
+// returns 400 Bad Request.
+func TestSendTestSignal_UnknownSignal(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	rec := postTestSignal(t, mux, 1, "bogus")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var er webtypes.ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&er); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(er.Error, "bogus") {
+		t.Errorf("error body = %q; want mention of bogus", er.Error)
+	}
+}
+
+// TestSendTestSignal_NonTxChannelReturns409 verifies that sending any valid
+// signal on a channel that is not TX-capable returns 409 Conflict. The
+// non-TX channel has an input device but no output device.
+func TestSendTestSignal_NonTxChannelReturns409(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	nonTxID := seedNonTxChannel(t, srv)
+
+	rec := postTestSignal(t, mux, nonTxID, "tone1200")
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var er webtypes.ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&er); err != nil {
+		t.Fatal(err)
+	}
+	if er.Error == "" {
+		t.Errorf("expected non-empty error message in 409 body")
+	}
+}
+
+// TestSendTestSignal_Tone1200TxCapableReturns503 verifies that a tone1200
+// request on a TX-capable channel clears all guards and reaches the bridge.
+// The test bridge is real but not running, so TransmitTestSignal returns
+// "not in RUNNING state" → 503. This proves the request passed parseID,
+// body decode, signal switch, and requireTxCapableChannel.
+func TestSendTestSignal_Tone1200TxCapableReturns503(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	// Channel 1 from newTestServer is TX-capable (input + output devices).
+	rec := postTestSignal(t, mux, 1, "tone1200")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 (bridge not running), got %d: %s", rec.Code, rec.Body.String())
+	}
+	var er webtypes.ErrorResponse
+	if err := json.NewDecoder(rec.Body).Decode(&er); err != nil {
+		t.Fatal(err)
+	}
+	if er.Error == "" {
+		t.Errorf("expected non-empty error message in 503 body")
+	}
+}

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1152,64 +1152,6 @@
                 }
             }
         },
-        "/audio-devices/{id}/test-tone": {
-            "post": {
-                "security": [
-                    {
-                        "CookieAuth": []
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "audio-devices"
-                ],
-                "summary": "Play test tone on audio device",
-                "operationId": "playTestTone",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Audio device id",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/dto.TestToneResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/webtypes.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/webtypes.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/webtypes.ErrorResponse"
-                        }
-                    },
-                    "503": {
-                        "description": "Service Unavailable",
-                        "schema": {
-                            "$ref": "#/definitions/webtypes.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/auth/login": {
             "post": {
                 "consumes": [
@@ -9935,14 +9877,6 @@
                 },
                 "ok": {
                     "type": "boolean"
-                }
-            }
-        },
-        "dto.TestToneResponse": {
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string"
                 }
             }
         },

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -2515,6 +2515,76 @@
                 }
             }
         },
+        "/channels/{id}/test-tx": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "channels"
+                ],
+                "summary": "Send a TX test signal (CW callsign or tone) on a channel",
+                "operationId": "sendTestSignal",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Signal to send",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.TestSignalRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.TestSignalResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/digipeater": {
             "get": {
                 "security": [
@@ -9877,6 +9947,24 @@
                 },
                 "ok": {
                     "type": "boolean"
+                }
+            }
+        },
+        "dto.TestSignalRequest": {
+            "type": "object",
+            "properties": {
+                "signal": {
+                    "type": "string",
+                    "example": "cw"
+                }
+            }
+        },
+        "dto.TestSignalResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "example": "sent"
                 }
             }
         },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -2121,11 +2121,6 @@ definitions:
       ok:
         type: boolean
     type: object
-  dto.TestToneResponse:
-    properties:
-      status:
-        type: string
-    type: object
   dto.ThemeConfigRequest:
     properties:
       id:
@@ -3500,43 +3495,6 @@ paths:
       security:
         - CookieAuth: []
       summary: Set audio device gain
-      tags:
-        - audio-devices
-  /audio-devices/{id}/test-tone:
-    post:
-      operationId: playTestTone
-      parameters:
-        - description: Audio device id
-          in: path
-          name: id
-          required: true
-          type: integer
-      produces:
-        - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/dto.TestToneResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/webtypes.ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/webtypes.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/webtypes.ErrorResponse'
-        "503":
-          description: Service Unavailable
-          schema:
-            $ref: '#/definitions/webtypes.ErrorResponse'
-      security:
-        - CookieAuth: []
-      summary: Play test tone on audio device
       tags:
         - audio-devices
   /audio-devices/available:

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -2121,6 +2121,18 @@ definitions:
       ok:
         type: boolean
     type: object
+  dto.TestSignalRequest:
+    properties:
+      signal:
+        example: cw
+        type: string
+    type: object
+  dto.TestSignalResponse:
+    properties:
+      status:
+        example: sent
+        type: string
+    type: object
   dto.ThemeConfigRequest:
     properties:
       id:
@@ -4418,6 +4430,51 @@ paths:
       security:
         - CookieAuth: []
       summary: Get channel stats
+      tags:
+        - channels
+  /channels/{id}/test-tx:
+    post:
+      consumes:
+        - application/json
+      operationId: sendTestSignal
+      parameters:
+        - description: Channel ID
+          in: path
+          name: id
+          required: true
+          type: integer
+        - description: Signal to send
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/dto.TestSignalRequest'
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.TestSignalResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Send a TX test signal (CW callsign or tone) on a channel
       tags:
         - channels
   /digipeater:

--- a/pkg/webapi/docs/op_ids.go
+++ b/pkg/webapi/docs/op_ids.go
@@ -56,9 +56,9 @@ const (
 
 // Audio devices resource — /api/audio-devices (Phase 2).
 //
-// Sub-resource endpoints (available, scan-levels, levels, test-tone,
-// gain) stay under the same tag. Operation IDs follow the
-// verbResource convention so generated clients read fluently
+// Sub-resource endpoints (available, scan-levels, levels, gain) stay
+// under the same tag. Operation IDs follow the verbResource convention
+// so generated clients read fluently
 // (client.listAvailableAudioDevices(), client.setAudioDeviceGain(...)).
 const (
 	OpListAudioDevices          = "listAudioDevices"
@@ -69,7 +69,6 @@ const (
 	OpListAvailableAudioDevices = "listAvailableAudioDevices"
 	OpScanAudioDeviceLevels     = "scanAudioDeviceLevels"
 	OpGetAudioDeviceLevels      = "getAudioDeviceLevels"
-	OpPlayTestTone              = "playTestTone"
 	OpSetAudioDeviceGain        = "setAudioDeviceGain"
 )
 

--- a/pkg/webapi/docs/op_ids.go
+++ b/pkg/webapi/docs/op_ids.go
@@ -33,6 +33,7 @@ const (
 	OpGetChannelStats     = "getChannelStats"
 	OpGetChannelReferrers = "getChannelReferrers"
 	OpManualPtt           = "manualPtt"
+	OpSendTestSignal      = "sendTestSignal"
 )
 
 // Beacons resource — /api/beacons (Phase 2).

--- a/pkg/webapi/dto/audio_device.go
+++ b/pkg/webapi/dto/audio_device.go
@@ -128,12 +128,6 @@ func (r AudioDeviceSetGainRequest) Validate() error {
 	return nil
 }
 
-// TestToneResponse is the body returned by POST /api/audio-devices/{id}/test-tone
-// on success. Preserves the pre-typed `{"status":"ok"}` wire shape.
-type TestToneResponse struct {
-	Status string `json:"status"`
-}
-
 // AudioDeviceLevelsResponse is the body returned by
 // GET /api/audio-devices/levels — a map from device id to the latest
 // cached peak/rms/clipping measurement. Swag cannot render a keyed

--- a/pkg/webapi/dto/channel.go
+++ b/pkg/webapi/dto/channel.go
@@ -339,6 +339,17 @@ func ChannelFromModel(m configstore.Channel) ChannelResponse {
 	}
 }
 
+// TestSignalRequest is the body for POST /api/channels/{id}/test-tx.
+// Signal is one of: "cw", "tone1200", "tone2400", "alt".
+type TestSignalRequest struct {
+	Signal string `json:"signal" example:"cw"`
+}
+
+// TestSignalResponse is the body returned by POST /api/channels/{id}/test-tx.
+type TestSignalResponse struct {
+	Status string `json:"status" example:"sent"`
+}
+
 // ChannelsFromModels maps a slice for list responses.
 func ChannelsFromModels(ms []configstore.Channel) []ChannelResponse {
 	out := make([]ChannelResponse, len(ms))

--- a/proto/graywolf.proto
+++ b/proto/graywolf.proto
@@ -24,7 +24,6 @@ message IpcMessage {
     StatusUpdate status_update = 3;
     ModemReady modem_ready = 4;
     AudioDeviceList audio_device_list = 5;
-    TestToneResult test_tone_result = 6;
     DeviceLevelUpdate device_level_update = 7;
     InputLevelScanResult input_level_scan_result = 8;
 
@@ -37,7 +36,6 @@ message IpcMessage {
     StopAudio stop_audio = 15;
     Shutdown shutdown = 16;
     EnumerateAudioDevices enumerate_audio_devices = 17;
-    PlayTestTone play_test_tone = 18;
     SetDeviceGain set_device_gain = 19;
     ScanInputLevels scan_input_levels = 20;
     ManualPtt manual_ptt = 21;           // Go → Rust: manual PTT toggle for testing
@@ -237,22 +235,6 @@ message Shutdown {
 message EnumerateAudioDevices {
   uint32 request_id = 1;        // echoed back in AudioDeviceList
   bool include_output = 2;      // include output devices in response
-}
-
-// Request a brief test tone on an output device.
-message PlayTestTone {
-  uint32 request_id = 1;        // echoed back in TestToneResult
-  string device_name = 2;       // cpal output device name
-  uint32 sample_rate = 3;
-  uint32 channels = 4;
-  uint32 device_id = 5;         // configstore ID for gain lookup and level metering
-}
-
-// Result of a test tone attempt.
-message TestToneResult {
-  uint32 request_id = 1;
-  bool success = 2;
-  string error = 3;             // empty on success
 }
 
 // Set software gain for an audio device (live update, no restart).

--- a/proto/graywolf.proto
+++ b/proto/graywolf.proto
@@ -26,6 +26,7 @@ message IpcMessage {
     AudioDeviceList audio_device_list = 5;
     DeviceLevelUpdate device_level_update = 7;
     InputLevelScanResult input_level_scan_result = 8;
+    TestSignalResult test_signal_result = 9;
 
     // Go application → Rust modem
     TransmitFrame transmit_frame = 10;
@@ -39,6 +40,7 @@ message IpcMessage {
     SetDeviceGain set_device_gain = 19;
     ScanInputLevels scan_input_levels = 20;
     ManualPtt manual_ptt = 21;           // Go → Rust: manual PTT toggle for testing
+    TransmitTestSignal transmit_test_signal = 22;
   }
 }
 
@@ -277,4 +279,26 @@ message InputDeviceLevel {
   float peak_dbfs = 2;          // peak level during scan
   bool has_signal = 3;          // true if peak > -40 dBFS
   string error = 4;             // non-empty if device couldn't be opened
+}
+
+// Go -> Rust: transmit a TX test signal on a channel. kind selects the
+// generator: 0 = station callsign in CW, 1 = steady tone, 2 = alternating
+// tone. Go fills the relevant parameters; the modem is a pure renderer.
+message TransmitTestSignal {
+  uint32 request_id = 1;     // echoed back in TestSignalResult
+  uint32 channel = 2;        // selects output device + PTT driver
+  uint32 kind = 3;           // 0=CW callsign, 1=steady tone, 2=alternating
+  string callsign = 4;       // kind 0; already resolved + uppercased by Go
+  uint32 cw_wpm = 5;         // kind 0
+  uint32 freq_a_hz = 6;      // CW sidetone (0) / tone (1) / tone A (2)
+  uint32 freq_b_hz = 7;      // tone B (kind 2)
+  uint32 duration_ms = 8;    // kinds 1, 2
+  uint32 alt_period_ms = 9;  // kind 2: ms per tone before switching
+}
+
+// Result of a TX test-signal submission to the TX worker.
+message TestSignalResult {
+  uint32 request_id = 1;
+  bool success = 2;
+  string error = 3;          // empty on success
 }

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -538,6 +538,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/channels/{id}/test-tx": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send a TX test signal (CW callsign or tone) on a channel */
+        post: operations["sendTestSignal"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/digipeater": {
         parameters: {
             query?: never;
@@ -2988,6 +3005,14 @@ export interface components {
             latency_ms?: number;
             message?: string;
             ok?: boolean;
+        };
+        "dto.TestSignalRequest": {
+            /** @example cw */
+            signal?: string;
+        };
+        "dto.TestSignalResponse": {
+            /** @example sent */
+            status?: string;
         };
         "dto.ThemeConfigRequest": {
             id?: string;
@@ -5582,6 +5607,70 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    sendTestSignal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Channel ID */
+                id: number;
+            };
+            cookie?: never;
+        };
+        /** @description Signal to send */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["dto.TestSignalRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.TestSignalResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -236,23 +236,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/audio-devices/{id}/test-tone": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Play test tone on audio device */
-        post: operations["playTestTone"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/auth/login": {
         parameters: {
             query?: never;
@@ -3006,9 +2989,6 @@ export interface components {
             message?: string;
             ok?: boolean;
         };
-        "dto.TestToneResponse": {
-            status?: string;
-        };
         "dto.ThemeConfigRequest": {
             id?: string;
         };
@@ -4389,65 +4369,6 @@ export interface operations {
             };
             /** @description Internal Server Error */
             500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
-                };
-            };
-        };
-    };
-    playTestTone: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Audio device id */
-                id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["dto.TestToneResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
-                };
-            };
-            /** @description Service Unavailable */
-            503: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -198,7 +198,6 @@ function getMockData(method, path, body) {
   if (path === '/audio-devices' && method === 'POST') return delay({ id: 2, ...body });
   if (path === '/audio-devices/available') return delay(mockAvailableDevices);
   if (path === '/audio-devices/levels') return delay({ 1: { device_id: 1, peak_dbfs: -18 + Math.random() * 6, rms_dbfs: -24 + Math.random() * 6, clipping: false } });
-  if (path.match(/^\/audio-devices\/\d+\/test-tone$/) && method === 'POST') return delay({ status: 'ok' });
   if (path.match(/^\/audio-devices\/\d+\/gain$/) && method === 'PUT') return delay(body);
   if (path.match(/^\/audio-devices\/\d+$/) && method === 'PUT') return delay(body);
   if (path.match(/^\/audio-devices\/\d+$/) && method === 'DELETE') return delay(null);

--- a/web/src/routes/AudioDevices.svelte
+++ b/web/src/routes/AudioDevices.svelte
@@ -24,7 +24,6 @@
   let deleteAffectedChannels = $state([]);
   let deleteCascadeAcked = $state(false);
   let deviceLevels = $state({});
-  let testingTone = $state(null);
   let gainTimers = {};
   let isWindows = $state(false);
 
@@ -61,18 +60,6 @@
     try {
       deviceLevels = await api.get('/audio-devices/levels') || {};
     } catch (_) {}
-  }
-
-  async function playTestTone(dev) {
-    testingTone = dev.id;
-    try {
-      await api.post(`/audio-devices/${dev.id}/test-tone`);
-      toasts.success(`Test tone played on "${dev.name}"`);
-    } catch (err) {
-      toasts.error(`Test tone failed: ${err.message}`);
-    } finally {
-      testingTone = null;
-    }
   }
 
   // Slider operates directly in dB: -60 to +12
@@ -407,15 +394,6 @@
           </div>
         </div>
         <div class="device-actions">
-          {#if dev.direction === 'output'}
-            <Button
-              variant="ghost"
-              onclick={() => playTestTone(dev)}
-              disabled={testingTone === dev.id}
-            >
-              {testingTone === dev.id ? 'Playing...' : 'Test Tone'}
-            </Button>
-          {/if}
           <Button variant="ghost" onclick={() => openEdit(dev)}>Edit</Button>
           <Button variant="danger" onclick={() => confirmDelete(dev)}>Delete</Button>
         </div>

--- a/web/src/routes/channels/ChannelRow.svelte
+++ b/web/src/routes/channels/ChannelRow.svelte
@@ -167,10 +167,9 @@
           </Button>
         </DropdownMenu.Trigger>
         <DropdownMenu.Content>
-          <DropdownMenu.Item onSelect={() => sendTestSignal('cw')}>Send callsign in CW</DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => sendTestSignal('tone1200')}>Send 1200 Hz tone</DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => sendTestSignal('tone2400')}>Send 2400 Hz tone</DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => sendTestSignal('alt')}>Send 1200/2400 Hz alternating tone</DropdownMenu.Item>
+          {#each Object.entries(SIGNAL_LABELS) as [sig, label]}
+            <DropdownMenu.Item onSelect={() => sendTestSignal(sig)}>{label}</DropdownMenu.Item>
+          {/each}
         </DropdownMenu.Content>
       </DropdownMenu.Root>
     {/if}

--- a/web/src/routes/channels/ChannelRow.svelte
+++ b/web/src/routes/channels/ChannelRow.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Badge, Button } from '@chrissnell/chonky-ui';
+  import { Badge, Button, DropdownMenu } from '@chrissnell/chonky-ui';
   import {
     healthGlyph,
     healthText,
@@ -14,8 +14,31 @@
     pttState,
     ariaLabel as pttAriaLabel,
   } from '../../lib/channelPtt.js';
+  import { api } from '../../lib/api.js';
+  import { toasts } from '../../lib/stores.js';
 
   let { channel, txTiming, audioDevices = [], onEdit, onDelete } = $props();
+
+  let sendingSignal = $state(false);
+
+  const SIGNAL_LABELS = {
+    cw: 'Send callsign in CW',
+    tone1200: 'Send 1200 Hz tone',
+    tone2400: 'Send 2400 Hz tone',
+    alt: 'Send 1200/2400 Hz alternating tone',
+  };
+
+  async function sendTestSignal(signal) {
+    sendingSignal = true;
+    try {
+      await api.post(`/channels/${channel.id}/test-tx`, { signal });
+      toasts.success(`Sent "${SIGNAL_LABELS[signal]}" on "${channel.name}"`);
+    } catch (err) {
+      toasts.error(`Test TX failed: ${err.message}`);
+    } finally {
+      sendingSignal = false;
+    }
+  }
 
   let isKissOnly = $derived(channel.input_device_id == null);
 
@@ -136,6 +159,21 @@
   </div>
 
   <div class="channel-actions">
+    {#if !isKissOnly && channel.output_device_id && channel.output_device_id !== 0}
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <Button variant="ghost" disabled={sendingSignal}>
+            {sendingSignal ? 'Sending…' : 'Test TX ▾'}
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={() => sendTestSignal('cw')}>Send callsign in CW</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => sendTestSignal('tone1200')}>Send 1200 Hz tone</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => sendTestSignal('tone2400')}>Send 2400 Hz tone</DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => sendTestSignal('alt')}>Send 1200/2400 Hz alternating tone</DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    {/if}
     <Button variant="ghost" onclick={() => onEdit?.(channel)}>Edit</Button>
     <Button variant="danger" onclick={() => onDelete?.(channel)}>Delete</Button>
   </div>


### PR DESCRIPTION
## Summary

Removes the broken audio **Test Tone** feature and replaces it with a per-channel **Test TX** dropdown that transmits four test signals through the channel's real TX path (key PTT -> audio -> unkey), exactly like a normal frame:

- **Send callsign in CW** -- station callsign keyed in Morse (20 WPM, 700 Hz sidetone)
- **1200 Hz tone** / **2400 Hz tone** -- steady 3 s tones
- **1200/2400 Hz alternating tone** -- 3 s warble (200 ms period)

The CW option refuses to key the radio (422) when the station callsign is empty or still N0CALL; the tones need no callsign.

### How it works
- New pure-Rust `graywolf-modem/src/txtest.rs` synthesizes i16 PCM (Morse encoder + steady/alternating tone generators, raised-cosine edges, phase-continuous alternation).
- New `TransmitTestSignal` / `TestSignalResult` IPC (proto fields 22 / 9) carries `{channel, kind, callsign, freqs, duration...}` from Go to Rust. The Go recipe switch is the single source of the hardcoded parameters.
- The modem's `handle_transmit_test_signal` renders by `kind`, applies output-device gain, and submits a `TxJob` to the existing TX worker (which keys/unkeys PTT) -- mirroring `handle_transmit_frame`.
- `POST /api/channels/{id}/test-tx` (handler `sendTestSignal`) maps the four UI signal ids, enforces the CW callsign guard (422), unknown-signal (400), and TX-capability (409) before any IPC.
- Frontend: a chonky-ui `DropdownMenu` on TX-capable channel rows, gated by the same condition as the PTT indicator.

Part A removes the old Test Tone across all six layers (UI, webapi, modembridge, Rust modem, proto, generated bindings); retired proto fields 6/18 are not reused. Wiki updated (code-map + invariant #39).

## Test Plan
- [x] `go build ./...` and `go test ./pkg/webapi/... ./pkg/modembridge/... ./pkg/ipcproto/...` pass
- [x] Rust `txtest` unit tests (10) pass; `cargo build` clean
- [x] `cd web && npm run build` passes
- [x] `make docs-check` -- no drift
- [x] webapi guard tests: CW empty -> 422, CW N0CALL -> 422, unknown signal -> 400, non-TX channel -> 409, valid signal reaches bridge
- [ ] On-device: each menu item keys PTT and transmits the expected signal (callsign decodable in Morse; steady 1200/2400 tones; audible warble), verified on a second radio; CW with unset callsign shows a clear refusal
- [ ] Browser: Test TX menu appears only on modem-backed TX channels; success/error toasts