### PR TITLE
Harden channel test-tx: pin recipe mapping, reorder guards, document 500

### DIFF
--- a/docs/superpowers/specs/2026-05-26-channel-cw-id-design.md
+++ b/docs/superpowers/specs/2026-05-26-channel-cw-id-design.md
@@ -136,12 +136,14 @@ key/unkey is handled by the worker.
 
 `POST /api/channels/{id}/test-tx` with body `{ "signal": "<id>" }` where
 `<id>` ∈ `cw | tone1200 | tone2400 | alt`. The handler:
-1. Parses channel ID and the signal id (unknown id → 400).
-2. For `cw` only: `ResolveStationCallsign` → 422 on empty/N0CALL.
-3. `requireTxCapableChannel` → 409 on failure.
-4. Maps the signal id to a hardcoded `modembridge.TestSignalParams`
-   (kind + frequencies + duration + period + callsign/wpm) and calls
-   `bridge.TransmitTestSignal` → 503 on failure.
+1. Parses channel ID and maps the signal id to a hardcoded
+   `modembridge.TestSignalParams` (kind + frequencies + duration + period +
+   wpm); unknown id → 400.
+2. `requireTxCapableChannel` → 409 on failure (the channel-config error
+   precedes the cw-only callsign guard).
+3. For `cw` only: `ResolveStationCallsign` → 422 on empty/N0CALL, then fills
+   `params.Callsign`.
+4. `bridge.TransmitTestSignal` → 503 on failure.
 5. `200 { "status": "sent" }`.
 
 The four recipes (the single source of the hardcoded values):

