### PR TITLE
Scale dashboard uptime display to days/weeks/months (#248)

### DIFF
--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -112,8 +112,26 @@
 
   function formatUptime(s) {
     if (!s && s !== 0) return '\u2014';
-    const h = Math.floor(s / 3600);
-    const m = Math.floor((s % 3600) / 60);
+    const MIN = 60, HOUR = 3600, DAY = 86400, WEEK = 7 * 86400, MONTH = 30 * 86400;
+    // Scale to the largest meaningful unit, showing at most two units so the
+    // value stays on one line in the stat card.
+    if (s >= MONTH) {
+      const months = Math.floor(s / MONTH);
+      const days = Math.floor((s % MONTH) / DAY);
+      return days ? `${months}mo ${days}d` : `${months}mo`;
+    }
+    if (s >= WEEK) {
+      const weeks = Math.floor(s / WEEK);
+      const days = Math.floor((s % WEEK) / DAY);
+      return days ? `${weeks}w ${days}d` : `${weeks}w`;
+    }
+    if (s >= DAY) {
+      const days = Math.floor(s / DAY);
+      const hours = Math.floor((s % DAY) / HOUR);
+      return hours ? `${days}d ${hours}h` : `${days}d`;
+    }
+    const h = Math.floor(s / HOUR);
+    const m = Math.floor((s % HOUR) / MIN);
     return `${h}h ${m}m`;
   }
 

--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -446,6 +446,7 @@
     font-size: 28px;
     font-weight: 700;
     color: var(--color-text);
+    white-space: nowrap;
   }
   .stat-value.gps-value {
     font-size: 18px;


### PR DESCRIPTION
Addresses #248.

The dashboard Uptime stat previously rendered only as hours and minutes (e.g. `172h 5m`), which got hard to read for long-running nodes. This scales the display to the largest meaningful unit once each threshold is met:

| Uptime | Before | After |
|---|---|---|
| 3h 23m | `3h 23m` | `3h 23m` |
| 1d 7h | `31h 0m` | `1d 7h` |
| 9 days | `216h 0m` | `1w 2d` |
| 45 days | `1080h 0m` | `1mo 15d` |

Sub-day uptimes keep the existing hours/minutes format. At most two units are shown so the value stays on a single line in the stat card -- no font-size or wrapping changes needed (the longest output, e.g. `13mo 10d`, is shorter than the existing GPS coordinate value rendered in the same grid).

Frontend `npm run build` passes.