### PR TITLE
packaging: drop ProtectClock=yes from systemd units (fixes #207)

### DIFF
--- a/packaging/aur/graywolf-aprs.service
+++ b/packaging/aur/graywolf-aprs.service
@@ -36,12 +36,6 @@ ProtectKernelModules=yes
 ProtectKernelTunables=yes
 ProtectKernelLogs=yes
 ProtectControlGroups=yes
-# ProtectClock=yes removed (issue #207): the implied DeviceAllow revokes
-# /dev/rtc*, which on some kernels prevents ALSA's timer init from
-# registering USB Audio class cards. Failure is silent — cpal enumeration
-# returns no entry for the card while `arecord -L` still lists it. We
-# don't grant CAP_SYS_TIME, so the process can't change the clock without
-# this directive anyway.
 ProtectHostname=yes
 
 # Execution hardening

--- a/packaging/aur/graywolf-aprs.service
+++ b/packaging/aur/graywolf-aprs.service
@@ -36,7 +36,12 @@ ProtectKernelModules=yes
 ProtectKernelTunables=yes
 ProtectKernelLogs=yes
 ProtectControlGroups=yes
-ProtectClock=yes
+# ProtectClock=yes removed (issue #207): the implied DeviceAllow revokes
+# /dev/rtc*, which on some kernels prevents ALSA's timer init from
+# registering USB Audio class cards. Failure is silent — cpal enumeration
+# returns no entry for the card while `arecord -L` still lists it. We
+# don't grant CAP_SYS_TIME, so the process can't change the clock without
+# this directive anyway.
 ProtectHostname=yes
 
 # Execution hardening

--- a/packaging/systemd/graywolf.service
+++ b/packaging/systemd/graywolf.service
@@ -48,12 +48,6 @@ ProtectKernelModules=yes
 ProtectKernelTunables=yes
 ProtectKernelLogs=yes
 ProtectControlGroups=yes
-# ProtectClock=yes removed (issue #207): the implied DeviceAllow revokes
-# /dev/rtc*, which on some kernels prevents ALSA's timer init from
-# registering USB Audio class cards. Failure is silent — cpal enumeration
-# returns no entry for the card while `arecord -L` still lists it. We
-# don't grant CAP_SYS_TIME, so the process can't change the clock without
-# this directive anyway.
 ProtectHostname=yes
 
 # Execution hardening

--- a/packaging/systemd/graywolf.service
+++ b/packaging/systemd/graywolf.service
@@ -48,7 +48,12 @@ ProtectKernelModules=yes
 ProtectKernelTunables=yes
 ProtectKernelLogs=yes
 ProtectControlGroups=yes
-ProtectClock=yes
+# ProtectClock=yes removed (issue #207): the implied DeviceAllow revokes
+# /dev/rtc*, which on some kernels prevents ALSA's timer init from
+# registering USB Audio class cards. Failure is silent — cpal enumeration
+# returns no entry for the card while `arecord -L` still lists it. We
+# don't grant CAP_SYS_TIME, so the process can't change the clock without
+# this directive anyway.
 ProtectHostname=yes
 
 # Execution hardening


### PR DESCRIPTION
## Summary

- Drops `ProtectClock=yes` from both `packaging/systemd/graywolf.service` (deb/rpm) and `packaging/aur/graywolf-aprs.service` (Arch).
- Inline comment in each unit explains *why* so the next person reaching for a hardening sweep doesn't re-add it.

## Why

`ProtectClock=yes` implies a `DeviceAllow` rule that revokes `/dev/rtc*`. On some kernel/userspace combinations (confirmed on Linux Mint with kernel 6.x) this prevents ALSA's timer subsystem from registering USB Audio class cards. The failure mode is silent:

- `arecord -L` still lists `hw:CARD=CODEC,DEV=0`
- `arecord -D plughw:1,0 -d 5` still captures
- But cpal's `host.input_devices()` iterator inside the long-running modem subprocess returns no entry for the card
- → UI "Detect Audio" returns an empty list
- → Manually typing the device into a channel fails with `input device not found`

The hardening benefit was already zero: `CapabilityBoundingSet=CAP_NET_BIND_SERVICE` excludes `CAP_SYS_TIME`, so the process can't change the clock with or without this directive.

Reported and root-caused by @cyba3r on issue #207 (FT-991A built-in USB CODEC). All other hardening (ProtectKernelModules, ProtectSystem=strict, NoNewPrivileges, etc.) is unaffected.

## Test plan

- [ ] Reporter (or local Linux box with USB audio device plugged in *after* service start) verifies that after upgrading and restarting graywolf, Detect populates and an `hw:CARD=…,DEV=0` channel binds successfully.
- [ ] `systemd-analyze security graywolf` shows the expected one-step regression in score (from removing this single directive), no surprises.