### PR TITLE
modem: build armhf with 64-bit time_t to fix t64 ALSA crash (#231)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,18 @@ jobs:
           CFLAGS_aarch64_unknown_linux_gnu: '-idirafter /usr/include'
           CFLAGS_arm_unknown_linux_gnueabihf: '-idirafter /usr/include'
           CFLAGS_armv7_unknown_linux_gnueabihf: '-idirafter /usr/include'
+          # Build the 32-bit armhf binaries with 64-bit `time_t` so Rust's
+          # `timespec` is 16 bytes, matching post-t64 Raspberry Pi OS
+          # `libasound2t64`. Fixes the cpal/alsa-rs `get_htstamp` stack
+          # overflow that crash-loops the modem on capture (issue #231).
+          # Applies to BOTH 32-bit armhf triples (armv6 + armv7), which link
+          # the same `libasound2t64:armhf` and share the exposure -- empty
+          # elsewhere (aarch64 is already 64-bit `time_t`; libc's build.rs
+          # ignores the var on 64-bit targets anyway, and Cross.toml only
+          # passes it through for these two targets). The matching
+          # passthrough entries live in Cross.toml so the var reaches libc's
+          # build.rs in the container.
+          RUST_LIBC_UNSTABLE_GNU_TIME_BITS: ${{ (matrix.target == 'arm-unknown-linux-gnueabihf' || matrix.target == 'armv7-unknown-linux-gnueabihf') && '64' || '' }}
         run: cross build --release --target ${{ matrix.target }} --bin graywolf-modem
 
       - name: Build with cargo

--- a/Cross.toml
+++ b/Cross.toml
@@ -29,11 +29,23 @@ pre-build = [
 # Same pkg-config cross-lookup story as the aarch64 target above; see
 # the note there for context. armhf's multi-arch path differs only in
 # triple.
+#
+# RUST_LIBC_UNSTABLE_GNU_TIME_BITS=64 forces the Rust `libc` crate to emit
+# the 64-bit-`time_t` (16-byte `timespec`) layout for this 32-bit target,
+# matching the post-t64 Raspberry Pi OS `libasound2t64:armhf`. Without it,
+# Rust's `timespec` is 8 bytes while the system library writes 16, and
+# cpal/alsa-rs's `get_htstamp` overflows its stack buffer -> SIGSEGV on
+# capture (issue #231). cross runs the build inside a container, so the
+# var only reaches libc's build.rs if it's passed through here. Applied to
+# both 32-bit armhf triples (this one and armv7 below); aarch64 is already
+# 64-bit `time_t`, and the legacy 32-bit-`time_t` (pre-t64) ABI is
+# intentionally not produced.
 [target.arm-unknown-linux-gnueabihf.env]
 passthrough = [
     "PKG_CONFIG_ALLOW_CROSS",
     "PKG_CONFIG_PATH_arm_unknown_linux_gnueabihf",
     "CFLAGS_arm_unknown_linux_gnueabihf",
+    "RUST_LIBC_UNSTABLE_GNU_TIME_BITS",
 ]
 
 # 32-bit ARMv7-A hard-float (NEON). Same hardfloat ABI and the same
@@ -49,9 +61,13 @@ pre-build = [
 
 # Multi-arch path is shared with armv6 (both are arm-linux-gnueabihf); the
 # passthrough env var names are keyed to the Rust triple, so they differ.
+# RUST_LIBC_UNSTABLE_GNU_TIME_BITS is passed through here for the same t64
+# reason as the armv6 target above -- armv7 is also 32-bit armhf linking
+# `libasound2t64:armhf`, so it needs the 16-byte `timespec` too (#231).
 [target.armv7-unknown-linux-gnueabihf.env]
 passthrough = [
     "PKG_CONFIG_ALLOW_CROSS",
     "PKG_CONFIG_PATH_armv7_unknown_linux_gnueabihf",
     "CFLAGS_armv7_unknown_linux_gnueabihf",
+    "RUST_LIBC_UNSTABLE_GNU_TIME_BITS",
 ]


### PR DESCRIPTION
## Problem
`graywolf-modem` crash-loops within ~0.3s of starting audio capture on post-t64 32-bit Raspberry Pi OS (Pi Zero / armv6). Root cause is an ABI mismatch: Debian's t64 transition rebuilt `libasound2t64:armhf` with 64-bit `time_t`, so `struct timespec` is 16 bytes, but the Rust `libc` armhf target still defaults to an 8-byte `timespec`. cpal/alsa-rs `get_htstamp()` allocates an 8-byte stack `timespec` and the C library writes 16 bytes into it, overwriting the saved return address → SIGSEGV (PC=0x0). See issue #231.

## Fix
Build the `arm-unknown-linux-gnueabihf` binary with `RUST_LIBC_UNSTABLE_GNU_TIME_BITS=64`, which makes Rust's `libc` emit the 16-byte `timespec` layout across the whole dependency graph (cpal, alsa-rs, nix), matching the system `libasound2t64`. No fork of cpal/alsa-rs, no `arecord` workaround.

- `release.yml`: set the env var via a matrix conditional so it applies to **armhf only** (empty for every other target).
- `Cross.toml`: add it to the armhf `passthrough` list so it reaches `libc`'s `build.rs` inside the cross container.

## Scope / caveats
- Scoped to the armhf target only. aarch64 is already 64-bit `time_t`; `libc`'s `build.rs` ignores the var on 64-bit targets regardless.
- The resulting armhf binary is **t64-only**: it requires 64-bit-`time_t` libasound at runtime and is not intended to run on legacy pre-t64 (Bullseye) systems. This makes Bookworm the effective baseline for the armv6 build.
- `RUST_LIBC_UNSTABLE_GNU_TIME_BITS` is a libc *unstable* knob (builds on stable rustc; behavior not under libc's stability guarantee). `libc` is pinned at 0.2.186 in `Cargo.lock`.

Fixes #231.
