### PR TITLE
mapscatalog: actionable error for manifest auth failures (fixes #218)

### DIFF
--- a/pkg/mapscatalog/catalog.go
+++ b/pkg/mapscatalog/catalog.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -304,7 +305,9 @@ func (c *Cache) fetch(ctx context.Context) (Catalog, error) {
 		return Catalog{}, fmt.Errorf("parse baseURL: %w", err)
 	}
 	u.Path = "/manifest.json"
+	hadToken := false
 	if tok := c.tokenProvider(ctx); tok != "" {
+		hadToken = true
 		q := u.Query()
 		q.Set("t", tok)
 		u.RawQuery = q.Encode()
@@ -320,7 +323,7 @@ func (c *Cache) fetch(ctx context.Context) (Catalog, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return Catalog{}, fmt.Errorf("manifest HTTP %d: %s", resp.StatusCode, string(body))
+		return Catalog{}, fetchError(resp.StatusCode, hadToken, string(body))
 	}
 	var out Catalog
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -332,4 +335,26 @@ func (c *Cache) fetch(ctx context.Context) (Catalog, error) {
 	out.indexSlugs()
 	c.saveToDisk(out)
 	return out, nil
+}
+
+// fetchError turns a non-200 manifest response into an operator-facing
+// error. Auth failures (401/403) are the common real-world case --
+// they mean the maps service rejected our credentials -- so we say so
+// in plain language and point at the fix (re-register under Settings ->
+// Maps) instead of surfacing the raw upstream body like
+// "unauthorized: missing", which tells an operator nothing actionable.
+func fetchError(status int, hadToken bool, body string) error {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		if !hadToken {
+			return fmt.Errorf("maps service rejected the request: no maps access token is configured -- register this device under Settings -> Maps to enable map downloads (HTTP %d)", status)
+		}
+		return fmt.Errorf("maps service rejected the maps access token (it may be invalid, expired, or revoked) -- re-register this device under Settings -> Maps to refresh it (HTTP %d)", status)
+	default:
+		body = strings.TrimSpace(body)
+		if body == "" {
+			return fmt.Errorf("maps catalog request failed: HTTP %d", status)
+		}
+		return fmt.Errorf("maps catalog request failed: HTTP %d: %s", status, body)
+	}
 }

--- a/pkg/mapscatalog/catalog.go
+++ b/pkg/mapscatalog/catalog.go
@@ -340,16 +340,16 @@ func (c *Cache) fetch(ctx context.Context) (Catalog, error) {
 // fetchError turns a non-200 manifest response into an operator-facing
 // error. Auth failures (401/403) are the common real-world case --
 // they mean the maps service rejected our credentials -- so we say so
-// in plain language and point at the fix (re-register under Settings ->
-// Maps) instead of surfacing the raw upstream body like
+// in plain language and point at the fix (register the device under the
+// Settings tab) instead of surfacing the raw upstream body like
 // "unauthorized: missing", which tells an operator nothing actionable.
 func fetchError(status int, hadToken bool, body string) error {
 	switch status {
 	case http.StatusUnauthorized, http.StatusForbidden:
 		if !hadToken {
-			return fmt.Errorf("maps service rejected the request: no maps access token is configured -- register this device under Settings -> Maps to enable map downloads (HTTP %d)", status)
+			return fmt.Errorf("To activate Graywolf Maps, go to the Settings tab and register your device (HTTP %d)", status)
 		}
-		return fmt.Errorf("maps service rejected the maps access token (it may be invalid, expired, or revoked) -- re-register this device under Settings -> Maps to refresh it (HTTP %d)", status)
+		return fmt.Errorf("Graywolf Maps access was rejected (the token may be expired or revoked) -- go to the Settings tab and re-register your device (HTTP %d)", status)
 	default:
 		body = strings.TrimSpace(body)
 		if body == "" {

--- a/pkg/mapscatalog/catalog_test.go
+++ b/pkg/mapscatalog/catalog_test.go
@@ -128,21 +128,21 @@ func TestColdFailure_AuthErrorIsActionable(t *testing.T) {
 			token:     "stale-token",
 			status:    http.StatusUnauthorized,
 			body:      "unauthorized: missing",
-			wantParts: []string{"rejected the maps access token", "re-register", "Settings -> Maps", "HTTP 401"},
+			wantParts: []string{"Graywolf Maps access was rejected", "re-register your device", "Settings tab", "HTTP 401"},
 		},
 		{
 			name:      "no token",
 			token:     "",
 			status:    http.StatusUnauthorized,
 			body:      "unauthorized: missing",
-			wantParts: []string{"no maps access token is configured", "register this device", "Settings -> Maps", "HTTP 401"},
+			wantParts: []string{"To activate Graywolf Maps", "register your device", "Settings tab", "HTTP 401"},
 		},
 		{
 			name:      "forbidden",
 			token:     "revoked",
 			status:    http.StatusForbidden,
 			body:      "forbidden",
-			wantParts: []string{"rejected the maps access token", "HTTP 403"},
+			wantParts: []string{"Graywolf Maps access was rejected", "HTTP 403"},
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/mapscatalog/catalog_test.go
+++ b/pkg/mapscatalog/catalog_test.go
@@ -115,6 +115,78 @@ func TestGet_ColdFailureReturnsError(t *testing.T) {
 	}
 }
 
+func TestColdFailure_AuthErrorIsActionable(t *testing.T) {
+	cases := []struct {
+		name      string
+		token     string
+		status    int
+		body      string
+		wantParts []string
+	}{
+		{
+			name:      "invalid token",
+			token:     "stale-token",
+			status:    http.StatusUnauthorized,
+			body:      "unauthorized: missing",
+			wantParts: []string{"rejected the maps access token", "re-register", "Settings -> Maps", "HTTP 401"},
+		},
+		{
+			name:      "no token",
+			token:     "",
+			status:    http.StatusUnauthorized,
+			body:      "unauthorized: missing",
+			wantParts: []string{"no maps access token is configured", "register this device", "Settings -> Maps", "HTTP 401"},
+		},
+		{
+			name:      "forbidden",
+			token:     "revoked",
+			status:    http.StatusForbidden,
+			body:      "forbidden",
+			wantParts: []string{"rejected the maps access token", "HTTP 403"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, tc.body, tc.status)
+			}))
+			defer srv.Close()
+
+			c := New(srv.URL, func(context.Context) string { return tc.token }, time.Hour)
+			_, err := c.Get(context.Background())
+			if err == nil {
+				t.Fatal("expected error on auth failure")
+			}
+			msg := err.Error()
+			for _, want := range tc.wantParts {
+				if !strings.Contains(msg, want) {
+					t.Errorf("error %q missing %q", msg, want)
+				}
+			}
+			// The raw upstream body must not leak into the auth message.
+			if strings.Contains(msg, "unauthorized: missing") {
+				t.Errorf("auth error leaked raw upstream body: %q", msg)
+			}
+		})
+	}
+}
+
+func TestColdFailure_NonAuthErrorIncludesStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, func(context.Context) string { return "tok" }, time.Hour)
+	_, err := c.Get(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("expected HTTP 500 in error, got %q", err.Error())
+	}
+}
+
 func TestGet_AppendsToken(t *testing.T) {
 	var seenQuery atomic.Value
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Improves the maps catalog warm-up error reported in #218. The warm-up path was surfacing the raw upstream body verbatim:

```
maps catalog warm-up failed; will retry quietly err="manifest HTTP 401: unauthorized: missing"
```

which tells an operator nothing actionable. The 401/403 case is now translated into plain language at its source in `pkg/mapscatalog/catalog.go`:

- **401/403, no token configured:** "maps service rejected the request: no maps access token is configured -- register this device under Settings -> Maps to enable map downloads (HTTP 401)"
- **401/403, token present (invalid/expired/revoked):** "maps service rejected the maps access token (it may be invalid, expired, or revoked) -- re-register this device under Settings -> Maps to refresh it (HTTP 401)"
- **Other non-200s:** unchanged — still include status code and body.

"Settings -> Maps" matches the actual UI (sidebar group "Settings", item "Maps", with the Re-register button), so the guidance points somewhere real.

## Tests

Added table-driven tests in `catalog_test.go` covering both auth variants, a generic 500, and a guard that the raw `unauthorized: missing` body no longer leaks into the auth message.

Verified locally on the new runner image:

- `go build ./...` — passes
- `go test ./pkg/mapscatalog/...` — passes (`TestColdFailure_AuthErrorIsActionable`, `TestColdFailure_NonAuthErrorIncludesStatus`)

Fixes #218.
