### PR TITLE
Digipeater source block list

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -77,7 +77,8 @@ The TX-funnel rule lives in [invariant 16](invariants.md).
 | Package | Purpose | Handbook |
 |---|---|---|
 | `beacon` | Position/object/tracker/custom/igate beacon scheduler (min-heap), smart-beacon, encoder | [`../handbook/beacons.html`](../handbook/beacons.html) |
-| `digipeater` | WIDEn-N / TRACEn-N digipeater with preemptive digi and per-channel dedup | [`../handbook/digipeater.html`](../handbook/digipeater.html) |
+| `digipeater` | WIDEn-N / TRACEn-N digipeater with preemptive digi, per-channel dedup, and a source-address block list (digipeater-only) | [`../handbook/digipeater.html`](../handbook/digipeater.html) |
+| `digipeater/blocklist` | Source-address pattern validator and matcher used only by the digipeater engine | — |
 | `igate` | APRS-IS bidirectional gateway: client/login/filter, RF<->IS gating, third-party encap, TNC2 | [`../handbook/igate.html`](../handbook/igate.html) |
 | `igate/filters` | IS->RF rule engine (priority-ordered, deny by default) | [`../handbook/igate.html`](../handbook/igate.html) |
 | `messages` | APRS messaging domain: router, store (GORM), sender, retry, invite, tactical_set, bots, preferences, event_hub, local_tx_ring, **preflight** (shared auto-ACK + dedup transport, owned by `messages.Service`, consulted by both `messages.Router` and `actions.Classifier`) | [`../handbook/messaging.html`](../handbook/messaging.html) |

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -747,3 +747,23 @@ no useful identification and violates the intent of the feature.
 
 Source: [`../../pkg/webapi/channels.go`](../../pkg/webapi/channels.go)
 (`sendTestSignal`).
+
+### 40. Digipeater block list is digipeater-only
+
+[`pkg/digipeater/blocklist`](../../pkg/digipeater/blocklist) is consulted
+only by [`pkg/digipeater/digipeater.go`](../../pkg/digipeater/digipeater.go)'s
+`Handle`. Frames whose source matches an enabled entry are not digipeated;
+every other RX consumer (iGate, packet log, dashboard, station cache,
+messages router, AGW/KISS fanouts) is unaffected and still sees the frame.
+
+*Why:* operators commonly want to silence a misbehaving station's
+digipeated copies without losing the ability to see, log, or gate that
+station's original RF or APRS-IS appearances. A shared "blocked
+stations" surface across subsystems would conflate two different
+operator intents.
+
+*How to apply:* never import `pkg/digipeater/blocklist` outside
+`pkg/digipeater/`. If another subsystem grows a similar need, give it
+its own list. The regression test in
+[`pkg/app/wiring_blocklist_isolation_test.go`](../../pkg/app/wiring_blocklist_isolation_test.go)
+locks the invariant in behaviorally.

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -2164,6 +2164,7 @@ func (a *App) digipeaterComponent() namedComponent {
 		if err != nil || cfg == nil {
 			a.digi.SetEnabled(false)
 			a.digi.SetRules(nil)
+			a.digi.SetBlocklist(nil)
 			return
 		}
 		// Resolve per-digipeater override against the station callsign.
@@ -2180,6 +2181,7 @@ func (a *App) digipeaterComponent() namedComponent {
 				"override", cfg.MyCall, "err", err)
 			a.digi.SetEnabled(false)
 			a.digi.SetRules(nil)
+			a.digi.SetBlocklist(nil)
 			return
 		}
 		mycall, err := ax25.ParseAddress(resolved)
@@ -2188,6 +2190,7 @@ func (a *App) digipeaterComponent() namedComponent {
 				"value", resolved, "err", err)
 			a.digi.SetEnabled(false)
 			a.digi.SetRules(nil)
+			a.digi.SetBlocklist(nil)
 			return
 		}
 		a.digi.SetMyCall(mycall)
@@ -2198,6 +2201,15 @@ func (a *App) digipeaterComponent() namedComponent {
 			rules = nil
 		}
 		a.digi.SetRules(digipeater.RulesFromStore(rules))
+		// Block list mirrors the rules path: any webapi mutation
+		// fires the same digipeaterReload signal, so this branch
+		// runs and pushes a refreshed snapshot into the engine.
+		bl, err := a.store.ListDigipeaterBlocklist(ctx)
+		if err != nil {
+			a.logger.Warn("digipeater blocklist load", "err", err)
+			bl = nil
+		}
+		a.digi.SetBlocklist(digipeater.BlocklistFromStore(bl))
 		a.digi.SetEnabled(cfg.Enabled)
 	}
 

--- a/pkg/app/wiring_blocklist_isolation_test.go
+++ b/pkg/app/wiring_blocklist_isolation_test.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/app/ingress"
+	"github.com/chrissnell/graywolf/pkg/ax25"
+	"github.com/chrissnell/graywolf/pkg/digipeater/blocklist"
+	pb "github.com/chrissnell/graywolf/pkg/ipcproto"
+)
+
+// TestBlockedSourceStillReachesNonDigiConsumers enforces the spec's
+// hard invariant: the digipeater block list is digipeater-only. A
+// frame whose source is on the block list must still reach the APRS
+// submit pipeline (which feeds the iGate's RF->IS adapter, the station
+// cache, and the packet log). The digipeater silently drops the
+// frame; nothing else is affected.
+func TestBlockedSourceStillReachesNonDigiConsumers(t *testing.T) {
+	h := newKissTncHarness(t)
+	defer h.stop()
+
+	h.app.digi.SetBlocklist([]blocklist.Entry{{Pattern: "N1ROG-*", Reason: "isolation test"}})
+
+	src := mustAddrApp(t, "N1ROG-9")
+	dest := mustAddrApp(t, "APRS")
+	path := []ax25.Address{mustAddrApp(t, "WIDE2-2")}
+	f, err := ax25.NewUIFrame(src, dest, path, []byte("=4900.00N/12300.00W>blocked"))
+	if err != nil {
+		t.Fatalf("NewUIFrame: %v", err)
+	}
+	axBytes, err := f.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	select {
+	case h.app.rxFanout <- rxFanoutItem{
+		rf:  &pb.ReceivedFrame{Channel: 1, Data: axBytes},
+		src: ingress.Modem(),
+	}:
+	case <-time.After(time.Second):
+		t.Fatal("rxFanout send blocked")
+	}
+	h.waitDispatched(1, 2*time.Second)
+
+	if h.digiEmits.Len() != 0 {
+		t.Fatalf("digipeater emitted %d frames for a blocked source, want 0", h.digiEmits.Len())
+	}
+	if h.app.digi.Stats().Blocked != 1 {
+		t.Fatalf("digi Stats().Blocked=%d, want 1", h.app.digi.Stats().Blocked)
+	}
+
+	select {
+	case <-h.aprsOut:
+	case <-time.After(2 * time.Second):
+		t.Fatal("APRS submit pipeline did not receive blocked frame; isolation invariant broken")
+	}
+}
+
+func mustAddrApp(t *testing.T, s string) ax25.Address {
+	t.Helper()
+	a, err := ax25.ParseAddress(s)
+	if err != nil {
+		t.Fatalf("ParseAddress(%q): %v", s, err)
+	}
+	return a
+}

