### PR TITLE
Live Map: fill-antialias=false on radar bands (remove seam lines)

### DIFF
--- a/web/src/lib/map/sources/radar-source.js
+++ b/web/src/lib/map/sources/radar-source.js
@@ -98,7 +98,12 @@ export function radarProvider(backend = ACTIVE_RADAR_BACKEND) {
           type: 'fill',
           source: RADAR_SOURCE_ID,
           'source-layer': 'radar', // MVT layer name produced by GRA-48
-          paint: { 'fill-color': buildDbzFillColor(), 'fill-antialias': true },
+          // fill-antialias MUST be false for stacked dBZ bands: with it on,
+          // MapLibre draws an antialiased outline on every band edge, and the
+          // feathered edge between two adjacent bands leaks the basemap through
+          // as a hairline seam (even though the generator's band geometry is
+          // coincident). false => hard edges that tile cleanly, no seams.
+          paint: { 'fill-color': buildDbzFillColor(), 'fill-antialias': false },
         },
       ],
       opacity: { property: 'fill-opacity', layerIds: ['radar-fill'] },


### PR DESCRIPTION
Hairline white seams between adjacent dBZ bands persist even after the generator-side fix (graywolf-maps #15) made band geometry coincident. Cause: MapLibre's `fill-antialias: true` draws a feathered outline on every band edge, so the shared edge between two bands leaks the basemap through. Setting `fill-antialias: false` on the radar-fill layer gives hard edges that tile cleanly. Deterministic rendering artifact, which is why it survived hard refreshes. One-line paint change; radar-source tests pass.