### PR TITLE
Decouple offline map render from live catalog

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -234,8 +234,19 @@ and embedded via `go:embed all:dist` -- see [invariant 12](invariants.md).
 |---|---|
 | Auth registration + bearer token | [`../../pkg/mapsauth/client.go`](../../pkg/mapsauth/client.go) |
 | Tile cache (PMTiles, atomic writes) | [`../../pkg/mapscache/manager.go`](../../pkg/mapscache/manager.go), `atomic_writer.go` |
+| PMTiles v3 header bbox reader (used by the startup backfill) | [`../../pkg/mapscache/pmtiles_header.go`](../../pkg/mapscache/pmtiles_header.go) |
+| Render-path bounds (offline-safe; reads `maps_downloads.bbox`, no remote dep) | [`../../pkg/webapi/local_bounds.go`](../../pkg/webapi/local_bounds.go) (`GET /api/maps/local-bounds`) |
+| Catalog fetcher + disk fallback for the region picker | [`../../pkg/mapscatalog/catalog.go`](../../pkg/mapscatalog/catalog.go) (`NewWithDiskCache` writes/reads `<TileCacheDir>/catalog.json`) |
 | Web-side glue | `web/src/lib/maps/`, `web/src/routes/MapsSettings.svelte` |
+| Web local-bounds store (consumed by gw-tile protocol) | `web/src/lib/maps/local-bounds-store.svelte.js` |
 | Map render | `web/src/lib/map/`, `web/src/routes/LiveMapV2.svelte` |
