### PR TITLE
web(kiss): add TCP (server) KISS type to Android + local-only bind toggle

### DIFF
--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -9331,6 +9331,10 @@
                     "description": "GateTxToIs opts a Mode=modem KISS interface in to gating frames\nsubmitted by connected KISS clients to APRS-IS, after the TX\ngovernor has accepted them. The iGate's own filter chain still\nruns, so this only opens the gate — it does not bypass NOGATE /\nRFONLY / TCPIP markers or the operator's filter rules. Default\nfalse on all migrated rows; meaningless in Mode=tnc (which\nalready feeds the iGate via the RX fanout) and silently ignored\nthere by the server.",
                     "type": "boolean"
                 },
+                "local_only": {
+                    "description": "LocalOnly, when set on a tcp (server-listen) interface, binds the\nKISS listener to loopback (127.0.0.1) instead of all interfaces\n(0.0.0.0). The intended use is an on-device iGate client (a KISS\napp on the same phone/host) dialing in over loopback without\nexposing the port to the LAN. Ignored for non-tcp types. Stored\nin the existing ListenAddr host -- no schema change.",
+                    "type": "boolean"
+                },
                 "mode": {
                     "type": "string"
                 },
@@ -9390,6 +9394,10 @@
                 },
                 "last_error": {
                     "type": "string"
+                },
+                "local_only": {
+                    "description": "LocalOnly mirrors KissRequest.LocalOnly: true when a tcp interface\nlistens on loopback only. Derived from the ListenAddr host.",
+                    "type": "boolean"
                 },
                 "mode": {
                     "type": "string"

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -1411,6 +1411,15 @@ definitions:
           already feeds the iGate via the RX fanout) and silently ignored
           there by the server.
         type: boolean
+      local_only:
+        description: |-
+          LocalOnly, when set on a tcp (server-listen) interface, binds the
+          KISS listener to loopback (127.0.0.1) instead of all interfaces
+          (0.0.0.0). The intended use is an on-device iGate client (a KISS
+          app on the same phone/host) dialing in over loopback without
+          exposing the port to the LAN. Ignored for non-tcp types. Stored
+          in the existing ListenAddr host -- no schema change.
+        type: boolean
       mode:
         type: string
       reconnect_init_ms:
@@ -1455,6 +1464,11 @@ definitions:
         type: integer
       last_error:
         type: string
+      local_only:
+        description: |-
+          LocalOnly mirrors KissRequest.LocalOnly: true when a tcp interface
+          listens on loopback only. Derived from the ListenAddr host.
+        type: boolean
       mode:
         type: string
       needs_reconfig:

