### PR TITLE
Fix Direct RX map filter hiding stations heard both directly and via a digipeater (#130)

### DIFF
--- a/pkg/historydb/historydb.go
+++ b/pkg/historydb/historydb.go
@@ -160,12 +160,38 @@ func insertPositionIfMoved(tx *gorm.DB, e *stationcache.CacheEntry) error {
 	pathJSON, _ := json.Marshal(e.Path)
 
 	if found && math.Abs(lastLat-e.Lat) <= posEpsilon && math.Abs(lastLon-e.Lon) <= posEpsilon {
-		// Static re-beacon — update timestamp and metadata on latest position.
+		// Static re-beacon — advance the timestamp and comment, but keep
+		// the reception-path metadata at the most direct copy seen for this
+		// fix so a later digipeated copy can't mask an earlier direct one
+		// (issue #130). The CASE guard overwrites via/path/hops/direction/
+		// channel only when the incoming copy is itself direct RF, or when
+		// the stored copy is not direct (latest-wins among non-direct).
+		// Mirrors MemCache.Update's static-re-beacon branch.
+		newDirect := 0
+		if e.Direction == "RX" && e.Hops == 0 {
+			newDirect = 1
+		}
+		// keep == 1 means: overwrite the path metadata for this row.
+		const keep = `(? = 1 OR NOT (direction = 'RX' AND hops = 0))`
 		return tx.Exec(
-			`UPDATE positions SET timestamp = ?, via = ?, path = ?, hops = ?, direction = ?, channel = ?, comment = ?
+			`UPDATE positions SET
+				timestamp = ?,
+				comment   = ?,
+				via       = CASE WHEN `+keep+` THEN ? ELSE via END,
+				path      = CASE WHEN `+keep+` THEN ? ELSE path END,
+				hops      = CASE WHEN `+keep+` THEN ? ELSE hops END,
+				direction = CASE WHEN `+keep+` THEN ? ELSE direction END,
+				channel   = CASE WHEN `+keep+` THEN ? ELSE channel END
 			 WHERE station_key = ? AND id = (
 				SELECT id FROM positions WHERE station_key = ? ORDER BY timestamp DESC LIMIT 1
-			)`, e.Timestamp, e.Via, string(pathJSON), e.Hops, e.Direction, e.Channel, e.Comment, e.Key, e.Key,
+			)`,
+			e.Timestamp, e.Comment,
+			newDirect, e.Via,
+			newDirect, string(pathJSON),
+			newDirect, e.Hops,
+			newDirect, e.Direction,
+			newDirect, e.Channel,
+			e.Key, e.Key,
 		).Error
 	}
 

--- a/pkg/historydb/historydb_test.go
+++ b/pkg/historydb/historydb_test.go
@@ -3,6 +3,9 @@ package historydb
 import (
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/stationcache"
 )
 
 // TestRainBackfillMigration verifies the issue #126 one-time backfill:
@@ -60,5 +63,55 @@ func TestRainBackfillMigration(t *testing.T) {
 	}
 	if r1, r24 := readRain(); r1 != 1.37 || r24 != 2.5 {
 		t.Fatalf("after reboot: rain_1h=%v rain_24h=%v, want unchanged 1.37 / 2.5", r1, r24)
+	}
+}
+
+// TestStaticRebeaconDirectNotMasked is the persistence-layer counterpart to
+// issue #130: a static station heard directly (hops 0) then via a digipeater
+// (hops > 0) must keep the direct reception on its single stored position so
+// hydration after a restart still satisfies the Direct RX filter.
+func TestStaticRebeaconDirectNotMasked(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "h.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	base := time.Now().Add(-time.Minute)
+	direct := stationcache.CacheEntry{
+		Key: "stn:DIGI1", Callsign: "DIGI1", HasPos: true,
+		Lat: 40.0, Lon: -105.0, Symbol: [2]byte{'/', '#'},
+		Via: "", Direction: "RX", Hops: 0, Channel: 0, Comment: "direct",
+		Timestamp: base,
+	}
+	digipeated := direct
+	digipeated.Via = "WIDE2-1"
+	digipeated.Path = []string{"DIGI2*", "WIDE2-1"}
+	digipeated.Hops = 2
+	digipeated.Comment = "via digi"
+	digipeated.Timestamp = base.Add(time.Second)
+
+	if err := db.WriteEntries([]stationcache.CacheEntry{direct}); err != nil {
+		t.Fatalf("write direct: %v", err)
+	}
+	if err := db.WriteEntries([]stationcache.CacheEntry{digipeated}); err != nil {
+		t.Fatalf("write digipeated: %v", err)
+	}
+
+	stations, err := db.LoadRecent(time.Hour, 200)
+	if err != nil {
+		t.Fatalf("load recent: %v", err)
+	}
+	s := stations["stn:DIGI1"]
+	if s == nil || len(s.Positions) != 1 {
+		t.Fatalf("expected 1 station with 1 position, got %+v", s)
+	}
+	p := s.Positions[0]
+	if p.Direction != "RX" || p.Hops != 0 {
+		t.Fatalf("direct reception masked in DB: Direction=%q Hops=%d", p.Direction, p.Hops)
+	}
+	// Timestamp must still advance to the latest re-beacon.
+	if !p.Timestamp.Equal(digipeated.Timestamp) {
+		t.Fatalf("timestamp not advanced: got %v want %v", p.Timestamp, digipeated.Timestamp)
 	}
 }

--- a/pkg/historydb/historydb_test.go
+++ b/pkg/historydb/historydb_test.go
@@ -115,3 +115,73 @@ func TestStaticRebeaconDirectNotMasked(t *testing.T) {
 		t.Fatalf("timestamp not advanced: got %v want %v", p.Timestamp, digipeated.Timestamp)
 	}
 }