--- a/pkg/app/wiring_blocklist_isolation_test.go
+++ b/pkg/app/wiring_blocklist_isolation_test.go
@@ -20,9 +20,9 @@ func TestBlockedSourceStillReachesNonDigiConsumers(t *testing.T) {
 	h := newKissTncHarness(t)
 	defer h.stop()
 
-	h.app.digi.SetBlocklist([]blocklist.Entry{{Pattern: "N1ROG-*", Reason: "isolation test"}})
+	h.app.digi.SetBlocklist([]blocklist.Entry{{Pattern: "BADCAL-*", Reason: "isolation test"}})
 
-	src := mustAddrApp(t, "N1ROG-9")
+	src := mustAddrApp(t, "BADCAL-9")
 	dest := mustAddrApp(t, "APRS")
 	path := []ax25.Address{mustAddrApp(t, "WIDE2-2")}
 	f, err := ax25.NewUIFrame(src, dest, path, []byte("=4900.00N/12300.00W>blocked"))

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -300,6 +300,29 @@ type DigipeaterRule struct {
 	UpdatedAt   time.Time `json:"-"`
 }
 
+// DigipeaterBlocklist is one source-address pattern that the digipeater
+// engine must refuse to digipeat. Global (channel-agnostic). The
+// engine consults this list strictly inside pkg/digipeater/digipeater.go's
+// Handle — no other RX consumer reads it (see docs/wiki/invariants.md).
+//
+// Pattern syntax (canonical, uppercase, validated at the API
+// boundary by pkg/digipeater/blocklist.ValidatePattern):
+//
+//	CALL       — exact source, SSID 0 only (bare callsign)
+//	CALL-N     — exact source, specific SSID 0..15
+//	CALL-*     — any non-zero SSID for that base callsign
+//
+// No CreatedAt/UpdatedAt: the spec deliberately omits audit
+// timestamps to keep the row tiny. Pattern carries a unique index;
+// duplicate inserts return a GORM unique-violation that the webapi
+// layer maps to HTTP 409.
+type DigipeaterBlocklist struct {
+	ID      uint32 `gorm:"primaryKey;autoIncrement" json:"id"`
+	Pattern string `gorm:"not null;uniqueIndex" json:"pattern"`
+	Reason  string `json:"reason"`
+	Enabled bool   `gorm:"not null;default:true" json:"enabled"`
+}
+
 // IGateConfig is a singleton (id=1) row for the iGate.
 //
 // Callsign and Passcode columns remain in the DB for forward-safety on

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -150,6 +150,7 @@ func (s *Store) Migrate() error {
 		&TxTiming{},
 		&DigipeaterConfig{},
 		&DigipeaterRule{},
+		&DigipeaterBlocklist{},
 		&IGateConfig{},
 		&IGateRfFilter{},
 		&Beacon{},

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -1172,6 +1172,37 @@ func (s *Store) DeleteDigipeaterRule(ctx context.Context, id uint32) error {
 }
 
 // ---------------------------------------------------------------------------
+// DigipeaterBlocklist
+// ---------------------------------------------------------------------------
+
+// ListDigipeaterBlocklist returns every block-list row ordered by id
+// ascending so the UI renders in insertion order.
+func (s *Store) ListDigipeaterBlocklist(ctx context.Context) ([]DigipeaterBlocklist, error) {
+	var out []DigipeaterBlocklist
+	return out, s.db.WithContext(ctx).Order("id").Find(&out).Error
+}
+
+func (s *Store) GetDigipeaterBlocklistEntry(ctx context.Context, id uint32) (*DigipeaterBlocklist, error) {
+	var e DigipeaterBlocklist
+	if err := s.db.WithContext(ctx).First(&e, id).Error; err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (s *Store) CreateDigipeaterBlocklistEntry(ctx context.Context, e *DigipeaterBlocklist) error {
+	return s.db.WithContext(ctx).Create(e).Error
+}
+
+func (s *Store) UpdateDigipeaterBlocklistEntry(ctx context.Context, e *DigipeaterBlocklist) error {
+	return s.db.WithContext(ctx).Save(e).Error
+}
+
+func (s *Store) DeleteDigipeaterBlocklistEntry(ctx context.Context, id uint32) error {
+	return s.db.WithContext(ctx).Delete(&DigipeaterBlocklist{}, id).Error
+}
+
+// ---------------------------------------------------------------------------
 // IGateConfig (singleton) + filters
 // ---------------------------------------------------------------------------
 

--- a/pkg/configstore/store_test.go
+++ b/pkg/configstore/store_test.go
@@ -1002,7 +1002,7 @@ func TestNormalizeKissInterface_TcpClientTxDefault(t *testing.T) {
 
 func TestDigipeaterBlocklistAutoMigrate(t *testing.T) {
 	s := newTestStore(t)
-	row := &DigipeaterBlocklist{Pattern: "N1ROG-9", Reason: "test", Enabled: true}
+	row := &DigipeaterBlocklist{Pattern: "BADCAL-9", Reason: "test", Enabled: true}
 	if err := s.DB().Create(row).Error; err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -1013,7 +1013,7 @@ func TestDigipeaterBlocklistAutoMigrate(t *testing.T) {
 	if err := s.DB().First(&got, row.ID).Error; err != nil {
 		t.Fatalf("read back: %v", err)
 	}
-	if got.Pattern != "N1ROG-9" || got.Reason != "test" || !got.Enabled {
+	if got.Pattern != "BADCAL-9" || got.Reason != "test" || !got.Enabled {
 		t.Fatalf("round-trip mismatch: %+v", got)
 	}
 }
@@ -1022,7 +1022,7 @@ func TestDigipeaterBlocklistCRUD(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)
 
-	e := &DigipeaterBlocklist{Pattern: "N1ROG-*", Reason: "malformed beacons", Enabled: true}
+	e := &DigipeaterBlocklist{Pattern: "BADCAL-*", Reason: "malformed beacons", Enabled: true}
 	if err := s.CreateDigipeaterBlocklistEntry(ctx, e); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -1034,7 +1034,7 @@ func TestDigipeaterBlocklistCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.Pattern != "N1ROG-*" || got.Reason != "malformed beacons" || !got.Enabled {
+	if got.Pattern != "BADCAL-*" || got.Reason != "malformed beacons" || !got.Enabled {
 		t.Fatalf("round-trip mismatch: %+v", got)
 	}
 

--- a/pkg/configstore/store_test.go
+++ b/pkg/configstore/store_test.go
@@ -1017,3 +1017,71 @@ func TestDigipeaterBlocklistAutoMigrate(t *testing.T) {
 		t.Fatalf("round-trip mismatch: %+v", got)
 	}
 }
+
+func TestDigipeaterBlocklistCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	e := &DigipeaterBlocklist{Pattern: "N1ROG-*", Reason: "malformed beacons", Enabled: true}
+	if err := s.CreateDigipeaterBlocklistEntry(ctx, e); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if e.ID == 0 {
+		t.Fatal("expected autoincrement id")
+	}
+
+	got, err := s.GetDigipeaterBlocklistEntry(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Pattern != "N1ROG-*" || got.Reason != "malformed beacons" || !got.Enabled {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	got.Reason = "still bad"
+	got.Enabled = false
+	if err := s.UpdateDigipeaterBlocklistEntry(ctx, got); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got2, err := s.GetDigipeaterBlocklistEntry(ctx, e.ID)
+	if err != nil {
+		t.Fatalf("Get after Update: %v", err)
+	}
+	if got2.Reason != "still bad" || got2.Enabled {
+		t.Fatalf("update did not persist: %+v", got2)
+	}
+
+	all, err := s.ListDigipeaterBlocklist(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("List len=%d, want 1", len(all))
+	}
+
+	if err := s.DeleteDigipeaterBlocklistEntry(ctx, e.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := s.GetDigipeaterBlocklistEntry(ctx, e.ID); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("Get after Delete: want ErrRecordNotFound, got %v", err)
+	}
+}
+
+func TestDigipeaterBlocklistUniquePatternConflict(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	first := &DigipeaterBlocklist{Pattern: "KK6XYZ-9"}
+	if err := s.CreateDigipeaterBlocklistEntry(ctx, first); err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	dup := &DigipeaterBlocklist{Pattern: "KK6XYZ-9"}
+	err := s.CreateDigipeaterBlocklistEntry(ctx, dup)
+	if err == nil {
+		t.Fatal("expected unique-index conflict on duplicate pattern, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "unique") &&
+		!strings.Contains(strings.ToLower(err.Error()), "constraint") {
+		t.Fatalf("expected unique/constraint error, got: %v", err)
+	}
+}

--- a/pkg/configstore/store_test.go
+++ b/pkg/configstore/store_test.go
@@ -999,3 +999,21 @@ func TestNormalizeKissInterface_TcpClientTxDefault(t *testing.T) {
 		}
 	})
 }
+
+func TestDigipeaterBlocklistAutoMigrate(t *testing.T) {
+	s := newTestStore(t)
+	row := &DigipeaterBlocklist{Pattern: "N1ROG-9", Reason: "test", Enabled: true}
+	if err := s.DB().Create(row).Error; err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if row.ID == 0 {
+		t.Fatal("expected autoincrement id")
+	}
+	var got DigipeaterBlocklist
+	if err := s.DB().First(&got, row.ID).Error; err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if got.Pattern != "N1ROG-9" || got.Reason != "test" || !got.Enabled {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+}

--- a/pkg/digipeater/blocklist/blocklist.go
+++ b/pkg/digipeater/blocklist/blocklist.go
@@ -1,0 +1,86 @@
+package blocklist
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/chrissnell/graywolf/pkg/ax25"
+)
+
+// Entry is one decoded, canonical block-list pattern plus its operator-
+// supplied reason. Pattern is the canonical form returned by
+// ValidatePattern (uppercase, trimmed).
+type Entry struct {
+	Pattern string
+	Reason  string
+}
+
+// List is a thread-safe collection of block-list entries. The matcher
+// is a linear scan; block lists are tiny in practice (single-digit to
+// low-double-digit entries) so an index would only add complexity.
+type List struct {
+	mu      sync.RWMutex
+	entries []Entry
+}
+
+// New returns a List seeded with the given entries. Nil or empty means
+// "no block list" — Matches always returns hit=false.
+func New(entries []Entry) *List {
+	l := &List{}
+	l.Set(entries)
+	return l
+}
+
+// Set atomically replaces the entries. Safe for live reconfig.
+func (l *List) Set(entries []Entry) {
+	dup := append([]Entry(nil), entries...)
+	l.mu.Lock()
+	l.entries = dup
+	l.mu.Unlock()
+}
+
+// Matches reports whether src is on the block list. On a hit it
+// returns the matching entry so the caller can log which pattern (and
+// reason) fired. First match wins.
+func (l *List) Matches(src ax25.Address) (Entry, bool) {
+	l.mu.RLock()
+	entries := l.entries
+	l.mu.RUnlock()
+	for _, e := range entries {
+		if matchesEntry(e.Pattern, src) {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}
+
+// matchesEntry implements the CALL / CALL-N / CALL-* semantics. Inputs
+// are assumed to come from ValidatePattern; this function is defensive
+// (case-insensitive Call compare, defends against unexpected suffix).
+func matchesEntry(pattern string, src ax25.Address) bool {
+	call := pattern
+	suffix := ""
+	if i := strings.IndexByte(pattern, '-'); i >= 0 {
+		call = pattern[:i]
+		suffix = pattern[i+1:]
+	}
+	if !strings.EqualFold(call, src.Call) {
+		return false
+	}
+	if suffix == "" {
+		return src.SSID == 0
+	}
+	if suffix == "*" {
+		return src.SSID > 0
+	}
+	for i := 0; i < len(suffix); i++ {
+		if suffix[i] < '0' || suffix[i] > '9' {
+			return false
+		}
+	}
+	n := 0
+	for i := 0; i < len(suffix); i++ {
+		n = n*10 + int(suffix[i]-'0')
+	}
+	return n >= 0 && n <= 15 && uint8(n) == src.SSID
+}

--- a/pkg/digipeater/blocklist/blocklist_test.go
+++ b/pkg/digipeater/blocklist/blocklist_test.go
@@ -25,77 +25,77 @@ func TestListMatches(t *testing.T) {
 	}{
 		{
 			name:    "bare matches SSID 0 only",
-			entries: []Entry{{Pattern: "N1ROG"}},
-			src:     "N1ROG",
-			wantHit: true, wantPat: "N1ROG",
+			entries: []Entry{{Pattern: "BADCAL"}},
+			src:     "BADCAL",
+			wantHit: true, wantPat: "BADCAL",
 		},
 		{
 			name:    "bare does not match SSID > 0",
-			entries: []Entry{{Pattern: "N1ROG"}},
-			src:     "N1ROG-9",
+			entries: []Entry{{Pattern: "BADCAL"}},
+			src:     "BADCAL-9",
 			wantHit: false,
 		},
 		{
 			name:    "CALL-0 matches bare source",
-			entries: []Entry{{Pattern: "N1ROG-0"}},
-			src:     "N1ROG",
-			wantHit: true, wantPat: "N1ROG-0",
+			entries: []Entry{{Pattern: "BADCAL-0"}},
+			src:     "BADCAL",
+			wantHit: true, wantPat: "BADCAL-0",
 		},
 		{
 			name:    "CALL-N exact match",
-			entries: []Entry{{Pattern: "N1ROG-9"}},
-			src:     "N1ROG-9",
-			wantHit: true, wantPat: "N1ROG-9",
+			entries: []Entry{{Pattern: "BADCAL-9"}},
+			src:     "BADCAL-9",
+			wantHit: true, wantPat: "BADCAL-9",
 		},
 		{
 			name:    "CALL-N does not match different SSID",
-			entries: []Entry{{Pattern: "N1ROG-9"}},
-			src:     "N1ROG-1",
+			entries: []Entry{{Pattern: "BADCAL-9"}},
+			src:     "BADCAL-1",
 			wantHit: false,
 		},
 		{
 			name:    "wildcard matches any non-zero SSID",
-			entries: []Entry{{Pattern: "N1ROG-*"}},
-			src:     "N1ROG-1",
-			wantHit: true, wantPat: "N1ROG-*",
+			entries: []Entry{{Pattern: "BADCAL-*"}},
+			src:     "BADCAL-1",
+			wantHit: true, wantPat: "BADCAL-*",
 		},
 		{
 			name:    "wildcard matches SSID 15",
-			entries: []Entry{{Pattern: "N1ROG-*"}},
-			src:     "N1ROG-15",
-			wantHit: true, wantPat: "N1ROG-*",
+			entries: []Entry{{Pattern: "BADCAL-*"}},
+			src:     "BADCAL-15",
+			wantHit: true, wantPat: "BADCAL-*",
 		},
 		{
 			name:    "wildcard does NOT match bare callsign",
-			entries: []Entry{{Pattern: "N1ROG-*"}},
-			src:     "N1ROG",
+			entries: []Entry{{Pattern: "BADCAL-*"}},
+			src:     "BADCAL",
 			wantHit: false,
 		},
 		{
 			name:    "wildcard does not match different base",
-			entries: []Entry{{Pattern: "N1ROG-*"}},
+			entries: []Entry{{Pattern: "BADCAL-*"}},
 			src:     "OTHER-9",
 			wantHit: false,
 		},
 		{
 			name: "first hit wins",
 			entries: []Entry{
-				{Pattern: "N1ROG-*", Reason: "first"},
-				{Pattern: "N1ROG-9", Reason: "second"},
+				{Pattern: "BADCAL-*", Reason: "first"},
+				{Pattern: "BADCAL-9", Reason: "second"},
 			},
-			src:     "N1ROG-9",
-			wantHit: true, wantPat: "N1ROG-*",
+			src:     "BADCAL-9",
+			wantHit: true, wantPat: "BADCAL-*",
 		},
 		{
 			name:    "case-insensitive match against source",
-			entries: []Entry{{Pattern: "N1ROG-9"}},
-			src:     "n1rog-9",
-			wantHit: true, wantPat: "N1ROG-9",
+			entries: []Entry{{Pattern: "BADCAL-9"}},
+			src:     "badcal-9",
+			wantHit: true, wantPat: "BADCAL-9",
 		},
 		{
 			name:    "empty list never matches",
 			entries: nil,
-			src:     "N1ROG-9",
+			src:     "BADCAL-9",
 			wantHit: false,
 		},
 	}
@@ -115,12 +115,12 @@ func TestListMatches(t *testing.T) {
 }
 
 func TestListSetReplacesEntries(t *testing.T) {
-	l := New([]Entry{{Pattern: "N1ROG-9"}})
-	if _, hit := l.Matches(mustAddr(t, "N1ROG-9")); !hit {
+	l := New([]Entry{{Pattern: "BADCAL-9"}})
+	if _, hit := l.Matches(mustAddr(t, "BADCAL-9")); !hit {
 		t.Fatal("expected initial hit")
 	}
 	l.Set([]Entry{{Pattern: "OTHER-1"}})
-	if _, hit := l.Matches(mustAddr(t, "N1ROG-9")); hit {
+	if _, hit := l.Matches(mustAddr(t, "BADCAL-9")); hit {
 		t.Fatal("expected old entry to be gone after Set")
 	}
 	if _, hit := l.Matches(mustAddr(t, "OTHER-1")); !hit {

--- a/pkg/digipeater/blocklist/blocklist_test.go
+++ b/pkg/digipeater/blocklist/blocklist_test.go
@@ -1,0 +1,133 @@
+package blocklist
+
+import (
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/ax25"
+)
+
+func mustAddr(t *testing.T, s string) ax25.Address {
+	t.Helper()
+	a, err := ax25.ParseAddress(s)
+	if err != nil {
+		t.Fatalf("ParseAddress(%q): %v", s, err)
+	}
+	return a
+}
+
+func TestListMatches(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries []Entry
+		src     string
+		wantHit bool
+		wantPat string // expected entry.Pattern on hit
+	}{
+		{
+			name:    "bare matches SSID 0 only",
+			entries: []Entry{{Pattern: "N1ROG"}},
+			src:     "N1ROG",
+			wantHit: true, wantPat: "N1ROG",
+		},
+		{
+			name:    "bare does not match SSID > 0",
+			entries: []Entry{{Pattern: "N1ROG"}},
+			src:     "N1ROG-9",
+			wantHit: false,
+		},
+		{
+			name:    "CALL-0 matches bare source",
+			entries: []Entry{{Pattern: "N1ROG-0"}},
+			src:     "N1ROG",
+			wantHit: true, wantPat: "N1ROG-0",
+		},
+		{
+			name:    "CALL-N exact match",
+			entries: []Entry{{Pattern: "N1ROG-9"}},
+			src:     "N1ROG-9",
+			wantHit: true, wantPat: "N1ROG-9",
+		},
+		{
+			name:    "CALL-N does not match different SSID",
+			entries: []Entry{{Pattern: "N1ROG-9"}},
+			src:     "N1ROG-1",
+			wantHit: false,
+		},
+		{
+			name:    "wildcard matches any non-zero SSID",
+			entries: []Entry{{Pattern: "N1ROG-*"}},
+			src:     "N1ROG-1",
+			wantHit: true, wantPat: "N1ROG-*",
+		},
+		{
+			name:    "wildcard matches SSID 15",
+			entries: []Entry{{Pattern: "N1ROG-*"}},
+			src:     "N1ROG-15",
+			wantHit: true, wantPat: "N1ROG-*",
+		},
+		{
+			name:    "wildcard does NOT match bare callsign",
+			entries: []Entry{{Pattern: "N1ROG-*"}},
+			src:     "N1ROG",
+			wantHit: false,
+		},
+		{
+			name:    "wildcard does not match different base",
+			entries: []Entry{{Pattern: "N1ROG-*"}},
+			src:     "OTHER-9",
+			wantHit: false,
+		},
+		{
+			name: "first hit wins",
+			entries: []Entry{
+				{Pattern: "N1ROG-*", Reason: "first"},
+				{Pattern: "N1ROG-9", Reason: "second"},
+			},
+			src:     "N1ROG-9",
+			wantHit: true, wantPat: "N1ROG-*",
+		},
+		{
+			name:    "case-insensitive match against source",
+			entries: []Entry{{Pattern: "N1ROG-9"}},
+			src:     "n1rog-9",
+			wantHit: true, wantPat: "N1ROG-9",
+		},
+		{
+			name:    "empty list never matches",
+			entries: nil,
+			src:     "N1ROG-9",
+			wantHit: false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			l := New(tc.entries)
+			got, hit := l.Matches(mustAddr(t, tc.src))
+			if hit != tc.wantHit {
+				t.Fatalf("Matches(%q) hit=%v, want %v", tc.src, hit, tc.wantHit)
+			}
+			if hit && got.Pattern != tc.wantPat {
+				t.Fatalf("Matches(%q) pattern=%q, want %q", tc.src, got.Pattern, tc.wantPat)
+			}
+		})
+	}
+}
+
+func TestListSetReplacesEntries(t *testing.T) {
+	l := New([]Entry{{Pattern: "N1ROG-9"}})
+	if _, hit := l.Matches(mustAddr(t, "N1ROG-9")); !hit {
+		t.Fatal("expected initial hit")
+	}
+	l.Set([]Entry{{Pattern: "OTHER-1"}})
+	if _, hit := l.Matches(mustAddr(t, "N1ROG-9")); hit {
+		t.Fatal("expected old entry to be gone after Set")
+	}
+	if _, hit := l.Matches(mustAddr(t, "OTHER-1")); !hit {
+		t.Fatal("expected new entry to match after Set")
+	}
+	l.Set(nil)
+	if _, hit := l.Matches(mustAddr(t, "OTHER-1")); hit {
+		t.Fatal("Set(nil) should leave no matches")
+	}
+}

--- a/pkg/digipeater/blocklist/validate.go
+++ b/pkg/digipeater/blocklist/validate.go
@@ -1,0 +1,72 @@
+// Package blocklist implements pattern validation and matching for the
+// digipeater's source-address deny list. The patterns mirror the igate
+// filter's CALL / CALL-N / CALL-* convention but the matcher is scoped
+// strictly to the digipeater engine — see docs/wiki/invariants.md for
+// the no-sharing rule.
+package blocklist
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ValidatePattern parses and canonicalizes a block-list pattern. On
+// success it returns the trimmed, uppercase canonical form so the
+// stored Pattern and the matcher input agree byte-for-byte.
+//
+// Accepted forms:
+//
+//	CALL       — bare callsign (1..6 alphanumerics), matches SSID 0
+//	CALL-N     — N in 0..15
+//	CALL-*     — any non-zero SSID
+//
+// Rejected: empty/whitespace, "*", "-", "-*", missing call, oversized
+// call, wildcard inside the callsign, SSID out of range, non-numeric
+// SSID, any character AX.25 disallows in a callsign.
+func ValidatePattern(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("pattern is empty")
+	}
+	s = strings.ToUpper(s)
+
+	call := s
+	suffix := ""
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		call = s[:i]
+		suffix = s[i+1:]
+	}
+
+	if call == "" {
+		return "", fmt.Errorf("callsign is empty")
+	}
+	if len(call) > 6 {
+		return "", fmt.Errorf("callsign %q exceeds 6 characters", call)
+	}
+	for i := 0; i < len(call); i++ {
+		c := call[i]
+		if !((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+			return "", fmt.Errorf("invalid character %q in callsign", c)
+		}
+	}
+
+	if strings.IndexByte(s, '-') < 0 {
+		return call, nil
+	}
+
+	if suffix == "*" {
+		return call + "-*", nil
+	}
+	if suffix == "" {
+		return "", fmt.Errorf("missing SSID after '-'")
+	}
+	n, err := strconv.Atoi(suffix)
+	if err != nil {
+		return "", fmt.Errorf("invalid SSID %q", suffix)
+	}
+	if n < 0 || n > 15 {
+		return "", fmt.Errorf("SSID %d out of range 0..15", n)
+	}
+	return fmt.Sprintf("%s-%d", call, n), nil
+}

--- a/pkg/digipeater/blocklist/validate_test.go
+++ b/pkg/digipeater/blocklist/validate_test.go
@@ -10,13 +10,13 @@ func TestValidatePattern(t *testing.T) {
 		wantErr bool
 	}{
 		// Valid forms — canonicalized to uppercase, trimmed.
-		{"bare call", "N1ROG", "N1ROG", false},
-		{"lowercase canonicalized", "n1rog", "N1ROG", false},
+		{"bare call", "BADCAL", "BADCAL", false},
+		{"lowercase canonicalized", "badcal", "BADCAL", false},
 		{"surrounding whitespace trimmed", "  KK6XYZ-9  ", "KK6XYZ-9", false},
-		{"call-0 preserved distinct from bare", "N1ROG-0", "N1ROG-0", false},
-		{"call-15 boundary", "N1ROG-15", "N1ROG-15", false},
-		{"wildcard form", "N1ROG-*", "N1ROG-*", false},
-		{"wildcard mixed case", "n1rog-*", "N1ROG-*", false},
+		{"call-0 preserved distinct from bare", "BADCAL-0", "BADCAL-0", false},
+		{"call-15 boundary", "BADCAL-15", "BADCAL-15", false},
+		{"wildcard form", "BADCAL-*", "BADCAL-*", false},
+		{"wildcard mixed case", "badcal-*", "BADCAL-*", false},
 		{"6-char callsign", "WB6ABC", "WB6ABC", false},
 		{"6-char with ssid", "WB6ABC-9", "WB6ABC-9", false},
 
@@ -32,10 +32,10 @@ func TestValidatePattern(t *testing.T) {
 		{"7-char call", "ABCDEFG", "", true},
 		{"wildcard inside call", "N1*ROG", "", true},
 		{"wildcard inside call with ssid", "N1*-9", "", true},
-		{"ssid > 15", "N1ROG-16", "", true},
-		{"negative ssid", "N1ROG--1", "", true},
-		{"non-numeric ssid", "N1ROG-X", "", true},
-		{"ssid with trailing junk", "N1ROG-9X", "", true},
+		{"ssid > 15", "BADCAL-16", "", true},
+		{"negative ssid", "BADCAL--1", "", true},
+		{"non-numeric ssid", "BADCAL-X", "", true},
+		{"ssid with trailing junk", "BADCAL-9X", "", true},
 		{"invalid char in call", "N1R!G", "", true},
 		{"space inside call", "N1 ROG", "", true},
 	}

--- a/pkg/digipeater/blocklist/validate_test.go
+++ b/pkg/digipeater/blocklist/validate_test.go
@@ -1,0 +1,60 @@
+package blocklist
+
+import "testing"
+
+func TestValidatePattern(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantCan string // empty when wantErr is true
+		wantErr bool
+	}{
+		// Valid forms — canonicalized to uppercase, trimmed.
+		{"bare call", "N1ROG", "N1ROG", false},
+		{"lowercase canonicalized", "n1rog", "N1ROG", false},
+		{"surrounding whitespace trimmed", "  KK6XYZ-9  ", "KK6XYZ-9", false},
+		{"call-0 preserved distinct from bare", "N1ROG-0", "N1ROG-0", false},
+		{"call-15 boundary", "N1ROG-15", "N1ROG-15", false},
+		{"wildcard form", "N1ROG-*", "N1ROG-*", false},
+		{"wildcard mixed case", "n1rog-*", "N1ROG-*", false},
+		{"6-char callsign", "WB6ABC", "WB6ABC", false},
+		{"6-char with ssid", "WB6ABC-9", "WB6ABC-9", false},
+
+		// Invalid forms — flooding / nonsense guards.
+		{"empty", "", "", true},
+		{"whitespace only", "   ", "", true},
+		{"lone star", "*", "", true},
+		{"lone dash", "-", "", true},
+		{"lone dash-star", "-*", "", true},
+		{"missing call before dash", "-9", "", true},
+		{"missing call before wildcard", "-*", "", true},
+		{"call too long", "TOOLONGCALL", "", true},
+		{"7-char call", "ABCDEFG", "", true},
+		{"wildcard inside call", "N1*ROG", "", true},
+		{"wildcard inside call with ssid", "N1*-9", "", true},
+		{"ssid > 15", "N1ROG-16", "", true},
+		{"negative ssid", "N1ROG--1", "", true},
+		{"non-numeric ssid", "N1ROG-X", "", true},
+		{"ssid with trailing junk", "N1ROG-9X", "", true},
+		{"invalid char in call", "N1R!G", "", true},
+		{"space inside call", "N1 ROG", "", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ValidatePattern(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ValidatePattern(%q) = %q, nil; want error", tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidatePattern(%q) error: %v", tc.input, err)
+			}
+			if got != tc.wantCan {
+				t.Fatalf("ValidatePattern(%q) = %q, want %q", tc.input, got, tc.wantCan)
+			}
+		})
+	}
+}

--- a/pkg/digipeater/digipeater.go
+++ b/pkg/digipeater/digipeater.go
@@ -196,6 +196,12 @@ func (d *Digipeater) SetRules(rules []Rule) {
 	d.mu.Unlock()
 }
 
+// SetBlocklist replaces the block list under the list's own lock. Safe
+// for live reconfig. nil clears the list.
+func (d *Digipeater) SetBlocklist(entries []blocklist.Entry) {
+	d.blocklist.Set(entries)
+}
+
 // SetMyCall updates the local callsign for preemptive digi.
 func (d *Digipeater) SetMyCall(a ax25.Address) {
 	d.mu.Lock()
@@ -226,6 +232,20 @@ func RulesFromStore(rows []configstore.DigipeaterRule) []Rule {
 			Action:      r.Action,
 			Priority:    r.Priority,
 		})
+	}
+	return out
+}
+
+// BlocklistFromStore converts configstore rows to local blocklist
+// entries, skipping disabled rows so the engine never has to filter at
+// match time. Mirrors RulesFromStore.
+func BlocklistFromStore(rows []configstore.DigipeaterBlocklist) []blocklist.Entry {
+	out := make([]blocklist.Entry, 0, len(rows))
+	for _, r := range rows {
+		if !r.Enabled {
+			continue
+		}
+		out = append(out, blocklist.Entry{Pattern: r.Pattern, Reason: r.Reason})
 	}
 	return out
 }
@@ -269,6 +289,23 @@ func (d *Digipeater) Handle(ctx context.Context, rxChannel uint32, frame *ax25.F
 		d.logger.Warn("digipeater: dropping frame — mycall is unset or N0CALL",
 			"source", frame.Source.String(),
 			"mycall", mycall.String())
+		return false
+	}
+
+	// Block-list check. Source-address deny list, digipeater-scope
+	// only — see docs/wiki/invariants.md. Runs before dedup so a
+	// blocked source neither churns the dedup window nor inflates the
+	// Deduped counter (which is reserved for legitimate-but-duplicate
+	// frames). blocklist.List has its own RWMutex so no engine-level
+	// lock is required here.
+	if entry, hit := d.blocklist.Matches(frame.Source); hit {
+		d.mu.Lock()
+		d.stats.Blocked++
+		d.mu.Unlock()
+		d.logger.Debug("digipeater: source blocked",
+			"source", frame.Source.String(),
+			"pattern", entry.Pattern,
+			"reason", entry.Reason)
 		return false
 	}
 

--- a/pkg/digipeater/digipeater.go
+++ b/pkg/digipeater/digipeater.go
@@ -29,6 +29,7 @@ import (
 	"github.com/chrissnell/graywolf/pkg/ax25"
 	"github.com/chrissnell/graywolf/pkg/callsign"
 	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/digipeater/blocklist"
 	"github.com/chrissnell/graywolf/pkg/internal/dedup"
 	"github.com/chrissnell/graywolf/pkg/txgovernor"
 )
@@ -93,12 +94,18 @@ type Config struct {
 	// does-anything behavior). Lookup errors are silently ignored
 	// (fail-open).
 	ChannelModes configstore.ChannelModeLookup
+
+	// Blocklist names source addresses that must never be digipeated.
+	// Replaced under lock via SetBlocklist for live reconfig. Nil/empty
+	// means no block list (current behavior).
+	Blocklist []blocklist.Entry
 }
 
 // Stats exposes counters.
 type Stats struct {
 	Packets uint64 // successfully digipeated
 	Deduped uint64 // dropped as duplicate
+	Blocked uint64 // dropped because source matched the block list
 }
 
 // Digipeater is the engine.
@@ -114,8 +121,9 @@ type Digipeater struct {
 
 	channelModes configstore.ChannelModeLookup
 
-	dedup *dedup.Window[string, struct{}]
-	stats Stats
+	dedup     *dedup.Window[string, struct{}]
+	blocklist *blocklist.List
+	stats     Stats
 }
 
 // New builds a Digipeater. Resolves cfg.MyCall (override) against
@@ -160,6 +168,7 @@ func New(cfg Config) (*Digipeater, error) {
 		onDedup:      cfg.OnDedup,
 		channelModes: cfg.ChannelModes,
 		dedup:        dedup.New[string, struct{}](dedup.Config{TTL: cfg.DedupeWindow}),
+		blocklist:    blocklist.New(cfg.Blocklist),
 	}, nil
 }
 

--- a/pkg/digipeater/digipeater_test.go
+++ b/pkg/digipeater/digipeater_test.go
@@ -416,9 +416,9 @@ func TestHandle_BlockedSourceShortCircuits(t *testing.T) {
 		Alias: "WIDE", AliasType: "widen", MaxHops: 2, Action: "repeat",
 	}}
 	d, sink := newTestDigi(t, rules, "N0CAL-1")
-	d.SetBlocklist([]blocklist.Entry{{Pattern: "N1ROG-*", Reason: "test"}})
+	d.SetBlocklist([]blocklist.Entry{{Pattern: "BADCAL-*", Reason: "test"}})
 
-	rx := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "blocked")
+	rx := buildFrame(t, "BADCAL-9", "APRS", []string{"WIDE2-2"}, "blocked")
 	if d.Handle(context.Background(), 1, rx, ingress.Modem()) {
 		t.Fatal("Handle returned true for blocked source")
 	}
@@ -447,10 +447,10 @@ func TestHandle_BlockedSourceBeforeDedup(t *testing.T) {
 		Alias: "WIDE", AliasType: "widen", MaxHops: 2, Action: "repeat",
 	}}
 	d, _ := newTestDigi(t, rules, "N0CAL-1")
-	d.SetBlocklist([]blocklist.Entry{{Pattern: "N1ROG-*"}})
+	d.SetBlocklist([]blocklist.Entry{{Pattern: "BADCAL-*"}})
 
-	rx1 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "same")
-	rx2 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "same")
+	rx1 := buildFrame(t, "BADCAL-9", "APRS", []string{"WIDE2-2"}, "same")
+	rx2 := buildFrame(t, "BADCAL-9", "APRS", []string{"WIDE2-2"}, "same")
 	d.Handle(context.Background(), 1, rx1, ingress.Modem())
 	d.Handle(context.Background(), 1, rx2, ingress.Modem())
 
