### PR TITLE
Show channel name instead of ID in packet logs (#232)

### DIFF
--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -11216,6 +11216,10 @@
                     "description": "Channel is the graywolf channel ID that observed or transmitted the packet.",
                     "type": "integer"
                 },
+                "channel_name": {
+                    "description": "ChannelName is the display name of the channel that handled the packet,\nresolved from the numeric Channel ID; omitted when the ID maps to no\nconfigured channel (e.g. channel 0, used for non-RF / APRS-IS arrivals).",
+                    "type": "string"
+                },
                 "decoded": {
                     "description": "Decoded is the parsed APRS payload when decoding succeeded; nil otherwise.",
                     "allOf": [

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -2805,6 +2805,12 @@ definitions:
       channel:
         description: Channel is the graywolf channel ID that observed or transmitted the packet.
         type: integer
+      channel_name:
+        description: |-
+          ChannelName is the display name of the channel that handled the packet,
+          resolved from the numeric Channel ID; omitted when the ID maps to no
+          configured channel (e.g. channel 0, used for non-RF / APRS-IS arrivals).
+        type: string
       decoded:
         allOf:
           - $ref: '#/definitions/aprs.DecodedAPRSPacket'

--- a/pkg/webapi/packets.go
+++ b/pkg/webapi/packets.go
@@ -15,6 +15,10 @@ import (
 // packetDTO enriches a packet log entry with device identification and distance.
 type packetDTO struct {
 	packetlog.Entry
+	// ChannelName is the display name of the channel that handled the packet,
+	// resolved from the numeric Channel ID; omitted when the ID maps to no
+	// configured channel (e.g. channel 0, used for non-RF / APRS-IS arrivals).
+	ChannelName string `json:"channel_name,omitempty"`
 	// Device is APRS device identification (manufacturer, model) inferred from the TOCALL field; omitted when unknown.
 	Device *aprs.DeviceInfo `json:"device,omitempty"`
 	// DistanceMi is the great-circle distance from this station's GPS fix to the packet's reported position, in statute miles; omitted when either position is unavailable.
@@ -36,8 +40,7 @@ type packetDTO struct {
 // constants in pkg/webapi/docs/op_ids.go; `make docs-lint` enforces the
 // correspondence.
 func RegisterPackets(srv *Server, mux *http.ServeMux, log *packetlog.Log, posCache gps.PositionCache) {
-	_ = srv // kept in signature for consistency with other RegisterXxx
-	mux.HandleFunc("GET /api/packets", listPackets(log, posCache))
+	mux.HandleFunc("GET /api/packets", listPackets(srv, log, posCache))
 }
 
 // listPackets returns recent APRS packets from the in-memory packet log.
@@ -58,7 +61,7 @@ func RegisterPackets(srv *Server, mux *http.ServeMux, log *packetlog.Log, posCac
 // @Failure  400 {object} webtypes.ErrorResponse
 // @Security CookieAuth
 // @Router   /packets [get]
-func listPackets(log *packetlog.Log, posCache gps.PositionCache) http.HandlerFunc {
+func listPackets(srv *Server, log *packetlog.Log, posCache gps.PositionCache) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		f := packetlog.Filter{
@@ -93,6 +96,19 @@ func listPackets(log *packetlog.Log, posCache gps.PositionCache) http.HandlerFun
 		}
 		entries := log.Query(f)
 
+		// Resolve channel IDs to display names once per request. The channels
+		// table is tiny, so a single ListChannels query is negligible next to
+		// the JSON encode below. A nil store (some tests) just skips names.
+		var chanNames map[uint32]string
+		if srv != nil && srv.store != nil {
+			if chs, err := srv.store.ListChannels(r.Context()); err == nil {
+				chanNames = make(map[uint32]string, len(chs))
+				for _, ch := range chs {
+					chanNames[ch.ID] = ch.Name
+				}
+			}
+		}
+
 		// Get our station position for distance calc
 		var myLat, myLon float64
 		var havePos bool
@@ -107,6 +123,7 @@ func listPackets(log *packetlog.Log, posCache gps.PositionCache) http.HandlerFun
 		out := make([]packetDTO, len(entries))
 		for i := range entries {
 			out[i].Entry = entries[i]
+			out[i].ChannelName = chanNames[entries[i].Channel]
 			enrichPacket(&out[i], havePos, myLat, myLon)
 		}
 

--- a/pkg/webapi/packets_test.go
+++ b/pkg/webapi/packets_test.go
@@ -1,0 +1,58 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/packetlog"
+)
+
+// TestListPackets_ResolvesChannelName verifies that /api/packets enriches
+// each entry with the configured channel's display name, falling back to no
+// name (the frontend then shows the raw ID) for IDs that map to no channel.
+func TestListPackets_ResolvesChannelName(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	// newTestServer seeds one channel named "rx0"; grab its ID.
+	chs, err := srv.store.ListChannels(context.Background())
+	if err != nil || len(chs) == 0 {
+		t.Fatalf("ListChannels: %v (n=%d)", err, len(chs))
+	}
+	seeded := chs[0]
+
+	log := packetlog.New(packetlog.Config{Capacity: 10})
+	log.Record(packetlog.Entry{Channel: seeded.ID, Direction: packetlog.DirRX, Display: "A>B:hi"})
+	log.Record(packetlog.Entry{Channel: 0, Direction: packetlog.DirRX, Source: "igate-is", Display: "C>D:is"})
+
+	mux := http.NewServeMux()
+	RegisterPackets(srv, mux, log, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/packets", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var got []packetDTO
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 packets, got %d", len(got))
+	}
+
+	byChannel := map[uint32]packetDTO{}
+	for _, p := range got {
+		byChannel[p.Channel] = p
+	}
+	if name := byChannel[seeded.ID].ChannelName; name != seeded.Name {
+		t.Errorf("channel %d: expected name %q, got %q", seeded.ID, seeded.Name, name)
+	}
+	if name := byChannel[0].ChannelName; name != "" {
+		t.Errorf("channel 0 maps to no channel; expected empty name, got %q", name)
+	}
+}

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -3473,6 +3473,12 @@ export interface components {
         "webapi.packetDTO": {
             /** @description Channel is the graywolf channel ID that observed or transmitted the packet. */
             channel?: number;
+            /**
+             * @description ChannelName is the display name of the channel that handled the packet,
+             *     resolved from the numeric Channel ID; omitted when the ID maps to no
+             *     configured channel (e.g. channel 0, used for non-RF / APRS-IS arrivals).
+             */
+            channel_name?: string;
             /** @description Decoded is the parsed APRS payload when decoding succeeded; nil otherwise. */
             decoded?: components["schemas"]["aprs.DecodedAPRSPacket"];
             /** @description Device is APRS device identification (manufacturer, model) inferred from the TOCALL field; omitted when unknown. */

--- a/web/src/components/PacketLogViewer.svelte
+++ b/web/src/components/PacketLogViewer.svelte
@@ -38,7 +38,7 @@
     { key: 'timestamp', label: 'Time',    width: '130px', class: 'pkt-c-time',           render: timeCell    },
     { key: 'type',      label: 'Type',    width: '180px', class: 'pkt-c-type',           render: typeCell    },
     { key: 'srcdst',    label: 'Src→Dst', width: '1fr',   class: 'pkt-c-srcdst',         render: srcDstCell  },
-    { key: 'channel',   label: 'Ch',      width: '50px',  class: 'pkt-c-channel', align: 'center', render: channelCell },
+    { key: 'channel',   label: 'Channel', width: '120px', class: 'pkt-c-channel', render: channelCell },
     { key: 'distance',  label: 'Distance',width: '120px', class: 'pkt-c-distance', align: 'right', render: distanceCell },
   ];
 </script>
@@ -73,7 +73,7 @@
 {/snippet}
 
 {#snippet channelCell(_value, entry)}
-  {entry.channel ?? '—'}
+  {entry.channel_name || (entry.channel ?? '—')}
 {/snippet}
 
 {#snippet distanceCell(_value, entry)}

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -161,8 +161,8 @@ const mockBeacons = [
 const mockGps = { source: 'serial', serial_port: '/dev/ttyACM0', baud_rate: 9600, gpsd_host: 'localhost', gpsd_port: 2947 };
 
 const mockPackets = [
-  { id: 1, timestamp: new Date().toISOString(), source: 'N0CALL-9', destination: 'APRS', path: 'WIDE1-1', type: 'position', raw: 'N0CALL-9>APRS,WIDE1-1:!3500.00N/10600.00W-PHG2360', direction: 'rx', channel: 'VHF APRS' },
-  { id: 2, timestamp: new Date(Date.now() - 5000).toISOString(), source: 'W5ABC-7', destination: 'APGRWO', path: 'WIDE2-1', type: 'position', raw: 'W5ABC-7>APGRWO,WIDE2-1:@092345z3501.00N/10601.00W_090/005', direction: 'rx', channel: 'VHF APRS' },
+  { id: 1, timestamp: new Date().toISOString(), source: 'N0CALL-9', destination: 'APRS', path: 'WIDE1-1', type: 'position', raw: 'N0CALL-9>APRS,WIDE1-1:!3500.00N/10600.00W-PHG2360', direction: 'rx', channel: 1, channel_name: 'VHF APRS' },
+  { id: 2, timestamp: new Date(Date.now() - 5000).toISOString(), source: 'W5ABC-7', destination: 'APGRWO', path: 'WIDE2-1', type: 'position', raw: 'W5ABC-7>APGRWO,WIDE2-1:@092345z3501.00N/10601.00W_090/005', direction: 'rx', channel: 1, channel_name: 'VHF APRS' },
 ];
 
 const mockPosition = { valid: true, lat: 35.0, lon: -106.0, alt_m: 1500, has_alt: true, speed_kt: 0, heading_deg: 0, has_course: false };


### PR DESCRIPTION
## What

The packet log "Ch" column showed graywolf's internal numeric channel **ID**. This resolves it to the channel's **name** (the label you set on the Channels page), addressing GitHub issue #232 where the bare IDs were confusing.

## Changes

- `/api/packets` now includes a `channel_name` field, resolved from the numeric channel ID against the configured channel inventory (consistent with the existing device/distance enrichment on that DTO).
- `PacketLogViewer` renders the name, relabels the column `Ch` -> `Channel`, and widens it. Falls back to the raw ID when the channel maps to no configured channel -- e.g. channel `0`, which is used for non-RF / APRS-IS arrivals.
- Regenerated the OpenAPI spec and the frontend API types.

## Notes

- Channel `0` (APRS-IS / non-RF) still shows `0` since it has no configured channel/name. Could be labeled "APRS-IS" in a follow-up if desired.

## Verification

- `go test ./pkg/webapi/` (incl. new `packets_test.go`), `make docs-check`, `go vet` -- all pass
- Frontend: `npm run api:check` (tsc), `npm run build`, `npm test` (232 pass) -- all pass
