### PR TITLE
fix(audio): pick native I16 playback format, never default_output_config (#227)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -524,32 +524,44 @@ Source:
 [`../../web/src/lib/sampleRate.js`](../../web/src/lib/sampleRate.js),
 [`../../pkg/configstore/migrate_audio_devices_clamp_sample_rate.go`](../../pkg/configstore/migrate_audio_devices_clamp_sample_rate.go).
 
-### 33. Capture stream format is device-advertised, never `default_input_config()`
+### 33. Stream format is device-advertised, never `default_{input,output}_config()` (both RX and TX)
 
-`soundcard::spawn` picks the input `SampleFormat` from the device's
-*advertised* supported configs at the chosen rate, preferring native
-`I16` (`pick_input_sample_format`). It must **never** open a capture
-stream using `device.default_input_config().sample_format()`.
+`soundcard::spawn` (capture) and `soundcard::spawn_output` (playback)
+both pick the `SampleFormat` from the device's *advertised* supported
+configs at the chosen rate, preferring native `I16`
+(`pick_input_sample_format` / `pick_output_sample_format`, both ranked
+by the shared `native_format_rank`). Neither path may open a stream
+using `device.default_input_config().sample_format()` or
+`device.default_output_config().sample_format()`; the cpal default is
+only a last-resort fallback when the device advertises nothing usable
+at the rate.
 
 *Why:* On an ALSA `plughw:`/`default` PCM, cpal's
-`default_input_config()` returns **`F32`**. Opening an `F32` capture
-stream on a full-speed USB radio codec (AIOC and similar) makes cpal
-`alsa::poll()` return `POLLERR` on essentially every period -- the
-holding thread rebuilds, POLLERRs again, and loops forever (observed:
-24,344 errors in one session, RX stuck at zero with no fatal error).
-The *same hardware* streams the native `I16` config cleanly (`arecord
--f S16_LE` and the detection probe both work). The detection probe
-(`pick_input_probe_config`) already selected I16; the runtime
-`spawn()` did not, so the probe verified a config the runtime never
-used. `pick_input_sample_format` and the probe now share
-`input_format_rank` so detection and runtime cannot drift. The
-sample-*rate* clamp (invariant 32) is necessary but independent: a
-clipping analog input or an `F32` plughw stream each kill RX on their
-own.
+`default_input_config()` **and** `default_output_config()` return
+**`F32`**. Opening an `F32` stream on a full-speed USB radio codec
+(AIOC, Signalink, Digirig) makes cpal `alsa::poll()` return `POLLERR`
+on essentially every period -- the holding thread rebuilds, POLLERRs
+again, and loops forever, flooding the log. The *same hardware*
+streams the native `I16` config cleanly (`arecord -f S16_LE` /
+`aplay`).
+
+This bit RX first: capture was observed looping 24,344 errors in one
+session with RX stuck at zero and no fatal error. The capture fix
+(`pick_input_sample_format`, commit `f917b8ff`) left `spawn_output`
+still calling `default_output_config().sample_format()`, so the
+identical failure resurfaced on **TX only** (issue #227: TX floods
+`cpal output stream error: ... alsa::poll() returned POLLERR` while RX
+is fine). `spawn_output` now selects the format the same way.
+
+The detection probe (`pick_input_probe_config`) and both runtime
+selectors share `native_format_rank`, so detection and runtime cannot
+drift. The sample-*rate* clamp (invariant 32) is necessary but
+independent: a clipping analog input or an `F32` plughw stream each
+kill audio on their own.
 
 Source:
 [`../../graywolf-modem/src/audio/soundcard.rs`](../../graywolf-modem/src/audio/soundcard.rs)
-(`pick_input_sample_format`, `input_format_rank`, `pick_input_probe_config`, `spawn`).
+(`pick_input_sample_format`, `pick_output_sample_format`, `native_format_rank`, `pick_input_probe_config`, `spawn`, `spawn_output`).
 
 ### 34. KISS InterfaceType dispatch must be updated in two independent places
 

--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -643,7 +643,7 @@ pub fn pick_input_probe_config(dev: &Device) -> Result<(SampleFormat, StreamConf
             if cfg.channels() < b.channels() {
                 return false;
             }
-            input_format_rank(cfg.sample_format()) >= input_format_rank(b.sample_format())
+            native_format_rank(cfg.sample_format()) >= native_format_rank(b.sample_format())
         });
         if !dominated_by_best {
             best = Some(cfg);
@@ -665,12 +665,12 @@ pub fn pick_input_probe_config(dev: &Device) -> Result<(SampleFormat, StreamConf
     ))
 }
 
