### PR TITLE
Move APRS Logs above System Logs in sidebar

### DIFF
--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -30,8 +30,8 @@
     { path: '/messages', label: 'Messages', icon: 'message-square', badge: 'messages' },
     { path: '/terminal', label: 'Terminal', svgIcon: 'terminal', badge: 'terminal' },
     { path: '/actions', label: 'Actions', svgIcon: 'zap' },
-    { path: '/system-logs', label: 'System Logs', svgIcon: 'system-logs' },
     { path: '/logs', label: 'APRS Logs', svgIcon: 'logs' },
+    { path: '/system-logs', label: 'System Logs', svgIcon: 'system-logs' },
   ];
 
   const allSettingsItems = [


### PR DESCRIPTION
Swaps the order of the two log nav entries in the sidebar so **APRS Logs** sits above **System Logs**, per user request (GRA-51).

Single-line change to the `mainItems` array in `web/src/components/Sidebar.svelte`. Web build passes.