+
+The render path (the `gw-tile://` MapLibre protocol) reads bounds from
+`/api/maps/local-bounds`, NOT the catalog. This is what lets the map
+serve already-downloaded regions on a host that has never reached
+maps.nw5w.com in the current boot. The picker still reads the catalog
+(via `/api/maps/catalog`), with a disk fallback so the operator sees
+the last-known region list when offline.
 
 PMTiles infrastructure (manifest gen, R2 sync, Cloudflare Worker) is in
 `~/dev/graywolf-maps`, not here. See [invariant 7](invariants.md).

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -1259,8 +1259,14 @@ func (a *App) wireHTTP(ctx context.Context) error {
 	if err := a.store.MigrateMapsDownloadSlugs(context.Background()); err != nil {
 		return fmt.Errorf("migrate maps_downloads slugs: %w", err)
 	}
+	if err := a.store.MigrateMapsDownloadBBox(context.Background()); err != nil {
+		return fmt.Errorf("migrate maps_downloads bbox column: %w", err)
+	}
 	if err := mapsCache.MigrateLegacyArchives(context.Background()); err != nil {
 		a.logger.Warn("legacy archive migration failed", "err", err)
+	}
+	if err := mapsCache.BackfillBBoxes(context.Background()); err != nil {
+		a.logger.Warn("bbox backfill failed", "err", err)
 	}
 
 	apiSrv, err := webapi.NewServer(webapi.Config{

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -1241,13 +1241,41 @@ func (a *App) wireHTTP(ctx context.Context) error {
 		time.Hour,
 		a.cfg.TileCacheDir,
 	)
-	// Best-effort warm; failures are non-fatal -- Get() will retry on
-	// the first request that needs the catalog.
+	// Warm the catalog in the background with exponential backoff,
+	// capped at 1 hour. Only emit a single state-change ERROR when we
+	// transition from healthy -> failing (and a single INFO when we
+	// recover); intermediate retries log at DEBUG so an offline Pi
+	// doesn't dominate the log buffer. The on-disk catalog.json keeps
+	// the picker functional while the warm-up retries.
 	go func() {
-		warmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if _, err := catalog.Refresh(warmCtx); err != nil {
-			a.logger.Warn("maps catalog warm-up failed", "err", err)
+		backoff := 30 * time.Second
+		const maxBackoff = time.Hour
+		healthy := true
+		for {
+			warmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			_, err := catalog.Refresh(warmCtx)
+			cancel()
+			if err == nil {
+				if !healthy {
+					a.logger.Info("maps catalog reachable again")
+				}
+				return
+			}
+			if healthy {
+				a.logger.Error("maps catalog warm-up failed; will retry quietly", "err", err)
+				healthy = false
+			} else {
+				a.logger.Debug("maps catalog retry failed", "err", err, "next_retry_in", backoff)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
 		}
 	}()
 

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -1235,10 +1235,11 @@ func (a *App) wireHTTP(ctx context.Context) error {
 	// path on every download request. Token comes from the same place
 	// mapsCache reads it (singleton MapsConfig) so re-registration
 	// rotates the bearer for catalog fetches too.
-	catalog := mapscatalog.New(
+	catalog := mapscatalog.NewWithDiskCache(
 		mapscache.DefaultMapsBaseURL,
 		mapsTokenProvider,
 		time.Hour,
+		a.cfg.TileCacheDir,
 	)
 	// Best-effort warm; failures are non-fatal -- Get() will retry on
 	// the first request that needs the catalog.

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -1258,6 +1258,7 @@ func (a *App) wireHTTP(ctx context.Context) error {
 			if err == nil {
 				if !healthy {
 					a.logger.Info("maps catalog reachable again")
+					healthy = true
 				}
 				return
 			}

--- a/pkg/configstore/migrate_downloads_bbox.go
+++ b/pkg/configstore/migrate_downloads_bbox.go
@@ -1,0 +1,14 @@
+package configstore
+
+import "context"
+
+// MigrateMapsDownloadBBox is a no-op shim. GORM's AutoMigrate (called
+// from Store.bootstrap) sees the new BBox field on MapsDownload and
+// adds the bbox TEXT column automatically; this helper exists so the
+// migration step is observable (callable from wiring.go) and so we
+// have a hook if we ever need to perform repair beyond AutoMigrate.
+// Idempotent: AutoMigrate is itself idempotent for column adds.
+func (s *Store) MigrateMapsDownloadBBox(ctx context.Context) error {
+	_ = ctx
+	return s.db.AutoMigrate(&MapsDownload{})
+}

--- a/pkg/configstore/migrate_downloads_bbox_test.go
+++ b/pkg/configstore/migrate_downloads_bbox_test.go
@@ -1,0 +1,56 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMigrateMapsDownloadBBox_AddsColumnAndIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	if err := store.MigrateMapsDownloadBBox(ctx); err != nil {
+		t.Fatalf("first migration: %v", err)
+	}
+	if err := store.MigrateMapsDownloadBBox(ctx); err != nil {
+		t.Fatalf("second migration: %v", err)
+	}
+
+	bbox := `[-109.05,36.99,-102.04,41.0]`
+	if err := store.UpsertMapsDownload(ctx, MapsDownload{
+		Slug: "state/colorado", Status: "complete", BBox: &bbox,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := store.GetMapsDownload(ctx, "state/colorado")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.BBox == nil || *got.BBox != bbox {
+		t.Fatalf("bbox: got %v want %q", got.BBox, bbox)
+	}
+}
+
+func TestMigrateMapsDownloadBBox_LegacyRowsRemainNull(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// Insert a pre-bbox row by going through Upsert without setting BBox.
+	if err := store.UpsertMapsDownload(ctx, MapsDownload{
+		Slug: "state/utah", Status: "complete",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := store.MigrateMapsDownloadBBox(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	got, err := store.GetMapsDownload(ctx, "state/utah")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.BBox != nil {
+		t.Fatalf("expected NULL bbox for legacy row, got %q", *got.BBox)
+	}
+}

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -523,8 +523,15 @@ type MapsDownload struct {
 	BytesDownloaded int64     `gorm:"not null;default:0" json:"bytes_downloaded"`
 	DownloadedAt    time.Time `json:"downloaded_at"`
 	ErrorMessage    string    `gorm:"not null;default:''" json:"error_message,omitempty"`
-	CreatedAt       time.Time `json:"-"`
-	UpdatedAt       time.Time `json:"-"`
+	// BBox is the catalog bbox snapshot captured at download-record
+	// creation time, JSON-encoded as "[west, south, east, north]".
+	// Nullable: legacy rows from pre-bbox installs hold NULL until the
+	// startup backfill reads the value from the pmtiles archive header.
+	// Render-path correctness depends on this column being populated
+	// for every completed download.
+	BBox      *string   `gorm:"column:bbox;type:text" json:"bbox,omitempty"`
+	CreatedAt time.Time `json:"-"`
+	UpdatedAt time.Time `json:"-"`
 }
 
 // GPSConfig is a singleton (id=1) row for the GPS receiver.

--- a/pkg/configstore/seed_downloads.go
+++ b/pkg/configstore/seed_downloads.go
@@ -74,6 +74,7 @@ func (s *Store) UpsertMapsDownload(ctx context.Context, d MapsDownload) error {
 		"bytes_downloaded": d.BytesDownloaded,
 		"downloaded_at":    d.DownloadedAt,
 		"error_message":    d.ErrorMessage,
+		"bbox":             d.BBox, // nil => NULL; *string => TEXT
 	}
 	if d.ID == 0 {
 		return db.Model(&MapsDownload{}).Create(cols).Error

--- a/pkg/configstore/seed_downloads.go
+++ b/pkg/configstore/seed_downloads.go
@@ -74,7 +74,14 @@ func (s *Store) UpsertMapsDownload(ctx context.Context, d MapsDownload) error {
 		"bytes_downloaded": d.BytesDownloaded,
 		"downloaded_at":    d.DownloadedAt,
 		"error_message":    d.ErrorMessage,
-		"bbox":             d.BBox, // nil => NULL; *string => TEXT
+	}
+	// bbox is "set if non-nil, leave untouched if nil." Status
+	// transitions (fail/complete) call Upsert without populating BBox;
+	// without this guard those upserts would wipe the bbox snapshot
+	// that Start put down, defeating the offline-render contract that
+	// every completed row holds a renderable bbox.
+	if d.BBox != nil {
+		cols["bbox"] = d.BBox
 	}
 	if d.ID == 0 {
 		return db.Model(&MapsDownload{}).Create(cols).Error

--- a/pkg/configstore/seed_downloads_test.go
+++ b/pkg/configstore/seed_downloads_test.go
@@ -78,3 +78,71 @@ func TestUpsertMapsDownload_SecondCallUpdatesNotInserts(t *testing.T) {
 		t.Fatalf("status not updated: %q", second.Status)
 	}
 }
+
+// TestUpsertMapsDownload_NilBBoxPreservesExisting locks in the
+// status-transition contract: once Start has snapshotted a bbox into
+// the row, subsequent upserts that don't populate BBox (m.fail, the
+// in-run "downloading" Content-Length update, and the final "complete"
+// transition) must NOT wipe the bbox column. A regression here means
+// every completed download serves a NULL bbox to /api/maps/local-bounds,
+// silently breaking offline render across reboots.
+func TestUpsertMapsDownload_NilBBoxPreservesExisting(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	bbox := `[-109.05,36.99,-102.04,41]`
+
+	if err := s.UpsertMapsDownload(ctx, MapsDownload{
+		Slug: "state/colorado", Status: "downloading", BBox: &bbox,
+	}); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+
+	// Transition without populating BBox -- this is what manager.fail()
+	// and the in-run "complete" path do.
+	if err := s.UpsertMapsDownload(ctx, MapsDownload{
+		Slug: "state/colorado", Status: "complete",
+	}); err != nil {
+		t.Fatalf("transition upsert: %v", err)
+	}
+
+	got, err := s.GetMapsDownload(ctx, "state/colorado")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != "complete" {
+		t.Fatalf("status: got %q want complete", got.Status)
+	}
+	if got.BBox == nil {
+		t.Fatalf("bbox was wiped by status transition")
+	}
+	if *got.BBox != bbox {
+		t.Fatalf("bbox: got %q want %q", *got.BBox, bbox)
+	}
+}
+
+// TestUpsertMapsDownload_NilBBoxOnFreshInsertStaysNull covers the
+// converse: a slug whose first-ever Upsert has no BBox (Start was
+// called with bbox=nil because the catalog had no bbox on that
+// region) lands with BBox=NULL and stays NULL across subsequent
+// transitions. The startup backfill is the only thing allowed to
+// populate it from there.
+func TestUpsertMapsDownload_NilBBoxOnFreshInsertStaysNull(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	if err := s.UpsertMapsDownload(ctx, MapsDownload{
+		Slug: "state/wyoming", Status: "downloading",
+	}); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+	if err := s.UpsertMapsDownload(ctx, MapsDownload{
+		Slug: "state/wyoming", Status: "complete",
+	}); err != nil {
+		t.Fatalf("transition upsert: %v", err)
+	}
+
+	got, _ := s.GetMapsDownload(ctx, "state/wyoming")
+	if got.BBox != nil {
+		t.Fatalf("expected NULL bbox throughout, got %q", *got.BBox)
+	}
+}

--- a/pkg/mapscache/manager.go
+++ b/pkg/mapscache/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -238,6 +239,43 @@ func encodeBBox(b [4]float64) string {
 		strconv.FormatFloat(b[2], 'f', -1, 64),
 		strconv.FormatFloat(b[3], 'f', -1, 64),
 	)
+}
+
+// BackfillBBoxes scans every completed maps_downloads row whose BBox
+// column is NULL and fills it in by reading the bbox from the
+// corresponding on-disk pmtiles archive header. Idempotent: rows that
+// already have a bbox are skipped without touching the filesystem.
+// Per-row failures (missing archive, malformed header) are logged at
+// WARN and don't abort the pass — the render path falls back to the
+// catalog for those slugs and a later re-download repopulates them.
+//
+// Called once at startup from pkg/app/wiring.go after
+// MigrateMapsDownloadSlugs. Cheap on warm installs (every row is
+// already populated); only does work on the first start after upgrade.
+func (m *Manager) BackfillBBoxes(ctx context.Context) error {
+	rows, err := m.store.ListMapsDownloads(ctx)
+	if err != nil {
+		return fmt.Errorf("list downloads: %w", err)
+	}
+	for _, r := range rows {
+		if r.Status != "complete" || r.BBox != nil {
+			continue
+		}
+		path := m.PathFor(r.Slug)
+		bbox, err := ReadArchiveBBox(path)
+		if err != nil {
+			slog.Warn("mapscache bbox backfill: skipping",
+				"slug", r.Slug, "path", path, "err", err)
+			continue
+		}
+		encoded := encodeBBox(bbox)
+		r.BBox = &encoded
+		if err := m.store.UpsertMapsDownload(ctx, r); err != nil {
+			slog.Warn("mapscache bbox backfill: upsert failed",
+				"slug", r.Slug, "err", err)
+		}
+	}
+	return nil
 }
 
 // Delete cancels any in-flight download for slug, removes the

--- a/pkg/mapscache/manager.go
+++ b/pkg/mapscache/manager.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -192,7 +193,13 @@ func (m *Manager) List(ctx context.Context) ([]Status, error) {
 // otherwise — re-downloads succeed by replacing the file atomically.
 // The caller does not block: this returns as soon as the goroutine
 // is spawned.
-func (m *Manager) Start(ctx context.Context, slug string) error {
+//
+// bbox is the catalog-supplied bbox snapshot in [west, south, east,
+// north] degrees, persisted into the maps_downloads row so the render
+// path can serve offline tiles without consulting the remote catalog
+// after a reboot. Pass nil only when no bbox is available; the startup
+// backfill will fill it in from the pmtiles header later.
+func (m *Manager) Start(ctx context.Context, slug string, bbox *[4]float64) error {
 	m.mu.Lock()
 	if _, busy := m.inflight[slug]; busy {
 		m.mu.Unlock()
@@ -206,13 +213,31 @@ func (m *Manager) Start(ctx context.Context, slug string) error {
 	// Persist a "downloading" row up front so a GET right after Start
 	// returns the right state even before the goroutine grabs the
 	// semaphore.
-	_ = m.store.UpsertMapsDownload(ctx, configstore.MapsDownload{
+	row := configstore.MapsDownload{
 		Slug:   slug,
 		Status: "downloading",
-	})
+	}
+	if bbox != nil {
+		encoded := encodeBBox(*bbox)
+		row.BBox = &encoded
+	}
+	_ = m.store.UpsertMapsDownload(ctx, row)
 
 	go m.run(dlCtx, a)
 	return nil
+}
+
+// encodeBBox writes [w,s,e,n] as the JSON array used on the wire and
+// in the maps_downloads.bbox column. We hand-format instead of going
+// through encoding/json so the result is deterministic (no insertion
+// of spaces, stable float formatting via 'g' verb with -1 precision).
+func encodeBBox(b [4]float64) string {
+	return fmt.Sprintf("[%s,%s,%s,%s]",
+		strconv.FormatFloat(b[0], 'f', -1, 64),
+		strconv.FormatFloat(b[1], 'f', -1, 64),
+		strconv.FormatFloat(b[2], 'f', -1, 64),
+		strconv.FormatFloat(b[3], 'f', -1, 64),
+	)
 }
 
 // Delete cancels any in-flight download for slug, removes the

--- a/pkg/mapscache/manager.go
+++ b/pkg/mapscache/manager.go
@@ -231,7 +231,8 @@ func (m *Manager) Start(ctx context.Context, slug string, bbox *[4]float64) erro
 // encodeBBox writes [w,s,e,n] as the JSON array used on the wire and
 // in the maps_downloads.bbox column. We hand-format instead of going
 // through encoding/json so the result is deterministic (no insertion
-// of spaces, stable float formatting via 'g' verb with -1 precision).
+// of spaces, stable float formatting via 'f' verb with -1 precision
+// — the shortest decimal representation that round-trips).
 func encodeBBox(b [4]float64) string {
 	return fmt.Sprintf("[%s,%s,%s,%s]",
 		strconv.FormatFloat(b[0], 'f', -1, 64),

--- a/pkg/mapscache/manager_test.go
+++ b/pkg/mapscache/manager_test.go
@@ -381,3 +381,77 @@ func TestStart_NilBBoxLeavesColumnNull(t *testing.T) {
 		t.Fatalf("expected NULL bbox, got %q", *row.BBox)
 	}
 }
+
+func TestBackfillBBoxes_FillsNullForCompletedRows(t *testing.T) {
+	ctx := context.Background()
+	mgr, store, _ := newTestManager(t, silentUpstream())
+
+	// Seed a completed row without a bbox and write a fake archive at
+	// the path the manager expects.
+	if err := store.UpsertMapsDownload(ctx, configstore.MapsDownload{
+		Slug: "state/colorado", Status: "complete",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	archive := mgr.PathFor("state/colorado")
+	if err := os.MkdirAll(filepath.Dir(archive), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	hdr := buildPMTilesV3Header(t, -109.05, 36.99, -102.04, 41.0)
+	if err := os.WriteFile(archive, hdr, 0o644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+
+	if err := mgr.BackfillBBoxes(ctx); err != nil {
+		t.Fatalf("BackfillBBoxes: %v", err)
+	}
+	row, _ := store.GetMapsDownload(ctx, "state/colorado")
+	if row.BBox == nil {
+		t.Fatalf("bbox still NULL after backfill")
+	}
+	want := `[-109.05,36.99,-102.04,41]`
+	if *row.BBox != want {
+		t.Fatalf("bbox: got %q want %q", *row.BBox, want)
+	}
+}
+
+func TestBackfillBBoxes_LeavesPopulatedRowsAlone(t *testing.T) {
+	ctx := context.Background()
+	mgr, store, _ := newTestManager(t, silentUpstream())
+
+	existing := `[1,2,3,4]`
+	if err := store.UpsertMapsDownload(ctx, configstore.MapsDownload{
+		Slug: "state/colorado", Status: "complete", BBox: &existing,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	// No archive on disk -- if backfill tried to read it, it would
+	// log a warning. The bbox value being unchanged proves the
+	// populated row was skipped without an archive read.
+	if err := mgr.BackfillBBoxes(ctx); err != nil {
+		t.Fatalf("BackfillBBoxes: %v", err)
+	}
+	row, _ := store.GetMapsDownload(ctx, "state/colorado")
+	if row.BBox == nil || *row.BBox != existing {
+		t.Fatalf("expected bbox %q preserved, got %v", existing, row.BBox)
+	}
+}
+
+func TestBackfillBBoxes_SkipsMissingArchives(t *testing.T) {
+	ctx := context.Background()
+	mgr, store, _ := newTestManager(t, silentUpstream())
+
+	if err := store.UpsertMapsDownload(ctx, configstore.MapsDownload{
+		Slug: "state/ghost", Status: "complete",
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	// No archive on disk. Backfill should log and continue, not error.
+	if err := mgr.BackfillBBoxes(ctx); err != nil {
+		t.Fatalf("BackfillBBoxes returned error on missing archive: %v", err)
+	}
+	row, _ := store.GetMapsDownload(ctx, "state/ghost")
+	if row.BBox != nil {
+		t.Fatalf("expected bbox to remain NULL for missing archive, got %q", *row.BBox)
+	}
+}

--- a/pkg/mapscache/manager_test.go
+++ b/pkg/mapscache/manager_test.go
@@ -54,7 +54,7 @@ func TestManager_HappyPath(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	if err := mgr.Start(context.Background(), "state/georgia"); err != nil {
+	if err := mgr.Start(context.Background(), "state/georgia", nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -97,10 +97,10 @@ func TestManager_AlreadyInflight(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	if err := mgr.Start(context.Background(), "state/texas"); err != nil {
+	if err := mgr.Start(context.Background(), "state/texas", nil); err != nil {
 		t.Fatal(err)
 	}
-	err := mgr.Start(context.Background(), "state/texas")
+	err := mgr.Start(context.Background(), "state/texas", nil)
 	if !errors.Is(err, ErrAlreadyInflight) {
 		t.Fatalf("expected ErrAlreadyInflight, got %v", err)
 	}
@@ -113,7 +113,7 @@ func TestManager_DeleteDuringActiveDownload(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	if err := mgr.Start(context.Background(), "state/ohio"); err != nil {
+	if err := mgr.Start(context.Background(), "state/ohio", nil); err != nil {
 		t.Fatal(err)
 	}
 	// Give the goroutine a moment to start the request
@@ -138,7 +138,7 @@ func TestManager_BadUpstreamStatus(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	if err := mgr.Start(context.Background(), "state/florida"); err != nil {
+	if err := mgr.Start(context.Background(), "state/florida", nil); err != nil {
 		t.Fatal(err)
 	}
 	deadline := time.Now().Add(2 * time.Second)
@@ -180,7 +180,7 @@ func TestManager_RetryAfterError(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	_ = mgr.Start(context.Background(), "state/ohio")
+	_ = mgr.Start(context.Background(), "state/ohio", nil)
 	// Wait for first attempt to fail
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -192,7 +192,7 @@ func TestManager_RetryAfterError(t *testing.T) {
 	}
 
 	// Second attempt
-	if err := mgr.Start(context.Background(), "state/ohio"); err != nil {
+	if err := mgr.Start(context.Background(), "state/ohio", nil); err != nil {
 		t.Fatal(err)
 	}
 	deadline = time.Now().Add(2 * time.Second)
@@ -334,5 +334,50 @@ func TestPathFor(t *testing.T) {
 		if got := m.PathFor(tc.slug); got != tc.want {
 			t.Errorf("PathFor(%q) = %q, want %q", tc.slug, got, tc.want)
 		}
+	}
+}
+
+// silentUpstream returns 500 so any download spawned by Start() fails
+// fast — bbox-persistence tests only need to observe the initial row
+// upsert, not a completed transfer.
+func silentUpstream() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusInternalServerError) }
+}
+
+func TestStart_SnapshotsBBoxIntoFirstRow(t *testing.T) {
+	ctx := context.Background()
+	mgr, store, _ := newTestManager(t, silentUpstream())
+
+	bbox := [4]float64{-109.05, 36.99, -102.04, 41.0}
+	if err := mgr.Start(ctx, "state/colorado", &bbox); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	row, err := store.GetMapsDownload(ctx, "state/colorado")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if row.BBox == nil {
+		t.Fatalf("expected bbox to be persisted, got NULL")
+	}
+	want := `[-109.05,36.99,-102.04,41]`
+	if *row.BBox != want {
+		t.Fatalf("bbox: got %q want %q", *row.BBox, want)
+	}
+}
+
+func TestStart_NilBBoxLeavesColumnNull(t *testing.T) {
+	ctx := context.Background()
+	mgr, store, _ := newTestManager(t, silentUpstream())
+
+	if err := mgr.Start(ctx, "state/wyoming", nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	row, err := store.GetMapsDownload(ctx, "state/wyoming")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if row.BBox != nil {
+		t.Fatalf("expected NULL bbox, got %q", *row.BBox)
 	}
 }

--- a/pkg/mapscache/pmtiles_header.go
+++ b/pkg/mapscache/pmtiles_header.go
@@ -1,0 +1,48 @@
+package mapscache
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// pmtilesV3HeaderLen is the fixed-length uncompressed header at the
+// start of every PMTiles v3 archive. See
+// https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md
+// for the byte layout. Only the bbox at offsets 102..117 is read here.
+const pmtilesV3HeaderLen = 127
+
+// ReadArchiveBBox opens a PMTiles v3 archive on disk and returns its
+// bbox in [west, south, east, north] degrees. Used by the startup
+// backfill to populate maps_downloads.bbox for rows that predate the
+// schema column. The header is not compressed; only the first 127
+// bytes are read.
+func ReadArchiveBBox(path string) ([4]float64, error) {
+	var zero [4]float64
+	f, err := os.Open(path)
+	if err != nil {
+		return zero, err
+	}
+	defer f.Close()
+
+	buf := make([]byte, pmtilesV3HeaderLen)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return zero, fmt.Errorf("read pmtiles header: %w", err)
+	}
+	if string(buf[0:7]) != "PMTiles" {
+		return zero, errors.New("not a pmtiles archive: bad magic")
+	}
+	if buf[7] != 3 {
+		return zero, fmt.Errorf("unsupported pmtiles version %d", buf[7])
+	}
+
+	// Bbox is stored as 4x int32 little-endian, each value scaled by 1e7.
+	minLon := float64(int32(binary.LittleEndian.Uint32(buf[102:106]))) / 1e7
+	minLat := float64(int32(binary.LittleEndian.Uint32(buf[106:110]))) / 1e7
+	maxLon := float64(int32(binary.LittleEndian.Uint32(buf[110:114]))) / 1e7
+	maxLat := float64(int32(binary.LittleEndian.Uint32(buf[114:118]))) / 1e7
+
+	return [4]float64{minLon, minLat, maxLon, maxLat}, nil
+}

--- a/pkg/mapscache/pmtiles_header_test.go
+++ b/pkg/mapscache/pmtiles_header_test.go
@@ -1,0 +1,82 @@
+package mapscache
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildPMTilesV3Header constructs a synthetic 127-byte PMTiles v3
+// header with the supplied bbox (in degrees). Returns the byte slice.
+func buildPMTilesV3Header(t *testing.T, w, s, e, n float64) []byte {
+	t.Helper()
+	buf := make([]byte, 127)
+	copy(buf[0:7], []byte("PMTiles"))
+	buf[7] = 3 // version
+	// 8..96 are directory/metadata offsets+lengths; zero is fine for
+	// header-parsing tests. clustered/compression/tile_type/zooms at
+	// 96..101 are also fine as zero.
+	binary.LittleEndian.PutUint32(buf[102:106], uint32(int32(w*1e7)))
+	binary.LittleEndian.PutUint32(buf[106:110], uint32(int32(s*1e7)))
+	binary.LittleEndian.PutUint32(buf[110:114], uint32(int32(e*1e7)))
+	binary.LittleEndian.PutUint32(buf[114:118], uint32(int32(n*1e7)))
+	return buf
+}
+
+func TestReadArchiveBBox_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "colorado.pmtiles")
+	hdr := buildPMTilesV3Header(t, -109.05, 36.99, -102.04, 41.0)
+	if err := os.WriteFile(path, hdr, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	bbox, err := ReadArchiveBBox(path)
+	if err != nil {
+		t.Fatalf("ReadArchiveBBox: %v", err)
+	}
+	want := [4]float64{-109.05, 36.99, -102.04, 41.0}
+	for i := range want {
+		if diff := bbox[i] - want[i]; diff > 1e-6 || diff < -1e-6 {
+			t.Fatalf("bbox[%d]: got %v want %v", i, bbox[i], want[i])
+		}
+	}
+}
+
+func TestReadArchiveBBox_RejectsBadMagic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.pmtiles")
+	bad := make([]byte, 127)
+	copy(bad, []byte("NOTPMTILES"))
+	if err := os.WriteFile(path, bad, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := ReadArchiveBBox(path); err == nil {
+		t.Fatalf("expected magic-mismatch error, got nil")
+	}
+}
+
+func TestReadArchiveBBox_RejectsShortFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "short.pmtiles")
+	if err := os.WriteFile(path, []byte("PMTiles\x03"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := ReadArchiveBBox(path); err == nil {
+		t.Fatalf("expected short-file error, got nil")
+	}
+}
+
+func TestReadArchiveBBox_RejectsWrongVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "v2.pmtiles")
+	hdr := buildPMTilesV3Header(t, 0, 0, 1, 1)
+	hdr[7] = 2 // wrong version
+	if err := os.WriteFile(path, hdr, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := ReadArchiveBBox(path); err == nil {
+		t.Fatalf("expected version-mismatch error, got nil")
+	}
+}

--- a/pkg/mapscatalog/catalog.go
+++ b/pkg/mapscatalog/catalog.go
@@ -163,17 +163,20 @@ func NewWithDiskCache(baseURL string, tokenProvider func(context.Context) string
 // loadFromDisk seeds c.cached from <diskCacheDir>/catalog.json when
 // present. Failures are silent — disk persistence is best-effort, and
 // a missing or corrupt file falls back to fetching from the network.
-// fetchedAt is set from the file mtime so the cached entry is
-// treated as expired and the first Get() triggers a refresh.
+//
+// fetchedAt is left at the zero value (not the file mtime) so the
+// disk-seeded entry is always considered expired: the first Get()
+// triggers a network refresh, and only if that refresh fails does
+// the stale-on-error branch fall back to the on-disk copy. Using the
+// file mtime would let a reboot inside the TTL window serve disk
+// content as "fresh" and skip the warm-up entirely — defeating the
+// point of disk persistence (a lifeline for offline operation, not a
+// shortcut around the TTL).
 func (c *Cache) loadFromDisk() {
 	if c.diskCacheDir == "" {
 		return
 	}
 	path := filepath.Join(c.diskCacheDir, "catalog.json")
-	info, err := os.Stat(path)
-	if err != nil {
-		return
-	}
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return
@@ -187,7 +190,7 @@ func (c *Cache) loadFromDisk() {
 	}
 	out.indexSlugs()
 	c.cached = &out
-	c.fetchedAt = info.ModTime()
+	// fetchedAt stays at time.Time{} — see comment above.
 }
 
 // saveToDisk writes c.cached atomically to <diskCacheDir>/catalog.json.

--- a/pkg/mapscatalog/catalog.go
+++ b/pkg/mapscatalog/catalog.go
@@ -14,6 +14,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -111,6 +113,11 @@ type Cache struct {
 	ttl           time.Duration
 	httpClient    *http.Client
 
+	// diskCacheDir is the directory holding the on-disk catalog.json
+	// stale fallback. Empty string disables disk persistence (existing
+	// callers that haven't migrated to NewWithDiskCache).
+	diskCacheDir string
+
 	mu        sync.Mutex
 	cached    *Catalog
 	fetchedAt time.Time
@@ -124,13 +131,98 @@ type Cache struct {
 // New constructs a Cache. baseURL is the maps host root (e.g.
 // https://maps.nw5w.com). tokenProvider returns the current bearer
 // token (may be empty for public testing). ttl is the cache lifetime;
-// 0 means always refresh.
+// 0 means always refresh. Equivalent to NewWithDiskCache with no
+// disk cache directory.
 func New(baseURL string, tokenProvider func(context.Context) string, ttl time.Duration) *Cache {
-	return &Cache{
+	return NewWithDiskCache(baseURL, tokenProvider, ttl, "")
+}
+
+// NewWithDiskCache constructs a Cache that also writes every
+// successful manifest fetch to <diskCacheDir>/catalog.json and seeds
+// the in-memory cache from that file on construction. The seeded
+// entry is treated as already-stale (fetchedAt = mtime), so the next
+// Get triggers a refresh; if the refresh fails the on-disk copy is
+// served via the existing stale-on-error path. This lets the region
+// picker show the last known catalog on an offline host instead of
+// erroring.
+//
+// The render path does NOT depend on this disk cache --
+// /api/maps/local-bounds is the offline-safe render-bounds source.
+func NewWithDiskCache(baseURL string, tokenProvider func(context.Context) string, ttl time.Duration, diskCacheDir string) *Cache {
+	c := &Cache{
 		baseURL:       baseURL,
 		tokenProvider: tokenProvider,
 		ttl:           ttl,
 		httpClient:    &http.Client{Timeout: 30 * time.Second},
+		diskCacheDir:  diskCacheDir,
+	}
+	c.loadFromDisk()
+	return c
+}
+
+// loadFromDisk seeds c.cached from <diskCacheDir>/catalog.json when
+// present. Failures are silent — disk persistence is best-effort, and
+// a missing or corrupt file falls back to fetching from the network.
+// fetchedAt is set from the file mtime so the cached entry is
+// treated as expired and the first Get() triggers a refresh.
+func (c *Cache) loadFromDisk() {
+	if c.diskCacheDir == "" {
+		return
+	}
+	path := filepath.Join(c.diskCacheDir, "catalog.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var out Catalog
+	if err := json.Unmarshal(b, &out); err != nil {
+		return
+	}
+	if out.SchemaVersion != 1 {
+		return
+	}
+	out.indexSlugs()
+	c.cached = &out
+	c.fetchedAt = info.ModTime()
+}
+
+// saveToDisk writes c.cached atomically to <diskCacheDir>/catalog.json.
+// Best-effort — failures (no diskCacheDir, transient I/O error) are
+// logged at WARN and do not affect the in-memory cache or the caller.
+func (c *Cache) saveToDisk(cat Catalog) {
+	if c.diskCacheDir == "" {
+		return
+	}
+	if err := os.MkdirAll(c.diskCacheDir, 0o755); err != nil {
+		slog.Warn("mapscatalog: mkdir disk cache failed", "err", err)
+		return
+	}
+	path := filepath.Join(c.diskCacheDir, "catalog.json")
+	tmp, err := os.CreateTemp(c.diskCacheDir, "catalog.json.*.tmp")
+	if err != nil {
+		slog.Warn("mapscatalog: tempfile failed", "err", err)
+		return
+	}
+	tmpName := tmp.Name()
+	enc := json.NewEncoder(tmp)
+	if err := enc.Encode(cat); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		slog.Warn("mapscatalog: encode disk cache failed", "err", err)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		slog.Warn("mapscatalog: close disk cache failed", "err", err)
+		return
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		slog.Warn("mapscatalog: rename disk cache failed", "err", err)
 	}
 }
 
@@ -235,5 +327,6 @@ func (c *Cache) fetch(ctx context.Context) (Catalog, error) {
 		return Catalog{}, errors.New("unsupported manifest schemaVersion")
 	}
 	out.indexSlugs()
+	c.saveToDisk(out)
 	return out, nil
 }

--- a/pkg/mapscatalog/catalog_test.go
+++ b/pkg/mapscatalog/catalog_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -127,5 +130,61 @@ func TestGet_AppendsToken(t *testing.T) {
 	q, _ := seenQuery.Load().(string)
 	if q != "t=abc123" {
 		t.Fatalf("expected t=abc123, got %q", q)
+	}
+}
+
+func TestNew_LoadsDiskCacheWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	contents := `{"schemaVersion":1,"generatedAt":"2026-05-01","countries":[],"provinces":[],"states":[{"slug":"colorado","name":"Colorado","sizeBytes":100,"sha256":"x","bbox":[-109,37,-102,41]}]}`
+	if err := os.WriteFile(filepath.Join(dir, "catalog.json"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	// Upstream that returns 500 -- forces stale-on-error path.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	c := NewWithDiskCache(upstream.URL, func(context.Context) string { return "" }, time.Hour, dir)
+	got, err := c.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.States) != 1 || got.States[0].Slug != "colorado" {
+		t.Fatalf("expected colorado from disk cache, got %+v", got.States)
+	}
+}
+
+func TestFetch_WritesDiskCacheOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"schemaVersion":1,"generatedAt":"x","countries":[],"provinces":[],"states":[{"slug":"utah","name":"Utah","sizeBytes":1,"sha256":"x"}]}`))
+	}))
+	defer upstream.Close()
+
+	c := NewWithDiskCache(upstream.URL, func(context.Context) string { return "" }, time.Hour, dir)
+	if _, err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(dir, "catalog.json"))
+	if err != nil {
+		t.Fatalf("read disk cache: %v", err)
+	}
+	if !strings.Contains(string(b), `"utah"`) {
+		t.Fatalf("disk cache missing utah: %s", string(b))
+	}
+}
+
+func TestNew_NoDiskCacheStillFunctions(t *testing.T) {
+	// Existing call site behavior: New() with no disk cache still works.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"schemaVersion":1,"generatedAt":"x","countries":[],"provinces":[],"states":[]}`))
+	}))
+	defer upstream.Close()
+	c := New(upstream.URL, func(context.Context) string { return "" }, time.Hour)
+	if _, err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
 	}
 }

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -3923,6 +3923,37 @@
                 }
             }
         },
+        "/maps/local-bounds": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "maps"
+                ],
+                "summary": "Get the bbox of every completed offline map",
+                "operationId": "getMapsLocalBounds",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.LocalBounds"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/messages": {
             "get": {
                 "security": [
@@ -9118,6 +9149,15 @@
                 },
                 "type": {
                     "type": "string"
+                }
+            }
+        },
+        "dto.LocalBounds": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "number"
                 }
             }
         },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -1460,6 +1460,12 @@ definitions:
       type:
         type: string
     type: object
+  dto.LocalBounds:
+    additionalProperties:
+      items:
+        type: number
+      type: array
+    type: object
   dto.MapsConfigRequest:
     properties:
       source:
@@ -5321,6 +5327,25 @@ paths:
       security:
         - CookieAuth: []
       summary: Start an offline download
+      tags:
+        - maps
+  /maps/local-bounds:
+    get:
+      operationId: getMapsLocalBounds
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.LocalBounds'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Get the bbox of every completed offline map
       tags:
         - maps
   /messages:

--- a/pkg/webapi/docs/op_ids.go
+++ b/pkg/webapi/docs/op_ids.go
@@ -362,6 +362,7 @@ const (
 	OpStartMapsDownload     = "startMapsDownload"
 	OpDeleteMapsDownload    = "deleteMapsDownload"
 	OpGetMapsCatalog        = "getMapsCatalog"
+	OpGetMapsLocalBounds    = "getMapsLocalBounds"
 )
 
 // Actions resource — /api/actions and friends. Remote command system

--- a/pkg/webapi/downloads.go
+++ b/pkg/webapi/downloads.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/chrissnell/graywolf/pkg/mapscache"
+	"github.com/chrissnell/graywolf/pkg/mapscatalog"
 	"github.com/chrissnell/graywolf/pkg/webapi/dto"
 )
 
@@ -167,11 +168,25 @@ func (s *Server) startDownload(w http.ResponseWriter, r *http.Request) {
 		serviceUnavailable(w, "maps cache not initialized")
 		return
 	}
-	slug, ok := s.resolveSlug(w, r)
+	slug, ok := s.validSlugGrammar(w, r)
 	if !ok {
 		return
 	}
-	if err := s.mapsCache.Start(r.Context(), slug); err != nil {
+	if s.catalog == nil {
+		serviceUnavailable(w, "maps catalog not initialized")
+		return
+	}
+	cat, err := s.catalog.Get(r.Context())
+	if err != nil {
+		s.internalError(w, r, "catalog lookup", err)
+		return
+	}
+	bbox, found := lookupCatalogBBox(cat, slug)
+	if !found {
+		badRequest(w, "unknown slug")
+		return
+	}
+	if err := s.mapsCache.Start(r.Context(), slug, bbox); err != nil {
 		if errors.Is(err, mapscache.ErrAlreadyInflight) {
 			writeJSON(w, http.StatusConflict, map[string]string{
 				"error":   "already_inflight",
@@ -188,6 +203,39 @@ func (s *Server) startDownload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusAccepted, toDTO(st))
+}
+
+// lookupCatalogBBox returns the bbox for a namespaced slug in the
+// catalog, or (nil, false) if the slug names no published archive.
+// The boolean covers both "slug not in catalog" (caller returns 400)
+// and "slug in catalog but bbox missing" (caller still starts the
+// download; render-path bounds come from the backfill).
+func lookupCatalogBBox(c mapscatalog.Catalog, slug string) (*[4]float64, bool) {
+	kind, a, b, ok := parseSlug(slug)
+	if !ok {
+		return nil, false
+	}
+	switch kind {
+	case "state":
+		for _, st := range c.States {
+			if st.Slug == a {
+				return st.BBox, true
+			}
+		}
+	case "country":
+		for _, x := range c.Countries {
+			if x.ISO2 == a {
+				return x.BBox, true
+			}
+		}
+	case "province":
+		for _, p := range c.Provinces {
+			if p.ISO2 == a && p.Slug == b {
+				return p.BBox, true
+			}
+		}
+	}
+	return nil, false
 }
 
 // @Summary  Delete an offline download

--- a/pkg/webapi/downloads_test.go
+++ b/pkg/webapi/downloads_test.go
@@ -275,7 +275,7 @@ func TestDeleteMapsDownload_Idempotent(t *testing.T) {
 
 	// Drive a download to completion so DELETE has both a row and a
 	// file to remove.
-	if err := mgr.Start(context.Background(), "state/ohio"); err != nil {
+	if err := mgr.Start(context.Background(), "state/ohio", nil); err != nil {
 		t.Fatal(err)
 	}
 	if !waitFor(t, 3*time.Second, func() bool {
@@ -544,5 +544,63 @@ func TestStartMapsDownload_NotInCatalog(t *testing.T) {
 	}
 	if !strings.Contains(body["error"], "unknown slug") {
 		t.Errorf("expected 'unknown slug', got %q", body["error"])
+	}
+}
+
+// TestStartDownload_PersistsBBoxFromCatalog wires a catalog stub whose
+// state row carries an explicit bbox. After POST /api/maps/downloads,
+// the maps_downloads row must hold the bbox snapshot encoded as the
+// canonical "[w,s,e,n]" string. Guards the offline-render durability
+// contract: render bounds come from this snapshot, not the live
+// catalog after the next boot.
+func TestStartDownload_PersistsBBoxFromCatalog(t *testing.T) {
+	// Catalog stub returning one state with a bbox.
+	bboxRef := [4]float64{-109.05, 36.99, -102.04, 41.0}
+	catalogSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(mapscatalog.Catalog{
+			SchemaVersion: 1,
+			GeneratedAt:   "now",
+			States: []mapscatalog.State{
+				{Slug: "colorado", Name: "Colorado", SizeBytes: 100, SHA256: "x", BBox: &bboxRef},
+			},
+		})
+	}))
+	t.Cleanup(catalogSrv.Close)
+
+	// Tile upstream — returns a tiny complete body. The bbox row is
+	// upserted synchronously in Start() before the download goroutine
+	// runs, so the test only needs to observe the row, not block the
+	// download.
+	tileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("pmtiles-bytes"))
+	}))
+	t.Cleanup(tileSrv.Close)
+
+	srv, _ := newTestServer(t)
+	cacheDir := t.TempDir()
+	mgr := mapscache.New(cacheDir, srv.store, func(context.Context) string { return "" }, tileSrv.URL, 1)
+	srv.mapsCache = mgr
+	srv.catalog = mapscatalog.New(catalogSrv.URL, func(context.Context) string { return "" }, time.Hour)
+	mux := newDownloadsMux(srv)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/maps/downloads/state/colorado", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d want 202; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Allow the goroutine to finish persisting the bbox.
+	want := `[-109.05,36.99,-102.04,41]`
+	if !waitFor(t, 2*time.Second, func() bool {
+		row, _ := srv.store.GetMapsDownload(context.Background(), "state/colorado")
+		return row.BBox != nil && *row.BBox == want
+	}) {
+		row, _ := srv.store.GetMapsDownload(context.Background(), "state/colorado")
+		var got string
+		if row.BBox != nil {
+			got = *row.BBox
+		}
+		t.Fatalf("bbox never reached %q (last seen: %q)", want, got)
 	}
 }

--- a/pkg/webapi/dto/local_bounds.go
+++ b/pkg/webapi/dto/local_bounds.go
@@ -1,0 +1,7 @@
+package dto
+
+// LocalBounds is the wire shape for GET /api/maps/local-bounds.
+// Keyed by namespaced slug ("state/colorado", "country/de",
+// "province/ca/british-columbia"); value is [west, south, east, north]
+// in degrees. Empty map (not 503) when no downloads are complete.
+type LocalBounds map[string][4]float64

--- a/pkg/webapi/local_bounds.go
+++ b/pkg/webapi/local_bounds.go
@@ -1,0 +1,52 @@
+package webapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+func (s *Server) registerLocalBounds(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/maps/local-bounds", s.getLocalBounds)
+}
+
+// @Summary  Get the bbox of every completed offline map
+// @Tags     maps
+// @ID       getMapsLocalBounds
+// @Produce  json
+// @Success  200 {object} dto.LocalBounds
+// @Failure  500 {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /maps/local-bounds [get]
+//
+// getLocalBounds is the render-path bounds source. It deliberately
+// does NOT consult the remote catalog: a completed download's bbox is
+// snapshotted into maps_downloads at download time and (for legacy
+// rows) backfilled from the on-disk pmtiles header at startup. This
+// is what lets the offline map render on a host that has never
+// reached maps.nw5w.com in this boot session.
+func (s *Server) getLocalBounds(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.store.ListMapsDownloads(r.Context())
+	if err != nil {
+		s.internalError(w, r, "list downloads", err)
+		return
+	}
+	out := dto.LocalBounds{}
+	for _, row := range rows {
+		if row.Status != "complete" || row.BBox == nil {
+			continue
+		}
+		var bbox [4]float64
+		if err := json.Unmarshal([]byte(*row.BBox), &bbox); err != nil {
+			// Malformed bbox shouldn't kill the response; skip the
+			// row and log. The render path falls back to the network
+			// for this slug until a re-download or restart heals it.
+			s.logger.Warn("local-bounds: skipping malformed bbox",
+				"slug", row.Slug, "raw", *row.BBox, "err", err)
+			continue
+		}
+		out[row.Slug] = bbox
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/pkg/webapi/local_bounds_test.go
+++ b/pkg/webapi/local_bounds_test.go
@@ -1,0 +1,75 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/configstore"
+)
+
+func TestLocalBounds_ReturnsCompletedSlugs(t *testing.T) {
+	ctx := context.Background()
+	srv, _ := newTestServer(t)
+	store := srv.store
+
+	bboxCO := `[-109.05,36.99,-102.04,41]`
+	if err := store.UpsertMapsDownload(ctx, configstore.MapsDownload{
+		Slug: "state/colorado", Status: "complete", BBox: &bboxCO,
+	}); err != nil {
+		t.Fatalf("upsert co: %v", err)
+	}
+	// In-progress row — excluded.
+	if err := store.UpsertMapsDownload(ctx, configstore.MapsDownload{
+		Slug: "state/utah", Status: "downloading",
+	}); err != nil {
+		t.Fatalf("upsert ut: %v", err)
+	}
+	// Complete-but-null-bbox row — excluded (legacy row whose backfill
+	// hasn't run yet).
+	if err := store.UpsertMapsDownload(ctx, configstore.MapsDownload{
+		Slug: "state/wyoming", Status: "complete",
+	}); err != nil {
+		t.Fatalf("upsert wy: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	req := httptest.NewRequest(http.MethodGet, "/api/maps/local-bounds", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got map[string][4]float64
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len: got %d want 1; payload=%v", len(got), got)
+	}
+	want := [4]float64{-109.05, 36.99, -102.04, 41}
+	if got["state/colorado"] != want {
+		t.Fatalf("bbox: got %v want %v", got["state/colorado"], want)
+	}
+}
+
+func TestLocalBounds_EmptyDatabaseReturnsEmptyMap(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	req := httptest.NewRequest(http.MethodGet, "/api/maps/local-bounds", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rec.Code)
+	}
+	body := strings.TrimSpace(rec.Body.String())
+	if body != "{}" {
+		t.Fatalf("body: got %q want \"{}\"", body)
+	}
+}

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -289,6 +289,7 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	s.registerMaps(mux)
 	s.registerCatalog(mux)
 	s.registerDownloads(mux)
+	s.registerLocalBounds(mux)
 	s.registerActions(mux)
 	s.registerOTPCredentials(mux)
 	s.registerActionListeners(mux)

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -913,6 +913,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/maps/local-bounds": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the bbox of every completed offline map */
+        get: operations["getMapsLocalBounds"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/messages": {
         parameters: {
             query?: never;
@@ -2555,6 +2572,9 @@ export interface components {
             tnc_ingress_burst?: number;
             tnc_ingress_rate_hz?: number;
             type?: string;
+        };
+        "dto.LocalBounds": {
+            [key: string]: number[];
         };
         "dto.MapsConfigRequest": {
             source?: string;
@@ -6890,6 +6910,35 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getMapsLocalBounds: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.LocalBounds"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
                 };
             };
         };

--- a/web/src/lib/map/maplibre-map.svelte
+++ b/web/src/lib/map/maplibre-map.svelte
@@ -14,6 +14,7 @@
   import { osmRasterStyle } from './sources/osm-raster.js';
   import { downloadsState } from '../maps/downloads-store.svelte.js';
   import { catalogStore } from '../maps/catalog-store.svelte.js';
+  import { localBoundsStore } from '../maps/local-bounds-store.svelte.js';
   import { createFederatedProtocol } from './sources/gw-federated-protocol.js';
 
   let { initialCenter = [-98, 39], initialZoom = 4, oncreate = null } = $props();
@@ -47,7 +48,7 @@
     if (gwTileRegistered) return;
     const federated = createFederatedProtocol({
       completedSlugsProvider: () => downloadsState.completed,
-      boundsBySlugProvider: () => catalogStore.boundsBySlug,
+      boundsBySlugProvider: () => localBoundsStore.boundsBySlug,
       fetchOnline: async (z, x, y, signal) => {
         const base = `https://maps.nw5w.com/${z}/${x}/${y}.mvt`;
         const url = bearerToken
@@ -175,7 +176,8 @@
   }
 
   onMount(async () => {
-    catalogStore.load(); // fire-and-forget; bounds become available when ready
+    catalogStore.load(); // fire-and-forget; picker uses these
+    localBoundsStore.load(); // fire-and-forget; render path uses these
     ensureGwTileProtocol();
     // Hydrate mapsState + downloadsState before the first style build
     // so the first paint reflects the persisted source choice and any

--- a/web/src/lib/maps/catalog-store.svelte.js
+++ b/web/src/lib/maps/catalog-store.svelte.js
@@ -24,7 +24,7 @@ export const catalogStore = (() => {
       try {
         const res = await fetch('/api/maps/catalog', { credentials: 'same-origin' });
         if (!res.ok) {
-          const msg = `catalog fetch failed (${res.status})`;
+          const msg = 'Cannot reach maps server -- downloads list may be out of date';
           error = msg;
           toasts.error(msg);
           return null;
@@ -37,8 +37,8 @@ export const catalogStore = (() => {
         }
         catalog = json;
         return json;
-      } catch (e) {
-        error = e.message ?? 'catalog network error';
+      } catch {
+        error = 'Cannot reach maps server -- downloads list may be out of date';
         toasts.error(error);
         return null;
       } finally {

--- a/web/src/lib/maps/downloads-store.svelte.js
+++ b/web/src/lib/maps/downloads-store.svelte.js
@@ -7,10 +7,15 @@
 // through unchanged.
 
 import { toasts } from '../stores.js';
+import { localBoundsStore } from './local-bounds-store.svelte.js';
 
 export const downloadsState = (() => {
   let items = $state(new Map()); // slug -> {state, bytes_total, bytes_downloaded, downloaded_at, error_message}
   let pollHandle = null;
+  // Tracks the previous count of completed rows so a transition
+  // into 'complete' triggers a single local-bounds refresh -- the
+  // new region must be renderable without a page reload.
+  let prevCompletedSize = 0;
 
   async function refresh() {
     try {
@@ -21,6 +26,11 @@ export const downloadsState = (() => {
       const next = new Map();
       for (const r of arr) next.set(r.slug, r);
       items = next;
+      const completedNow = [...next.values()].filter((v) => v.state === 'complete').length;
+      if (completedNow !== prevCompletedSize) {
+        prevCompletedSize = completedNow;
+        localBoundsStore.refresh();
+      }
     } catch {
       // Silent -- toasts on user-initiated actions, not background polls.
     }

--- a/web/src/lib/maps/local-bounds-store.svelte.js
+++ b/web/src/lib/maps/local-bounds-store.svelte.js
@@ -1,0 +1,59 @@
+// Reactive store for the render-path bounds of every completed offline
+// download. Fetched once per session from /api/maps/local-bounds.
+//
+// Unlike catalog-store.svelte.js, this store has zero remote
+// dependencies on the backend side -- the endpoint reads from the
+// local sqlite maps_downloads table. That's the whole point: the
+// federated tile protocol uses this store so that a host with no
+// network can still render the regions it has on disk.
+//
+// boundsBySlug returns Map<namespacedSlug, [west, south, east, north]>
+// which matches the shape gw-federated-protocol expects.
+
+export const localBoundsStore = (() => {
+  let raw = $state(null); // { [slug]: [w, s, e, n] } | null
+  let inflight = null;
+
+  async function load() {
+    if (raw) return raw;
+    if (inflight) return inflight;
+    inflight = (async () => {
+      try {
+        const res = await fetch('/api/maps/local-bounds', { credentials: 'same-origin' });
+        if (!res.ok) {
+          raw = {};
+          return raw;
+        }
+        const json = await res.json();
+        raw = json && typeof json === 'object' ? json : {};
+        return raw;
+      } catch {
+        raw = {};
+        return raw;
+      } finally {
+        inflight = null;
+      }
+    })();
+    return inflight;
+  }
+
+  // refresh forces a fresh fetch (e.g. after a download completes so
+  // the new region's bounds show up without a page reload).
+  async function refresh() {
+    raw = null;
+    return load();
+  }
+
+  return {
+    load,
+    refresh,
+    get boundsBySlug() {
+      const out = new Map();
+      if (!raw) return out;
+      for (const [slug, bbox] of Object.entries(raw)) {
+        if (Array.isArray(bbox) && bbox.length === 4) out.set(slug, bbox);
+      }
+      return out;
+    },
+  };
+})();

--- a/web/src/routes/MapsSettings.svelte
+++ b/web/src/routes/MapsSettings.svelte
@@ -261,8 +261,13 @@
         {@const cat = catalogStore.catalog}
         {@const total = cat ? cat.countries.length + cat.provinces.length + cat.states.length : 0}
         <p class="source-offline-hint">
-          Using offline tiles for {downloadsState.completed.size}
-          of {total} region{total === 1 ? '' : 's'}.
+          {#if total > 0}
+            Using offline tiles for {downloadsState.completed.size}
+            of {total} region{total === 1 ? '' : 's'}.
+          {:else}
+            Using offline tiles for {downloadsState.completed.size}
+            region{downloadsState.completed.size === 1 ? '' : 's'}.
+          {/if}
           Areas without offline coverage fall back to online.
         </p>
       {/if}

--- a/web/src/routes/MapsSettings.svelte
+++ b/web/src/routes/MapsSettings.svelte
@@ -5,6 +5,7 @@
   import { validateCallsign } from '../lib/maps/callsign.js';
   import { downloadsState } from '../lib/maps/downloads-store.svelte.js';
   import { catalogStore } from '../lib/maps/catalog-store.svelte.js';
+  import { localBoundsStore } from '../lib/maps/local-bounds-store.svelte.js';
   import { formatBytes } from '../lib/maps/format-bytes.js';
   import RegionPicker from '../lib/maps/region-picker.svelte';
   import PageHeader from '../components/PageHeader.svelte';
@@ -22,6 +23,7 @@
   onMount(() => {
     mapsState.fetchConfig();
     catalogStore.load();
+    localBoundsStore.load();
     downloadsState.refresh().then(() => {
       if (
         [...downloadsState.items.values()].some(


### PR DESCRIPTION
## Summary

- A downloaded region used to stop rendering on a reboot if `maps.nw5w.com` was unreachable, because the render path looked up each tile's bbox from the live catalog. This branch severs that dependency: the bbox is snapshotted into `maps_downloads.bbox` at download time (and backfilled from the on-disk PMTiles header for legacy rows at startup), then served from a new `GET /api/maps/local-bounds` endpoint with zero remote deps. The MapLibre `gw-tile://` protocol now reads bounds from there instead of the catalog.
- The catalog still drives the region picker, but it now persists to `<TileCacheDir>/catalog.json` so the picker degrades gracefully when offline. Warm-up retries use exponential backoff (capped at 1h) with state-change-only logging instead of one WARN per startup.
- Picker UI hides "of N regions" when the catalog is null and softens the fetch-failure toast.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `cd web && npm test` — 232/232 pass
- [x] `cd web && npm run build` — clean
- [x] `make docs-check api-client-check` — generated swagger + TS client committed and verified
- [ ] Scenario A: download two states online, take the host offline, reboot — confirm both render
- [ ] Scenario B: pre-bbox install (NULL bbox + on-disk archive) — confirm startup backfill populates `/api/maps/local-bounds`
- [ ] Scenario C: catalog endpoint with on-disk fallback only — confirm 200 with last-known catalog
- [ ] Scenario E: 30 min offline — confirm at most one ERROR + DEBUG retries (no WARN spam)