-/// Rank for input sample-format preference: lower is better. Native
+/// Rank for sample-format preference: lower is better. Native
 /// integer `I16` first (every cheap USB radio codec runs it and ALSA
 /// `plughw:` streams it without resampling jitter), then `F32`, then
-/// the rest. Single source of truth shared by the runtime stream and
-/// the detection probe.
-fn input_format_rank(f: SampleFormat) -> u8 {
+/// the rest. Single source of truth shared by the capture/playback
+/// runtime streams and the detection probe.
+fn native_format_rank(f: SampleFormat) -> u8 {
     match f {
         SampleFormat::I16 => 0,
         SampleFormat::F32 => 1,
@@ -696,7 +696,32 @@ pub fn pick_input_sample_format(
     configs
         .iter()
         .filter(|&&(_ch, _f, min, max)| rate >= min && rate <= max)
-        .min_by_key(|&&(_ch, f, _min, _max)| input_format_rank(f))
+        .min_by_key(|&&(_ch, f, _min, _max)| native_format_rank(f))
+        .map(|&(_ch, f, _min, _max)| f)
+}
+
+/// Pick the sample format to actually open a playback stream with, given
+/// the device's supported `(channels, format, min_rate, max_rate)`
+/// configs and the rate we will open at.
+///
+/// Same trap as capture, on the TX side (#227). `default_output_config()`
+/// on an ALSA `plughw:`/`default` PCM hands back `F32`, and opening an
+/// F32 *output* stream on the same cheap USB radio codecs (Signalink,
+/// Digirig, AIOC) makes `alsa::poll()` return POLLERR every period -- the
+/// holding thread then rebuilds with the identical bad format and floods
+/// the log forever while TX audio never reaches the rig. The RX path was
+/// fixed to never trust `default_input_config()`; this is the matching
+/// fix for TX. We pick the best format the device advertises *at the
+/// chosen rate*, preferring native `I16`, falling back to the cpal
+/// default only if the device advertises nothing usable.
+pub fn pick_output_sample_format(
+    configs: &[(u16, SampleFormat, u32, u32)],
+    rate: u32,
+) -> Option<SampleFormat> {
+    configs
+        .iter()
+        .filter(|&&(_ch, _f, min, max)| rate >= min && rate <= max)
+        .min_by_key(|&&(_ch, f, _min, _max)| native_format_rank(f))
         .map(|&(_ch, f, _min, _max)| f)
 }
 
@@ -947,7 +972,29 @@ pub fn spawn_output(cfg: SoundcardOutputConfig, device: Option<Device>) -> Resul
     let stream_failed = Arc::new(AtomicBool::new(false));
 
     let want_ch = cfg.audio_channel as usize;
-    let sample_format = supported.sample_format();
+    // Never trust default_output_config()'s format: on an ALSA plughw:/
+    // default PCM it is F32, which POLLERR-loops cpal forever on the
+    // cheap USB radio codecs used for TX (Signalink, Digirig, AIOC) --
+    // the same failure the RX path hit (#227). Pick the format the
+    // device actually advertises at our rate, preferring native I16,
+    // and fall back to the cpal default only if it advertises nothing
+    // usable.
+    let output_cfgs: Vec<(u16, SampleFormat, u32, u32)> = device
+        .supported_output_configs()
+        .map(|it| {
+            it.map(|c| {
+                (
+                    c.channels(),
+                    c.sample_format(),
+                    c.min_sample_rate(),
+                    c.max_sample_rate(),
+                )
+            })
+            .collect()
+        })
+        .unwrap_or_default();
+    let sample_format = pick_output_sample_format(&output_cfgs, cfg.sample_rate)
+        .unwrap_or_else(|| supported.sample_format());
 
     let drained_for_thread = drained.clone();
     let submitted_for_thread = submitted.clone();
@@ -1286,6 +1333,35 @@ mod tests {
         // Nothing covers the rate.
         assert_eq!(pick_input_sample_format(&cfgs, 96_000), None);
         assert_eq!(pick_input_sample_format(&[], 48_000), None);
+    }
+
+    #[test]
+    fn pick_output_format_prefers_i16_over_f32_at_rate() {
+        // #227: the TX mirror of the AIOC case. A synthetic plug PCM
+        // advertises F32 (huge range) alongside native I16/48k. Must
+        // pick I16 -- opening the F32 output stream is what POLLERR-loops
+        // cpal on Signalink/Digirig/AIOC and floods the TX log.
+        let cfgs = [
+            (2u16, SampleFormat::F32, 4_000u32, 4_294_967_295u32),
+            (1u16, SampleFormat::I16, 48_000u32, 48_000u32),
+        ];
+        assert_eq!(pick_output_sample_format(&cfgs, 48_000), Some(SampleFormat::I16));
+    }
+
+    #[test]
+    fn pick_output_format_falls_back_and_respects_rate_bounds() {
+        // F32 used only when no I16 covers the rate.
+        let cfgs = [(1u16, SampleFormat::F32, 8_000u32, 48_000u32)];
+        assert_eq!(pick_output_sample_format(&cfgs, 48_000), Some(SampleFormat::F32));
+        // I16 exists but outside the target rate; F32 covers it.
+        let cfgs2 = [
+            (1u16, SampleFormat::I16, 8_000u32, 16_000u32),
+            (1u16, SampleFormat::F32, 8_000u32, 48_000u32),
+        ];
+        assert_eq!(pick_output_sample_format(&cfgs2, 48_000), Some(SampleFormat::F32));
+        // Nothing covers the rate / no configs → caller uses cpal default.
+        assert_eq!(pick_output_sample_format(&cfgs2, 96_000), None);
+        assert_eq!(pick_output_sample_format(&[], 48_000), None);
     }
 
     #[test]

--- a/graywolf-modem/src/audio/soundcard.rs
+++ b/graywolf-modem/src/audio/soundcard.rs
@@ -693,6 +693,20 @@ pub fn pick_input_sample_format(
     configs: &[(u16, SampleFormat, u32, u32)],
     rate: u32,
 ) -> Option<SampleFormat> {
+    pick_native_sample_format(configs, rate)
+}
+
+/// Shared selection core for both directions: from the device's
+/// advertised `(channels, format, min_rate, max_rate)` configs, keep
+/// only those whose range covers `rate`, then return the best-ranked
+/// format (`native_format_rank`, native `I16` first). Returns `None`
+/// when nothing is advertised at `rate`, so callers fall back to the
+/// cpal default. Capture and playback share this so their format choice
+/// cannot drift (invariant 33).
+fn pick_native_sample_format(
+    configs: &[(u16, SampleFormat, u32, u32)],
+    rate: u32,
+) -> Option<SampleFormat> {
     configs
         .iter()
         .filter(|&&(_ch, _f, min, max)| rate >= min && rate <= max)
@@ -718,11 +732,7 @@ pub fn pick_output_sample_format(
     configs: &[(u16, SampleFormat, u32, u32)],
     rate: u32,
 ) -> Option<SampleFormat> {
-    configs
-        .iter()
-        .filter(|&&(_ch, _f, min, max)| rate >= min && rate <= max)
-        .min_by_key(|&&(_ch, f, _min, _max)| native_format_rank(f))
-        .map(|&(_ch, f, _min, _max)| f)
+    pick_native_sample_format(configs, rate)
 }
 
 /// Decide the sample rate to actually open a stream at, given the


### PR DESCRIPTION
## Root cause of #227

The TX-side POLLERR flood is the transmit twin of a capture bug that was already fixed for RX.

cpal's `default_output_config()` on an ALSA `plughw:`/`default` PCM returns **F32**. Opening an F32 *output* stream on the cheap USB radio codecs in these rigs (Signalink, Digirig, AIOC) makes `alsa::poll()` return `POLLERR` every period. The output holding thread then rebuilds the stream with the *same* bad format, POLLERRs again, and loops forever — which is exactly the reported behavior: TX floods `cpal output stream error: A backend-specific error has occurred: alsa::poll() returned POLLERR` at high frequency while RX keeps working.

RX works because commit `f917b8ff` ("pick native I16 capture format, never default_input_config") already taught the **input** path (`spawn`) to select the format from the device's advertised configs, preferring native I16. That fix never touched the **output** path: `spawn_output` still called `default_output_config().sample_format()`. So the identical POLLERR loop was latent on TX and resurfaced — "previously thought resolved but came back," on transmit only. This matches the report: Fedora 44 + Pi 4, Signalink + Digirig, RX fine / TX broken.

## Fix

`spawn_output` now selects the output `SampleFormat` from the device's advertised supported configs at the chosen rate, preferring native `I16` (`pick_output_sample_format`), falling back to the cpal default only when the device advertises nothing usable — mirroring the proven capture fix. The input and output selectors share `native_format_rank` (renamed from `input_format_rank`) so capture, playback, and the detection probe can't drift.

Invariant #33 in the wiki is broadened to cover both directions.

## Tests

Added `pick_output_format_prefers_i16_over_f32_at_rate` and `pick_output_format_falls_back_and_respects_rate_bounds`, mirroring the input tests. All format-selection tests pass (`cargo test --lib audio::soundcard`).

Note: hardware-dependent tests can't run in CI without an audio device, and full verification on a real Signalink/Digirig rig is recommended before release.