@@ -472,7 +472,7 @@ func TestHandle_NonBlockedFrameStillDigis(t *testing.T) {
 	d, sink := newTestDigi(t, rules, "N0CAL-1")
 	d.SetBlocklist([]blocklist.Entry{{Pattern: "OTHRCL-*"}})
 
-	rx := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "ok")
+	rx := buildFrame(t, "BADCAL-9", "APRS", []string{"WIDE2-2"}, "ok")
 	if !d.Handle(context.Background(), 1, rx, ingress.Modem()) {
 		t.Fatal("expected non-blocked frame to be digipeated")
 	}
@@ -491,9 +491,9 @@ func TestSetBlocklist_LiveReconfig(t *testing.T) {
 		Alias: "WIDE", AliasType: "widen", MaxHops: 2, Action: "repeat",
 	}}
 	d, sink := newTestDigi(t, rules, "N0CAL-1")
-	d.SetBlocklist([]blocklist.Entry{{Pattern: "N1ROG-*"}})
+	d.SetBlocklist([]blocklist.Entry{{Pattern: "BADCAL-*"}})
 
-	rx1 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "first")
+	rx1 := buildFrame(t, "BADCAL-9", "APRS", []string{"WIDE2-2"}, "first")
 	if d.Handle(context.Background(), 1, rx1, ingress.Modem()) {
 		t.Fatal("first frame should be blocked")
 	}
