### PR TITLE
Fix intermittent missing gap between sidebar and content pane

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -74,11 +74,13 @@
     return r;
   })();
 
-  let currentPath = $state('');
-  $effect(() => {
-    const unsub = location.subscribe((v) => { currentPath = v; });
-    return unsub;
-  });
+  // Derive the path straight from the router's own `location` store so it
+  // stays in lockstep with the rendered route. A hand-rolled subscription
+  // into a separate $state copy can lag a tick behind <Router>, and when
+  // leaving a full-bleed route (/map, /messages) that stale value kept
+  // `full-bleed` (padding:0) on the next page, rendering it flush against
+  // the sidebar with no gap.
+  let currentPath = $derived($location);
 
   let isLoginPage = $derived(currentPath === '/login' && Platform.kind !== 'android');
 


### PR DESCRIPTION
## Problem

Occasionally, after navigating around the UI, the right content pane renders flush against the sidebar with no gap. It happens intermittently and is tied to navigation.

## Cause

`.main-content` normally has `padding: 24px`, which is the gap against the fixed sidebar. The `.full-bleed` modifier (used by `/map` and `/messages`) sets `padding: 0`. In `App.svelte`, `<main class:full-bleed={...}>` was driven by `currentPath`, a separate `$state` copy maintained by a hand-rolled `location.subscribe` inside an `$effect` — decoupled from the `<Router>` that renders the page from the same `location` store.

When leaving a full-bleed route (e.g. clicking a station on the Live Map navigates to `#/beacons?...`), the Router could swap in the new page before that stale `currentPath` copy propagated, leaving `full-bleed` (padding:0) applied to the now-normal page → flush against the sidebar. A desync race, hence intermittent.

## Fix

Derive `currentPath` directly from the router's `location` store (`$derived($location)`) so the `full-bleed` class stays in lockstep with the rendered route. Removes the lagging manual subscription entirely.

Verified: `npm run build` succeeds.