+
+// TestStaticRebeaconUpgradeAndLatestWins pins the other two transition
+// directions of the issue #130 SQL CASE guard: a digipeated fix is upgraded
+// to direct when a direct copy arrives, and among non-direct copies the
+// latest one still wins. Together with TestStaticRebeaconDirectNotMasked
+// this locks the guard against an inverted boolean binding.
+func TestStaticRebeaconUpgradeAndLatestWins(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "h.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	base := time.Now().Add(-time.Minute)
+	mk := func(dir string, hops int, via, comment string, ts time.Time) stationcache.CacheEntry {
+		e := stationcache.CacheEntry{
+			Key: "stn:DIGI1", Callsign: "DIGI1", HasPos: true,
+			Lat: 40.0, Lon: -105.0, Symbol: [2]byte{'/', '#'},
+			Via: via, Direction: dir, Hops: hops, Comment: comment, Timestamp: ts,
+		}
+		if hops > 0 {
+			e.Path = []string{"DIGI2*", "WIDE2-1"}
+		}
+		return e
+	}
+
+	load := func() stationcache.Position {
+		stations, err := db.LoadRecent(time.Hour, 200)
+		if err != nil {
+			t.Fatalf("load recent: %v", err)
+		}
+		s := stations["stn:DIGI1"]
+		if s == nil || len(s.Positions) != 1 {
+			t.Fatalf("expected 1 station with 1 position, got %+v", s)
+		}
+		return s.Positions[0]
+	}
+
+	// Heard via a digipeater first, then directly: must upgrade to direct.
+	if err := db.WriteEntries([]stationcache.CacheEntry{mk("RX", 2, "WIDE2-1", "via digi", base)}); err != nil {
+		t.Fatalf("write digipeated: %v", err)
+	}
+	if err := db.WriteEntries([]stationcache.CacheEntry{mk("RX", 0, "", "direct", base.Add(time.Second))}); err != nil {
+		t.Fatalf("write direct: %v", err)
+	}
+	if p := load(); p.Direction != "RX" || p.Hops != 0 {
+		t.Fatalf("direct copy did not upgrade fix: Direction=%q Hops=%d", p.Direction, p.Hops)
+	}
+
+	// Among non-direct copies (no direct ever heard), latest still wins.
+	db2, err := Open(filepath.Join(t.TempDir(), "h2.db"))
+	if err != nil {
+		t.Fatalf("open h2: %v", err)
+	}
+	defer db2.Close()
+	if err := db2.WriteEntries([]stationcache.CacheEntry{mk("RX", 2, "WIDE2-1", "first digi", base)}); err != nil {
+		t.Fatalf("write first digi: %v", err)
+	}
+	if err := db2.WriteEntries([]stationcache.CacheEntry{mk("IS", 0, "is", "from aprs-is", base.Add(time.Second))}); err != nil {
+		t.Fatalf("write IS: %v", err)
+	}
+	stations, err := db2.LoadRecent(time.Hour, 200)
+	if err != nil {
+		t.Fatalf("load recent h2: %v", err)
+	}
+	p := stations["stn:DIGI1"].Positions[0]
+	if p.Direction != "IS" || p.Hops != 0 {
+		t.Fatalf("latest non-direct copy did not win: Direction=%q Hops=%d", p.Direction, p.Hops)
+	}
+}

