### PR TITLE
logbuffer: store error attrs as their message string

### DIFF
--- a/pkg/logbuffer/handler.go
+++ b/pkg/logbuffer/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"reflect"
 	"sync"
 	"time"
 )
@@ -178,9 +179,23 @@ func flattenAttr(out map[string]any, prefix string, a slog.Attr) {
 	// the Error() string so logged errors stay readable. slog's own
 	// handlers do the same.
 	if err, ok := v.(error); ok {
-		v = err.Error()
+		v = errString(err)
 	}
 	out[key] = v
+}
+
+// errString renders an error's message, degrading a typed-nil error (a
+// non-nil error interface wrapping a nil pointer/value -- the classic Go
+// gotcha) to "<nil>" instead of panicking when Error() dereferences its
+// nil receiver. Matches how slog's built-in handlers render such values.
+func errString(err error) string {
+	switch v := reflect.ValueOf(err); v.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+		if v.IsNil() {
+			return "<nil>"
+		}
+	}
+	return err.Error()
 }
 
 // afterInsert delegates to maintenance() so the eviction policy can

--- a/pkg/logbuffer/handler.go
+++ b/pkg/logbuffer/handler.go
@@ -172,7 +172,15 @@ func flattenAttr(out map[string]any, prefix string, a slog.Attr) {
 	if prefix != "" {
 		key = prefix + "." + key
 	}
-	out[key] = a.Value.Any()
+	v := a.Value.Any()
+	// Errors marshal to "{}" via encoding/json because their fields are
+	// unexported (e.g. fmt.wrapError), losing the message entirely. Store
+	// the Error() string so logged errors stay readable. slog's own
+	// handlers do the same.
+	if err, ok := v.(error); ok {
+		v = err.Error()
+	}
+	out[key] = v
 }
 
 // afterInsert delegates to maintenance() so the eviction policy can

--- a/pkg/logbuffer/handler_test.go
+++ b/pkg/logbuffer/handler_test.go
@@ -3,6 +3,7 @@ package logbuffer
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -98,6 +99,31 @@ func TestHandlerStringifiesErrorAttrs(t *testing.T) {
 	db.gorm.Raw("SELECT attrs_json FROM logs ORDER BY id DESC LIMIT 1").Row().Scan(&attrs)
 	if !strings.Contains(attrs, `"err":"parse source: bad ssid \"D\""`) {
 		t.Fatalf("attrs missing stringified err: %s", attrs)
+	}
+}
+
+type typedNilErr struct{ msg string }
+
+func (e *typedNilErr) Error() string { return e.msg } // dereferences receiver
+
+func TestHandlerHandlesTypedNilErrorAttr(t *testing.T) {
+	h, db, _ := newTestHandler(t, slog.LevelDebug)
+	logger := slog.New(h)
+
+	// A typed-nil error: the interface is non-nil but wraps a nil pointer,
+	// so Error() would panic. The handler must degrade it to "<nil>"
+	// instead of crashing the logging goroutine.
+	var e *typedNilErr
+	logger.Debug("typed nil", "err", error(e))
+
+	var attrs string
+	db.gorm.Raw("SELECT attrs_json FROM logs ORDER BY id DESC LIMIT 1").Row().Scan(&attrs)
+	var m map[string]any
+	if err := json.Unmarshal([]byte(attrs), &m); err != nil {
+		t.Fatalf("unmarshal attrs %q: %v", attrs, err)
+	}
+	if got := m["err"]; got != "<nil>" {
+		t.Fatalf("err attr = %v, want <nil>", got)
 	}
 }
 

--- a/pkg/logbuffer/handler_test.go
+++ b/pkg/logbuffer/handler_test.go
@@ -3,6 +3,8 @@ package logbuffer
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"path/filepath"
 	"strings"
@@ -79,6 +81,23 @@ func TestHandlerForwardsAttrs(t *testing.T) {
 	}
 	if !strings.Contains(attrs, `"remote":"10.0.0.1"`) {
 		t.Fatalf("attrs missing remote: %s", attrs)
+	}
+}
+
+func TestHandlerStringifiesErrorAttrs(t *testing.T) {
+	h, db, _ := newTestHandler(t, slog.LevelDebug)
+	logger := slog.New(h)
+
+	// A wrapped error: its fields are unexported, so json.Marshal of the
+	// raw value would yield "{}" and drop the message. The handler must
+	// store Error() instead.
+	err := fmt.Errorf("parse source: %w", errors.New(`bad ssid "D"`))
+	logger.Debug("tnc2 parse failed", "err", err)
+
+	var attrs string
+	db.gorm.Raw("SELECT attrs_json FROM logs ORDER BY id DESC LIMIT 1").Row().Scan(&attrs)
+	if !strings.Contains(attrs, `"err":"parse source: bad ssid \"D\""`) {
+		t.Fatalf("attrs missing stringified err: %s", attrs)
 	}
 }
 


### PR DESCRIPTION
## Problem

`tnc2 parse failed` (and any other error) logged through the `logbuffer` SQLite ring showed up as `err={}`, dropping the message entirely. The handler persists slog attrs by JSON-marshaling the raw value (`flattenAttr` -> `out[key] = a.Value.Any()`), and error implementations like `fmt.wrapError` have only unexported fields, so `encoding/json` renders them as `{}`.

This is what made GRA-62's failures so hard to diagnose -- the real error (`igate: parse source: ax25: bad ssid "D"`) was invisible to anyone dumping the ring.

## Fix

Stringify `error`-typed attr values to their `Error()` output in `flattenAttr`, matching what slog's own handlers do. Centralized in the handler so every component benefits, not just the igate call site.

## Test

Added `TestHandlerStringifiesErrorAttrs`, which logs a wrapped error and asserts the persisted `attrs_json` contains the message string rather than `{}`.
