### PR TITLE
Add cancel button for in-progress offline map downloads (#221)

### DIFF
--- a/pkg/mapscache/manager.go
+++ b/pkg/mapscache/manager.go
@@ -416,16 +416,23 @@ func (m *Manager) MigrateLegacyArchives(ctx context.Context) error {
 
 func (m *Manager) fail(ctx context.Context, slug string, err error) {
 	// A user-initiated cancel (Delete) cancels the download context,
-	// which surfaces here as an error from http.Do or writeAtomic. In
-	// that case Delete has already removed the persisted row and the
-	// on-disk file; writing an "error" row now would resurrect a phantom
-	// entry and flash a spurious failure in the UI. cancel() returns
-	// before the goroutine unblocks, so ctx.Err() is reliably non-nil on
-	// the cancel path -- skip the write entirely.
+	// which surfaces here as an error from http.Do or writeAtomic -- but
+	// it is not a real failure. Delete has already removed the persisted
+	// row and the on-disk file, so there is nothing to report; recording
+	// an "error" row would resurrect a phantom entry and flash a spurious
+	// failure in the UI. cancel() returns before the goroutine unblocks,
+	// so ctx.Err() is reliably non-nil on the cancel path. This guard is
+	// the sole gate for the cancel case.
 	if ctx.Err() != nil {
 		return
 	}
-	_ = m.store.UpsertMapsDownload(ctx, configstore.MapsDownload{
+	// Persist the failure on a fresh context. A genuine download error
+	// must be recorded even though the download's own context is the one
+	// that just errored out -- tying this write to that context would
+	// make error reporting depend on the driver's ctx handling and could
+	// silently drop the row. The guard above, not the context, is what
+	// suppresses the cancel case.
+	_ = m.store.UpsertMapsDownload(context.Background(), configstore.MapsDownload{
 		Slug: slug, Status: "error", ErrorMessage: err.Error(),
 	})
 }

--- a/pkg/mapscache/manager.go
+++ b/pkg/mapscache/manager.go
@@ -415,6 +415,16 @@ func (m *Manager) MigrateLegacyArchives(ctx context.Context) error {
 }
 
 func (m *Manager) fail(ctx context.Context, slug string, err error) {
+	// A user-initiated cancel (Delete) cancels the download context,
+	// which surfaces here as an error from http.Do or writeAtomic. In
+	// that case Delete has already removed the persisted row and the
+	// on-disk file; writing an "error" row now would resurrect a phantom
+	// entry and flash a spurious failure in the UI. cancel() returns
+	// before the goroutine unblocks, so ctx.Err() is reliably non-nil on
+	// the cancel path -- skip the write entirely.
+	if ctx.Err() != nil {
+		return
+	}
 	_ = m.store.UpsertMapsDownload(ctx, configstore.MapsDownload{
 		Slug: slug, Status: "error", ErrorMessage: err.Error(),
 	})

--- a/pkg/mapscache/manager_test.go
+++ b/pkg/mapscache/manager_test.go
@@ -131,6 +131,58 @@ func TestManager_DeleteDuringActiveDownload(t *testing.T) {
 	}
 }
 
+// TestManager_CancelLeavesNoErrorRow guards the cancel-button path:
+// deleting an in-flight download must not leave a phantom "error" row
+// behind once the download goroutine unwinds. The upstream streams a
+// little, then blocks, so the cancel lands mid-transfer (after the .tmp
+// file has bytes in it) -- the realistic accidental-download scenario.
+func TestManager_CancelLeavesNoErrorRow(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1048576") // claim 1 MiB
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(strings.Repeat("X", 8192)))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done() // block until the download is cancelled
+	})
+	mgr, _, _ := newTestManager(t, upstream)
+
+	if err := mgr.Start(context.Background(), "state/nebraska", nil); err != nil {
+		t.Fatal(err)
+	}
+	// Let the goroutine grab the semaphore, issue the request, and start
+	// streaming bytes into the .tmp file.
+	time.Sleep(150 * time.Millisecond)
+
+	if err := mgr.Delete(context.Background(), "state/nebraska"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Poll past the point where the download goroutine has fully unwound
+	// (the blocked handler returns once the context is cancelled, then
+	// run() calls fail()). The state must stay "absent" the whole time --
+	// never flicker to "error".
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		s, err := mgr.Status(context.Background(), "state/nebraska")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s.State != "absent" {
+			t.Fatalf("expected state to stay absent after cancel, got %+v", s)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	if _, err := os.Stat(mgr.PathFor("state/nebraska")); !os.IsNotExist(err) {
+		t.Fatalf("archive should not exist after cancel: %v", err)
+	}
+	if _, err := os.Stat(mgr.PathFor("state/nebraska") + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf(".tmp file should not exist after cancel: %v", err)
+	}
+}
+
 func TestManager_BadUpstreamStatus(t *testing.T) {
 	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/web/src/lib/maps/downloads-store.svelte.js
+++ b/web/src/lib/maps/downloads-store.svelte.js
@@ -58,20 +58,29 @@ export const downloadsState = (() => {
     }
   }
 
-  async function remove(slug) {
+  async function remove(slug, action = 'delete') {
     try {
       const res = await fetch(`/api/maps/downloads/${slug}`, {
         method: 'DELETE',
         credentials: 'same-origin',
       });
       if (!res.ok) {
-        toasts.error(`${slug}: delete failed (${res.status})`);
+        toasts.error(`${slug}: ${action} failed (${res.status})`);
         return;
       }
       await refresh();
     } catch (e) {
       toasts.error(`${slug}: network error -- ${e.message}`);
     }
+  }
+
+  // Cancelling an in-progress download is the same backend operation as
+  // deleting a completed one: DELETE halts the transfer (the server
+  // cancels the download context) and discards the partial file. Kept as
+  // a named method so the UI reads clearly and failure toasts say
+  // "cancel" rather than "delete".
+  function cancel(slug) {
+    return remove(slug, 'cancel');
   }
 
   function hasActiveDownload() {
@@ -97,6 +106,7 @@ export const downloadsState = (() => {
     refresh,
     start,
     remove,
+    cancel,
     ensurePolling,
 
     // Set<slug> of completed downloads -- driven by the items Map.

--- a/web/src/lib/maps/region-picker.svelte
+++ b/web/src/lib/maps/region-picker.svelte
@@ -106,7 +106,7 @@
                   {:else if cStatus === 'complete'}
                     <Button variant="danger" onclick={() => downloadsState.remove(country.slug)}>Delete</Button>
                   {:else}
-                    <Button variant="default" disabled>Downloading...</Button>
+                    <Button variant="danger" onclick={() => downloadsState.cancel(country.slug)}>Cancel</Button>
                   {/if}
                 {/if}
               </div>
@@ -133,7 +133,7 @@
                       {:else if status === 'complete'}
                         <Button variant="danger" onclick={() => downloadsState.remove(child.slug)}>Delete</Button>
                       {:else}
-                        <Button variant="default" disabled>Downloading...</Button>
+                        <Button variant="danger" onclick={() => downloadsState.cancel(child.slug)}>Cancel</Button>
                       {/if}
                     </div>
                   </li>

--- a/web/src/routes/MapsSettings.svelte
+++ b/web/src/routes/MapsSettings.svelte
@@ -302,6 +302,11 @@
                 Pending...
               {/if}
             </span>
+            {#if row.state === 'error'}
+              <Button variant="default" onclick={() => downloadsState.remove(row.slug)}>Dismiss</Button>
+            {:else}
+              <Button variant="danger" onclick={() => downloadsState.cancel(row.slug)}>Cancel</Button>
+            {/if}
             {#if row.state === 'downloading' && row.bytes_total > 0}
               <progress class="downloaded-progress" value={row.bytes_downloaded} max={row.bytes_total}></progress>
             {/if}


### PR DESCRIPTION
Closes #221.

Turns the "Downloading" indicator on the Offline Maps download screen into a functional **Cancel** button. Cancelling halts an in-progress download and discards the partial file, so a mistaken download (the reporter's Nebraska-vs-Nevada case) can be stopped to reclaim storage and bandwidth.

## What was already there

The `DELETE /api/maps/downloads/{slug}` handler already cancels an in-flight download (cancels the download context, which closes the connection and cleans up the partial `.tmp`) and removes the on-disk archive. The missing piece was purely UI -- the "Downloading..." indicator was a disabled, non-clickable button.

## Changes

- **Offline Maps screen** ("In progress" list): each active download now has a **Cancel** button; error rows get a **Dismiss** button.
- **Region picker drawer**: the disabled "Downloading..." button is now a functional **Cancel** on both country and child rows.
- **Downloads store**: added a `cancel()` action (same DELETE call as delete, with cancel-flavored error messaging).
- **Backend hardening**: guarded `mapscache.fail()` so a user-cancelled download can never persist a phantom `error` row. Previously this was only avoided incidentally (the cancelled context made the DB write fail); now it's explicit. Added `TestManager_CancelLeavesNoErrorRow` covering a mid-transfer cancel -- asserts no error row and no leftover archive or `.tmp`.

## Verification

- Web build clean; 232 JS tests pass.
- `pkg/mapscache` + `pkg/webapi` Go tests pass (`pkg/mapscache` also clean under `-race`).