### PR TITLE
Fix incorrect hop count on map screen (#222): exclude generic path aliases

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -773,7 +773,8 @@ locks the invariant in behaviorally.
 The displayed "hop" count for a station/packet is the number of *real*
 digipeaters that retransmitted it, not the number of path elements with
 the H-bit set (`*`). Generic routing aliases — `WIDE`, `RELAY`, `TRACE`,
-and the APRS-IS `qA*` constructs — are excluded even when flagged used,
+the APRS-IS `qA*` constructs, and the IS-injection markers `TCPIP` /
+`TCPXX` — are excluded even when flagged used,
 because a used alias rides alongside the digipeater that consumed it
 rather than being a hop of its own. Example: `SHEPRD*,WIDE1*,ELY*,WIDE2*`
 is **2** hops (SHEPRD, ELY), not 4.

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -767,3 +767,25 @@ operator intents.
 its own list. The regression test in
 [`pkg/app/wiring_blocklist_isolation_test.go`](../../pkg/app/wiring_blocklist_isolation_test.go)
 locks the invariant in behaviorally.
+
+### 41. Hop count excludes generic path aliases
+
+The displayed "hop" count for a station/packet is the number of *real*
+digipeaters that retransmitted it, not the number of path elements with
+the H-bit set (`*`). Generic routing aliases — `WIDE`, `RELAY`, `TRACE`,
+and the APRS-IS `qA*` constructs — are excluded even when flagged used,
+because a used alias rides alongside the digipeater that consumed it
+rather than being a hop of its own. Example: `SHEPRD*,WIDE1*,ELY*,WIDE2*`
+is **2** hops (SHEPRD, ELY), not 4.
+
+*Why:* counting raw `*` elements over-reported hops on the map station
+view (GitHub issue #222) — WIDEn-N aliases left in the path by callsign-
+inserting digipeaters were each tallied as a separate repeat.
+
+*How to apply:* route any hop-counting or last-digipeater logic through
+[`aprs.CountHops`](../../pkg/aprs/path.go) /
+[`aprs.IsGenericPathAlias`](../../pkg/aprs/path.go) — the single source
+of truth for which path entries are real hops. The map's `hops` field is
+computed once in [`pkg/stationcache/extract.go`](../../pkg/stationcache/extract.go)
+and consumed verbatim by the frontend popup; do not recompute it from
+`path.length` client-side.

--- a/pkg/aprs/path.go
+++ b/pkg/aprs/path.go
@@ -1,0 +1,48 @@
+package aprs
+
+import "strings"
+
+// IsGenericPathAlias reports whether a path callsign is a generic routing
+// alias rather than the call of a real station that retransmitted the
+// packet. The asterisk (H-bit) on these entries marks the alias as "used"
+// by a digipeater, but the alias itself is not an additional hop — the
+// digipeater that consumed it is listed separately (and counts on its own).
+//
+// Recognised aliases: WIDEn-N / WIDE, RELAY, TRACEn-N / TRACE, and the
+// APRS-IS q-constructs (qAC, qAR, qAS, …). The argument may carry a
+// trailing '*' and/or an SSID; both are tolerated.
+func IsGenericPathAlias(call string) bool {
+	upper := strings.ToUpper(strings.TrimSuffix(call, "*"))
+	switch {
+	case strings.HasPrefix(upper, "WIDE"),
+		strings.HasPrefix(upper, "RELAY"),
+		strings.HasPrefix(upper, "TRACE"),
+		strings.HasPrefix(upper, "QA"):
+		return true
+	default:
+		return false
+	}
+}
+
+// CountHops returns the number of actual packet retransmissions represented
+// by an APRS path, i.e. the count of real digipeaters that set the H-bit
+// (trailing '*') on their entry. Generic routing aliases (WIDE, RELAY,
+// TRACE, q-constructs) are excluded even when flagged used, because the
+// used-alias entry rides alongside the digipeater that consumed it rather
+// than representing a hop of its own.
+//
+// Example: SHEPRD*,WIDE1*,ELY*,WIDE2* counts as 2 hops (SHEPRD and ELY),
+// not 4 — the WIDE1/WIDE2 aliases were consumed by those two digipeaters.
+func CountHops(path []string) int {
+	n := 0
+	for _, p := range path {
+		if !strings.HasSuffix(p, "*") {
+			continue
+		}
+		if IsGenericPathAlias(p) {
+			continue
+		}
+		n++
+	}
+	return n
+}

--- a/pkg/aprs/path.go
+++ b/pkg/aprs/path.go
@@ -8,15 +8,26 @@ import "strings"
 // by a digipeater, but the alias itself is not an additional hop — the
 // digipeater that consumed it is listed separately (and counts on its own).
 //
-// Recognised aliases: WIDEn-N / WIDE, RELAY, TRACEn-N / TRACE, and the
-// APRS-IS q-constructs (qAC, qAR, qAS, …). The argument may carry a
-// trailing '*' and/or an SSID; both are tolerated.
+// Recognised aliases: WIDEn-N / WIDE, RELAY, TRACEn-N / TRACE, the APRS-IS
+// q-constructs (qAC, qAR, qAS, …), and the IS-injection markers TCPIP /
+// TCPXX (these ride with the H-bit set on gated and third-party packets,
+// but represent the Internet, not a real RF retransmission). The argument
+// may carry a trailing '*' and/or an SSID; both are tolerated.
+//
+// Matching is prefix-based and intentionally errs toward excluding
+// aliases: a (vanishingly rare) literal call like TRACEY in path position
+// is treated as an alias. The "QA" prefix is deliberately loose — bare
+// "QA" rather than "QA"+letter — which is safe because amateur callsigns
+// never begin with Q (the block is reserved for Q-codes) and q-constructs
+// never carry an H-bit anyway, so they are already skipped by CountHops.
 func IsGenericPathAlias(call string) bool {
 	upper := strings.ToUpper(strings.TrimSuffix(call, "*"))
 	switch {
 	case strings.HasPrefix(upper, "WIDE"),
 		strings.HasPrefix(upper, "RELAY"),
 		strings.HasPrefix(upper, "TRACE"),
+		strings.HasPrefix(upper, "TCPIP"),
+		strings.HasPrefix(upper, "TCPXX"),
 		strings.HasPrefix(upper, "QA"):
 		return true
 	default:

--- a/pkg/aprs/path_test.go
+++ b/pkg/aprs/path_test.go
@@ -1,0 +1,41 @@
+package aprs
+
+import "testing"
+
+func TestCountHops(t *testing.T) {
+	tests := []struct {
+		name string
+		path []string
+		want int
+	}{
+		{"direct, no path", nil, 0},
+		{"requested but unused", []string{"WIDE1-1", "WIDE2-1"}, 0},
+		{"single real digi", []string{"N0CALL*"}, 1},
+		{"issue #222 example", []string{"SHEPRD*", "WIDE1*", "ELY*", "WIDE2*"}, 2},
+		{"used aliases only", []string{"WIDE1*", "RELAY*"}, 0},
+		{"real digi with consumed alias", []string{"N0DIGI*", "WIDE1*"}, 1},
+		{"mixed used/unused", []string{"WIDE1-1", "N0CALL*", "WIDE2-1", "N1CALL*", "N2CALL*"}, 3},
+		{"trace alias used", []string{"TRACE3-2*", "K7ABC*"}, 1},
+		{"q-construct ignored", []string{"qAR*", "K7XYZ*"}, 1},
+	}
+	for _, tt := range tests {
+		if got := CountHops(tt.path); got != tt.want {
+			t.Errorf("%s: CountHops(%v) = %d, want %d", tt.name, tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestIsGenericPathAlias(t *testing.T) {
+	aliases := []string{"WIDE1-1", "WIDE2*", "RELAY", "TRACE3-3", "qAR", "qAC*"}
+	for _, a := range aliases {
+		if !IsGenericPathAlias(a) {
+			t.Errorf("IsGenericPathAlias(%q) = false, want true", a)
+		}
+	}
+	reals := []string{"SHEPRD", "ELY*", "K7ABC-1", "N0CALL"}
+	for _, r := range reals {
+		if IsGenericPathAlias(r) {
+			t.Errorf("IsGenericPathAlias(%q) = true, want false", r)
+		}
+	}
+}

--- a/pkg/aprs/path_test.go
+++ b/pkg/aprs/path_test.go
@@ -17,6 +17,9 @@ func TestCountHops(t *testing.T) {
 		{"mixed used/unused", []string{"WIDE1-1", "N0CALL*", "WIDE2-1", "N1CALL*", "N2CALL*"}, 3},
 		{"trace alias used", []string{"TRACE3-2*", "K7ABC*"}, 1},
 		{"q-construct ignored", []string{"qAR*", "K7XYZ*"}, 1},
+		{"is-originated TCPIP", []string{"TCPIP*"}, 0},
+		{"third-party gated", []string{"TCPIP*", "qAC", "T2USA"}, 0},
+		{"tcpxx marker", []string{"TCPXX*", "K7ABC*"}, 1},
 	}
 	for _, tt := range tests {
 		if got := CountHops(tt.path); got != tt.want {
@@ -26,7 +29,7 @@ func TestCountHops(t *testing.T) {
 }
 
 func TestIsGenericPathAlias(t *testing.T) {
-	aliases := []string{"WIDE1-1", "WIDE2*", "RELAY", "TRACE3-3", "qAR", "qAC*"}
+	aliases := []string{"WIDE1-1", "WIDE2*", "RELAY", "TRACE3-3", "qAR", "qAC*", "TCPIP*", "TCPXX"}
 	for _, a := range aliases {
 		if !IsGenericPathAlias(a) {
 			t.Errorf("IsGenericPathAlias(%q) = false, want true", a)

--- a/pkg/stationcache/extract.go
+++ b/pkg/stationcache/extract.go
@@ -1,7 +1,6 @@
 package stationcache
 
 import (
-	"strings"
 	"time"
 
 	"github.com/chrissnell/graywolf/pkg/aprs"
@@ -49,7 +48,7 @@ func ExtractEntry(decoded *aprs.DecodedAPRSPacket, source, dir string, ch uint32
 
 	via := deriveVia(source)
 	path := pkt.Path
-	hops := countHops(path)
+	hops := aprs.CountHops(path)
 	ts := pkt.Timestamp
 	if ts.IsZero() {
 		// Inner packet (third-party) often lacks a timestamp — fall back
@@ -166,16 +165,6 @@ func deriveVia(source string) string {
 	default:
 		return "rf"
 	}
-}
-
-func countHops(path []string) int {
-	n := 0
-	for _, p := range path {
-		if strings.HasSuffix(p, "*") {
-			n++
-		}
-	}
-	return n
 }
 
 // convertWeather converts aprs.Weather to the cache Weather struct.

--- a/pkg/stationcache/extract_test.go
+++ b/pkg/stationcache/extract_test.go
@@ -183,7 +183,7 @@ func TestExtractEntry_KilledItem(t *testing.T) {
 func TestExtractEntry_ThirdPartyUnwrap(t *testing.T) {
 	inner := &aprs.DecodedAPRSPacket{
 		Source: "W2INNER",
-		Path:   []string{"WIDE1*", "RELAY*"},
+		Path:   []string{"N0DIGI*", "WIDE1*", "RELAY*"},
 		Position: &aprs.Position{
 			Latitude:  41.0,
 			Longitude: -106.0,
@@ -208,7 +208,7 @@ func TestExtractEntry_ThirdPartyUnwrap(t *testing.T) {
 	assertEqual(t, "Callsign", e.Callsign, "W2INNER")
 	assertFloat(t, "Lat", e.Lat, 41.0)
 	assertEqual(t, "Via", e.Via, "is")
-	assertEqual(t, "Hops", e.Hops, 2) // WIDE1* and RELAY*
+	assertEqual(t, "Hops", e.Hops, 1) // only N0DIGI* is a real digi; WIDE1*/RELAY* are aliases
 	assertEqual(t, "Comment", e.Comment, "inner comment")
 	// Inner packet has zero timestamp → should fall back to outer packet's timestamp
 	outerTS := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
@@ -289,7 +289,7 @@ func TestExtractEntry_Weather(t *testing.T) {
 			HasTemp:       true,
 			WindSpeed:     15.0,
 			HasWindSpeed:  true,
-			WindDirection:  180,
+			WindDirection: 180,
 			HasWindDir:    true,
 			WindGust:      25.0,
 			HasWindGust:   true,

--- a/pkg/webapi/packets.go
+++ b/pkg/webapi/packets.go
@@ -170,16 +170,11 @@ func lastDigipeater(path []string) string {
 	last := ""
 	for _, hop := range path {
 		if strings.HasSuffix(hop, "*") {
-			call := strings.TrimSuffix(hop, "*")
 			// Skip generic aliases like WIDE1-1, RELAY, etc.
-			upper := strings.ToUpper(call)
-			if strings.HasPrefix(upper, "WIDE") ||
-				strings.HasPrefix(upper, "RELAY") ||
-				strings.HasPrefix(upper, "TRACE") ||
-				strings.HasPrefix(upper, "QA") {
+			if aprs.IsGenericPathAlias(hop) {
 				continue
 			}
-			last = call
+			last = strings.TrimSuffix(hop, "*")
 		}
 	}
 	return last


### PR DESCRIPTION
## Summary

Fixes #222. The map station view over-reported hop counts by counting every H-bit (`*`) path element as a hop, including consumed generic routing aliases (`WIDEn-N`, `RELAY`, `TRACE`, APRS-IS `qA*`). A path like `SHEPRD*,WIDE1*,ELY*,WIDE2*` displayed as **4 hops** when it represents only **2** actual retransmissions (SHEPRD, ELY) — the WIDE1/WIDE2 aliases were consumed by those two digipeaters, not separate repeats.

## Changes

- New `pkg/aprs/path.go` with `CountHops` and `IsGenericPathAlias` — a single source of truth for APRS path hop semantics.
- `pkg/stationcache/extract.go` hop counting now routes through `aprs.CountHops` (this `hops` field is consumed verbatim by the map popup, so the fix flows to the UI without client-side changes).
- `pkg/webapi/packets.go` `lastDigipeater` reuses `aprs.IsGenericPathAlias` instead of its inline alias check.
- Tests in `pkg/aprs/path_test.go` (including the exact issue example) and updated `stationcache` expectations.
- Documented the rule as invariant #41 in `docs/wiki/invariants.md`.

## Note

`web/src/components/messages/MessageMetaPanel.svelte` computes a separate "Digi hops" value from raw `path.split(',').length` on the Messages drawer — a different (unreported) surface. Left unchanged here to keep the fix scoped to the map screen; worth a follow-up if the same correction is wanted there.

## Verification

`go build ./...`, `go vet`, and `go test ./pkg/aprs/ ./pkg/stationcache/ ./pkg/webapi/` all pass.