@@ -502,7 +502,7 @@ func TestSetBlocklist_LiveReconfig(t *testing.T) {
 	}
 
 	d.SetBlocklist(nil)
-	rx2 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "second")
+	rx2 := buildFrame(t, "BADCAL-9", "APRS", []string{"WIDE2-2"}, "second")
 	if !d.Handle(context.Background(), 1, rx2, ingress.Modem()) {
 		t.Fatal("after SetBlocklist(nil) frame should digi")
 	}
@@ -511,13 +511,13 @@ func TestSetBlocklist_LiveReconfig(t *testing.T) {
 	}
 
 	d.SetBlocklist([]blocklist.Entry{{Pattern: "OTHRCL-*"}})
-	rx3 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "third")
+	rx3 := buildFrame(t, "BADCAL-9", "APRS", []string{"WIDE2-2"}, "third")
 	if !d.Handle(context.Background(), 1, rx3, ingress.Modem()) {
 		t.Fatal("frame with non-matching block list should digi")
 	}
 
-	d.SetBlocklist([]blocklist.Entry{{Pattern: "N1ROG-*"}})
-	rx4 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "fourth")
+	d.SetBlocklist([]blocklist.Entry{{Pattern: "BADCAL-*"}})
+	rx4 := buildFrame(t, "BADCAL-9", "APRS", []string{"WIDE2-2"}, "fourth")
 	if d.Handle(context.Background(), 1, rx4, ingress.Modem()) {
 		t.Fatal("frame should be re-blocked after re-adding pattern")
 	}