--- a/pkg/stationcache/memcache.go
+++ b/pkg/stationcache/memcache.go
@@ -27,7 +27,7 @@ type MemCache struct {
 	stations map[string]*Station
 	gen      uint64        // monotonic generation counter
 	maxAge   time.Duration // station TTL for pruning
-	done     chan struct{}  // signals pruning goroutine to stop
+	done     chan struct{} // signals pruning goroutine to stop
 }
 
 var _ StationStore = (*MemCache)(nil)
@@ -109,14 +109,24 @@ func (c *MemCache) Update(entries []CacheEntry) {
 				s.Positions = s.Positions[:MaxTrailLen]
 			}
 		} else {
-			// Static re-beacon — update timestamp and metadata.
+			// Static re-beacon — advance the last-heard timestamp and the
+			// free-form comment from the latest packet. Reception-path
+			// metadata (via/path/hops/direction/channel), however, is kept
+			// at the *most direct* copy seen for this fix: a station heard
+			// both directly and via a digipeater (common when two digis
+			// repeat each other's beacons) would otherwise have its direct
+			// copy clobbered by a later-arriving digipeated copy, hiding it
+			// from the Live Map "Direct RX" filter (issue #130). A direct
+			// RF copy therefore never gets masked by a non-direct one.
 			s.Positions[0].Timestamp = e.Timestamp
-			s.Positions[0].Via = e.Via
-			s.Positions[0].Path = e.Path
-			s.Positions[0].Hops = e.Hops
-			s.Positions[0].Direction = e.Direction
-			s.Positions[0].Channel = e.Channel
 			s.Positions[0].Comment = e.Comment
+			if isDirectRF(e.Direction, e.Hops) || !isDirectRF(s.Positions[0].Direction, s.Positions[0].Hops) {
+				s.Positions[0].Via = e.Via
+				s.Positions[0].Path = e.Path
+				s.Positions[0].Hops = e.Hops
+				s.Positions[0].Direction = e.Direction
+				s.Positions[0].Channel = e.Channel
+			}
 		}
 	}
 }
@@ -244,6 +254,14 @@ func updateMetadata(s *Station, e *CacheEntry, now time.Time) {
 	if e.Weather != nil {
 		s.Weather = e.Weather
 	}
+}
+
+// isDirectRF reports whether a packet was heard directly over RF with no
+// digipeater hops. This is the reception the Live Map "Direct RX" filter
+// keys on; a fix that has ever been heard this way must not be downgraded
+// by a subsequent digipeated copy of the same beacon (issue #130).
+func isDirectRF(direction string, hops int) bool {
+	return direction == "RX" && hops == 0
 }
 
 func positionMoved(old, new Position) bool {

--- a/pkg/stationcache/memcache_test.go
+++ b/pkg/stationcache/memcache_test.go
@@ -375,3 +375,62 @@ func TestMemCache_PositionEpsilon(t *testing.T) {
 		t.Fatalf("above-epsilon movement should create trail point, got %d positions", positions)
 	}
 }
