### PR TITLE
Wind barbs for weather station markers on live map (#215)

### DIFF
--- a/web/src/lib/map/layers/stations.js
+++ b/web/src/lib/map/layers/stations.js
@@ -41,10 +41,24 @@ export function mountStationsLayer(map, getStations, {
     icon.classList.add('gw-station-icon');
     root.appendChild(icon);
 
+    // Right-of-icon column: callsign on top, temperature chip beneath it.
+    // align-items:flex-end (CSS) right-justifies the temp to the callsign.
+    // The temp slot is filled by the weather layer (see weather.js) and
+    // stays hidden until then, so stations without weather show nothing.
+    const aside = document.createElement('div');
+    aside.className = 'gw-station-aside';
+
     const label = document.createElement('div');
     label.className = 'gw-station-label';
     label.textContent = s.callsign;
-    root.appendChild(label);
+    aside.appendChild(label);
+
+    const temp = document.createElement('div');
+    temp.className = 'wx-temp';
+    temp.style.display = 'none';
+    aside.appendChild(temp);
+
+    root.appendChild(aside);
 
     if (onMarkerEnter) {
       root.addEventListener('mouseenter', () => {
@@ -141,10 +155,18 @@ export function mountStationsLayer(map, getStations, {
     applyDisplay();
   }
   // Wrap refresh so newly-minted markers honor current visibility + filter.
+  // Hand the weather layer the temp slot inside a station's marker so it
+  // can write the temperature chip there (null if the marker isn't up).
+  function getTempSlot(callsign) {
+    const entry = markers.get(callsign);
+    if (!entry) return null;
+    return entry.marker.getElement().querySelector('.wx-temp');
+  }
+
   const wrappedRefresh = () => {
     refresh();
     applyDisplay();
   };
 
-  return { refresh: wrappedRefresh, destroy, setVisible, setFilter };
+  return { refresh: wrappedRefresh, destroy, setVisible, setFilter, getTempSlot };
 }

--- a/web/src/lib/map/layers/weather.js
+++ b/web/src/lib/map/layers/weather.js
@@ -19,20 +19,16 @@
 
 import maplibregl from 'maplibre-gl';
 import { unitsState } from '../../settings/units-store.svelte.js';
-import { cardinal, KMH_PER_MPH } from '../popup-helpers.js';
 
+// Wind speed/direction used to live in this chip as text; it now renders
+// as a meteorological wind barb in the dedicated wind-barbs layer (see
+// wind-barbs.js). The chip carries the remaining scalar wx -- temperature.
 function formatLabel(wx, isMetric) {
   if (!wx) return '';
   const parts = [];
   if (wx.temp_f != null) {
     const t = isMetric ? ((wx.temp_f - 32) * 5) / 9 : wx.temp_f;
     parts.push(`${Math.round(t)}°${isMetric ? 'C' : 'F'}`);
-  }
-  if (wx.wind_mph != null) {
-    const s = isMetric ? wx.wind_mph * KMH_PER_MPH : wx.wind_mph;
-    let wind = `${Math.round(s)}${isMetric ? 'km/h' : 'mph'}`;
-    if (wx.wind_dir != null) wind = `${wind} ${cardinal(wx.wind_dir)}`;
-    parts.push(wind);
   }
   return parts.join(' ');
 }

--- a/web/src/lib/map/layers/weather.js
+++ b/web/src/lib/map/layers/weather.js
@@ -19,6 +19,14 @@
 
 import maplibregl from 'maplibre-gl';
 import { unitsState } from '../../settings/units-store.svelte.js';
+import { hasWindBarb } from './wind-barb-glyph.js';
+
+// Default upward offset: floats the chip just above the 21x21 station
+// icon. When a wind barb is present it radiates up to ~49px from the
+// station in the wind direction, so we lift the chip clear of that reach
+// to avoid overlapping the barb (see wind-barbs.js).
+const OFFSET_NEAR = [0, -14];
+const OFFSET_LIFTED = [0, -54];
 
 // Wind speed/direction used to live in this chip as text; it now renders
 // as a meteorological wind barb in the dedicated wind-barbs layer (see
@@ -37,7 +45,7 @@ export function mountWeatherLayer(map, getStations) {
   // callsign → { marker, label, lat, lon }
   const markers = new Map();
 
-  function createMarker(label, lat, lon) {
+  function createMarker(label, lat, lon, offset) {
     const root = document.createElement('div');
     root.className = 'wx-label';
     const text = document.createElement('div');
@@ -45,13 +53,10 @@ export function mountWeatherLayer(map, getStations) {
     text.textContent = label;
     root.appendChild(text);
 
-    // Anchor 'bottom' + small upward offset so the chip floats above
-    // the 21x21 station icon (which sits centered on the lat/lon, so
-    // its top is ~10.5px above it). 14px offset leaves a hairline gap.
     return new maplibregl.Marker({
       element: root,
       anchor: 'bottom',
-      offset: [0, -14],
+      offset,
     }).setLngLat([lon, lat]).addTo(map);
   }
 
@@ -74,11 +79,15 @@ export function mountWeatherLayer(map, getStations) {
       const label = formatLabel(s.weather, isMetric);
       if (!label) continue;
 
+      // Lift the chip only when a real barb sits beneath it.
+      const lifted = hasWindBarb(s.weather.wind_mph, s.weather.wind_dir);
+      const offset = lifted ? OFFSET_LIFTED : OFFSET_NEAR;
+
       seen.add(callsign);
       const entry = markers.get(callsign);
       if (!entry) {
-        const marker = createMarker(label, pos.lat, pos.lon);
-        markers.set(callsign, { marker, label, lat: pos.lat, lon: pos.lon });
+        const marker = createMarker(label, pos.lat, pos.lon, offset);
+        markers.set(callsign, { marker, label, lat: pos.lat, lon: pos.lon, lifted });
       } else {
         // Cheap change detection: skip the DOM/setLngLat work when
         // nothing meaningful moved. The text node only updates when
@@ -93,6 +102,10 @@ export function mountWeatherLayer(map, getStations) {
           const textEl = entry.marker.getElement().querySelector('.wx-text');
           if (textEl) textEl.textContent = label;
           entry.label = label;
+        }
+        if (entry.lifted !== lifted) {
+          entry.marker.setOffset(offset);
+          entry.lifted = lifted;
         }
       }
     }

--- a/web/src/lib/map/layers/weather.js
+++ b/web/src/lib/map/layers/weather.js
@@ -1,68 +1,42 @@
-// Weather labels: per-station DOM marker with the legacy Leaflet
-// wx-text chip styling. Floats above the station icon, anchored at the
-// chip's bottom so its position relative to the station stays stable
-// across zoom levels.
+// Weather labels: the temperature chip. Rather than floating as its own
+// map marker, the temp is written into a slot that lives inside the
+// station marker (the `.wx-temp` element, see stations.js), stacked just
+// below the callsign label and right-justified to it. That keeps the temp
+// pinned to the callsign at every zoom/wind direction instead of drifting
+// over the wind barb.
 //
-// Implementation parallels stations.js: keep a Map<callsign, marker>
-// in sync with the data store. The weather layer reads s.weather from
-// the stations Map (the data store also keeps a separate weather
-// SvelteMap, but stations[callsign].weather is the canonical view).
+// This layer owns only the temp's *content*: the formatted value, unit
+// conversion (unitsState.isMetric), visibility (Weather toggle) and the
+// Direct RX filter. Layout/positioning is the station marker's job (CSS).
+// The slot element is fetched per-callsign via the getTempSlot callback
+// the host wires to the stations layer.
 //
-// Why DOM over symbol layer: the legacy wx-text chip has a translucent
-// dark background, muted-dim text, and a thin border. MapLibre's
-// symbol layer can't paint a backing rectangle behind text -- it can
-// only halo. A DOM marker reproduces the chip exactly and toggles via
-// element.style.display, matching the stations and my-position layers.
-//
-// Field names match WeatherDTO in pkg/webapi/stations.go: temp_f,
-// wind_mph, wind_dir. Unit conversion honors unitsState.isMetric.
+// Field name matches WeatherDTO in pkg/webapi/stations.go: temp_f. Wind
+// is rendered separately as a barb (see wind-barbs.js).
 
-import maplibregl from 'maplibre-gl';
 import { unitsState } from '../../settings/units-store.svelte.js';
-import { hasWindBarb } from './wind-barb-glyph.js';
 
-// Default upward offset: floats the chip just above the 21x21 station
-// icon. When a wind barb is present it radiates up to ~49px from the
-// station in the wind direction, so we lift the chip clear of that reach
-// to avoid overlapping the barb (see wind-barbs.js).
-const OFFSET_NEAR = [0, -14];
-const OFFSET_LIFTED = [0, -54];
-
-// Wind speed/direction used to live in this chip as text; it now renders
-// as a meteorological wind barb in the dedicated wind-barbs layer (see
-// wind-barbs.js). The chip carries the remaining scalar wx -- temperature.
-function formatLabel(wx, isMetric) {
-  if (!wx) return '';
-  const parts = [];
-  if (wx.temp_f != null) {
-    const t = isMetric ? ((wx.temp_f - 32) * 5) / 9 : wx.temp_f;
-    parts.push(`${Math.round(t)}°${isMetric ? 'C' : 'F'}`);
-  }
-  return parts.join(' ');
+function formatTemp(wx, isMetric) {
+  if (!wx || wx.temp_f == null) return '';
+  const t = isMetric ? ((wx.temp_f - 32) * 5) / 9 : wx.temp_f;
+  return `${Math.round(t)}°${isMetric ? 'C' : 'F'}`;
 }
 
-export function mountWeatherLayer(map, getStations) {
-  // callsign → { marker, label, lat, lon }
-  const markers = new Map();
-
-  function createMarker(label, lat, lon, offset) {
-    const root = document.createElement('div');
-    root.className = 'wx-label';
-    const text = document.createElement('div');
-    text.className = 'wx-text';
-    text.textContent = label;
-    root.appendChild(text);
-
-    return new maplibregl.Marker({
-      element: root,
-      anchor: 'bottom',
-      offset,
-    }).setLngLat([lon, lat]).addTo(map);
+function hideSlot(slot) {
+  if (slot && slot.isConnected) {
+    slot.textContent = '';
+    slot.style.display = 'none';
   }
+}
 
-  // Optional per-station predicate. Stations failing it are dropped
-  // from the weather layer. Driven by the Direct RX toggle.
+export function mountWeatherLayer(map, getStations, { getTempSlot } = {}) {
+  // callsign → { slot, label }
+  const slots = new Map();
+
+  // Optional per-station predicate. Stations failing it have no temp.
+  // Driven by the Direct RX toggle.
   let filter = null;
+  let visible = true;
 
   function refresh() {
     const stations = getStations();
@@ -74,80 +48,53 @@ export function mountWeatherLayer(map, getStations) {
     for (const [callsign, s] of stations) {
       if (filter && !filter(s)) continue;
       if (!s.weather) continue;
-      const pos = s.positions && s.positions[0];
-      if (!pos) continue;
-      const label = formatLabel(s.weather, isMetric);
+      const label = formatTemp(s.weather, isMetric);
       if (!label) continue;
-
-      // Lift the chip only when a real barb sits beneath it.
-      const lifted = hasWindBarb(s.weather.wind_mph, s.weather.wind_dir);
-      const offset = lifted ? OFFSET_LIFTED : OFFSET_NEAR;
+      const slot = getTempSlot && getTempSlot(callsign);
+      if (!slot) continue; // station marker not mounted yet; next pass
 
       seen.add(callsign);
-      const entry = markers.get(callsign);
-      if (!entry) {
-        const marker = createMarker(label, pos.lat, pos.lon, offset);
-        markers.set(callsign, { marker, label, lat: pos.lat, lon: pos.lon, lifted });
-      } else {
-        // Cheap change detection: skip the DOM/setLngLat work when
-        // nothing meaningful moved. The text node only updates when
-        // the formatted label actually changes (units toggle, fresh
-        // weather packet).
-        if (entry.lat !== pos.lat || entry.lon !== pos.lon) {
-          entry.marker.setLngLat([pos.lon, pos.lat]);
-          entry.lat = pos.lat;
-          entry.lon = pos.lon;
-        }
-        if (entry.label !== label) {
-          const textEl = entry.marker.getElement().querySelector('.wx-text');
-          if (textEl) textEl.textContent = label;
-          entry.label = label;
-        }
-        if (entry.lifted !== lifted) {
-          entry.marker.setOffset(offset);
-          entry.lifted = lifted;
-        }
+      let entry = slots.get(callsign);
+      if (!entry || entry.slot !== slot) {
+        // First sight, or the station marker was recreated under us.
+        entry = { slot, label: null };
+        slots.set(callsign, entry);
       }
+      if (entry.label !== label) {
+        slot.textContent = label;
+        entry.label = label;
+      }
+      slot.style.display = visible ? 'block' : 'none';
     }
 
-    // Drop markers whose station no longer reports weather (or fell
-    // out of the timerange / bbox).
-    for (const [callsign, entry] of markers) {
+    // Clear slots whose station no longer reports weather (or fell out of
+    // the timerange / bbox / Direct RX filter). The station marker itself
+    // may still exist, so we blank the slot rather than remove anything.
+    for (const [callsign, entry] of slots) {
       if (!seen.has(callsign)) {
-        entry.marker.remove();
-        markers.delete(callsign);
+        hideSlot(entry.slot);
+        slots.delete(callsign);
       }
     }
   }
 
-  let visible = true;
   function setVisible(next) {
     visible = !!next;
-    const display = visible ? '' : 'none';
-    for (const { marker } of markers.values()) {
-      marker.getElement().style.display = display;
+    const display = visible ? 'block' : 'none';
+    for (const { slot } of slots.values()) {
+      if (slot && slot.isConnected) slot.style.display = display;
     }
   }
-
-  // Wrap refresh so newly-minted markers honor the current visibility.
-  const wrappedRefresh = () => {
-    refresh();
-    if (!visible) {
-      for (const { marker } of markers.values()) {
-        marker.getElement().style.display = 'none';
-      }
-    }
-  };
 
   function setFilter(pred) {
     filter = typeof pred === 'function' ? pred : null;
-    wrappedRefresh();
+    refresh();
   }
 
   function destroy() {
-    for (const { marker } of markers.values()) marker.remove();
-    markers.clear();
+    for (const { slot } of slots.values()) hideSlot(slot);
+    slots.clear();
   }
 
-  return { refresh: wrappedRefresh, destroy, setVisible, setFilter };
+  return { refresh, destroy, setVisible, setFilter };
 }

--- a/web/src/lib/map/layers/wind-barb-glyph.js
+++ b/web/src/lib/map/layers/wind-barb-glyph.js
@@ -31,14 +31,6 @@ export function quantizeKnots(mph) {
   return Math.round((mph * KT_PER_MPH) / 5) * 5;
 }
 
-// hasWindBarb reports whether a station's wind will render an actual barb
-// (staff + ticks) rather than nothing or the small calm ring. Callers use
-// it to lift the temperature chip clear of the barb only when one exists.
-export function hasWindBarb(mph, dirDeg) {
-  if (mph == null || dirDeg == null || !isFinite(mph)) return false;
-  return quantizeKnots(mph) > 0;
-}
-
 // buildWindBarb returns the inner SVG markup (no <svg> wrapper) for a barb
 // at the given sustained wind speed (mph) and direction (degrees true,
 // the bearing the wind blows FROM). Returns '' when there's nothing

--- a/web/src/lib/map/layers/wind-barb-glyph.js
+++ b/web/src/lib/map/layers/wind-barb-glyph.js
@@ -25,6 +25,20 @@ function n2(v) {
   return Number(v.toFixed(2));
 }
 
+// quantizeKnots rounds an mph reading to the 5-kt resolution a barb draws.
+export function quantizeKnots(mph) {
+  if (mph == null || !isFinite(mph)) return 0;
+  return Math.round((mph * KT_PER_MPH) / 5) * 5;
+}
+
+// hasWindBarb reports whether a station's wind will render an actual barb
+// (staff + ticks) rather than nothing or the small calm ring. Callers use
+// it to lift the temperature chip clear of the barb only when one exists.
+export function hasWindBarb(mph, dirDeg) {
+  if (mph == null || dirDeg == null || !isFinite(mph)) return false;
+  return quantizeKnots(mph) > 0;
+}
+
 // buildWindBarb returns the inner SVG markup (no <svg> wrapper) for a barb
 // at the given sustained wind speed (mph) and direction (degrees true,
 // the bearing the wind blows FROM). Returns '' when there's nothing
@@ -33,7 +47,7 @@ export function buildWindBarb(mph, dirDeg) {
   if (mph == null || dirDeg == null || !isFinite(mph)) return '';
 
   // Quantize to the nearest 5 kt -- the resolution a barb can express.
-  const knots = Math.round((mph * KT_PER_MPH) / 5) * 5;
+  const knots = quantizeKnots(mph);
 
   if (knots <= 0) {
     return `<circle cx="0" cy="0" r="6.5" class="wb-calm"/>`;

--- a/web/src/lib/map/layers/wind-barb-glyph.js
+++ b/web/src/lib/map/layers/wind-barb-glyph.js
@@ -1,0 +1,84 @@
+// Pure wind-barb glyph builder -- no DOM / MapLibre dependencies so it
+// can be unit-tested under node and reused by the map layer. Produces the
+// inner SVG markup for a standard meteorological wind barb.
+//
+// Convention (WMO): the staff points toward the direction the wind blows
+// FROM; speed is encoded in knots as half barbs (5 kt), full barbs
+// (10 kt) and pennants (50 kt). Calm is an open ring.
+
+const KT_PER_MPH = 0.868976;
+
+// Geometry in a local "north-up" frame: the staff points straight up and
+// the whole glyph is rotated to the wind bearing by the caller's <g>.
+const GAP = 11; // clear radius around the ~21px station icon
+const STAFF = 30; // staff length
+const STEP = 7; // spacing between successive ticks
+const PENNANT_BASE = 7; // staff length consumed by one pennant
+// Full-barb tick: out to the left and angled back toward the tip (~65°
+// off the staff) so it reads as a barb, not a plus sign.
+const FULL_DX = -11.8;
+const FULL_DY = -5.5;
+const HALF_DX = FULL_DX / 2;
+const HALF_DY = FULL_DY / 2;
+
+function n2(v) {
+  return Number(v.toFixed(2));
+}
+
+// buildWindBarb returns the inner SVG markup (no <svg> wrapper) for a barb
+// at the given sustained wind speed (mph) and direction (degrees true,
+// the bearing the wind blows FROM). Returns '' when there's nothing
+// meaningful to draw.
+export function buildWindBarb(mph, dirDeg) {
+  if (mph == null || dirDeg == null || !isFinite(mph)) return '';
+
+  // Quantize to the nearest 5 kt -- the resolution a barb can express.
+  const knots = Math.round((mph * KT_PER_MPH) / 5) * 5;
+
+  if (knots <= 0) {
+    return `<circle cx="0" cy="0" r="6.5" class="wb-calm"/>`;
+  }
+
+  let rem = knots;
+  const pennants = Math.floor(rem / 50);
+  rem -= pennants * 50;
+  const full = Math.floor(rem / 10);
+  rem -= full * 10;
+  const half = Math.floor(rem / 5);
+
+  const yStart = -GAP;
+  const yTip = -(GAP + STAFF);
+  const parts = [`<g transform="rotate(${n2(dirDeg)})">`];
+  parts.push(`<line x1="0" y1="${yStart}" x2="0" y2="${yTip}" class="wb-staff"/>`);
+
+  // Walk from the tip back toward the station: pennants, then full barbs,
+  // then a half barb.
+  let y = yTip;
+
+  for (let i = 0; i < pennants; i++) {
+    parts.push(
+      `<polygon points="0,${n2(y)} ${n2(FULL_DX)},${n2(y + FULL_DY)} 0,${n2(y + PENNANT_BASE)}" class="wb-pennant"/>`,
+    );
+    y += PENNANT_BASE;
+  }
+  if (pennants && (full || half)) y += 2;
+
+  for (let i = 0; i < full; i++) {
+    parts.push(
+      `<line x1="0" y1="${n2(y)}" x2="${n2(FULL_DX)}" y2="${n2(y + FULL_DY)}" class="wb-barb"/>`,
+    );
+    y += STEP;
+  }
+
+  if (half) {
+    // A lone half barb is inset one step from the tip so it can't be
+    // mistaken for the staff tip -- standard plotting convention.
+    if (!pennants && !full) y += STEP;
+    parts.push(
+      `<line x1="0" y1="${n2(y)}" x2="${n2(HALF_DX)}" y2="${n2(y + HALF_DY)}" class="wb-barb"/>`,
+    );
+  }
+
+  parts.push('</g>');
+  return parts.join('');
+}

--- a/web/src/lib/map/layers/wind-barbs.js
+++ b/web/src/lib/map/layers/wind-barbs.js
@@ -18,7 +18,7 @@ import maplibregl from 'maplibre-gl';
 import { buildWindBarb } from './wind-barb-glyph.js';
 
 export function mountWindBarbsLayer(map, getStations) {
-  // callsign → { marker, mph, dir, lat, lon }
+  // callsign → { marker, svg, mph, dir, lat, lon }
   const markers = new Map();
 
   function makeSvg(inner) {
@@ -35,10 +35,12 @@ export function mountWindBarbsLayer(map, getStations) {
   function createMarker(inner, lat, lon) {
     const root = document.createElement('div');
     root.className = 'wb-marker';
-    root.appendChild(makeSvg(inner));
-    return new maplibregl.Marker({ element: root, anchor: 'center' })
+    const svg = makeSvg(inner);
+    root.appendChild(svg);
+    const marker = new maplibregl.Marker({ element: root, anchor: 'center' })
       .setLngLat([lon, lat])
       .addTo(map);
+    return { marker, svg };
   }
 
   let filter = null;
@@ -62,9 +64,10 @@ export function mountWindBarbsLayer(map, getStations) {
       seen.add(callsign);
       const entry = markers.get(callsign);
       if (!entry) {
-        const marker = createMarker(inner, pos.lat, pos.lon);
+        const { marker, svg } = createMarker(inner, pos.lat, pos.lon);
         markers.set(callsign, {
           marker,
+          svg,
           mph: wx.wind_mph,
           dir: wx.wind_dir,
           lat: pos.lat,
@@ -78,8 +81,7 @@ export function mountWindBarbsLayer(map, getStations) {
         }
         // Only rebuild the SVG when the wind actually changed.
         if (entry.mph !== wx.wind_mph || entry.dir !== wx.wind_dir) {
-          const svg = entry.marker.getElement().querySelector('.wb-svg');
-          if (svg) svg.innerHTML = inner;
+          entry.svg.innerHTML = inner;
           entry.mph = wx.wind_mph;
           entry.dir = wx.wind_dir;
         }

--- a/web/src/lib/map/layers/wind-barbs.js
+++ b/web/src/lib/map/layers/wind-barbs.js
@@ -1,0 +1,125 @@
+// Wind-barb layer (MapLibre): per-station DOM marker carrying a standard
+// meteorological wind barb rendered as inline SVG. Replaces the old
+// text-based wind speed/direction annotation that used to live in the
+// weather chip -- the barb now carries both, oriented to wind direction
+// and encoding sustained speed with the conventional WMO barbs/pennants.
+//
+// Architecture mirrors weather.js / stations.js: keep a
+// Map<callsign, entry> in sync with the data store, expose an imperative
+// refresh() plus setVisible()/setFilter()/destroy(). Each marker is a
+// maplibregl.Marker wrapping an inert (pointer-events:none) <svg>, so the
+// station icon underneath keeps its click/hover behavior.
+//
+// The barb glyph math lives in wind-barb-glyph.js (pure, unit-tested).
+// Field names match WeatherDTO in pkg/webapi/stations.go: wind_mph,
+// wind_dir.
+
+import maplibregl from 'maplibre-gl';
+import { buildWindBarb } from './wind-barb-glyph.js';
+
+export function mountWindBarbsLayer(map, getStations) {
+  // callsign → { marker, mph, dir, lat, lon }
+  const markers = new Map();
+
+  function makeSvg(inner) {
+    const ns = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('class', 'wb-svg');
+    svg.setAttribute('viewBox', '-55 -55 110 110');
+    svg.setAttribute('width', '55');
+    svg.setAttribute('height', '55');
+    svg.innerHTML = inner;
+    return svg;
+  }
+
+  function createMarker(inner, lat, lon) {
+    const root = document.createElement('div');
+    root.className = 'wb-marker';
+    root.appendChild(makeSvg(inner));
+    return new maplibregl.Marker({ element: root, anchor: 'center' })
+      .setLngLat([lon, lat])
+      .addTo(map);
+  }
+
+  let filter = null;
+
+  function refresh() {
+    const stations = getStations();
+    if (!stations) return;
+
+    const seen = new Set();
+
+    for (const [callsign, s] of stations) {
+      if (filter && !filter(s)) continue;
+      const wx = s.weather;
+      if (!wx || wx.wind_mph == null || wx.wind_dir == null) continue;
+      const pos = s.positions && s.positions[0];
+      if (!pos) continue;
+
+      const inner = buildWindBarb(wx.wind_mph, wx.wind_dir);
+      if (!inner) continue;
+
+      seen.add(callsign);
+      const entry = markers.get(callsign);
+      if (!entry) {
+        const marker = createMarker(inner, pos.lat, pos.lon);
+        markers.set(callsign, {
+          marker,
+          mph: wx.wind_mph,
+          dir: wx.wind_dir,
+          lat: pos.lat,
+          lon: pos.lon,
+        });
+      } else {
+        if (entry.lat !== pos.lat || entry.lon !== pos.lon) {
+          entry.marker.setLngLat([pos.lon, pos.lat]);
+          entry.lat = pos.lat;
+          entry.lon = pos.lon;
+        }
+        // Only rebuild the SVG when the wind actually changed.
+        if (entry.mph !== wx.wind_mph || entry.dir !== wx.wind_dir) {
+          const svg = entry.marker.getElement().querySelector('.wb-svg');
+          if (svg) svg.innerHTML = inner;
+          entry.mph = wx.wind_mph;
+          entry.dir = wx.wind_dir;
+        }
+      }
+    }
+
+    for (const [callsign, entry] of markers) {
+      if (!seen.has(callsign)) {
+        entry.marker.remove();
+        markers.delete(callsign);
+      }
+    }
+  }
+
+  let visible = true;
+  function applyVisibility() {
+    const display = visible ? '' : 'none';
+    for (const { marker } of markers.values()) {
+      marker.getElement().style.display = display;
+    }
+  }
+  function setVisible(next) {
+    visible = !!next;
+    applyVisibility();
+  }
+
+  function setFilter(pred) {
+    filter = typeof pred === 'function' ? pred : null;
+    wrappedRefresh();
+  }
+
+  function destroy() {
+    for (const { marker } of markers.values()) marker.remove();
+    markers.clear();
+  }
+
+  const wrappedRefresh = () => {
+    refresh();
+    applyVisibility();
+  };
+
+  return { refresh: wrappedRefresh, destroy, setVisible, setFilter };
+}

--- a/web/src/lib/map/layers/wind-barbs.test.js
+++ b/web/src/lib/map/layers/wind-barbs.test.js
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildWindBarb } from './wind-barb-glyph.js';
+
+const count = (svg, frag) => svg.split(frag).length - 1;
+
+test('missing data renders nothing', () => {
+  assert.equal(buildWindBarb(null, 90), '');
+  assert.equal(buildWindBarb(10, null), '');
+  assert.equal(buildWindBarb(NaN, 90), '');
+});
+
+test('calm wind renders the open ring, no staff', () => {
+  const svg = buildWindBarb(0, 0);
+  assert.match(svg, /wb-calm/);
+  assert.equal(count(svg, 'wb-staff'), 0);
+});
+
+test('sub-2.5kt rounds to calm', () => {
+  // 2 mph ≈ 1.7 kt → rounds to 0
+  assert.match(buildWindBarb(2, 180), /wb-calm/);
+});
+
+test('a single half barb is drawn and inset from the tip', () => {
+  // 6 mph ≈ 5.2 kt → 5 kt → one half barb, no full, no pennant
+  const svg = buildWindBarb(6, 270);
+  assert.equal(count(svg, 'wb-pennant'), 0);
+  assert.equal(count(svg, 'wb-barb'), 1);
+  assert.equal(count(svg, 'wb-staff'), 1);
+});
+
+test('10 kt is one full barb', () => {
+  // 11.5 mph ≈ 9.99 kt → 10 kt
+  const svg = buildWindBarb(11.5, 0);
+  assert.equal(count(svg, 'wb-barb'), 1);
+});
+
+test('15 kt is one full + one half barb', () => {
+  // 17.3 mph ≈ 15.03 kt → 15 kt
+  const svg = buildWindBarb(17.3, 0);
+  assert.equal(count(svg, 'wb-barb'), 2);
+  assert.equal(count(svg, 'wb-pennant'), 0);
+});
+
+test('50 kt is one pennant', () => {
+  // 57.6 mph ≈ 50.05 kt → 50 kt
+  const svg = buildWindBarb(57.6, 0);
+  assert.equal(count(svg, 'wb-pennant'), 1);
+  assert.equal(count(svg, 'wb-barb'), 0);
+});
+
+test('65 kt is one pennant + one full + one half', () => {
+  // 74.8 mph ≈ 65.0 kt
+  const svg = buildWindBarb(74.8, 0);
+  assert.equal(count(svg, 'wb-pennant'), 1);
+  assert.equal(count(svg, 'wb-barb'), 2);
+});
+
+test('direction sets the group rotation', () => {
+  assert.match(buildWindBarb(20, 45), /rotate\(45\)/);
+  assert.match(buildWindBarb(20, 215), /rotate\(215\)/);
+});

--- a/web/src/lib/map/layers/wind-barbs.test.js
+++ b/web/src/lib/map/layers/wind-barbs.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildWindBarb } from './wind-barb-glyph.js';
+import { buildWindBarb, hasWindBarb, quantizeKnots } from './wind-barb-glyph.js';
 
 const count = (svg, frag) => svg.split(frag).length - 1;
 
@@ -59,4 +59,20 @@ test('65 kt is one pennant + one full + one half', () => {
 test('direction sets the group rotation', () => {
   assert.match(buildWindBarb(20, 45), /rotate\(45\)/);
   assert.match(buildWindBarb(20, 215), /rotate\(215\)/);
+});
+
+test('quantizeKnots rounds mph to the nearest 5 kt', () => {
+  assert.equal(quantizeKnots(0), 0);
+  assert.equal(quantizeKnots(2), 0); // ~1.7 kt
+  assert.equal(quantizeKnots(11.5), 10); // ~10 kt
+  assert.equal(quantizeKnots(null), 0);
+  assert.equal(quantizeKnots(NaN), 0);
+});
+
+test('hasWindBarb is true only when a barb (not calm/empty) renders', () => {
+  assert.equal(hasWindBarb(15, 90), true);
+  assert.equal(hasWindBarb(2, 90), false); // rounds to calm
+  assert.equal(hasWindBarb(0, 90), false);
+  assert.equal(hasWindBarb(15, null), false); // no direction
+  assert.equal(hasWindBarb(null, 90), false);
 });

--- a/web/src/lib/map/layers/wind-barbs.test.js
+++ b/web/src/lib/map/layers/wind-barbs.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildWindBarb, hasWindBarb, quantizeKnots } from './wind-barb-glyph.js';
+import { buildWindBarb, quantizeKnots } from './wind-barb-glyph.js';
 
 const count = (svg, frag) => svg.split(frag).length - 1;
 
@@ -67,12 +67,4 @@ test('quantizeKnots rounds mph to the nearest 5 kt', () => {
   assert.equal(quantizeKnots(11.5), 10); // ~10 kt
   assert.equal(quantizeKnots(null), 0);
   assert.equal(quantizeKnots(NaN), 0);
-});
-
-test('hasWindBarb is true only when a barb (not calm/empty) renders', () => {
-  assert.equal(hasWindBarb(15, 90), true);
-  assert.equal(hasWindBarb(2, 90), false); // rounds to calm
-  assert.equal(hasWindBarb(0, 90), false);
-  assert.equal(hasWindBarb(15, null), false); // no direction
-  assert.equal(hasWindBarb(null, 90), false);
 });

--- a/web/src/lib/map/layers/wind-barbs.test.js
+++ b/web/src/lib/map/layers/wind-barbs.test.js
@@ -61,6 +61,28 @@ test('direction sets the group rotation', () => {
   assert.match(buildWindBarb(20, 215), /rotate\(215\)/);
 });
 
+// Pull the y1 of the first <line class="wb-barb"> out of the markup so we
+// can assert WHERE a barb sits, not just how many there are.
+const firstBarbY1 = (svg) => {
+  const m = svg.match(/<line x1="0" y1="(-?\d+(?:\.\d+)?)"[^>]*class="wb-barb"/);
+  return m ? Number(m[1]) : null;
+};
+
+test('a lone half barb is inset one step from the tip', () => {
+  // 6 mph → 5 kt → single half barb, inset; 11.5 mph → 10 kt → full barb
+  // at the tip. The half barb must sit closer to the station (greater y).
+  const halfY = firstBarbY1(buildWindBarb(6, 0));
+  const fullAtTipY = firstBarbY1(buildWindBarb(11.5, 0));
+  assert.ok(halfY != null && fullAtTipY != null);
+  assert.ok(halfY > fullAtTipY, `expected inset half (${halfY}) below tip (${fullAtTipY})`);
+});
+
+test('calm renders identically regardless of direction', () => {
+  // The open ring has no staff to orient, so direction must not matter.
+  assert.equal(buildWindBarb(0, 0), buildWindBarb(0, 270));
+  assert.doesNotMatch(buildWindBarb(0, 90), /rotate/);
+});
+
 test('quantizeKnots rounds mph to the nearest 5 kt', () => {
   assert.equal(quantizeKnots(0), 0);
   assert.equal(quantizeKnots(2), 0); // ~1.7 kt

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1038,33 +1038,34 @@
 
   /* Wind barbs -- inline SVG glyph rendered per station by
      wind-barbs.js. The marker is inert so it never steals clicks from
-     the station icon underneath. A soft drop-shadow keeps the thin
-     strokes legible over any basemap. */
+     the station icon underneath. Black strokes with a white halo so the
+     barb stays legible over both light and dark basemaps. */
   :global(.wb-marker) {
     background: none !important;
     border: none !important;
     pointer-events: none;
-    filter: drop-shadow(0 0 1.5px rgba(0, 0, 0, 0.85));
+    filter: drop-shadow(0 0 1px rgba(255, 255, 255, 0.95))
+      drop-shadow(0 0 1.5px rgba(255, 255, 255, 0.85));
   }
   :global(.wb-svg) {
     overflow: visible;
   }
   :global(.wb-staff),
   :global(.wb-barb) {
-    stroke: var(--wb-color, #7fdfff);
+    stroke: var(--wb-color, #111);
     stroke-width: 2;
     stroke-linecap: round;
     fill: none;
   }
   :global(.wb-pennant) {
-    fill: var(--wb-color, #7fdfff);
-    stroke: var(--wb-color, #7fdfff);
+    fill: var(--wb-color, #111);
+    stroke: var(--wb-color, #111);
     stroke-width: 1;
     stroke-linejoin: round;
   }
   :global(.wb-calm) {
     fill: none;
-    stroke: var(--wb-color, #7fdfff);
+    stroke: var(--wb-color, #111);
     stroke-width: 2;
   }
 

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -256,7 +256,12 @@
         hoverPathLayer?.clear();
       },
     });
-    weatherLayer = mountWeatherLayer(map, () => dataStore.stations);
+    // getTempSlot reaches into the station marker (assigned below) so the
+    // temperature chip renders right under the callsign, not as its own
+    // floating marker.
+    weatherLayer = mountWeatherLayer(map, () => dataStore.stations, {
+      getTempSlot: (callsign) => stationsLayer?.getTempSlot(callsign),
+    });
     // Wind barbs mount before the station markers so the (DOM) station
     // icons stack above the barb staffs that radiate out from them.
     windBarbsLayer = mountWindBarbsLayer(map, () => dataStore.stations);
@@ -909,10 +914,11 @@
      override with position:relative — that pulls the marker into document
      flow and the per-marker transform stacks all of them at the canvas
      origin). The 21x21 icon child is the visual anchor (anchor:'center'
-     in stations.js puts the icon center on the lat/lon). The callsign
-     label is absolutely positioned to the right of the icon, anchored
-     within the maplibregl-applied positioning context, so its width
-     doesn't shift the icon off-target. */
+     in stations.js puts the icon center on the lat/lon). The aside column
+     (callsign + temperature) is absolutely positioned to the right of the
+     icon and vertically centered, so its width doesn't shift the icon
+     off-target. align-items:flex-end right-justifies the temp chip to the
+     callsign's right edge regardless of callsign length. */
   :global(.gw-station-marker) {
     width: 21px;
     height: 21px;
@@ -924,12 +930,18 @@
     width: 21px;
     height: 21px;
   }
-  :global(.gw-station-label) {
+  :global(.gw-station-aside) {
     position: absolute;
     left: 100%;
     top: 50%;
     transform: translateY(-50%);
     margin-left: 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+  }
+  :global(.gw-station-label) {
     padding: 0 4px;
     line-height: 12px;
     font-family: var(--font-mono);
@@ -943,6 +955,22 @@
     max-width: 120px;
     overflow: hidden;
     text-overflow: ellipsis;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  }
+  /* Temperature chip: sits just below the callsign, right-justified to
+     it. Filled by the weather layer; dimmer than the callsign so the
+     callsign stays the primary label. */
+  :global(.gw-station-aside .wx-temp) {
+    padding: 0 4px;
+    line-height: 13px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--color-text-dim, #c9d1d9);
+    background: rgba(22, 27, 34, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    border-radius: 2px;
+    white-space: nowrap;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
   }
 
@@ -1016,25 +1044,6 @@
   :global(.stn-popup .b-rx) { background: rgba(63, 185, 80, 0.15); color: var(--color-success); }
   :global(.stn-popup .b-tx) { background: rgba(210, 153, 34, 0.15); color: var(--color-warning); }
   :global(.stn-popup .b-is) { background: rgba(195, 155, 255, 0.15); color: #c39bff; }
-
-  /* Weather label chip -- ports the legacy Leaflet wx-label/wx-text
-     styling. The marker root is a maplibregl.Marker (DOM-based) so
-     these have to be :global. */
-  :global(.wx-label) {
-    background: none !important;
-    border: none !important;
-    pointer-events: none;
-  }
-  :global(.wx-text) {
-    background: rgba(22, 27, 34, 0.85);
-    color: var(--color-text-dim);
-    font-family: var(--font-mono);
-    font-size: 10px;
-    padding: 1px 4px;
-    border-radius: 3px;
-    white-space: nowrap;
-    text-align: center;
-  }
 
   /* Wind barbs -- inline SVG glyph rendered per station by
      wind-barbs.js. The marker is inert so it never steals clicks from

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -67,7 +67,6 @@
     stations: true,
     trails: true,
     weather: true,
-    windBarbs: true,
     myPosition: true,
     directRxOnly: false,
   });
@@ -386,12 +385,12 @@
     const v = layerToggles.trails;
     trailsLayer?.setVisible(v);
   });
+  // Wind barbs ride along with the Weather overlay -- they ARE the
+  // weather wind display, so one toggle governs both the temp chip and
+  // the barb rather than splitting them across two controls.
   $effect(() => {
     const v = layerToggles.weather;
     weatherLayer?.setVisible(v);
-  });
-  $effect(() => {
-    const v = layerToggles.windBarbs;
     windBarbsLayer?.setVisible(v);
   });
   $effect(() => {
@@ -556,14 +555,6 @@
           onchange={(e) => (layerToggles.weather = e.currentTarget.checked)}
         />
         <span>Weather</span>
-      </label>
-      <label class="toggle-row">
-        <input
-          type="checkbox"
-          checked={layerToggles.windBarbs}
-          onchange={(e) => (layerToggles.windBarbs = e.currentTarget.checked)}
-        />
-        <span>Wind barbs</span>
       </label>
       <label class="toggle-row">
         <input

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -14,6 +14,7 @@
   import { mountStationsLayer } from '../lib/map/layers/stations.js';
   import { mountTrailsLayer } from '../lib/map/layers/trails.js';
   import { mountWeatherLayer } from '../lib/map/layers/weather.js';
+  import { mountWindBarbsLayer } from '../lib/map/layers/wind-barbs.js';
   import { mountHoverPathLayer } from '../lib/map/layers/hover-path.js';
   import { mountMyPositionLayer } from '../lib/map/layers/my-position.js';
   import { renderStationPopupHTML } from '../lib/map/popup.js';
@@ -50,6 +51,7 @@
   let stationsLayer = null;
   let trailsLayer = null;
   let weatherLayer = null;
+  let windBarbsLayer = null;
   let hoverPathLayer = null;
   let myPositionLayer = null;
   let mapRef = null;
@@ -65,6 +67,7 @@
     stations: true,
     trails: true,
     weather: true,
+    windBarbs: true,
     myPosition: true,
     directRxOnly: false,
   });
@@ -255,6 +258,9 @@
       },
     });
     weatherLayer = mountWeatherLayer(map, () => dataStore.stations);
+    // Wind barbs mount before the station markers so the (DOM) station
+    // icons stack above the barb staffs that radiate out from them.
+    windBarbsLayer = mountWindBarbsLayer(map, () => dataStore.stations);
     hoverPathLayer = mountHoverPathLayer(map, () => {
       const my = dataStore.myPosition;
       return my ? { lat: my.lat, lon: my.lon } : null;
@@ -361,6 +367,7 @@
     if (stationsLayer) stationsLayer.refresh();
     if (trailsLayer) trailsLayer.refresh();
     if (weatherLayer) weatherLayer.refresh();
+    if (windBarbsLayer) windBarbsLayer.refresh();
     if (myPositionLayer) myPositionLayer.refresh();
   });
 
@@ -384,18 +391,23 @@
     weatherLayer?.setVisible(v);
   });
   $effect(() => {
+    const v = layerToggles.windBarbs;
+    windBarbsLayer?.setVisible(v);
+  });
+  $effect(() => {
     const v = layerToggles.myPosition;
     myPositionLayer?.setVisible(v);
   });
-  // Direct RX filter: predicate is shared across stations/trails/weather
-  // so the three layers stay in lockstep. my-position is the operator's
-  // own beacon and is intentionally exempt.
+  // Direct RX filter: predicate is shared across stations/trails/weather/
+  // wind-barbs so the layers stay in lockstep. my-position is the
+  // operator's own beacon and is intentionally exempt.
   $effect(() => {
     const on = layerToggles.directRxOnly;
     const pred = on ? isDirectRx : null;
     stationsLayer?.setFilter(pred);
     trailsLayer?.setFilter(pred);
     weatherLayer?.setFilter(pred);
+    windBarbsLayer?.setFilter(pred);
   });
 
   // Push the timerange into the data store.
@@ -492,11 +504,13 @@
     stationsLayer?.destroy();
     trailsLayer?.destroy();
     weatherLayer?.destroy();
+    windBarbsLayer?.destroy();
     hoverPathLayer?.destroy();
     myPositionLayer?.destroy();
     stationsLayer = null;
     trailsLayer = null;
     weatherLayer = null;
+    windBarbsLayer = null;
     hoverPathLayer = null;
     myPositionLayer = null;
     mapRef = null;
@@ -542,6 +556,14 @@
           onchange={(e) => (layerToggles.weather = e.currentTarget.checked)}
         />
         <span>Weather</span>
+      </label>
+      <label class="toggle-row">
+        <input
+          type="checkbox"
+          checked={layerToggles.windBarbs}
+          onchange={(e) => (layerToggles.windBarbs = e.currentTarget.checked)}
+        />
+        <span>Wind barbs</span>
       </label>
       <label class="toggle-row">
         <input
@@ -1021,6 +1043,38 @@
     border-radius: 3px;
     white-space: nowrap;
     text-align: center;
+  }
+
+  /* Wind barbs -- inline SVG glyph rendered per station by
+     wind-barbs.js. The marker is inert so it never steals clicks from
+     the station icon underneath. A soft drop-shadow keeps the thin
+     strokes legible over any basemap. */
+  :global(.wb-marker) {
+    background: none !important;
+    border: none !important;
+    pointer-events: none;
+    filter: drop-shadow(0 0 1.5px rgba(0, 0, 0, 0.85));
+  }
+  :global(.wb-svg) {
+    overflow: visible;
+  }
+  :global(.wb-staff),
+  :global(.wb-barb) {
+    stroke: var(--wb-color, #7fdfff);
+    stroke-width: 2;
+    stroke-linecap: round;
+    fill: none;
+  }
+  :global(.wb-pennant) {
+    fill: var(--wb-color, #7fdfff);
+    stroke: var(--wb-color, #7fdfff);
+    stroke-width: 1;
+    stroke-linejoin: round;
+  }
+  :global(.wb-calm) {
+    fill: none;
+    stroke: var(--wb-color, #7fdfff);
+    stroke-width: 2;
   }
 
   /* Trail hover tooltip: small dim chip with the callsign, tip-less and


### PR DESCRIPTION
## Wind barbs for weather station markers (closes #215)

Replaces the text-based wind speed/direction annotation on the live map's weather station markers with standard meteorological **wind barbs**, rendered as per-station inline SVG overlays.

### What changed
- **Wind barbs** — each weather station shows a WMO-style barb: the staff points the direction the wind blows *from*, and sustained speed is encoded in knots (half barb = 5 kt, full barb = 10 kt, pennant = 50 kt; calm = open ring). Black stroke with a white halo so it stays legible on light and dark basemaps.
- **Temperature chip** — moved out of a free-floating marker into the station marker itself: it now stacks directly below the callsign, right-justified to the callsign's edge, so it stays pinned at every zoom and never overlaps the barb.
- **Toggle** — wind barbs ride the existing **Weather** overlay toggle (no separate layers-panel control); they honor the Direct RX filter like the other layers.

### Implementation
- New `wind-barbs.js` layer mirrors the existing stations/weather layer pattern (per-station DOM markers synced to the data store).
- Barb geometry lives in a pure, dependency-free `wind-barb-glyph.js` with unit tests covering the 5/10/50 kt encoding, calm, the lone-half-barb inset, direction rotation, and knot quantization.
- The temperature is written into a `.wx-temp` slot the stations layer exposes via `getTempSlot()`; the weather layer keeps units/visibility/Direct-RX logic, the station marker owns layout.

### Verification
- `npm run build` succeeds; new unit tests pass (`node --test`).