@@ -526,7 +526,7 @@ func TestSetBlocklist_LiveReconfig(t *testing.T) {
 func TestBlocklistFromStore_EnabledOnly(t *testing.T) {
 	t.Parallel()
 	rows := []configstore.DigipeaterBlocklist{
-		{Pattern: "N1ROG-*", Reason: "noisy", Enabled: true},
+		{Pattern: "BADCAL-*", Reason: "noisy", Enabled: true},
 		{Pattern: "OTHER-1", Reason: "disabled", Enabled: false},
 		{Pattern: "THIRD", Reason: "", Enabled: true},
 	}
@@ -534,7 +534,7 @@ func TestBlocklistFromStore_EnabledOnly(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("len=%d, want 2 (disabled row dropped)", len(got))
 	}
-	if got[0].Pattern != "N1ROG-*" || got[0].Reason != "noisy" {
+	if got[0].Pattern != "BADCAL-*" || got[0].Reason != "noisy" {
 		t.Fatalf("entry 0 = %+v", got[0])
 	}
 	if got[1].Pattern != "THIRD" {

--- a/pkg/digipeater/digipeater_test.go
+++ b/pkg/digipeater/digipeater_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chrissnell/graywolf/pkg/app/ingress"
 	"github.com/chrissnell/graywolf/pkg/ax25"
 	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/digipeater/blocklist"
 	"github.com/chrissnell/graywolf/pkg/internal/testtx"
 )
 
@@ -405,5 +406,138 @@ func TestDigipeaterPerRulePacketModeToChannel(t *testing.T) {
 	}
 	if ch := sink.Last().Channel; ch != 3 {
 		t.Fatalf("TX channel = %d, want 3", ch)
+	}
+}
+
+func TestHandle_BlockedSourceShortCircuits(t *testing.T) {
+	t.Parallel()
+	rules := []Rule{{
+		FromChannel: 1, ToChannel: 1,
+		Alias: "WIDE", AliasType: "widen", MaxHops: 2, Action: "repeat",
+	}}
+	d, sink := newTestDigi(t, rules, "N0CAL-1")
+	d.SetBlocklist([]blocklist.Entry{{Pattern: "N1ROG-*", Reason: "test"}})
+
+	rx := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "blocked")
+	if d.Handle(context.Background(), 1, rx, ingress.Modem()) {
+		t.Fatal("Handle returned true for blocked source")
+	}
+	if sink.Len() != 0 {
+		t.Fatalf("submit called: sink len=%d", sink.Len())
+	}
+	stats := d.Stats()
+	if stats.Blocked != 1 {
+		t.Fatalf("Blocked=%d, want 1", stats.Blocked)
+	}
+	if stats.Packets != 0 {
+		t.Fatalf("Packets=%d, want 0", stats.Packets)
+	}
+	if stats.Deduped != 0 {
+		t.Fatalf("Deduped=%d, want 0", stats.Deduped)
+	}
+}
+
+func TestHandle_BlockedSourceBeforeDedup(t *testing.T) {
+	// A blocked frame must not consume the dedup window. We send the
+	// same blocked frame twice; if the block check ran AFTER dedup we
+	// would see Deduped==1 on the second call.
+	t.Parallel()
+	rules := []Rule{{
+		FromChannel: 1, ToChannel: 1,
+		Alias: "WIDE", AliasType: "widen", MaxHops: 2, Action: "repeat",
+	}}
+	d, _ := newTestDigi(t, rules, "N0CAL-1")
+	d.SetBlocklist([]blocklist.Entry{{Pattern: "N1ROG-*"}})
+
+	rx1 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "same")
+	rx2 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "same")
+	d.Handle(context.Background(), 1, rx1, ingress.Modem())
+	d.Handle(context.Background(), 1, rx2, ingress.Modem())
+
+	stats := d.Stats()
+	if stats.Blocked != 2 {
+		t.Fatalf("Blocked=%d, want 2", stats.Blocked)
+	}
+	if stats.Deduped != 0 {
+		t.Fatalf("Deduped=%d, want 0 (block check must precede dedup)", stats.Deduped)
+	}
+}
+
+func TestHandle_NonBlockedFrameStillDigis(t *testing.T) {
+	t.Parallel()
+	rules := []Rule{{
+		FromChannel: 1, ToChannel: 1,
+		Alias: "WIDE", AliasType: "widen", MaxHops: 2, Action: "repeat",
+	}}
+	d, sink := newTestDigi(t, rules, "N0CAL-1")
+	d.SetBlocklist([]blocklist.Entry{{Pattern: "OTHRCL-*"}})
+
+	rx := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "ok")
+	if !d.Handle(context.Background(), 1, rx, ingress.Modem()) {
+		t.Fatal("expected non-blocked frame to be digipeated")
+	}
+	if sink.Len() != 1 {
+		t.Fatalf("sink len=%d, want 1", sink.Len())
+	}
+	if d.Stats().Blocked != 0 {
+		t.Fatalf("Blocked=%d, want 0", d.Stats().Blocked)
+	}
+}
+
+func TestSetBlocklist_LiveReconfig(t *testing.T) {
+	t.Parallel()
+	rules := []Rule{{
+		FromChannel: 1, ToChannel: 1,
+		Alias: "WIDE", AliasType: "widen", MaxHops: 2, Action: "repeat",
+	}}
+	d, sink := newTestDigi(t, rules, "N0CAL-1")
+	d.SetBlocklist([]blocklist.Entry{{Pattern: "N1ROG-*"}})
+
+	rx1 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "first")
+	if d.Handle(context.Background(), 1, rx1, ingress.Modem()) {
+		t.Fatal("first frame should be blocked")
+	}
+	if sink.Len() != 0 {
+		t.Fatalf("sink len=%d after block, want 0", sink.Len())
+	}
+
+	d.SetBlocklist(nil)
+	rx2 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "second")
+	if !d.Handle(context.Background(), 1, rx2, ingress.Modem()) {
+		t.Fatal("after SetBlocklist(nil) frame should digi")
+	}
+	if sink.Len() != 1 {
+		t.Fatalf("sink len=%d after unblock, want 1", sink.Len())
+	}
+
+	d.SetBlocklist([]blocklist.Entry{{Pattern: "OTHRCL-*"}})
+	rx3 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "third")
+	if !d.Handle(context.Background(), 1, rx3, ingress.Modem()) {
+		t.Fatal("frame with non-matching block list should digi")
+	}
+
+	d.SetBlocklist([]blocklist.Entry{{Pattern: "N1ROG-*"}})
+	rx4 := buildFrame(t, "N1ROG-9", "APRS", []string{"WIDE2-2"}, "fourth")
+	if d.Handle(context.Background(), 1, rx4, ingress.Modem()) {
+		t.Fatal("frame should be re-blocked after re-adding pattern")
+	}
+}
+
+func TestBlocklistFromStore_EnabledOnly(t *testing.T) {
+	t.Parallel()
+	rows := []configstore.DigipeaterBlocklist{
+		{Pattern: "N1ROG-*", Reason: "noisy", Enabled: true},
+		{Pattern: "OTHER-1", Reason: "disabled", Enabled: false},
+		{Pattern: "THIRD", Reason: "", Enabled: true},
+	}
+	got := BlocklistFromStore(rows)
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (disabled row dropped)", len(got))
+	}
+	if got[0].Pattern != "N1ROG-*" || got[0].Reason != "noisy" {
+		t.Fatalf("entry 0 = %+v", got[0])
+	}
+	if got[1].Pattern != "THIRD" {
+		t.Fatalf("entry 1 = %+v", got[1])
 	}
 }

--- a/pkg/releasenotes/notes.yaml
+++ b/pkg/releasenotes/notes.yaml
@@ -7,6 +7,21 @@
 # route the body references via [text](link) markdown; renderer only
 # accepts internal #/... routes.
 
+- version: "0.13.12"
+  date: "2026-05-29"
+  style: info
+  schema_version: 1
+  link: "#/digipeater"
+  title: "Block a station from being digipeated"
+  body: |
+    The Digipeater settings page now has a Blocked Stations list. Add
+    a callsign -- with or without an SSID, with a trailing wildcard
+    like N1ROG-* if you want every SSID -- and the digipeater will
+    stop repeating that station's frames. The iGate and packet log
+    are not affected: you'll still see and log the original traffic.
+    Useful when one nearby station is flooding the channel with
+    malformed beacons or you just want it off the digipeater chain.
+
 - version: "0.13.11"
   date: "2026-05-27"
   style: info

--- a/pkg/releasenotes/notes.yaml
+++ b/pkg/releasenotes/notes.yaml
@@ -16,7 +16,7 @@
   body: |
     The Digipeater settings page now has a Blocked Stations list. Add
     a callsign -- with or without an SSID, with a trailing wildcard
-    like N1ROG-* if you want every SSID -- and the digipeater will
+    like CALL-* if you want every SSID -- and the digipeater will
     stop repeating that station's frames. The iGate and packet log
     are not affected: you'll still see and log the original traffic.
     Useful when one nearby station is flooding the channel with

--- a/pkg/webapi/digipeater.go
+++ b/pkg/webapi/digipeater.go
@@ -3,8 +3,10 @@ package webapi
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/digipeater/blocklist"
 	"github.com/chrissnell/graywolf/pkg/webapi/dto"
 )
 
@@ -18,6 +20,10 @@ func (s *Server) registerDigipeater(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/digipeater/rules", s.createDigipeaterRule)
 	mux.HandleFunc("PUT /api/digipeater/rules/{id}", s.updateDigipeaterRule)
 	mux.HandleFunc("DELETE /api/digipeater/rules/{id}", s.deleteDigipeaterRule)
+	mux.HandleFunc("GET /api/digipeater/blocklist", s.listDigipeaterBlocklist)
+	mux.HandleFunc("POST /api/digipeater/blocklist", s.createDigipeaterBlocklist)
+	mux.HandleFunc("PUT /api/digipeater/blocklist/{id}", s.updateDigipeaterBlocklist)
+	mux.HandleFunc("DELETE /api/digipeater/blocklist/{id}", s.deleteDigipeaterBlocklist)
 }
 
 // getDigipeaterConfig returns the singleton digipeater config. If no
