### PR TITLE
Warn at startup when the system clock is not synced

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -87,6 +87,7 @@ The TX-funnel rule lives in [invariant 16](invariants.md).
 | `gps` | GPSD client + serial NMEA reader + cache + station-position layered cache + enumerate | [`../handbook/gps.html`](../handbook/gps.html) |
 | `callsign` | Callsign parsing, N0CALL detection, APRS-IS passcode | [`../handbook/preferences.html`](../handbook/preferences.html) |
 | `stationcache` | Heard-station cache (memory + persistent) and APRS-extract helpers | (no dedicated page) |
+| `clocksync` | Host clock-discipline check (Linux `adjtimex(2)` read-only query; `Unknown` elsewhere). The startup banner in `pkg/app/wiring.go` warns once when `Check() == Unsynced` because an undisciplined clock skews packet ages and the map Time Range filter (graywolf#234). | (no dedicated page) |
 
 ## Go service: storage & telemetry
 

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -23,6 +23,7 @@ import (
 	"github.com/chrissnell/graywolf/pkg/ax25conn"
 	"github.com/chrissnell/graywolf/pkg/beacon"
 	"github.com/chrissnell/graywolf/pkg/callsign"
+	"github.com/chrissnell/graywolf/pkg/clocksync"
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/demoseed"
 	"github.com/chrissnell/graywolf/pkg/digipeater"
@@ -197,6 +198,16 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 		a.logger.Info("starting graywolf (modem connect-only)",
 			"graywolf", a.cfg.FullVersion(),
 			"modem_socket", a.cfg.ModemSocketPath)
+	}
+
+	// --- Clock sync check ----------------------------------------------
+	// An undisciplined system clock skews packet ages and the map's Time
+	// Range filter, which can silently hide stations (graywolf#234). Warn
+	// once at startup; stay quiet when the state can't be measured.
+	if clocksync.Check() == clocksync.Unsynced {
+		a.logger.Warn("system clock is not synchronized to a time source; " +
+			"this skews packet ages and can hide stations from the map -- " +
+			"enable NTP (systemd-timesyncd, chrony, or ntpd)")
 	}
 
 	// --- Packet log ----------------------------------------------------

--- a/pkg/clocksync/clocksync.go
+++ b/pkg/clocksync/clocksync.go
@@ -1,0 +1,24 @@
+// Package clocksync reports whether the host's system clock is being
+// disciplined by a time source (NTP, chrony, systemd-timesyncd, ...).
+//
+// An undisciplined clock skews every time-relative calculation in
+// Graywolf: packet ages go wrong (and can even read negative), and the
+// web map's Time Range filter hides stations whose beacons fall outside
+// the skewed window. See chrissnell/graywolf#234. The startup banner
+// calls Check so operators get a heads-up before chasing phantom bugs.
+package clocksync
+
+// Status is the outcome of a clock-sync check.
+type Status int
+
+const (
+	// Unknown means the check could not be performed -- the platform has
+	// no query API or the syscall failed. Callers should stay silent
+	// rather than warn on a value they couldn't actually measure.
+	Unknown Status = iota
+	// Synced means the kernel reports the clock is disciplined.
+	Synced
+	// Unsynced means the kernel reports no time source is disciplining
+	// the clock.
+	Unsynced
+)

--- a/pkg/clocksync/clocksync_linux.go
+++ b/pkg/clocksync/clocksync_linux.go
@@ -6,16 +6,27 @@ import "golang.org/x/sys/unix"
 
 // Check queries the kernel NTP discipline state via adjtimex(2). A zero
 // Modes field makes this a read-only query that needs no privileges.
-// The clock is treated as unsynced when the kernel returns TIME_ERROR
-// or sets the STA_UNSYNC status bit -- the same signal `timedatectl`'s
-// "System clock synchronized" line is derived from.
+//
+// The kernel initializes its NTP status word to STA_UNSYNC at boot and
+// clears that bit only once a time source (NTP, chrony, systemd-timesyncd)
+// has disciplined the clock -- the same signal `timedatectl`'s "System
+// clock synchronized" line is derived from. STA_UNSYNC alone is therefore
+// the precise "not disciplined" signal: it covers both the no-daemon case
+// (bit still set from boot) and the daemon-not-yet-converged case, while a
+// synced clock with a leap second pending (TIME_INS/TIME_DEL) keeps the
+// bit clear and is correctly reported as Synced.
 func Check() Status {
 	var tmx unix.Timex
-	state, err := unix.Adjtimex(&tmx)
-	if err != nil {
+	if _, err := unix.Adjtimex(&tmx); err != nil {
 		return Unknown
 	}
-	if state == unix.TIME_ERROR || tmx.Status&unix.STA_UNSYNC != 0 {
+	return classify(tmx.Status)
+}
+
+// classify maps an adjtimex status word to a Status. Split out so the bit
+// logic is unit-testable without a live syscall.
+func classify(status int32) Status {
+	if status&unix.STA_UNSYNC != 0 {
 		return Unsynced
 	}
 	return Synced

--- a/pkg/clocksync/clocksync_linux.go
+++ b/pkg/clocksync/clocksync_linux.go
@@ -1,0 +1,22 @@
+//go:build linux
+
+package clocksync
+
+import "golang.org/x/sys/unix"
+
+// Check queries the kernel NTP discipline state via adjtimex(2). A zero
+// Modes field makes this a read-only query that needs no privileges.
+// The clock is treated as unsynced when the kernel returns TIME_ERROR
+// or sets the STA_UNSYNC status bit -- the same signal `timedatectl`'s
+// "System clock synchronized" line is derived from.
+func Check() Status {
+	var tmx unix.Timex
+	state, err := unix.Adjtimex(&tmx)
+	if err != nil {
+		return Unknown
+	}
+	if state == unix.TIME_ERROR || tmx.Status&unix.STA_UNSYNC != 0 {
+		return Unsynced
+	}
+	return Synced
+}

--- a/pkg/clocksync/clocksync_linux_test.go
+++ b/pkg/clocksync/clocksync_linux_test.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package clocksync
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int32
+		want   Status
+	}{
+		{"clean status", 0, Synced},
+		{"disciplined PLL, no unsync bit", unix.STA_PLL, Synced},
+		{"boot default / no daemon", unix.STA_UNSYNC, Unsynced},
+		{"daemon running but not converged", unix.STA_PLL | unix.STA_UNSYNC, Unsynced},
+		// A synced clock with a leap second queued sets STA_INS, not
+		// STA_UNSYNC -- it must not be reported as unsynced.
+		{"leap insert pending, still synced", unix.STA_INS, Synced},
+	}
+	for _, tc := range tests {
+		if got := classify(tc.status); got != tc.want {
+			t.Errorf("%s: classify(%#x) = %d, want %d", tc.name, tc.status, got, tc.want)
+		}
+	}
+}

--- a/pkg/clocksync/clocksync_other.go
+++ b/pkg/clocksync/clocksync_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package clocksync
+
+// Check has no adjtimex-style query to call on non-Linux hosts, so it
+// reports Unknown and the caller stays silent.
+func Check() Status { return Unknown }

--- a/pkg/clocksync/clocksync_test.go
+++ b/pkg/clocksync/clocksync_test.go
@@ -1,0 +1,16 @@
+package clocksync
+
+import "testing"
+
+// Check must always return one of the three defined states and never
+// panic, regardless of platform or the host's actual sync state. On
+// Linux the adjtimex query should also resolve to a concrete state
+// rather than Unknown when the syscall is available.
+func TestCheckReturnsValidStatus(t *testing.T) {
+	switch s := Check(); s {
+	case Unknown, Synced, Unsynced:
+		// ok
+	default:
+		t.Fatalf("Check returned undefined Status %d", int(s))
+	}
+}


### PR DESCRIPTION
Logs a startup WARN when the host clock isn't disciplined by a time source. An unsynced clock skews packet ages and the map's Time Range filter, which can silently hide stations from the map (relates to #234).

- New `pkg/clocksync`: Linux uses a read-only `adjtimex(2)` query (the same signal behind `timedatectl`'s "System clock synchronized"); other platforms report `Unknown` and stay silent.
- The startup banner in `pkg/app/wiring.go` emits one WARN when the clock is unsynced, pointing operators at NTP (systemd-timesyncd, chrony, ntpd).
- Read-only query needs no privileges; `Unknown` means "couldn't measure" so we never warn on a false negative.
- Added a small test; `go test ./pkg/clocksync/...` and `./pkg/app/` pass, and the package cross-compiles for darwin/windows/android.