### PR TITLE
Restore armv6 / 32-bit Pi builds (fixes #199)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,19 +26,11 @@ jobs:
             arch: arm64
             platform: linux
             use_cross: true
-          # FOLLOWUP: armv6 (Pi 1 / Pi Zero / Pi Zero W) build is
-          # temporarily removed for v0.13.6. cross-rs upstream image
-          # changes broke the libudev linkage path
-          # (getrandom@GLIBC_2.25 missing because the installed libudev
-          # is newer than the sysroot glibc). The PKG_CONFIG_* and
-          # CFLAGS_* env-var fixes elsewhere in this file are kept
-          # and will still be useful when the row is restored. See
-          # project memory: project_followup_armv6_release.
-          # - os: ubuntu-latest
-          #   target: arm-unknown-linux-gnueabihf
-          #   arch: arm
-          #   platform: linux
-          #   use_cross: true
+          - os: ubuntu-latest
+            target: arm-unknown-linux-gnueabihf
+            arch: arm
+            platform: linux
+            use_cross: true
           - os: macos-15
             target: x86_64-apple-darwin
             arch: amd64
@@ -218,13 +210,10 @@ jobs:
 
       - name: Arrange Rust binaries for GoReleaser
         run: |
-          # FOLLOWUP: armv6 (linux_arm) artifact is temporarily missing
-          # because the rust-build matrix row is commented out above.
-          # Restore both lines together when armv6 cross-compile is fixed.
-          mkdir -p rust-bin/{linux_amd64,linux_arm64,darwin_amd64,darwin_arm64,windows_amd64}
+          mkdir -p rust-bin/{linux_amd64,linux_arm64,linux_arm,darwin_amd64,darwin_arm64,windows_amd64}
           cp rust-artifacts/rust-linux-amd64/graywolf-modem       rust-bin/linux_amd64/
           cp rust-artifacts/rust-linux-arm64/graywolf-modem       rust-bin/linux_arm64/
-          # cp rust-artifacts/rust-linux-arm/graywolf-modem         rust-bin/linux_arm/
+          cp rust-artifacts/rust-linux-arm/graywolf-modem         rust-bin/linux_arm/
           cp rust-artifacts/rust-darwin-amd64/graywolf-modem      rust-bin/darwin_amd64/
           cp rust-artifacts/rust-darwin-arm64/graywolf-modem      rust-bin/darwin_arm64/
           cp rust-artifacts/rust-windows-amd64/graywolf-modem.exe rust-bin/windows_amd64/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,6 +251,11 @@ jobs:
     name: Windows Installer
     runs-on: windows-latest
     needs: release
+    # NSIS computes VIProductVersion from github.ref_name and requires
+    # X.X.X.X format. On workflow_dispatch the ref is a branch name
+    # ("feat/foo") which fails that check. The real-tag release path
+    # (push tag v*) still runs as before.
+    if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,23 @@ jobs:
           path: dist/graywolf_windows_amd64_v1/graywolf.exe
           retention-days: 1
 
+      # On workflow_dispatch (snapshot mode) the produced .deb/.rpm/.tar.gz
+      # would otherwise evaporate with the runner. Upload them so we can
+      # download and test the artifacts on real hardware (e.g. Pi 5) before
+      # cutting a real release tag.
+      - name: Upload snapshot packages (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v5
+        with:
+          name: snapshot-packages
+          path: |
+            dist/*.deb
+            dist/*.rpm
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+          retention-days: 7
+
   installer:
     name: Windows Installer
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    # Lets us manually exercise the cross-rs + GoReleaser pipeline on a
+    # branch without cutting a release tag. Useful for verifying
+    # cross-compile changes (e.g. the armv6 / hidapi linux-native-basic-udev
+    # swap) before pushing a real tag and getting stuck in the retag dance.
+    # GoReleaser will still run on the dispatched ref; it builds + packages
+    # but won't upload because there's no associated tag.
 
 permissions:
   contents: write
@@ -226,7 +233,10 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --clean
+          # On a tag push we cut a real release; on workflow_dispatch we
+          # run in snapshot mode so the build pipeline executes end-to-end
+          # without needing a tag context (no upload, no draft release).
+          args: ${{ github.event_name == 'workflow_dispatch' && 'release --snapshot --clean' || 'release --clean' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,15 +24,9 @@ builds:
     goarch:
       - amd64
       - arm64
-      # FOLLOWUP: armv6 (Go GOARCH=arm GOARM=6) build temporarily
-      # removed for v0.13.6. The Rust modem cross-compile broke on
-      # cross-rs upstream image changes; without rust-bin/linux_arm
-      # to package against, the Go arm6 archive would have no modem
-      # binary. Restore - arm + goarm: ["6"] when the Rust side is
-      # fixed; see project memory project_followup_armv6_release.
-      # - arm
-    # goarm:
-    #   - "6"
+      - arm
+    goarm:
+      - "6"
     ignore:
       - goos: windows
         goarch: arm64

--- a/docs/handbook/installation.html
+++ b/docs/handbook/installation.html
@@ -85,9 +85,9 @@
 
         <p>
           Download the <code>.deb</code> package for your architecture
-          (<code>amd64</code>, <code>arm64</code>, or <code>armhf</code> for
-          older 32-bit Raspberry Pi hardware -- Pi 1, Pi 2, Pi Zero, Zero W)
-          from the
+          (<code>amd64</code>, <code>arm64</code>, or <code>armv6l</code>
+          for 32-bit Raspberry Pi OS on any Pi model -- Pi 1, Pi 2, Pi 3,
+          Pi 4, Pi 5, Pi Zero, or Zero W) from the
           <a href="https://github.com/chrissnell/graywolf/releases">GitHub Releases</a>
           page, then install it:
         </p>

--- a/graywolf-modem/Cargo.toml
+++ b/graywolf-modem/Cargo.toml
@@ -25,11 +25,20 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # hidapi (CM108 HID PTT) and nusb (USB topology enumeration) require host
-# OS facilities (libudev / IOKit / SetupAPI) that aren't available on
-# Android, and CM108 PTT isn't a target for Android anyway. Limit them
-# to desktop targets so the POC-A cross-compile doesn't drag in libudev.
+# OS facilities (IOKit / SetupAPI) that aren't available on Android, and
+# CM108 PTT isn't a target for Android anyway. Limit them to desktop
+# targets so the Android cross-compile doesn't drag them in.
+#
+# linux-native-basic-udev selects hidapi's pure-Rust hidraw backend with
+# the basic-udev pure-Rust enumeration crate. No libudev build/runtime
+# dep on Linux. Same kernel /dev/hidraw* interface for I/O; device
+# discovery walks /sys/class/hidraw/ directly. macOS (IOKit) and Windows
+# (SetupAPI) backends compile via cfg(target_os = ...) gates and are
+# unaffected. Avoid the "linux-native" feature: it still pulls the
+# libudev-FFI udev crate, which would defeat the point of the swap and
+# re-trigger the cross-rs armv6 link failure.
 [target.'cfg(not(target_os = "android"))'.dependencies]
-hidapi = "2.6"
+hidapi = { version = "2.6", default-features = false, features = ["linux-native-basic-udev"] }
 nusb = "0.1"
 
 [target.'cfg(target_os = "android")'.dependencies]


### PR DESCRIPTION
## Summary
- Switch hidapi to its `linux-native-basic-udev` feature, dropping the libudev build/runtime dep on all Linux targets
- Restore the `arm-unknown-linux-gnueabihf` build row in the release workflow + matching artifact copy
- Restore `arm` / `goarm: ["6"]` in goreleaser
- Fix the install handbook: `armhf` -> `armv6l`, and call out 32-bit Pi OS on Pi 3/4/5

Closes #199.

## Why this approach

The armv6 build broke in v0.13.6 because cross-rs's base-image glibc went out of sync with `libudev-dev:armhf` (`getrandom@GLIBC_2.25` link error). `hidapi` 2.6 ships a `linux-native-basic-udev` feature that does hidraw enumeration via the pure-Rust `basic-udev` crate, removing libudev from the picture entirely. Same kernel `/dev/hidraw*` interface for I/O; only device discovery changes.

Note: the `linux-native` feature is **not** the right choice -- it still pulls the libudev-FFI `udev` crate as a dependency and would re-trigger the cross-rs link failure. `linux-native-basic-udev` is the pure-Rust path.

amd64 and arm64 also lose the libudev dep -- desired, since regressions surface earliest on the platforms with most users.

## Test plan
- [x] Local `cargo build --release` on host (macOS) passes
- [x] Local `cargo test --workspace --no-run` passes
- [x] Local `cargo test --release --lib` passes (185/185 green in graywolf-modem)
- [ ] CI green: rust-build matrix succeeds on all 6 platforms (amd64, arm64, **armv6**, darwin-amd64, darwin-arm64, windows-amd64)
- [ ] CI green: `release` job produces `graywolf_X.Y.Z_linux_armv6l.deb` and `.rpm` and `.tar.gz`
- [ ] Manual smoke test on Linux with AIOC + digirig PTT (CDC-ACM DTR / serial RTS paths) - these do NOT exercise the CM108 HID enumeration path that actually changed
- [ ] **CM108 HID PTT verification still owed**: the `basic-udev` enumeration backend is the actual code path being swapped here and is not exercised by AIOC / digirig PTT. Either a CM108-equipped tester verifies before merge, OR the release-note entry for the restoring version flags this as a "please report regressions" item to CM108 users.
- [ ] Manual: install the produced armv6l `.deb` on a 32-bit Pi OS host (Pi 5 ideal, since that's the reporter's case) and confirm `graywolf` + `graywolf-modem` start and enumerate audio devices