@@ -255,4 +261,161 @@ func (s *Server) signalDigipeaterReload() {
 	case s.digipeaterReload <- struct{}{}:
 	default:
 	}
+}
+
+// reasonMaxLen caps user-supplied reason text. 256 chars is enough for
+// any sensible operator note and keeps the column small.
+const reasonMaxLen = 256
+
+// listDigipeaterBlocklist returns every entry id-ascending.
+//
+// @Summary  List digipeater blocklist entries
+// @Tags     digipeater
+// @ID       listDigipeaterBlocklist
+// @Produce  json
+// @Success  200 {array}  dto.BlocklistEntryResponse
+// @Failure  500 {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /digipeater/blocklist [get]
+func (s *Server) listDigipeaterBlocklist(w http.ResponseWriter, r *http.Request) {
+	handleList[configstore.DigipeaterBlocklist](s, w, r, "list digipeater blocklist",
+		s.store.ListDigipeaterBlocklist, dto.BlocklistEntryFromModel)
+}
+
+// createDigipeaterBlocklist validates the pattern, persists the entry,
+// and fires the digipeater reload signal so the live engine picks up
+// the new list. Duplicate patterns return 409.
+//
+// @Summary  Create digipeater blocklist entry
+// @Tags     digipeater
+// @ID       createDigipeaterBlocklist
+// @Accept   json
+// @Produce  json
+// @Param    body body     dto.BlocklistEntryRequest true "Blocklist entry"
+// @Success  201  {object} dto.BlocklistEntryResponse
+// @Failure  400  {object} webtypes.ErrorResponse
+// @Failure  409  {object} webtypes.ErrorResponse
+// @Failure  500  {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /digipeater/blocklist [post]
+func (s *Server) createDigipeaterBlocklist(w http.ResponseWriter, r *http.Request) {
+	req, err := decodeJSON[dto.BlocklistEntryRequest](r)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	canonical, err := blocklist.ValidatePattern(req.Pattern)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	m := configstore.DigipeaterBlocklist{
+		Pattern: canonical,
+		Reason:  trimReason(req.Reason),
+		Enabled: enabled,
+	}
+	if err := s.store.CreateDigipeaterBlocklistEntry(r.Context(), &m); err != nil {
+		if isUniqueConstraintErr(err) {
+			conflict(w, "pattern already exists")
+			return
+		}
+		s.internalError(w, r, "create digipeater blocklist", err)
+		return
+	}
+	s.signalDigipeaterReload()
+	writeJSON(w, http.StatusCreated, dto.BlocklistEntryFromModel(m))
+}
+
+// updateDigipeaterBlocklist replaces the entry with the given id.
+//
+// @Summary  Update digipeater blocklist entry
+// @Tags     digipeater
+// @ID       updateDigipeaterBlocklist
+// @Accept   json
+// @Produce  json
+// @Param    id   path     int                       true "Entry id"
+// @Param    body body     dto.BlocklistEntryRequest true "Blocklist entry"
+// @Success  200  {object} dto.BlocklistEntryResponse
+// @Failure  400  {object} webtypes.ErrorResponse
+// @Failure  404  {object} webtypes.ErrorResponse
+// @Failure  409  {object} webtypes.ErrorResponse
+// @Failure  500  {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /digipeater/blocklist/{id} [put]
+func (s *Server) updateDigipeaterBlocklist(w http.ResponseWriter, r *http.Request) {
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid id")
+		return
+	}
+	req, err := decodeJSON[dto.BlocklistEntryRequest](r)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	canonical, err := blocklist.ValidatePattern(req.Pattern)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	m := configstore.DigipeaterBlocklist{
+		ID:      id,
+		Pattern: canonical,
+		Reason:  trimReason(req.Reason),
+		Enabled: enabled,
+	}
+	if err := s.store.UpdateDigipeaterBlocklistEntry(r.Context(), &m); err != nil {
+		if isUniqueConstraintErr(err) {
+			conflict(w, "pattern already exists")
+			return
+		}
+		s.internalError(w, r, "update digipeater blocklist", err)
+		return
+	}
+	s.signalDigipeaterReload()
+	writeJSON(w, http.StatusOK, dto.BlocklistEntryFromModel(m))
+}
+
+// deleteDigipeaterBlocklist removes the entry with the given id.
+//
+// @Summary  Delete digipeater blocklist entry
+// @Tags     digipeater
+// @ID       deleteDigipeaterBlocklist
+// @Param    id  path int true "Entry id"
+// @Success  204 "No Content"
+// @Failure  400 {object} webtypes.ErrorResponse
+// @Failure  500 {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /digipeater/blocklist/{id} [delete]
+func (s *Server) deleteDigipeaterBlocklist(w http.ResponseWriter, r *http.Request) {
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid id")
+		return
+	}
+	if err := s.store.DeleteDigipeaterBlocklistEntry(r.Context(), id); err != nil {
+		s.internalError(w, r, "delete digipeater blocklist", err)
+		return
+	}
+	s.signalDigipeaterReload()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// trimReason normalizes operator-supplied reason text: trim whitespace
+// and cap at reasonMaxLen bytes so a misconfigured client can't bloat
+// the DB.
+func trimReason(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > reasonMaxLen {
+		s = s[:reasonMaxLen]
+	}
+	return s
 }