--- a/pkg/webapi/channels.go
+++ b/pkg/webapi/channels.go
@@ -649,6 +649,7 @@ const (
 // @Failure  400 {object} webtypes.ErrorResponse
 // @Failure  409 {object} webtypes.ErrorResponse
 // @Failure  422 {object} webtypes.ErrorResponse
+// @Failure  500 {object} webtypes.ErrorResponse
 // @Failure  503 {object} webtypes.ErrorResponse
 // @Security CookieAuth
 // @Router   /channels/{id}/test-tx [post]
@@ -669,9 +670,22 @@ func (s *Server) sendTestSignal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params := modembridge.TestSignalParams{Channel: id}
-	switch req.Signal {
-	case "cw":
+	// Validate the signal (400) before checking channel capability (409) so a
+	// malformed request is rejected on its own terms; then the more
+	// fundamental TX-capability error precedes the cw-only callsign guard (422).
+	params, ok := buildTestSignalParams(id, req.Signal)
+	if !ok {
+		badRequest(w, "unknown signal: "+req.Signal)
+		return
+	}
+
+	if err := s.requireTxCapableChannel(r.Context(), "channel", id); err != nil {
+		writeJSON(w, http.StatusConflict, webtypes.ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	// The cw signal keys the radio with the station callsign; refuse if unset.
+	if req.Signal == "cw" {
 		call, err := s.store.ResolveStationCallsign(r.Context())
 		if err != nil {
 			switch {
@@ -684,8 +698,25 @@ func (s *Server) sendTestSignal(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-		params.Kind = 0 // CW callsign
 		params.Callsign = call
+	}
+
+	if err := s.bridge.TransmitTestSignal(r.Context(), params); err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, dto.TestSignalResponse{Status: "sent"})
+}
+
+// buildTestSignalParams maps a UI signal id to modem TX test-signal parameters.
+// The "cw" case leaves Callsign empty for the caller to fill from resolved
+// station config. ok is false for an unrecognized signal id.
+func buildTestSignalParams(channelID uint32, signal string) (modembridge.TestSignalParams, bool) {
+	params := modembridge.TestSignalParams{Channel: channelID}
+	switch signal {
+	case "cw":
+		params.Kind = 0 // CW callsign
 		params.CwWpm = cwTestWpm
 		params.FreqAHz = cwTestToneHz
 	case "tone1200":
@@ -703,21 +734,9 @@ func (s *Server) sendTestSignal(w http.ResponseWriter, r *http.Request) {
 		params.DurationMs = toneTestDurMs
 		params.AltPeriodMs = altTestPeriodMs
 	default:
-		badRequest(w, "unknown signal: "+req.Signal)
-		return
+		return modembridge.TestSignalParams{}, false
 	}
-
-	if err := s.requireTxCapableChannel(r.Context(), "channel", id); err != nil {
-		writeJSON(w, http.StatusConflict, webtypes.ErrorResponse{Error: err.Error()})
-		return
-	}
-
-	if err := s.bridge.TransmitTestSignal(r.Context(), params); err != nil {
-		writeJSON(w, http.StatusServiceUnavailable, webtypes.ErrorResponse{Error: err.Error()})
-		return
-	}
-
-	writeJSON(w, http.StatusOK, dto.TestSignalResponse{Status: "sent"})
+	return params, true
 }
 
 // manualPtt keys or unkeys the radio on the given channel for SPA testing.

--- a/pkg/webapi/channels_test_tx_test.go
+++ b/pkg/webapi/channels_test_tx_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/modembridge"
 	"github.com/chrissnell/graywolf/pkg/webtypes"
 )
 
@@ -140,6 +141,40 @@ func TestSendTestSignal_NonTxChannelReturns409(t *testing.T) {
 	}
 	if er.Error == "" {
 		t.Errorf("expected non-empty error message in 409 body")
+	}
+}
+
+// TestBuildTestSignalParams pins the four UI signal ids to their modem TX
+// parameters. This guards the hardcoded recipe table against a silent swap
+// (e.g. tone1200<->tone2400 frequencies, or a wrong Kind) that the HTTP-level
+// guard tests would not catch.
+func TestBuildTestSignalParams(t *testing.T) {
+	const ch = 7
+	tests := []struct {
+		signal string
+		want   modembridge.TestSignalParams
+	}{
+		{"cw", modembridge.TestSignalParams{Channel: ch, Kind: 0, CwWpm: cwTestWpm, FreqAHz: cwTestToneHz}},
+		{"tone1200", modembridge.TestSignalParams{Channel: ch, Kind: 1, FreqAHz: toneTestLowHz, DurationMs: toneTestDurMs}},
+		{"tone2400", modembridge.TestSignalParams{Channel: ch, Kind: 1, FreqAHz: toneTestHighHz, DurationMs: toneTestDurMs}},
+		{"alt", modembridge.TestSignalParams{Channel: ch, Kind: 2, FreqAHz: toneTestLowHz, FreqBHz: toneTestHighHz, DurationMs: toneTestDurMs, AltPeriodMs: altTestPeriodMs}},
+	}
+	for _, tt := range tests {
+		got, ok := buildTestSignalParams(ch, tt.signal)
+		if !ok {
+			t.Errorf("%s: ok = false, want true", tt.signal)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("%s: got %+v, want %+v", tt.signal, got, tt.want)
+		}
+	}
+	// cw must leave Callsign empty for the handler to fill from station config.
+	if got, _ := buildTestSignalParams(ch, "cw"); got.Callsign != "" {
+		t.Errorf("cw: Callsign = %q, want empty (handler fills it)", got.Callsign)
+	}
+	if _, ok := buildTestSignalParams(ch, "bogus"); ok {
+		t.Errorf("bogus: ok = true, want false")
 	}
 }
 

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -2576,6 +2576,12 @@
                             "$ref": "#/definitions/webtypes.ErrorResponse"
                         }
                     },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -4468,6 +4468,10 @@ paths:
           description: Unprocessable Entity
           schema:
             $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -5678,6 +5678,15 @@ export interface operations {
                     "application/json": components["schemas"]["webtypes.ErrorResponse"];
                 };
             };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
             /** @description Service Unavailable */
             503: {
                 headers: {


### PR DESCRIPTION
## Summary

Follow-up to #193 (already merged) addressing code-review findings on the channel TX test-signal endpoint. No behavior change for the happy path; tightens tests, guard precedence, and API docs.

- **Pin the recipe mapping (test gap).** Extract the signal->params switch in `sendTestSignal` into a pure `buildTestSignalParams()` and add `TestBuildTestSignalParams`, which pins all four signal ids (`cw`, `tone1200`, `tone2400`, `alt`) to their exact `kind`/frequencies/duration/period/wpm, plus the cw-leaves-callsign-empty and unknown-signal contracts. The previous HTTP-level guard tests would not have caught a silent recipe swap (e.g. `tone1200`<->`tone2400` frequencies or a wrong `kind`).
- **Reorder guards.** Handler precedence is now **400** (unknown signal) -> **409** (not TX-capable) -> **422** (cw callsign), so the channel-config error surfaces before the cw-only callsign guard. A `cw` request on a non-TX channel with no callsign now returns 409, not 422.
- **Document the 500 path.** `sendTestSignal` can emit 500 via `internalError` on the callsign-resolution default branch; added the missing `@Failure 500` annotation and regenerated the swagger spec and TS client.

Wiki invariant #39 (cw never keys the radio with empty/N0CALL) still holds -- the 422 still fires before any IPC. The design spec's documented handler step order was updated to match the new precedence.

## Test Plan
- [x] `go build ./...`, `go vet ./pkg/webapi/...` clean
- [x] `go test ./pkg/webapi/... ./pkg/modembridge/... ./pkg/ipcproto/...` pass (six `TestSendTestSignal*` + new `TestBuildTestSignalParams`)
- [x] `make docs-check` -- no drift
- [x] `make api-client-check` -- in sync