+
+// digiEntry builds a static-position entry for a digipeater whose beacon
+// arrived over a digipeated path (Hops > 0).
+func digiEntry(key, callsign string, lat, lon float64, hops int) CacheEntry {
+	e := stationEntry(key, callsign, lat, lon)
+	e.Hops = hops
+	e.Via = "WIDE2-1"
+	e.Path = []string{"DIGI2*", "WIDE2-1"}
+	return e
+}
+
+// TestMemCache_DirectRFNotMaskedByDigipeat reproduces issue #130: a static
+// station heard directly (hops 0) and then via a digipeater (hops > 0) of
+// the same beacon must keep its direct reception on the collapsed position
+// so the Live Map Direct RX filter still shows it.
+func TestMemCache_DirectRFNotMaskedByDigipeat(t *testing.T) {
+	c := newTestCache(t)
+
+	// Direct copy first (hops 0), then the digipeated copy arrives.
+	c.Update([]CacheEntry{stationEntry("stn:DIGI1", "DIGI1", 40.0, -105.0)}) // RX, hops 0
+	c.Update([]CacheEntry{digiEntry("stn:DIGI1", "DIGI1", 40.0, -105.0, 2)}) // RX, hops 2
+
+	results := c.QueryBBox(BBox{SwLat: 39, SwLon: -106, NeLat: 41, NeLon: -104}, 1*time.Hour)
+	if len(results) != 1 || len(results[0].Positions) != 1 {
+		t.Fatalf("expected 1 station with 1 position, got %+v", results)
+	}
+	p := results[0].Positions[0]
+	if !isDirectRF(p.Direction, p.Hops) {
+		t.Fatalf("direct reception masked by digipeated copy: Direction=%q Hops=%d", p.Direction, p.Hops)
+	}
+
+	// A subsequent direct copy must refresh (and still be direct).
+	c.Update([]CacheEntry{stationEntry("stn:DIGI1", "DIGI1", 40.0, -105.0)})
+	results = c.QueryBBox(BBox{SwLat: 39, SwLon: -106, NeLat: 41, NeLon: -104}, 1*time.Hour)
+	p = results[0].Positions[0]
+	if !isDirectRF(p.Direction, p.Hops) {
+		t.Fatalf("expected direct reception after refresh, got Direction=%q Hops=%d", p.Direction, p.Hops)
+	}
+}
+
+// TestMemCache_DigipeatedThenDirect verifies the latest-wins path still
+// applies for non-direct copies and that a direct copy upgrades the fix.
+func TestMemCache_DigipeatedThenDirect(t *testing.T) {
+	c := newTestCache(t)
+
+	// Only ever heard via a digipeater so far.
+	c.Update([]CacheEntry{digiEntry("stn:DIGI1", "DIGI1", 40.0, -105.0, 2)})
+	results := c.QueryBBox(BBox{SwLat: 39, SwLon: -106, NeLat: 41, NeLon: -104}, 1*time.Hour)
+	if isDirectRF(results[0].Positions[0].Direction, results[0].Positions[0].Hops) {
+		t.Fatal("digipeated-only fix must not be classified as direct")
+	}
+
+	// Now a direct copy arrives — it should upgrade the fix to direct.
+	c.Update([]CacheEntry{stationEntry("stn:DIGI1", "DIGI1", 40.0, -105.0)})
+	results = c.QueryBBox(BBox{SwLat: 39, SwLon: -106, NeLat: 41, NeLon: -104}, 1*time.Hour)
+	if !isDirectRF(results[0].Positions[0].Direction, results[0].Positions[0].Hops) {
+		t.Fatal("direct copy should upgrade a previously-digipeated fix to direct")
+	}
+}


### PR DESCRIPTION
## Problem (issue #130)

Switching on the Live Map **Direct RX** filter produced a completely empty map, even though the operator reliably hears digipeaters and other stations directly.

Root cause, as diagnosed by @pflarue in the issue: a station that beacons a fixed position (a digipeater) is collapsed in the station cache to a **single** stored position, whose path metadata was overwritten by whichever copy of the beacon arrived **last**. When the same beacon is received both directly (hops 0) and via another digipeater (hops > 0) -- common when two digis repeat each other's beacons -- the digipeated copy always lands last. It clobbered the direct copy's hop count, so the only stored position showed hops > 0 and the Direct RX filter (which keys on `direction == "RX" && hops == 0`) hid the station.

## Fix

In the static re-beacon path, keep the **reception-path metadata** (via/path/hops/direction/channel) at the *most direct* copy seen for that fix:

- A direct RF copy (RX, hops 0) is never downgraded by a later non-direct copy.
- A direct copy still upgrades a previously-digipeated fix.
- Timestamp and comment continue to advance to the latest packet, so "last heard" stays current.

The same guard is mirrored in the history DB upsert so the behavior survives a restart/hydration.

No frontend change is needed -- the existing `isDirectRx` predicate already scans all positions for a direct one; it was simply never given a direct copy to find.

## Tradeoff

Classification is now "ever heard directly while at this position" rather than "most recent copy." A static station heard directly once and then only via a digipeater can stay in Direct RX until the station ages out of the cache window. This is intended and matches the filter's purpose; the previous behavior (showing nothing) was strictly worse.

## Tests

- `pkg/stationcache`: direct-then-digipeated keeps the fix direct; a refresh stays direct; digipeated-only is not direct and a later direct copy upgrades it.
- `pkg/historydb`: the same direct-not-masked behavior holds across a write + `LoadRecent`, with the timestamp still advancing.