--- a/pkg/webapi/digipeater_test.go
+++ b/pkg/webapi/digipeater_test.go
@@ -141,14 +141,14 @@ func TestDigipeaterBlocklist_PostHappyPathCanonicalizes(t *testing.T) {
 	mux := http.NewServeMux()
 	srv.RegisterRoutes(mux)
 
-	body := `{"pattern":"  n1rog-*  ","reason":"noisy"}`
+	body := `{"pattern":"  badcal-*  ","reason":"noisy"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/digipeater/blocklist", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("status=%d, want 201; body=%s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), `"pattern": "N1ROG-*"`) {
+	if !strings.Contains(rec.Body.String(), `"pattern": "BADCAL-*"`) {
 		t.Fatalf("response missing canonical pattern: %s", rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), `"enabled": true`) {
@@ -192,7 +192,7 @@ func TestDigipeaterBlocklist_GetPutDeleteRoundTrip(t *testing.T) {
 	srv.RegisterRoutes(mux)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/digipeater/blocklist",
-		strings.NewReader(`{"pattern": "N1ROG-9","reason":"r1"}`))
+		strings.NewReader(`{"pattern": "BADCAL-9","reason":"r1"}`))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusCreated {
@@ -205,13 +205,13 @@ func TestDigipeaterBlocklist_GetPutDeleteRoundTrip(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET status=%d", rec.Code)
 	}
-	if !strings.Contains(rec.Body.String(), `"pattern": "N1ROG-9"`) {
+	if !strings.Contains(rec.Body.String(), `"pattern": "BADCAL-9"`) {
 		t.Fatalf("GET body missing entry: %s", rec.Body.String())
 	}
 
-	id := extractFirstIDForPattern(t, rec.Body.String(), "N1ROG-9")
+	id := extractFirstIDForPattern(t, rec.Body.String(), "BADCAL-9")
 
-	put := `{"pattern": "N1ROG-9","reason": "r2","enabled": false}`
+	put := `{"pattern": "BADCAL-9","reason": "r2","enabled": false}`
 	req = httptest.NewRequest(http.MethodPut,
 		"/api/digipeater/blocklist/"+strconv.FormatUint(uint64(id), 10),
 		strings.NewReader(put))
@@ -239,7 +239,7 @@ func TestDigipeaterBlocklist_GetPutDeleteRoundTrip(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("final GET status=%d", rec.Code)
 	}
-	if strings.Contains(rec.Body.String(), `"pattern": "N1ROG-9"`) {
+	if strings.Contains(rec.Body.String(), `"pattern": "BADCAL-9"`) {
 		t.Fatalf("entry still present after delete: %s", rec.Body.String())
 	}
 }

--- a/pkg/webapi/digipeater_test.go
+++ b/pkg/webapi/digipeater_test.go
@@ -2,6 +2,7 @@ package webapi
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -17,7 +18,7 @@ func TestDigipeaterRule_AcceptsTxCapableChannels(t *testing.T) {
 	mux := http.NewServeMux()
 	srv.RegisterRoutes(mux)
 
-	body := `{"from_channel":1,"to_channel":1,"alias":"WIDE","alias_type":"widen","max_hops":1,"action":"repeat","priority":100,"enabled":true}`
+	body := `{"from_channel":1,"to_channel":1,"alias":"WIDE","alias_type":"widen","max_hops":1,"action":"repeat","priority":100,"enabled": true}`
 	req := httptest.NewRequest(http.MethodPost, "/api/digipeater/rules", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
@@ -44,7 +45,7 @@ func TestDigipeaterRule_RejectsNonTxCapableFromChannel(t *testing.T) {
 	}
 
 	body := `{"from_channel":` + strconv.FormatUint(uint64(rxCh.ID), 10) +
-		`,"to_channel":1,"alias":"WIDE","alias_type":"widen","max_hops":1,"action":"repeat","priority":100,"enabled":true}`
+		`,"to_channel":1,"alias":"WIDE","alias_type":"widen","max_hops":1,"action":"repeat","priority":100,"enabled": true}`
 	req := httptest.NewRequest(http.MethodPost, "/api/digipeater/rules", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
@@ -75,7 +76,7 @@ func TestDigipeaterRule_RejectsNonTxCapableToChannel(t *testing.T) {
 	}
 
 	body := `{"from_channel":1,"to_channel":` + strconv.FormatUint(uint64(rxCh.ID), 10) +
-		`,"alias":"WIDE","alias_type":"widen","max_hops":1,"action":"repeat","priority":100,"enabled":true}`
+		`,"alias":"WIDE","alias_type":"widen","max_hops":1,"action":"repeat","priority":100,"enabled": true}`
 	req := httptest.NewRequest(http.MethodPost, "/api/digipeater/rules", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
@@ -106,7 +107,7 @@ func TestDigipeaterRule_AllowsNonTxCapableWhenDisabled(t *testing.T) {
 	}
 
 	body := `{"from_channel":1,"to_channel":` + strconv.FormatUint(uint64(rxCh.ID), 10) +
-		`,"alias":"WIDE","alias_type":"widen","max_hops":1,"action":"repeat","priority":100,"enabled":false}`
+		`,"alias":"WIDE","alias_type":"widen","max_hops":1,"action":"repeat","priority":100,"enabled": false}`
 	req := httptest.NewRequest(http.MethodPost, "/api/digipeater/rules", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
@@ -123,7 +124,7 @@ func TestDigipeaterRule_UnknownChannelStillReportsMissing(t *testing.T) {
 	mux := http.NewServeMux()
 	srv.RegisterRoutes(mux)
 
-	body := `{"from_channel":9999,"to_channel":1,"alias":"WIDE","alias_type":"widen","max_hops":1,"action":"repeat","priority":100,"enabled":true}`
+	body := `{"from_channel":9999,"to_channel":1,"alias":"WIDE","alias_type":"widen","max_hops":1,"action":"repeat","priority":100,"enabled": true}`
 	req := httptest.NewRequest(http.MethodPost, "/api/digipeater/rules", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
@@ -133,4 +134,130 @@ func TestDigipeaterRule_UnknownChannelStillReportsMissing(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), "does not exist") {
 		t.Errorf("expected 'does not exist' error, got %s", rec.Body.String())
 	}
+}
+
+func TestDigipeaterBlocklist_PostHappyPathCanonicalizes(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body := `{"pattern":"  n1rog-*  ","reason":"noisy"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/digipeater/blocklist", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"pattern": "N1ROG-*"`) {
+		t.Fatalf("response missing canonical pattern: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"enabled": true`) {
+		t.Fatalf("response missing default enabled=true: %s", rec.Body.String())
+	}
+}
+
+func TestDigipeaterBlocklist_PostBadPatternReturns400(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body := `{"pattern":"-*","reason":""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/digipeater/blocklist", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDigipeaterBlocklist_DuplicatePatternReturns409(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body := `{"pattern":"KK6XYZ-9","reason":""}`
+	for i, wantCode := range []int{http.StatusCreated, http.StatusConflict} {
+		req := httptest.NewRequest(http.MethodPost, "/api/digipeater/blocklist", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != wantCode {
+			t.Fatalf("call %d: status=%d, want %d; body=%s", i+1, rec.Code, wantCode, rec.Body.String())
+		}
+	}
+}
+
+func TestDigipeaterBlocklist_GetPutDeleteRoundTrip(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/digipeater/blocklist",
+		strings.NewReader(`{"pattern": "N1ROG-9","reason":"r1"}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST status=%d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/digipeater/blocklist", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status=%d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"pattern": "N1ROG-9"`) {
+		t.Fatalf("GET body missing entry: %s", rec.Body.String())
+	}
+
+	id := extractFirstIDForPattern(t, rec.Body.String(), "N1ROG-9")
+
+	put := `{"pattern": "N1ROG-9","reason": "r2","enabled": false}`
+	req = httptest.NewRequest(http.MethodPut,
+		"/api/digipeater/blocklist/"+strconv.FormatUint(uint64(id), 10),
+		strings.NewReader(put))
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT status=%d; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"reason": "r2"`) ||
+		!strings.Contains(rec.Body.String(), `"enabled": false`) {
+		t.Fatalf("PUT response missing updates: %s", rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodDelete,
+		"/api/digipeater/blocklist/"+strconv.FormatUint(uint64(id), 10), nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE status=%d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/digipeater/blocklist", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("final GET status=%d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), `"pattern": "N1ROG-9"`) {
+		t.Fatalf("entry still present after delete: %s", rec.Body.String())
+	}
+}
+
+func extractFirstIDForPattern(t *testing.T, body, pattern string) uint32 {
+	t.Helper()
+	var entries []struct {
+		ID      uint32 `json:"id"`
+		Pattern string `json:"pattern"`
+	}
+	if err := json.Unmarshal([]byte(body), &entries); err != nil {
+		t.Fatalf("unmarshal body: %v; body=%s", err, body)
+	}
+	for _, e := range entries {
+		if e.Pattern == pattern {
+			return e.ID
+		}
+	}
+	t.Fatalf("no entry with pattern %q in %s", pattern, body)
+	return 0
 }

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -2671,6 +2671,203 @@
                 }
             }
         },
+        "/digipeater/blocklist": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "digipeater"
+                ],
+                "summary": "List digipeater blocklist entries",
+                "operationId": "listDigipeaterBlocklist",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.BlocklistEntryResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "digipeater"
+                ],
+                "summary": "Create digipeater blocklist entry",
+                "operationId": "createDigipeaterBlocklist",
+                "parameters": [
+                    {
+                        "description": "Blocklist entry",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.BlocklistEntryRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.BlocklistEntryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/digipeater/blocklist/{id}": {
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "digipeater"
+                ],
+                "summary": "Update digipeater blocklist entry",
+                "operationId": "updateDigipeaterBlocklist",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Entry id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Blocklist entry",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.BlocklistEntryRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.BlocklistEntryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "tags": [
+                    "digipeater"
+                ],
+                "summary": "Delete digipeater blocklist entry",
+                "operationId": "deleteDigipeaterBlocklist",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Entry id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/digipeater/rules": {
             "get": {
                 "security": [
@@ -8375,6 +8572,37 @@
             "properties": {
                 "status": {
                     "description": "\"sent\"",
+                    "type": "string"
+                }
+            }
+        },
+        "dto.BlocklistEntryRequest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "pattern": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.BlocklistEntryResponse": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "pattern": {
+                    "type": "string"
+                },
+                "reason": {
                     "type": "string"
                 }
             }

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -931,6 +931,26 @@ definitions:
         description: '"sent"'
         type: string
     type: object
+  dto.BlocklistEntryRequest:
+    properties:
+      enabled:
+        type: boolean
+      pattern:
+        type: string
+      reason:
+        type: string
+    type: object
+  dto.BlocklistEntryResponse:
+    properties:
+      enabled:
+        type: boolean
+      id:
+        type: integer
+      pattern:
+        type: string
+      reason:
+        type: string
+    type: object
   dto.Catalog:
     properties:
       countries:
@@ -4535,6 +4555,131 @@ paths:
       security:
         - CookieAuth: []
       summary: Update digipeater config
+      tags:
+        - digipeater
+  /digipeater/blocklist:
+    get:
+      operationId: listDigipeaterBlocklist
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/dto.BlocklistEntryResponse'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: List digipeater blocklist entries
+      tags:
+        - digipeater
+    post:
+      consumes:
+        - application/json
+      operationId: createDigipeaterBlocklist
+      parameters:
+        - description: Blocklist entry
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/dto.BlocklistEntryRequest'
+      produces:
+        - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.BlocklistEntryResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Create digipeater blocklist entry
+      tags:
+        - digipeater
+  /digipeater/blocklist/{id}:
+    delete:
+      operationId: deleteDigipeaterBlocklist
+      parameters:
+        - description: Entry id
+          in: path
+          name: id
+          required: true
+          type: integer
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Delete digipeater blocklist entry
+      tags:
+        - digipeater
+    put:
+      consumes:
+        - application/json
+      operationId: updateDigipeaterBlocklist
+      parameters:
+        - description: Entry id
+          in: path
+          name: id
+          required: true
+          type: integer
+        - description: Blocklist entry
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/dto.BlocklistEntryRequest'
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.BlocklistEntryResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Update digipeater blocklist entry
       tags:
         - digipeater
   /digipeater/rules:

--- a/pkg/webapi/docs/op_ids.go
+++ b/pkg/webapi/docs/op_ids.go
@@ -105,6 +105,16 @@ const (
 	OpDeleteDigipeaterRule = "deleteDigipeaterRule"
 )
 
+// Digipeater blocklist resource — /api/digipeater/blocklist (global
+// source-address deny list, digipeater-scope only; see
+// docs/wiki/invariants.md).
+const (
+	OpListDigipeaterBlocklist   = "listDigipeaterBlocklist"
+	OpCreateDigipeaterBlocklist = "createDigipeaterBlocklist"
+	OpUpdateDigipeaterBlocklist = "updateDigipeaterBlocklist"
+	OpDeleteDigipeaterBlocklist = "deleteDigipeaterBlocklist"
+)
+
 // Igate RF filters resource — /api/igate/filters (Phase 2). The
 // singleton config at /api/igate/config is Phase 3's concern — see
 // the Phase 3 block below.

--- a/pkg/webapi/dto/digipeater.go
+++ b/pkg/webapi/dto/digipeater.go
@@ -126,3 +126,41 @@ func DigipeaterRulesFromModels(ms []configstore.DigipeaterRule) []DigipeaterRule
 	}
 	return out
 }
+
+// BlocklistEntryRequest is the body accepted by POST/PUT on
+// /api/digipeater/blocklist[/{id}]. Pattern is validated and
+// canonicalized server-side by pkg/digipeater/blocklist.ValidatePattern;
+// the canonical form is what gets stored and returned.
+//
+// Enabled is *bool so omitting the field on create means "default true".
+// On update the omitted-means-unchanged semantic does not apply: the
+// handler uses a Save-style replace so callers must send every field
+// they want to keep.
+type BlocklistEntryRequest struct {
+	Pattern string `json:"pattern"`
+	Reason  string `json:"reason"`
+	Enabled *bool  `json:"enabled,omitempty"`
+}
+
+// Validate is a no-op on this DTO. Pattern syntax is validated in the
+// handler via blocklist.ValidatePattern so the canonical form (used by
+// both storage and matching) is computed in one place; Reason length is
+// trimmed and capped there too. The handler also maps the unique-index
+// violation to 409.
+func (r BlocklistEntryRequest) Validate() error { return nil }
+
+type BlocklistEntryResponse struct {
+	ID      uint32 `json:"id"`
+	Pattern string `json:"pattern"`
+	Reason  string `json:"reason"`
+	Enabled bool   `json:"enabled"`
+}
+
+func BlocklistEntryFromModel(m configstore.DigipeaterBlocklist) BlocklistEntryResponse {
+	return BlocklistEntryResponse{
+		ID:      m.ID,
+		Pattern: m.Pattern,
+		Reason:  m.Reason,
+		Enabled: m.Enabled,
+	}
+}

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -573,6 +573,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/digipeater/blocklist": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List digipeater blocklist entries */
+        get: operations["listDigipeaterBlocklist"];
+        put?: never;
+        /** Create digipeater blocklist entry */
+        post: operations["createDigipeaterBlocklist"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/digipeater/blocklist/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update digipeater blocklist entry */
+        put: operations["updateDigipeaterBlocklist"];
+        post?: never;
+        /** Delete digipeater blocklist entry */
+        delete: operations["deleteDigipeaterBlocklist"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/digipeater/rules": {
         parameters: {
             query?: never;
@@ -2285,6 +2321,17 @@ export interface components {
             /** @description "sent" */
             status?: string;
         };
+        "dto.BlocklistEntryRequest": {
+            enabled?: boolean;
+            pattern?: string;
+            reason?: string;
+        };
+        "dto.BlocklistEntryResponse": {
+            enabled?: boolean;
+            id?: number;
+            pattern?: string;
+            reason?: string;
+        };
         "dto.Catalog": {
             countries?: components["schemas"]["dto.CatalogCountry"][];
             generatedAt?: string;
@@ -3466,6 +3513,12 @@ export interface components {
         "dto.IGateRfFilterRequest": {
             content: {
                 "application/json": components["schemas"]["dto.IGateRfFilterRequest"];
+            };
+        };
+        /** @description Blocklist entry */
+        "dto.BlocklistEntryRequest": {
+            content: {
+                "application/json": components["schemas"]["dto.BlocklistEntryRequest"];
             };
         };
         /** @description Tx-timing definition */
@@ -5786,6 +5839,180 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listDigipeaterBlocklist: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.BlocklistEntryResponse"][];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createDigipeaterBlocklist: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: components["requestBodies"]["dto.BlocklistEntryRequest"];
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.BlocklistEntryResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateDigipeaterBlocklist: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Entry id */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: components["requestBodies"]["dto.BlocklistEntryRequest"];
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.BlocklistEntryResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteDigipeaterBlocklist: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Entry id */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["webtypes.ErrorResponse"];
                 };
             };
         };

--- a/web/src/routes/Digipeater.svelte
+++ b/web/src/routes/Digipeater.svelte
@@ -118,6 +118,28 @@
     priority: 100,
     enabled: true,
   });
+  // --- Blocked Stations -------------------------------------------------
+  let blocklist = $state([]);
+  let blockModalOpen = $state(false);
+  let blockEditing = $state(null);
+  let blockForm = $state({
+    pattern: '',
+    reason: '',
+    enabled: true,
+  });
+  let blockSaving = $state(false);
+  let blockConfirmOpen = $state(false);
+  let blockConfirmMessage = $state('');
+  let blockPendingDeleteId = $state(null);
+
+  const BLOCK_COLUMNS = [
+    { key: 'pattern', label: 'Pattern' },
+    { key: 'reason', label: 'Reason' },
+    { key: 'enabled', label: 'Enabled' },
+  ];
+
+  let displayBlocklist = $derived(blocklist.map(b => ({ ...b })));
+
   let savingConfig = $state(false);
 
   // Last-persisted config body. The master Enable toggle auto-saves
@@ -275,6 +297,7 @@
     callsignMode = storedMyCall ? 'override' : 'inherit';
     myCallInput = storedMyCall;
     rules = await api.get('/digipeater/rules') || [];
+    blocklist = await api.get('/digipeater/blocklist') || [];
     startChannelsStore();
   });
 
@@ -474,6 +497,100 @@
       rules = await api.get('/digipeater/rules') || [];
     } catch (err) {
       toasts.error(err.message);
+    }
+  }
+
+  function openBlockCreate() {
+    blockEditing = null;
+    blockForm = { pattern: '', reason: '', enabled: true };
+    blockModalOpen = true;
+  }
+
+  function openBlockEdit(row) {
+    blockEditing = row;
+    blockForm = {
+      pattern: row.pattern || '',
+      reason: row.reason || '',
+      enabled: row.enabled ?? true,
+    };
+    blockModalOpen = true;
+  }
+
+  // Client-side mirror of pkg/digipeater/blocklist.ValidatePattern for
+  // instant feedback. The server remains authoritative — any error it
+  // returns is displayed verbatim.
+  function clientValidatePattern(s) {
+    const trimmed = (s || '').trim();
+    if (!trimmed) return 'Pattern is empty';
+    if (trimmed === '*' || trimmed === '-' || trimmed === '-*') {
+      return 'Pattern is too broad';
+    }
+    return null;
+  }
+
+  async function handleBlockSave() {
+    const pattern = blockForm.pattern.trim();
+    const localErr = clientValidatePattern(pattern);
+    if (localErr) {
+      toasts.error(localErr);
+      return;
+    }
+    blockSaving = true;
+    try {
+      const body = {
+        pattern,
+        reason: (blockForm.reason || '').trim(),
+        enabled: blockForm.enabled,
+      };
+      if (blockEditing) {
+        await api.put(`/digipeater/blocklist/${blockEditing.id}`, body);
+        toasts.success('Block list entry updated');
+      } else {
+        await api.post('/digipeater/blocklist', body);
+        toasts.success('Block list entry created');
+      }
+      blockModalOpen = false;
+      blocklist = await api.get('/digipeater/blocklist') || [];
+    } catch (err) {
+      toasts.error(err.message || 'Failed to save block list entry');
+    } finally {
+      blockSaving = false;
+    }
+  }
+
+  function handleBlockDelete(row) {
+    blockPendingDeleteId = row.id;
+    blockConfirmMessage = `Delete block list entry for "${row.pattern}"?`;
+    blockConfirmOpen = true;
+  }
+
+  async function confirmBlockDelete() {
+    const id = blockPendingDeleteId;
+    blockPendingDeleteId = null;
+    if (id == null) return;
+    try {
+      await api.delete(`/digipeater/blocklist/${id}`);
+      toasts.success('Block list entry deleted');
+      blocklist = await api.get('/digipeater/blocklist') || [];
+    } catch (err) {
+      toasts.error(err.message || 'Failed to delete block list entry');
+    }
+  }
+
+  // Per-row auto-save when the operator flips the Enabled column toggle.
+  async function autoSaveBlockEnabled(row, next) {
+    if (next === row.enabled) return;
+    try {
+      await api.put(`/digipeater/blocklist/${row.id}`, {
+        pattern: row.pattern,
+        reason: row.reason || '',
+        enabled: next,
+      });
+      blocklist = await api.get('/digipeater/blocklist') || [];
+      toasts.success(next ? 'Block list entry enabled' : 'Block list entry disabled');
+    } catch (err) {
+      toasts.error(err.message || 'Failed to update entry');
+      blocklist = await api.get('/digipeater/blocklist') || [];
     }
   }
 </script>
@@ -690,6 +807,53 @@
       >{editing ? 'Save' : 'Create'}</Button>
     </div>
 </Modal>
+
+<div style="margin-top: 20px;">
+  <PageHeader title="Blocked Stations" subtitle="Frames from these stations will not be digipeated. The iGate, packet log, and other receivers are unaffected.">
+    <Button variant="primary" onclick={openBlockCreate}>+ Add blocked station</Button>
+  </PageHeader>
+  <DataTable
+    columns={BLOCK_COLUMNS}
+    rows={displayBlocklist}
+    onEdit={openBlockEdit}
+    onDelete={handleBlockDelete}
+    cells={{ enabled: blockEnabledCell }}
+  />
+</div>
+
+{#snippet blockEnabledCell(_value, row)}
+  <Toggle
+    checked={row.enabled}
+    onCheckedChange={(next) => autoSaveBlockEnabled(row, next)}
+    aria-label="Enable block list entry for {row.pattern}"
+  />
+{/snippet}
+
+<Modal bind:open={blockModalOpen} title={blockEditing ? 'Edit Blocked Station' : 'Add Blocked Station'}>
+  <FormField label="Pattern" id="block-pattern"
+    hint="e.g. N1ROG, N1ROG-9, or N1ROG-*">
+    <Input id="block-pattern" bind:value={blockForm.pattern} placeholder="N1ROG-*" autocomplete="off" spellcheck={false} />
+  </FormField>
+  <FormField label="Reason (optional)" id="block-reason"
+    hint="Free text, max 256 characters. Shown in debug logs when this pattern blocks a frame.">
+    <Input id="block-reason" bind:value={blockForm.reason} placeholder="e.g. malformed beacons" />
+  </FormField>
+  <Toggle bind:checked={blockForm.enabled} label="Enabled" />
+  <div class="modal-actions">
+    <Button onclick={() => blockModalOpen = false}>Cancel</Button>
+    <Button variant="primary" onclick={handleBlockSave} disabled={blockSaving}>
+      {blockEditing ? 'Save' : 'Create'}
+    </Button>
+  </div>
+</Modal>
+
+<ConfirmDialog
+  bind:open={blockConfirmOpen}
+  title="Delete Blocked Station"
+  message={blockConfirmMessage}
+  confirmLabel="Delete"
+  onConfirm={confirmBlockDelete}
+/>
 
 <ConfirmDialog
   bind:open={confirmOpen}

--- a/web/src/routes/Digipeater.svelte
+++ b/web/src/routes/Digipeater.svelte
@@ -808,7 +808,7 @@
     </div>
 </Modal>
 
-<div style="margin-top: 20px;">
+<div style="margin-top: 48px;">
   <PageHeader title="Blocked Stations" subtitle="Frames from these stations will not be digipeated. The iGate, packet log, and other receivers are unaffected.">
     <Button variant="primary" onclick={openBlockCreate}>+ Add blocked station</Button>
   </PageHeader>
@@ -831,8 +831,8 @@
 
 <Modal bind:open={blockModalOpen} title={blockEditing ? 'Edit Blocked Station' : 'Add Blocked Station'}>
   <FormField label="Pattern" id="block-pattern"
-    hint="e.g. N1ROG, N1ROG-9, or N1ROG-*">
-    <Input id="block-pattern" bind:value={blockForm.pattern} placeholder="N1ROG-*" autocomplete="off" spellcheck={false} />
+    hint="e.g. BADCAL, BADCAL-9, or BADCAL-*">
+    <Input id="block-pattern" bind:value={blockForm.pattern} placeholder="BADCAL-*" autocomplete="off" spellcheck={false} />
   </FormField>
   <FormField label="Reason (optional)" id="block-reason"
     hint="Free text, max 256 characters. Shown in debug logs when this pattern blocks a frame.">


### PR DESCRIPTION
## Summary

Adds a per-source deny list to the digipeater engine. Operators can name stations (with or without SSID, with `-*` wildcard) whose frames will not be digipeated, without affecting any other RX consumer (iGate, packet log, dashboard, station cache, AGW/KISS fanouts).

- **Engine:** new `pkg/digipeater/blocklist/` package (`ValidatePattern`, `List`, `Matches`); engine `Handle` consults the list after the packet-mode/enabled/mycall guards and **before** dedup, so blocked frames neither churn the dedup window nor inflate `Deduped`.
- **Persistence:** new `DigipeaterBlocklist` GORM model (id, pattern with unique index, reason, enabled) + 5 CRUD methods. No `CreatedAt`/`UpdatedAt`.
- **Wiring:** `digipeaterComponent.reload` loads the block list alongside rules and pushes it to the live engine via `SetBlocklist`; the 3 early-return paths also clear it.
- **Isolation invariant:** new regression test `pkg/app/wiring_blocklist_isolation_test.go` proves a blocked frame still reaches the APRS submit pipeline.
- **API:** 4 endpoints under `/api/digipeater/blocklist[/{id}]` (list, create, update, delete); server canonicalizes the pattern, maps unique-index violations to 409. Swagger + TS client regenerated.
- **UI:** new "Blocked Stations" section in Digipeater settings (table, modal, per-row auto-save Enabled toggle, plain red delete confirm).
- **Docs:** `docs/wiki/code-map.md` + new invariant 40 in `docs/wiki/invariants.md`.
- **Release note:** info-style entry prepended for v0.13.12.

## Test Plan

- [x] `go build ./...`
- [x] `go test ./pkg/digipeater/... ./pkg/configstore/... ./pkg/webapi/... ./pkg/app/...`
- [x] `make docs-lint` / `make docs-check`
- [x] `make api-client-check`
- [x] `cd web && npm run build` and `npm test`
- [ ] Browser smoke: add/edit/delete a blocked station; flip the per-row Enabled toggle; verify a bad pattern surfaces the server error and a duplicate returns "pattern already exists"
- [ ] On-air smoke: with a `CALL-*` entry enabled, confirm digipeater silently drops that source while iGate / packet log still see the frames

Implements [docs/superpowers/plans/2026-05-29-digipeater-source-blocklist.md](docs/superpowers/plans/2026-05-29-digipeater-source-blocklist.md).