--- a/pkg/webapi/dto/kiss.go
+++ b/pkg/webapi/dto/kiss.go
@@ -29,8 +29,15 @@ const (
 // rejects obviously-wrong non-zero values up front so the error lands
 // at the API boundary instead of the SQLite boundary.
 type KissRequest struct {
-	Type             string `json:"type"`
-	TcpPort          int    `json:"tcp_port"`
+	Type    string `json:"type"`
+	TcpPort int    `json:"tcp_port"`
+	// LocalOnly, when set on a tcp (server-listen) interface, binds the
+	// KISS listener to loopback (127.0.0.1) instead of all interfaces
+	// (0.0.0.0). The intended use is an on-device iGate client (a KISS
+	// app on the same phone/host) dialing in over loopback without
+	// exposing the port to the LAN. Ignored for non-tcp types. Stored
+	// in the existing ListenAddr host -- no schema change.
+	LocalOnly        bool   `json:"local_only"`
 	SerialDevice     string `json:"serial_device"`
 	BaudRate         uint32 `json:"baud_rate"`
 	Channel          uint32 `json:"channel"`
@@ -194,7 +201,11 @@ func (r KissRequest) ToModel() configstore.KissInterface {
 	switch r.Type {
 	case configstore.KissTypeTCP:
 		if r.TcpPort > 0 {
-			ki.ListenAddr = fmt.Sprintf("0.0.0.0:%d", r.TcpPort)
+			host := "0.0.0.0"
+			if r.LocalOnly {
+				host = "127.0.0.1"
+			}
+			ki.ListenAddr = fmt.Sprintf("%s:%d", host, r.TcpPort)
 			ki.Name = fmt.Sprintf("kiss-tcp-%d", r.TcpPort)
 		}
 	case configstore.KissTypeTCPClient:
@@ -227,9 +238,12 @@ func (r KissRequest) ToUpdate(id uint32) configstore.KissInterface {
 // can surface a "reconfigure me" banner on rows whose Channel was
 // nulled by a Phase 5 cascade delete.
 type KissResponse struct {
-	ID                  uint32 `json:"id"`
-	Type                string `json:"type"`
-	TcpPort             int    `json:"tcp_port"`
+	ID      uint32 `json:"id"`
+	Type    string `json:"type"`
+	TcpPort int    `json:"tcp_port"`
+	// LocalOnly mirrors KissRequest.LocalOnly: true when a tcp interface
+	// listens on loopback only. Derived from the ListenAddr host.
+	LocalOnly           bool   `json:"local_only"`
 	SerialDevice        string `json:"serial_device"`
 	BaudRate            uint32 `json:"baud_rate"`
 	Channel             uint32 `json:"channel"`
@@ -258,6 +272,23 @@ type KissResponse struct {
 	BackoffSeconds uint32 `json:"backoff_seconds,omitempty"`
 }
 
+// isLoopbackHost reports whether a ListenAddr host binds loopback only.
+// Covers the literal "localhost" plus any loopback IP (127.0.0.0/8,
+// ::1). An empty host (":8001") means "all interfaces", so it is not
+// loopback.
+func isLoopbackHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
 func KissFromModel(m configstore.KissInterface) KissResponse {
 	out := KissResponse{
 		ID:                  m.ID,
@@ -277,10 +308,11 @@ func KissFromModel(m configstore.KissInterface) KissResponse {
 		ReconnectMaxMs:      m.ReconnectMaxMs,
 	}
 	if m.ListenAddr != "" {
-		if _, portStr, err := net.SplitHostPort(m.ListenAddr); err == nil {
+		if host, portStr, err := net.SplitHostPort(m.ListenAddr); err == nil {
 			if p, err := strconv.Atoi(portStr); err == nil {
 				out.TcpPort = p
 			}
+			out.LocalOnly = isLoopbackHost(host)
 		}
 	}
 	return out

--- a/pkg/webapi/dto/kiss_test.go
+++ b/pkg/webapi/dto/kiss_test.go
@@ -389,6 +389,68 @@ func TestKissFromModel_TcpClient_Roundtrip(t *testing.T) {
 	}
 }
 
+// TestKissRequest_LocalOnly_RoundTrip verifies that the tcp-server
+// local-only flag survives DTO -> model -> DTO. LocalOnly binds the
+// listener to loopback (127.0.0.1); the off case binds 0.0.0.0. The
+// flag is encoded in the ListenAddr host, not a dedicated column, so
+// the round-trip also asserts the resulting bind address.
+func TestKissRequest_LocalOnly_RoundTrip(t *testing.T) {
+	cases := []struct {
+		localOnly bool
+		wantAddr  string
+	}{
+		{false, "0.0.0.0:8001"},
+		{true, "127.0.0.1:8001"},
+	}
+	for _, tc := range cases {
+		req := KissRequest{
+			Type:      configstore.KissTypeTCP,
+			TcpPort:   8001,
+			Channel:   1,
+			Mode:      configstore.KissModeModem,
+			LocalOnly: tc.localOnly,
+		}
+		m := req.ToModel()
+		if m.ListenAddr != tc.wantAddr {
+			t.Fatalf("ToModel: ListenAddr=%q, want %q", m.ListenAddr, tc.wantAddr)
+		}
+		resp := KissFromModel(m)
+		if resp.LocalOnly != tc.localOnly {
+			t.Fatalf("KissFromModel: LocalOnly=%v, want %v", resp.LocalOnly, tc.localOnly)
+		}
+		if resp.TcpPort != 8001 {
+			t.Fatalf("KissFromModel: TcpPort=%d, want 8001", resp.TcpPort)
+		}
+	}
+}
+
+// TestKissFromModel_LocalOnly_HostForms checks loopback detection across
+// the host spellings a ListenAddr can carry: IPv4 loopback, the IPv6
+// loopback literal, "localhost", an empty host (all interfaces), and a
+// routable LAN address.
+func TestKissFromModel_LocalOnly_HostForms(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:8001", true},
+		{"[::1]:8001", true},
+		{"localhost:8001", true},
+		{"0.0.0.0:8001", false},
+		{":8001", false},
+		{"192.168.1.50:8001", false},
+	}
+	for _, tc := range cases {
+		resp := KissFromModel(configstore.KissInterface{
+			InterfaceType: "tcp",
+			ListenAddr:    tc.addr,
+		})
+		if resp.LocalOnly != tc.want {
+			t.Errorf("ListenAddr %q: LocalOnly=%v, want %v", tc.addr, resp.LocalOnly, tc.want)
+		}
+	}
+}
+
 // TestKissRequest_GateTxToIs_RoundTrip verifies the new field survives
 // the DTO -> model -> DTO cycle unchanged for both true and false.
 func TestKissRequest_GateTxToIs_RoundTrip(t *testing.T) {

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2599,6 +2599,15 @@ export interface components {
              *     there by the server.
              */
             gate_tx_to_is?: boolean;
+            /**
+             * @description LocalOnly, when set on a tcp (server-listen) interface, binds the
+             *     KISS listener to loopback (127.0.0.1) instead of all interfaces
+             *     (0.0.0.0). The intended use is an on-device iGate client (a KISS
+             *     app on the same phone/host) dialing in over loopback without
+             *     exposing the port to the LAN. Ignored for non-tcp types. Stored
+             *     in the existing ListenAddr host -- no schema change.
+             */
+            local_only?: boolean;
             mode?: string;
             reconnect_init_ms?: number;
             reconnect_max_ms?: number;
@@ -2625,6 +2634,11 @@ export interface components {
             gate_tx_to_is?: boolean;
             id?: number;
             last_error?: string;
+            /**
+             * @description LocalOnly mirrors KissRequest.LocalOnly: true when a tcp interface
+             *     listens on loopback only. Derived from the ListenAddr host.
+             */
+            local_only?: boolean;
             mode?: string;
             needs_reconfig?: boolean;
             peer_addr?: string;

--- a/web/src/routes/Kiss.svelte
+++ b/web/src/routes/Kiss.svelte
@@ -297,11 +297,11 @@
   function openCreate() {
     editing = null;
     form = emptyForm();
-    // The Type select only shows {bluetooth, tcp-client} on Android —
-    // the default `tcp` from emptyForm() would render an invisible
-    // selection and silently submit a server-listen interface if the
-    // operator never touched the field. Pick a visible default for
-    // the platform's actual menu.
+    // emptyForm() defaults to `tcp` (the desktop common case). On
+    // Android, Bluetooth-to-a-paired-TNC is the far more common setup,
+    // so default new interfaces there to bluetooth. (tcp is selectable
+    // on Android too — this is a default-value choice, not a menu
+    // restriction.)
     if (Platform.isAndroid) {
       form.type = 'bluetooth';
     }

--- a/web/src/routes/Kiss.svelte
+++ b/web/src/routes/Kiss.svelte
@@ -78,12 +78,16 @@
     { key: 'status', label: 'Status' },
   ];
 
-  // Platform-conditional type menu. On Android, operators see only
-  // the two interface types we actually support there: Bluetooth
-  // (serial-over-RFCOMM to a paired TNC) and TCP-Client (which we
-  // relabel "Network" because that's the term Android operators
-  // expect). Desktop keeps the full set including server-listen TCP
-  // and host-serial. Platform.isAndroid is read reactively so the
+  // Platform-conditional type menu. On Android, operators see the
+  // interface types we support there: Bluetooth (serial-over-RFCOMM to
+  // a paired TNC), USB Serial, TCP-Client (which we relabel "Network"
+  // because that's the term Android operators expect), and TCP server
+  // (graywolf listens; a local KISS app — e.g. a same-device iGate
+  // client — dials in over loopback). The on-device Go binary binds
+  // the listen socket directly, so TCP server needs no platform
+  // adapter (unlike Bluetooth/USB, which relay bytes over the platform
+  // UDS); it's the same fully-supported code path as desktop. Desktop
+  // keeps host-serial too. Platform.isAndroid is read reactively so the
   // menu re-derives if the JS bridge appears/disappears mid-session
   // (rare, but the reactive shape costs us nothing).
   const desktopTypeOptions = [
@@ -94,6 +98,7 @@
   const androidTypeOptions = [
     { value: 'bluetooth',  label: 'Bluetooth Serial' },
     { value: 'usbserial',  label: 'USB Serial' },
+    { value: 'tcp',        label: 'TCP (server)' },
     { value: 'tcp-client', label: 'Network' },
   ];
   let typeOptions = $derived(Platform.isAndroid ? androidTypeOptions : desktopTypeOptions);
@@ -220,6 +225,10 @@
     return {
       type: 'tcp',
       tcp_port: TCP_PORT_DEFAULT,
+      // tcp (server) bind scope: false => listen on all interfaces
+      // (0.0.0.0), true => loopback only (127.0.0.1). Off by default to
+      // match desktop semantics; the operator opts into local-only.
+      local_only: false,
       // tcp-client fields:
       remote_host: '',
       remote_port: TCP_PORT_DEFAULT,
@@ -310,6 +319,7 @@
     form = {
       ...row,
       tcp_port: String(row.tcp_port ?? ''),
+      local_only: !!row.local_only,
       remote_host: row.remote_host || '',
       remote_port: String(row.remote_port || ''),
       reconnect_init_ms: String(row.reconnect_init_ms || RECONNECT_INIT_DEFAULT_MS),
@@ -548,6 +558,7 @@
     switch (form.type) {
       case 'tcp':
         data.tcp_port = parseInt(form.tcp_port) || 0;
+        data.local_only = !!form.local_only;
         break;
       case 'tcp-client':
         data.remote_host = (form.remote_host || '').trim();
@@ -661,7 +672,7 @@
   }
 
   function endpointText(row) {
-    if (row.type === 'tcp') return `:${row.tcp_port}`;
+    if (row.type === 'tcp') return row.local_only ? `127.0.0.1:${row.tcp_port}` : `:${row.tcp_port}`;
     if (row.type === 'tcp-client') return `${row.remote_host}:${row.remote_port}`;
     if (row.type === 'serial') return row.serial_device || '—';
     if (row.type === 'bluetooth') return friendlyDevice(row) || '—';
@@ -813,7 +824,7 @@
             </div>
           {/if}
         {:else if row.type === 'tcp'}
-          <div class="detail-row"><span class="detail-label">Listening:</span> <span>:{row.tcp_port}</span></div>
+          <div class="detail-row"><span class="detail-label">Listening:</span> <span>{row.local_only ? `127.0.0.1:${row.tcp_port} (local only)` : `:${row.tcp_port}`}</span></div>
         {:else if row.type === 'bluetooth'}
           <div class="detail-row"><span class="detail-label">Device:</span> <span>{friendlyDevice(row) || '—'}</span></div>
         {:else if row.type === 'usbserial'}
@@ -841,6 +852,21 @@
       <FormField label="TCP Port" id="kiss-port">
         <Input id="kiss-port" bind:value={form.tcp_port} type="number" placeholder="8001" />
       </FormField>
+      <!-- Bind scope for the KISS listener. Unchecked binds all
+           interfaces (0.0.0.0); checked binds loopback (127.0.0.1) so
+           only apps on this device can connect — the common case for an
+           on-device iGate client. -->
+      <div class="field checkbox-field">
+        <label class="checkbox-row" for="kiss-local-only">
+          <Checkbox id="kiss-local-only" bind:checked={form.local_only} />
+          <span>Local only (this device)</span>
+        </label>
+        <span class="field-hint">
+          Listen on loopback (127.0.0.1) instead of every network interface.
+          Recommended when a KISS app on this same device connects in — it
+          keeps the port off your Wi-Fi/LAN.
+        </span>
+      </div>
     {:else if form.type === 'tcp-client'}
       <FormField
         label="Remote Host"


### PR DESCRIPTION
## Summary

Closes the gap behind chrissnell/graywolf#211: the Android app's KISS config Type picklist offered only Bluetooth Serial, USB Serial, and Network (tcp-client), omitting **TCP (server)**. That blocked the local-iGate use case where a KISS app on the same device dials into graywolf.

The TCP server was never a backend limitation — the on-device Go binary already implements it (`pkg/kiss/server.go`) and binds the listen socket directly, no platform adapter needed. It was simply filtered out of the Android picklist in the web UI.

This PR:

1. **Adds TCP (server) to the Android Type picklist** (`web/src/routes/Kiss.svelte`). Same fully-supported code path as desktop.
2. **Adds a "Local only" toggle for tcp (server) interfaces.** Checked binds the listener to `127.0.0.1` instead of `0.0.0.0`, keeping the KISS port off the Wi-Fi/LAN — the common case for a same-device iGate client. Off by default (preserves today's `0.0.0.0` behavior).

## UI

When Type = TCP (server), a single "Local only (this device)" checkbox appears under the port field, reusing the existing KISS checkbox styling. Running interfaces show `127.0.0.1:8001 (local only)` in the detail row when enabled.

## Implementation notes

- **No DB migration.** The local-only flag rides in the existing `ListenAddr` host (`127.0.0.1` vs `0.0.0.0`). `KissRequest.LocalOnly` -> bind host on write; `KissResponse.LocalOnly` is derived by loopback-detecting the stored host (covers `127.0.0.0/8`, `::1`, `localhost`).
- OpenAPI spec and generated TS client regenerated for the new `local_only` field.

## Verification

- `go test ./pkg/webapi/...` passes (added round-trip + host-form coverage for the flag)
- web build + all 232 unit tests pass
- `make docs-check` clean; generated `api.d.ts` drift-checked clean
