### PR TITLE
fix(map): prune stale markers on viewport change; trim trails by timerange

### DIFF
--- a/pkg/webapi/stations.go
+++ b/pkg/webapi/stations.go
@@ -220,10 +220,15 @@ func listStations(cache StationCache) http.HandlerFunc {
 			digiPositions = cache.Lookup(digiCallsigns)
 		}
 
-		// Build DTOs
+		// Build DTOs. The trail-cutoff trims each station's Positions
+		// slice to entries within the timerange window so trail dots
+		// don't stretch back days for a currently-active station.
+		// Delta mode emits only positions[0] anyway, so the cutoff is
+		// only consulted on full reloads.
+		trailCutoff := time.Now().Add(-timerange)
 		out := make([]StationDTO, len(stations))
 		for i, s := range stations {
-			out[i] = stationToDTO(s, isDelta, includeWeather, digiPositions)
+			out[i] = stationToDTO(s, isDelta, includeWeather, digiPositions, trailCutoff)
 		}
 
 		// Sort newest-first
@@ -288,7 +293,7 @@ func collectDigiCallsigns(stations []stationcache.Station) []string {
 	return out
 }
 
-func stationToDTO(s stationcache.Station, isDelta, includeWeather bool, digiPos map[string]stationcache.LatLon) StationDTO {
+func stationToDTO(s stationcache.Station, isDelta, includeWeather bool, digiPos map[string]stationcache.LatLon, trailCutoff time.Time) StationDTO {
 	dto := StationDTO{
 		Callsign:      s.Callsign,
 		IsObject:      s.IsObject,
@@ -308,9 +313,18 @@ func stationToDTO(s stationcache.Station, isDelta, includeWeather bool, digiPos 
 	if isDelta && len(s.Positions) > 0 {
 		dto.Positions = []StationPosDTO{positionToDTO(s.Positions[0], digiPos)}
 	} else {
-		dto.Positions = make([]StationPosDTO, len(s.Positions))
+		// Trim trail positions older than trailCutoff so a station
+		// heard 2 minutes ago doesn't ship 28 days of historical
+		// breadcrumbs. positions[0] is the head and is always
+		// included even when slightly past the cutoff (its parent
+		// station passed the QueryBBox time filter; dropping the
+		// head would render a station with no current location).
+		dto.Positions = make([]StationPosDTO, 0, len(s.Positions))
 		for i, p := range s.Positions {
-			dto.Positions[i] = positionToDTO(p, digiPos)
+			if i > 0 && p.Timestamp.Before(trailCutoff) {
+				continue
+			}
+			dto.Positions = append(dto.Positions, positionToDTO(p, digiPos))
 		}
 	}
 

--- a/pkg/webapi/stations_test.go
+++ b/pkg/webapi/stations_test.go
@@ -532,3 +532,50 @@ func TestStations_ObjectDTO(t *testing.T) {
 		t.Errorf("symbol = %q/%q", dtos[0].SymbolTable, dtos[0].SymbolCode)
 	}
 }
+
+// TestStations_TrailPositionsTrimmedByTimerange asserts that a station
+// whose head position is fresh but whose trail extends back beyond the
+// requested timerange ships only the in-window positions. Guards
+// against the case where a currently-active station's trail dots
+// stretch back days because the cache holds up to MaxTrailLen history
+// entries regardless of age.
+func TestStations_TrailPositionsTrimmedByTimerange(t *testing.T) {
+	now := time.Now()
+	s := stationcache.Station{
+		Key:      "stn:KC7RUF-4",
+		Callsign: "KC7RUF-4",
+		Symbol:   [2]byte{'/', '>'},
+		Via:      "rf",
+		Positions: []stationcache.Position{
+			{Lat: 35, Lon: -95, Timestamp: now.Add(-1 * time.Minute)},     // head -- fresh
+			{Lat: 35.01, Lon: -95.01, Timestamp: now.Add(-10 * time.Minute)}, // inside 15min
+			{Lat: 35.02, Lon: -95.02, Timestamp: now.Add(-30 * time.Minute)}, // outside 15min
+			{Lat: 35.03, Lon: -95.03, Timestamp: now.Add(-24 * time.Hour)},   // way outside
+		},
+		LastHeard: now.Add(-1 * time.Minute),
+	}
+	cache := &mockStationCache{stations: []stationcache.Station{s}}
+	h := stationsHandler(cache)
+
+	// 15-minute window: expect head + the -10min position only.
+	dtos := decodeStations(t, getStations(t, h, "bbox="+defaultBBox+"&timerange=900", nil))
+	if len(dtos) != 1 {
+		t.Fatalf("got %d stations, want 1", len(dtos))
+	}
+	if got := len(dtos[0].Positions); got != 2 {
+		t.Fatalf("got %d positions, want 2 (head + within-window)", got)
+	}
+
+	// 1-hour window: head + the -10min and -30min positions; -24h dropped.
+	dtos = decodeStations(t, getStations(t, h, "bbox="+defaultBBox+"&timerange=3600", nil))
+	if got := len(dtos[0].Positions); got != 3 {
+		t.Fatalf("1h window: got %d positions, want 3", got)
+	}
+
+	// Delta mode keeps emitting only positions[0] regardless of cutoff.
+	since := now.Add(-2 * time.Minute).Format(time.RFC3339Nano)
+	dtos = decodeStations(t, getStations(t, h, "bbox="+defaultBBox+"&timerange=900&since="+since, nil))
+	if got := len(dtos[0].Positions); got != 1 {
+		t.Fatalf("delta mode: got %d positions, want 1", got)
+	}
+}

--- a/web/src/lib/map/data-store.svelte.js
+++ b/web/src/lib/map/data-store.svelte.js
@@ -236,11 +236,32 @@ export function createDataStore() {
 
   // --- Imperative API ---
 
+  // pruneOutOfBounds drops stations whose primary position is outside
+  // the supplied bbox. Called from setBounds so a pan or zoom-in
+  // doesn't leave stale markers from the prior viewport floating around
+  // after the next /api/stations fetch (the server only returns
+  // stations inside the new bbox, so without this they'd never be
+  // removed from the SvelteMap).
+  function pruneOutOfBounds(b) {
+    if (!b) return;
+    for (const [callsign, s] of stations) {
+      const p = s.positions && s.positions[0];
+      if (!p) continue;
+      if (p.lat < b.swLat || p.lat > b.neLat ||
+          p.lon < b.swLon || p.lon > b.neLon) {
+        stations.delete(callsign);
+        trails.delete(callsign);
+        weather.delete(callsign);
+      }
+    }
+  }
+
   function setBounds(next) {
     // next: { swLat, swLon, neLat, neLon }
     if (bboxEqual(bbox, next)) return;
     bbox = next;
     invalidate();
+    pruneOutOfBounds(next);
     if (started) {
       // Force an immediate refresh on bounds change.
       clearTimeout(timer);


### PR DESCRIPTION
## Summary

Two bugs in the Live Map data plane that surface together when you pan/zoom or shorten the time-range filter:

1. **Stale markers from prior viewport.** `setBounds` invalidated the cursor and re-fetched, but did not drop stations from the reactive `stations` SvelteMap whose head position now falls outside the new bbox. Result: markers from a wider earlier viewport stuck around indefinitely. The new `pruneOutOfBounds` runs as part of `setBounds` and deletes both the station and its trail/weather entries.

2. **Trail dots stretch back days.** `/api/stations` always returned each station's full `Positions[]` slice (up to `MaxTrailLen = 200` entries) regardless of `timerange`. So a station heard 2 minutes ago shipped trail positions from days back, defeating the "15 minutes" filter for anyone with the Trails layer on. `stationToDTO` now trims by a `trailCutoff = now - timerange`; `positions[0]` is always kept (the parent station has already passed `QueryBBox`'s time filter, and dropping the head would render a marker with no location). Delta mode still emits only `positions[0]` and is unaffected.

## Reproduction

Loaded `anguilla.local:8080/#/map`, zoomed in to UT, switched time range to 15 min. API returned 7 stations; client rendered 29. The 22 extras had recent `last_heard` but their positions were outside the current bbox — they were stuck from the wider initial viewport. Some currently-visible stations also had trail positions from 28+ days ago.

## Test plan

- [x] `go test ./pkg/webapi/ ./pkg/stationcache/` — green; new `TestStations_TrailPositionsTrimmedByTimerange` covers full, delta, and >cutoff cases
- [x] `cd web && npm test` — 232/232 pass
- [x] `cd web && npm run build` — clean
- [ ] Manual: pan/zoom on Live Map, switch time range to 15m, confirm only stations within the current bbox AND heard in the last 15 min remain on screen, with no trail dots older than 15 min

## Notes

Not related to #196 (offline map render durability). Discovered while verifying that PR; the data-store/stations-handler files were not touched there.