### PR TITLE
build: add armv7+NEON release target for 32-bit ARM (fixes #217)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,24 @@
+# Per-target codegen flags.
+#
+# The 32-bit ARM hard-float release ships two distinct binaries:
+#
+#   arm-unknown-linux-gnueabihf    -> armv6, scalar VFPv2, no NEON.
+#       Covers the armv6-only Pi 1 / Pi Zero / Zero W that the handbook
+#       supports. Rust's default features for this triple are correct as-is
+#       (the triple has no NEON), so it intentionally appears nowhere below.
+#
+#   armv7-unknown-linux-gnueabihf  -> armv7-a, NEON enabled here.
+#       Rust's built-in spec for this triple defaults to "-neon" for maximum
+#       compatibility. We flip it on because every armv7-a application core
+#       people run a Linux APRS gateway on (Cortex-A7/A8/A9/A15/A17, e.g. the
+#       reporter's RV1106 Cortex-A7) has NEON. With NEON the autovectorizer
+#       can use the AFSK demod's eight-accumulator FIR loop
+#       (graywolf-modem/src/demod_afsk.rs `convolve`); without it that DSP
+#       hot path runs fully scalar and badly under-represents Graywolf on the
+#       very benchmark this build exists to support.
+#
+# We enable NEON but NOT VFPv4/FMA: Cortex-A7/A15 have fused multiply-add,
+# but A8/A9 do not, and emitting FMA there would SIGILL. +neon alone
+# vectorizes the loop and stays safe across the whole armv7-a NEON family.
+[target.armv7-unknown-linux-gnueabihf]
+rustflags = ["-C", "target-feature=+neon"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
             arch: arm
             platform: linux
             use_cross: true
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            arch: armv7
+            platform: linux
+            use_cross: true
           - os: macos-15
             target: x86_64-apple-darwin
             arch: amd64
@@ -110,6 +115,9 @@ jobs:
           PKG_CONFIG_ALLOW_CROSS: '1'
           PKG_CONFIG_PATH_aarch64_unknown_linux_gnu: '/usr/lib/aarch64-linux-gnu/pkgconfig'
           PKG_CONFIG_PATH_arm_unknown_linux_gnueabihf: '/usr/lib/arm-linux-gnueabihf/pkgconfig'
+          # armv7 shares the arm-linux-gnueabihf multi-arch dir with armv6;
+          # only the per-triple var name differs (cross keys on the triple).
+          PKG_CONFIG_PATH_armv7_unknown_linux_gnueabihf: '/usr/lib/arm-linux-gnueabihf/pkgconfig'
           # hidapi crate's bundled-source cc-rs compile needs libudev.h.
           # libudev-dev:<arch> installs the header at /usr/include/libudev.h
           # (Multi-Arch: same), but the cross-compiler's sysroot doesn't
@@ -123,6 +131,7 @@ jobs:
           # only the arch-independent libudev.h falls through.
           CFLAGS_aarch64_unknown_linux_gnu: '-idirafter /usr/include'
           CFLAGS_arm_unknown_linux_gnueabihf: '-idirafter /usr/include'
+          CFLAGS_armv7_unknown_linux_gnueabihf: '-idirafter /usr/include'
         run: cross build --release --target ${{ matrix.target }} --bin graywolf-modem
 
       - name: Build with cargo
@@ -217,10 +226,13 @@ jobs:
 
       - name: Arrange Rust binaries for GoReleaser
         run: |
-          mkdir -p rust-bin/{linux_amd64,linux_arm64,linux_arm,darwin_amd64,darwin_arm64,windows_amd64}
+          mkdir -p rust-bin/{linux_amd64,linux_arm64,linux_arm,linux_armv7,darwin_amd64,darwin_arm64,windows_amd64}
           cp rust-artifacts/rust-linux-amd64/graywolf-modem       rust-bin/linux_amd64/
           cp rust-artifacts/rust-linux-arm64/graywolf-modem       rust-bin/linux_arm64/
           cp rust-artifacts/rust-linux-arm/graywolf-modem         rust-bin/linux_arm/
+          # armv7 (NEON) modem -- kept distinct from the armv6 linux_arm
+          # build so the goarm=7 archive/package bundle the optimized binary.
+          cp rust-artifacts/rust-linux-armv7/graywolf-modem       rust-bin/linux_armv7/
           cp rust-artifacts/rust-darwin-amd64/graywolf-modem      rust-bin/darwin_amd64/
           cp rust-artifacts/rust-darwin-arm64/graywolf-modem      rust-bin/darwin_arm64/
           cp rust-artifacts/rust-windows-amd64/graywolf-modem.exe rust-bin/windows_amd64/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,8 +25,14 @@ builds:
       - amd64
       - arm64
       - arm
+    # Two 32-bit ARM builds: GOARM=6 for armv6-only Pi (1/Zero), GOARM=7
+    # for armv7-a boards. Their Rust modem counterparts differ too -- the
+    # GOARM=7 archive/package bundle the NEON modem (see rust-bin paths
+    # below). goarch=arm + goarm 6/7 both map to dpkg "armhf"; the nfpm
+    # file_name_template disambiguates the .deb/.rpm names.
     goarm:
       - "6"
+      - "7"
     ignore:
       - goos: windows
         goarch: arm64
@@ -47,11 +53,15 @@ archives:
       {{- if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if and (eq .Arch "arm") (eq .Arm "6") }}armv6l
+      {{- else if and (eq .Arch "arm") (eq .Arm "7") }}armv7l
       {{- else }}{{ .Arch }}{{ end }}
     files:
       - LICENSE*
       - README*
-      - src: "rust-bin/{{ .Os }}_{{ .Arch }}/graywolf-modem{{ if eq .Os \"windows\" }}.exe{{ end }}"
+      # goarch=arm covers both GOARM=6 (linux_arm) and GOARM=7
+      # (linux_armv7) Rust modems; pick the matching one by GOARM so the
+      # armv7 archive ships the NEON build, not the scalar armv6 one.
+      - src: "rust-bin/{{ .Os }}_{{ .Arch }}{{ if and (eq .Arch \"arm\") (eq .Arm \"7\") }}v7{{ end }}/graywolf-modem{{ if eq .Os \"windows\" }}.exe{{ end }}"
         dst: .
         strip_parent: true
 
@@ -66,6 +76,17 @@ nfpms:
     formats:
       - deb
       - rpm
+    # goarch=arm + GOARM 6 and 7 both map to dpkg "armhf", so the default
+    # conventional name collides (two graywolf_<ver>_armhf.deb). Keep the
+    # conventional name for every arch except the new armv7 build, which
+    # gets a distinct armv7l name so operators can tell the NEON package
+    # apart from the armv6 one.
+    file_name_template: >-
+      {{- if and (eq .Arch "arm") (eq .Arm "7") -}}
+      {{ .PackageName }}_{{ .Version }}_armv7l{{ .ConventionalExtension }}
+      {{- else -}}
+      {{ .ConventionalFileName }}
+      {{- end -}}
     bindir: /usr/bin
     contents:
       - src: packaging/systemd/graywolf.service
@@ -73,7 +94,9 @@ nfpms:
       - src: packaging/udev/99-graywolf-cm108.rules
         dst: /etc/udev/rules.d/99-graywolf-cm108.rules
         type: config
-      - src: "rust-bin/linux_{{ .Arch }}/graywolf-modem"
+      # armv7 (GOARM=7) ships the NEON modem from linux_armv7; every other
+      # arch (including armv6) uses linux_<arch>.
+      - src: "rust-bin/linux_{{ .Arch }}{{ if and (eq .Arch \"arm\") (eq .Arm \"7\") }}v7{{ end }}/graywolf-modem"
         dst: /usr/bin/graywolf-modem
     scripts:
       postinstall: packaging/scripts/postinstall.sh

--- a/Cross.toml
+++ b/Cross.toml
@@ -35,3 +35,23 @@ passthrough = [
     "PKG_CONFIG_PATH_arm_unknown_linux_gnueabihf",
     "CFLAGS_arm_unknown_linux_gnueabihf",
 ]
+
+# 32-bit ARMv7-A hard-float (NEON). Same hardfloat ABI and the same
+# `arm-linux-gnueabihf` multi-arch tuple as the armv6 target above, so the
+# :armhf dev packages and pkg-config dir are identical -- only the Rust
+# triple differs. The two builds are kept separate so armv6-only Pi models
+# keep a scalar binary while armv7-a boards (Cortex-A7+) get the NEON build;
+# the +neon codegen flag lives in .cargo/config.toml, keyed to this triple.
+[target.armv7-unknown-linux-gnueabihf]
+pre-build = [
+    "dpkg --add-architecture armhf && apt-get update && apt-get install -y libasound2-dev:armhf libudev-dev:armhf unzip && curl -Lo /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip && unzip -o /tmp/protoc.zip -d /usr/local bin/protoc && chmod +x /usr/local/bin/protoc && rm /tmp/protoc.zip",
+]
+
+# Multi-arch path is shared with armv6 (both are arm-linux-gnueabihf); the
+# passthrough env var names are keyed to the Rust triple, so they differ.
+[target.armv7-unknown-linux-gnueabihf.env]
+passthrough = [
+    "PKG_CONFIG_ALLOW_CROSS",
+    "PKG_CONFIG_PATH_armv7_unknown_linux_gnueabihf",
+    "CFLAGS_armv7_unknown_linux_gnueabihf",
+]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ Graywolf is used all around the world! **[See a map of currently active stations
 
 Written by Chris Snell, [NW5W](https://nw5w.com). 
 
+## Which download do I use?
+
+Grab the build that matches your hardware from the [latest release](https://github.com/chrissnell/graywolf/releases/latest). On Linux, pick the `.deb` (Debian/Ubuntu), `.rpm` (Fedora/RHEL), or `.tar.gz` (anything else) with the matching architecture suffix.
+
+| Your hardware | Build to download |
+|---|---|
+| PC, server, or mini-PC (Intel/AMD 64-bit) | `x86_64` (`amd64`) |
+| Raspberry Pi 3 / 4 / 5, Pi Zero 2 W, or any ARM board running a **64-bit** OS | `arm64` (`aarch64`) |
+| 32-bit OS on a NEON-capable ARMv7 board — Pi 2 / 3 / 4, Rockchip RV1106, BeagleBone, most modern SBCs | `armv7l` |
+| Oldest Pis — Pi 1, Pi Zero / Zero W (ARMv6) | `armv6l` |
+| macOS, Apple Silicon (M1–M4) | macOS `arm64` |
+| macOS, Intel | macOS `x86_64` |
+| Windows | `Windows_x86_64` installer |
+
+**Not sure?** On Linux, run `uname -m` — its output is exactly the suffix to look for: `x86_64`, `aarch64` (use the `arm64` build), `armv7l`, or `armv6l`.
+
+**armv6l vs. armv7l:** both are 32-bit ARM hard-float. The `armv7l` build enables NEON, so the Rust modem's demodulator runs vectorized and noticeably faster — use it whenever your board is Cortex-A7 or newer. The `armv6l` build is the universal fallback that runs on every 32-bit Pi (including the ARMv6-only Pi 1 / Zero) but stays scalar; it will also run on ARMv7 boards, just slower. Don't use `armv7l` on an ARMv6-only Pi — it will fail with an illegal-instruction error.
+
+Running a 64-bit OS on a Pi 3/4/5? Prefer the `arm64` build over either 32-bit one.
+
 The modem is written in Rust and includes a port of the AFSK demodulator from [Dire Wolf](https://github.com/wb2osz/direwolf) by WB2OSZ.  The decision-feedback AGC and hard-limiter correlator techniques are credited to Ion Todirel (W7ION), from his [libmodem](https://github.com/iontodirel/libmodem).
 
 The AX.25 decoding, APRS operatations (beacons, digipeater, and iGate), and the web API is handled by a service written in the Go programming language.

--- a/docs/wiki/build-pipelines.md
+++ b/docs/wiki/build-pipelines.md
@@ -11,7 +11,8 @@ Release pipeline definition: [`../../.goreleaser.yml`](../../.goreleaser.yml).
 | Go binary + web only (skip Rust) | `make graywolf-quick` (= `web` + `go build`) | same as above, minus `target/release/graywolf-modem` | `bin/graywolf` only; reuses existing `bin/graywolf-modem` | Manual; safe when `proto/` + `VERSION` unchanged |
 | Rust modem (native dev) | `make release` | `graywolf-modem/`, `proto/graywolf.proto`, `VERSION` | `target/release/graywolf-modem` (workspace root, not `graywolf-modem/target/`) | Manual; see [invariant 1](invariants.md) |
 | Rust modem (cross arm64) | `cross` per [`../../Cross.toml`](../../Cross.toml) | same + Docker image with aarch64 ALSA/udev libs and protoc | `target/<triple>/release/graywolf-modem` | Release CI |
-| Rust modem (cross armv6) | `cross` per [`../../Cross.toml`](../../Cross.toml) target `arm-unknown-linux-gnueabihf` | same + Docker image with armhf ALSA/udev libs and protoc | `target/arm-unknown-linux-gnueabihf/release/graywolf-modem` | Release CI; one ARMv6 build covers Pi 1, Pi 2, Pi Zero / Zero W (Pi 2 is ARMv7 but runs ARMv6 binaries) |
+| Rust modem (cross armv6) | `cross` per [`../../Cross.toml`](../../Cross.toml) target `arm-unknown-linux-gnueabihf` | same + Docker image with armhf ALSA/udev libs and protoc | `target/arm-unknown-linux-gnueabihf/release/graywolf-modem` | Release CI; scalar VFP, no NEON -- covers ARMv6-only Pi 1, Pi Zero / Zero W (and runs on any ARMv7 board too) |
+| Rust modem (cross armv7+NEON) | `cross` per [`../../Cross.toml`](../../Cross.toml) target `armv7-unknown-linux-gnueabihf` | same Docker image / `:armhf` libs as armv6 (shared `arm-linux-gnueabihf` multi-arch tuple) | `target/armv7-unknown-linux-gnueabihf/release/graywolf-modem` | Release CI; NEON enabled via [`../../.cargo/config.toml`](../../.cargo/config.toml) so the AFSK demod FIR loop vectorizes -- for Cortex-A7+ boards (e.g. RV1106). Will SIGILL on ARMv6-only Pi |
 | Web UI | `make web` (`npm install`, `npm run build`) | `web/src/`, `package.json`, themes, public, generated TS client | `web/dist/` (gitignored, then `go:embed` -- [invariant 12](invariants.md)) | Triggered by `make graywolf` / `make all` / `make api-client`. On Android, the `webBuild` Gradle task in `android/app/build.gradle.kts` also produces `web/dist/` before `goCrossCompile` runs, so APK builds can never ship a stale SPA. |
 | Android APK / AAB | `./gradlew :app:assembleDebug` (APK) / `:app:bundleRelease` (Play AAB), run from `android/` | `android/`, `web/dist/` (auto-built via `webBuild`), Rust cdylib via `cargoNdkBuild`, Go binary cross-compiled per ABI via `goCrossCompile_{arm64-v8a,x86_64}` | `android/app/build/outputs/{apk,bundle}/...` | Manual; CI workflow planned in [`../superpowers/plans/2026-05-21-android-play-store-pipeline.md`](../superpowers/plans/2026-05-21-android-play-store-pipeline.md). Release signing reads keystore from `GRAYWOLF_KEYSTORE_*` env vars; emits an unsigned APK if env is absent. `versionCode` / `versionName` derive from the repo-root `VERSION` file at configure time, so `make bump-*` cascades into Android automatically. |
 | TS API client | `make api-client` (`make docs` + `npm run api:generate`) | `pkg/webapi/docs/gen/swagger.{json,yaml}` | `web/src/api/generated/api.d.ts` (committed) | `make bump-*`; CI guard `api-client-check` |
@@ -26,7 +27,7 @@ Release pipeline definition: [`../../.goreleaser.yml`](../../.goreleaser.yml).
 | OCI image | goreleaser `dockers:` + [`../../Dockerfile.goreleaser`](../../Dockerfile.goreleaser), [`../../Dockerfile.goreleaser.arm64`](../../Dockerfile.goreleaser.arm64) | Go binary + `graywolf-modem-{amd64,arm64}` | `ghcr.io/chrissnell/graywolf:<tag>-{amd64,arm64}`, manifest list `:<tag>` and `:latest` | Tag push |
 | Arch AUR | [`../../packaging/aur/PKGBUILD`](../../packaging/aur/PKGBUILD) (pkgname `graywolf-aprs`) | github archive of the tag, `.service`, `.sysusers` | AUR (off-repo upload by maintainer) | `make bump-*` rewrites `pkgver` in `PKGBUILD` and `.SRCINFO` |
 | Windows NSIS installer | [`../../packaging/nsis/graywolf.nsi`](../../packaging/nsis/graywolf.nsi) (`makensis`) | `BINARY_PATH`, `MODEM_PATH`, `APP_VERSION`, `APP_VERSION_NUMERIC` | `graywolf_<ver>_Windows_x86_64.exe` | Manual; outside goreleaser |
-| Pre-built rust-bin (CI) | rust-build matrix in `.github/workflows/release.yml` | Per-target `cargo build --release` (Linux amd64, arm64, arm; macOS amd64, arm64; Windows amd64) | `rust-bin/<os>_<arch>/graywolf-modem[.exe]`, plus top-level `graywolf-modem-{amd64,arm64}` for the docker context (no 32-bit ARM docker image) | Tag push |
+| Pre-built rust-bin (CI) | rust-build matrix in `.github/workflows/release.yml` | Per-target `cargo build --release` (Linux amd64, arm64, armv6, armv7; macOS amd64, arm64; Windows amd64) | `rust-bin/<os>_<arch>/graywolf-modem[.exe]` -- note the two 32-bit ARM modems land in distinct dirs `linux_arm` (armv6) and `linux_armv7` (NEON); plus top-level `graywolf-modem-{amd64,arm64}` for the docker context (no 32-bit ARM docker image) | Tag push |
 
 ## CI workflows
 
@@ -39,6 +40,28 @@ Release pipeline definition: [`../../.goreleaser.yml`](../../.goreleaser.yml).
 The pre-commit hook in [`../../.githooks/`](../../.githooks/) (wired via
 `make install-hooks`) runs the same `docs-check` / `api-client-check`
 guards locally.
+
+## Two 32-bit ARM builds share one dpkg arch
+
+There are two distinct 32-bit ARM hard-float builds, and both the Go
+(`GOARM=6`/`GOARM=7`) and Rust (`arm-` / `armv7-unknown-linux-gnueabihf`)
+sides build twice:
+
+- **armv6** (`GOARM=6`, scalar): broad compatibility, runs on every 32-bit
+  Pi including ARMv6-only Pi 1 / Pi Zero.
+- **armv7+NEON** (`GOARM=7`): NEON enabled in
+  [`../../.cargo/config.toml`](../../.cargo/config.toml) so the demod FIR
+  loop vectorizes. For Cortex-A7+ boards; **SIGILLs on ARMv6-only Pi**.
+
+The trap: Go reports both as `goarch=arm` and dpkg labels both `armhf`, so
+naive config makes the two collide (same archive name, same
+`graywolf_<ver>_armhf.deb`, and the wrong Rust modem gets bundled). The
+`.goreleaser.yml` disambiguates **by `GOARM`** in three places — archive
+`name_template` (`armv6l` vs `armv7l`), the Rust modem `src` paths
+(`rust-bin/linux_arm` vs `rust-bin/linux_armv7`), and the nfpm
+`file_name_template` (armv7 gets an explicit `_armv7l` name; everything
+else keeps `ConventionalFileName`). If you add another `goarm` value,
+update all three or artifacts will silently overwrite each other.
 
 ## OpenAPI lives in two places
 


### PR DESCRIPTION
## Summary

Adds a dedicated **armv7 + NEON** release target for 32-bit ARM, alongside the existing armv6 build. Fixes #217.

The reporter wants to benchmark Graywolf's Rust modem on a Rockchip RV1106 (ARM Cortex-A7). The existing `armv6l` package runs there, but it's built for `arm-unknown-linux-gnueabihf` (scalar VFP, no NEON/FMA), so the AFSK demodulator's FIR inner loop (`graywolf-modem/src/demod_afsk.rs`, `convolve` — deliberately written with independent accumulators to feed NEON pipes) runs fully scalar and under-represents real DSP throughput on a NEON-capable board.

This adds a second build that vectorizes that loop on Cortex-A7+ hardware, while keeping the armv6 build for ARMv6-only boards (Pi 1 / Zero / Zero W).

## Changes

- **`.cargo/config.toml`** (new): enables `target-feature=+neon` only for the `armv7-unknown-linux-gnueabihf` triple. NEON only (not VFPv4/FMA), so it stays safe across the whole armv7-a NEON family (A8/A9 lack FMA). armv6 is untouched and stays scalar.
- **`Cross.toml`**: new armv7 target block — shares the `:armhf` multiarch dev packages and `arm-linux-gnueabihf` dir with armv6; only the Rust triple differs.
- **`.github/workflows/release.yml`**: armv7 matrix row (cross) + pkg-config/CFLAGS env + an arrange step that lands the NEON modem in its own `rust-bin/linux_armv7` dir.
- **`.goreleaser.yml`**: `GOARM=7` Go build. Since `goarch=arm` + `GOARM` 6/7 both collapse to dpkg `armhf`, disambiguate by GOARM in three places — archive name (`armv6l` vs `armv7l`), the rust-modem `src` paths, and the nfpm `file_name_template` (armv7 gets an explicit `_armv7l` .deb/.rpm). Every other arch keeps its conventional name, so nothing existing is renamed.
- **`docs/wiki/build-pipelines.md`**: documents the new target and the armv6-vs-armv7 split.

## Verification

- `goreleaser check` passes (only pre-existing deprecation warnings)
- nfpm template fields (`.ConventionalExtension` / `.ConventionalFileName`) confirmed valid
- both TOML files lint clean

**Not run in the build sandbox:** the actual cross-compile / NEON codegen and a full goreleaser package build. `release.yml` supports a `workflow_dispatch` snapshot run that builds + packages without cutting a tag — worth firing once and handing the `armv7l` package to the reporter to validate on the RV1106 before tagging a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
