### PR TITLE
Live Map: add "RF Only" filter to hide Internet-to-RF gated stations

### DIFF
--- a/pkg/stationcache/extract.go
+++ b/pkg/stationcache/extract.go
@@ -42,9 +42,12 @@ func ExtractEntry(decoded *aprs.DecodedAPRSPacket, source, dir string, ch uint32
 	}
 
 	// Third-party unwrapping: use the inner packet's Source/Path/Position.
-	// A non-nil ThirdParty means this position reached us as Internet-to-RF
-	// gated traffic (the path carries TCPIP/qA* markers) rather than a
-	// packet heard over the air on its own.
+	// We treat any third-party (`}`) packet as Internet-to-RF gated traffic.
+	// In modern APRS that framing is, in practice, exclusively IGate->RF
+	// gating (the inner path carries TCPIP/qA* markers); the rare, deprecated
+	// RF-to-RF third-party relay would also be flagged here, an accepted
+	// trade-off for keying on the structural wrapper rather than parsing the
+	// path. The "RF Only" map filter uses this to drop gated points.
 	pkt := decoded
 	gated := decoded.ThirdParty != nil
 	if decoded.ThirdParty != nil {

--- a/pkg/stationcache/extract.go
+++ b/pkg/stationcache/extract.go
@@ -24,6 +24,7 @@ type CacheEntry struct {
 	Path      []string
 	Hops      int
 	Direction string
+	Gated     bool // arrived as the inner packet of an Internet-to-RF third-party gate
 	Channel   uint32
 	Comment   string
 	Weather   *Weather
@@ -41,7 +42,11 @@ func ExtractEntry(decoded *aprs.DecodedAPRSPacket, source, dir string, ch uint32
 	}
 
 	// Third-party unwrapping: use the inner packet's Source/Path/Position.
+	// A non-nil ThirdParty means this position reached us as Internet-to-RF
+	// gated traffic (the path carries TCPIP/qA* markers) rather than a
+	// packet heard over the air on its own.
 	pkt := decoded
+	gated := decoded.ThirdParty != nil
 	if decoded.ThirdParty != nil {
 		pkt = decoded.ThirdParty
 	}
@@ -63,7 +68,7 @@ func ExtractEntry(decoded *aprs.DecodedAPRSPacket, source, dir string, ch uint32
 
 	// Object or item → keyed by object/item name in the "obj:" namespace.
 	if pkt.Object != nil {
-		e := buildObjectEntry(pkt.Object.Name, pkt.Object.Live, pkt.Object.Position, pkt.Object.Comment, via, path, hops, dir, ch, ts)
+		e := buildObjectEntry(pkt.Object.Name, pkt.Object.Live, pkt.Object.Position, pkt.Object.Comment, via, path, hops, dir, gated, ch, ts)
 		if pkt.Weather != nil {
 			e.Weather = convertWeather(pkt.Weather)
 		}
@@ -72,13 +77,13 @@ func ExtractEntry(decoded *aprs.DecodedAPRSPacket, source, dir string, ch uint32
 		// Also emit a station entry for the originator if we have
 		// a top-level position (rare but possible in some encodings).
 		if pkt.Position != nil {
-			entries = append(entries, buildStationEntry(pkt.Source, pkt.Position, pkt.Comment, via, path, hops, dir, ch, ts, pkt.Weather))
+			entries = append(entries, buildStationEntry(pkt.Source, pkt.Position, pkt.Comment, via, path, hops, dir, gated, ch, ts, pkt.Weather))
 		}
 		return entries
 	}
 
 	if pkt.Item != nil {
-		e := buildObjectEntry(pkt.Item.Name, pkt.Item.Live, pkt.Item.Position, pkt.Item.Comment, via, path, hops, dir, ch, ts)
+		e := buildObjectEntry(pkt.Item.Name, pkt.Item.Live, pkt.Item.Position, pkt.Item.Comment, via, path, hops, dir, gated, ch, ts)
 		if pkt.Weather != nil {
 			e.Weather = convertWeather(pkt.Weather)
 		}
@@ -89,14 +94,14 @@ func ExtractEntry(decoded *aprs.DecodedAPRSPacket, source, dir string, ch uint32
 	// Normal station packet — position may come from Position field
 	// (includes Mic-E, which the parser copies to pkt.Position).
 	if pkt.Position != nil || pkt.Weather != nil {
-		entries = append(entries, buildStationEntry(pkt.Source, pkt.Position, pkt.Comment, via, path, hops, dir, ch, ts, pkt.Weather))
+		entries = append(entries, buildStationEntry(pkt.Source, pkt.Position, pkt.Comment, via, path, hops, dir, gated, ch, ts, pkt.Weather))
 		return entries
 	}
 
 	return nil
 }
 
-func buildStationEntry(callsign string, pos *aprs.Position, comment, via string, path []string, hops int, dir string, ch uint32, ts time.Time, wx *aprs.Weather) CacheEntry {
+func buildStationEntry(callsign string, pos *aprs.Position, comment, via string, path []string, hops int, dir string, gated bool, ch uint32, ts time.Time, wx *aprs.Weather) CacheEntry {
 	e := CacheEntry{
 		Key:       "stn:" + callsign,
 		Callsign:  callsign,
@@ -104,6 +109,7 @@ func buildStationEntry(callsign string, pos *aprs.Position, comment, via string,
 		Path:      path,
 		Hops:      hops,
 		Direction: dir,
+		Gated:     gated,
 		Channel:   ch,
 		Comment:   comment,
 		Timestamp: ts,
@@ -125,7 +131,7 @@ func buildStationEntry(callsign string, pos *aprs.Position, comment, via string,
 	return e
 }
 
-func buildObjectEntry(name string, live bool, pos *aprs.Position, comment, via string, path []string, hops int, dir string, ch uint32, ts time.Time) CacheEntry {
+func buildObjectEntry(name string, live bool, pos *aprs.Position, comment, via string, path []string, hops int, dir string, gated bool, ch uint32, ts time.Time) CacheEntry {
 	e := CacheEntry{
 		Key:       "obj:" + name,
 		Callsign:  name,
@@ -135,6 +141,7 @@ func buildObjectEntry(name string, live bool, pos *aprs.Position, comment, via s
 		Path:      path,
 		Hops:      hops,
 		Direction: dir,
+		Gated:     gated,
 		Channel:   ch,
 		Comment:   comment,
 		Timestamp: ts,

--- a/pkg/stationcache/extract_test.go
+++ b/pkg/stationcache/extract_test.go
@@ -208,13 +208,34 @@ func TestExtractEntry_ThirdPartyUnwrap(t *testing.T) {
 	assertEqual(t, "Callsign", e.Callsign, "W2INNER")
 	assertFloat(t, "Lat", e.Lat, 41.0)
 	assertEqual(t, "Via", e.Via, "is")
-	assertEqual(t, "Hops", e.Hops, 1) // only N0DIGI* is a real digi; WIDE1*/RELAY* are aliases
+	assertEqual(t, "Hops", e.Hops, 1)     // only N0DIGI* is a real digi; WIDE1*/RELAY* are aliases
+	assertBool(t, "Gated", e.Gated, true) // unwrapped third party → Internet-to-RF gated
 	assertEqual(t, "Comment", e.Comment, "inner comment")
 	// Inner packet has zero timestamp → should fall back to outer packet's timestamp
 	outerTS := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
 	if !e.Timestamp.Equal(outerTS) {
 		t.Errorf("Timestamp: got %v, want outer packet timestamp %v", e.Timestamp, outerTS)
 	}
+}
+
+func TestExtractEntry_DirectRFNotGated(t *testing.T) {
+	// A normal RF-heard packet (no third-party wrapper) is not gated.
+	pkt := &aprs.DecodedAPRSPacket{
+		Source: "W1ABC-9",
+		Path:   []string{"WIDE1-1*"},
+		Position: &aprs.Position{
+			Latitude:  41.0,
+			Longitude: -106.0,
+			Symbol:    aprs.Symbol{Table: '/', Code: '>'},
+		},
+		Timestamp: time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	entries := ExtractEntry(pkt, "modem", "RX", 0)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	assertBool(t, "Gated", entries[0].Gated, false)
 }
 
 func TestExtractEntry_ThirdPartyTimestampFallback(t *testing.T) {

--- a/pkg/stationcache/memcache.go
+++ b/pkg/stationcache/memcache.go
@@ -112,16 +112,17 @@ func (c *MemCache) Update(entries []CacheEntry) {
 		} else {
 			// Static re-beacon — advance the last-heard timestamp and the
 			// free-form comment from the latest packet. Reception-path
-			// metadata (via/path/hops/direction/channel), however, is kept
-			// at the *most direct* copy seen for this fix: a station heard
-			// both directly and via a digipeater (common when two digis
-			// repeat each other's beacons) would otherwise have its direct
-			// copy clobbered by a later-arriving digipeated copy, hiding it
-			// from the Live Map "Direct RX" filter (issue #130). A direct
-			// RF copy therefore never gets masked by a non-direct one.
+			// metadata (via/path/hops/direction/channel/gated), however, is
+			// kept at the *most RF-reachable* copy seen for this fix (see
+			// rfRank). A station heard both directly and via a digipeater
+			// would otherwise have its direct copy clobbered by a later
+			// digipeated one, hiding it from the "Direct RX" filter (issue
+			// #130); likewise an RF-heard copy must not be clobbered by a
+			// later Internet-to-RF gated copy, which would hide it from the
+			// "RF Only" filter. Ties refresh (latest wins).
 			s.Positions[0].Timestamp = e.Timestamp
 			s.Positions[0].Comment = e.Comment
-			if isDirectRF(e.Direction, e.Hops) || !isDirectRF(s.Positions[0].Direction, s.Positions[0].Hops) {
+			if rfRank(e.Direction, e.Hops, e.Gated) >= rfRank(s.Positions[0].Direction, s.Positions[0].Hops, s.Positions[0].Gated) {
 				s.Positions[0].Via = e.Via
 				s.Positions[0].Path = e.Path
 				s.Positions[0].Hops = e.Hops
@@ -265,6 +266,27 @@ func updateMetadata(s *Station, e *CacheEntry, now time.Time) {
 // by a subsequent digipeated copy of the same beacon (issue #130).
 func isDirectRF(direction string, hops int) bool {
 	return direction == "RX" && hops == 0
+}
+
+// rfRank scores a reception copy by how strongly it demonstrates RF
+// reachability, so the static-rebeacon merge keeps the best copy seen for
+// a fix. Higher wins; equal ranks refresh (latest wins). This generalizes
+// the issue-#130 "most direct" rule to also protect the "RF Only" filter:
+//
+//	2  heard directly on RF (RX, no digi hops, not gated)
+//	1  heard over RF via digipeater(s) (RX, not gated)
+//	0  Internet-to-RF gated, APRS-IS, or our own TX
+//
+// A direct copy thus never gets masked by a digipeated one, and an
+// RF-heard copy never gets masked by an Internet-to-RF gated one.
+func rfRank(direction string, hops int, gated bool) int {
+	if direction != "RX" || gated {
+		return 0
+	}
+	if hops == 0 {
+		return 2
+	}
+	return 1
 }
 
 func positionMoved(old, new Position) bool {

--- a/pkg/stationcache/memcache.go
+++ b/pkg/stationcache/memcache.go
@@ -93,6 +93,7 @@ func (c *MemCache) Update(entries []CacheEntry) {
 			Path:      e.Path,
 			Hops:      e.Hops,
 			Direction: e.Direction,
+			Gated:     e.Gated,
 			Channel:   e.Channel,
 			Comment:   e.Comment,
 			Timestamp: e.Timestamp,
@@ -125,6 +126,7 @@ func (c *MemCache) Update(entries []CacheEntry) {
 				s.Positions[0].Path = e.Path
 				s.Positions[0].Hops = e.Hops
 				s.Positions[0].Direction = e.Direction
+				s.Positions[0].Gated = e.Gated
 				s.Positions[0].Channel = e.Channel
 			}
 		}
@@ -248,6 +250,7 @@ func updateMetadata(s *Station, e *CacheEntry, now time.Time) {
 	s.Path = e.Path
 	s.Hops = e.Hops
 	s.Direction = e.Direction
+	s.Gated = e.Gated
 	s.Channel = e.Channel
 	s.Comment = e.Comment
 	s.LastHeard = now

--- a/pkg/stationcache/memcache_test.go
+++ b/pkg/stationcache/memcache_test.go
@@ -434,3 +434,51 @@ func TestMemCache_DigipeatedThenDirect(t *testing.T) {
 		t.Fatal("direct copy should upgrade a previously-digipeated fix to direct")
 	}
 }
+
+// gatedEntry is a position fix that reached us as Internet-to-RF gated
+// traffic (the inner packet of a third-party gate): heard on RF (RX) but
+// flagged gated, so the "RF Only" filter should exclude it.
+func gatedEntry(key, callsign string, lat, lon float64) CacheEntry {
+	e := stationEntry(key, callsign, lat, lon)
+	e.Gated = true
+	e.Path = []string{"TCPIP*", "qAR", "IGATE"}
+	return e
+}
+
+// TestMemCache_RFCopyNotMaskedByGated verifies the merge keeps an RF-heard
+// (non-gated) copy of a static fix even when a later Internet-to-RF gated
+// copy of the same beacon arrives, so the "RF Only" filter still shows it.
+func TestMemCache_RFCopyNotMaskedByGated(t *testing.T) {
+	c := newTestCache(t)
+
+	// Heard over RF via a digipeater first, then a gated copy at the same
+	// position. The digipeated (non-gated) reception must be retained.
+	c.Update([]CacheEntry{digiEntry("stn:GW1", "GW1", 40.0, -105.0, 2)}) // RX, hops 2, not gated
+	c.Update([]CacheEntry{gatedEntry("stn:GW1", "GW1", 40.0, -105.0)})   // RX, gated
+
+	results := c.QueryBBox(BBox{SwLat: 39, SwLon: -106, NeLat: 41, NeLon: -104}, 1*time.Hour)
+	if len(results) != 1 || len(results[0].Positions) != 1 {
+		t.Fatalf("expected 1 station with 1 position, got %+v", results)
+	}
+	if results[0].Positions[0].Gated {
+		t.Fatal("RF-heard copy masked by later gated copy: Gated=true")
+	}
+
+	// The reverse order must upgrade: a gated-only fix that is later heard
+	// over RF should drop the gated flag.
+	c.Update([]CacheEntry{gatedEntry("stn:GW2", "GW2", 41.0, -105.0)})
+	c.Update([]CacheEntry{digiEntry("stn:GW2", "GW2", 41.0, -105.0, 2)})
+	results = c.QueryBBox(BBox{SwLat: 40, SwLon: -106, NeLat: 42, NeLon: -104}, 1*time.Hour)
+	var gw2 *Station
+	for i := range results {
+		if results[i].Callsign == "GW2" {
+			gw2 = &results[i]
+		}
+	}
+	if gw2 == nil {
+		t.Fatal("GW2 not found")
+	}
+	if gw2.Positions[0].Gated {
+		t.Fatal("gated-only fix not upgraded by later RF-heard copy: Gated=true")
+	}
+}

--- a/pkg/stationcache/store.go
+++ b/pkg/stationcache/store.go
@@ -47,6 +47,7 @@ type Station struct {
 	Path      []string   // digi path from AX.25 header
 	Hops      int        // count of H-bit digi addresses
 	Direction string     // "RX", "TX", "IS"
+	Gated     bool       // Internet-to-RF gated (inner of a third-party packet)
 	Channel   uint32
 	Comment   string
 	Weather   *Weather // nil if not a weather station
@@ -69,6 +70,7 @@ type Position struct {
 	Path      []string
 	Hops      int
 	Direction string
+	Gated     bool
 	Channel   uint32
 	Comment   string
 	Timestamp time.Time

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -11006,6 +11006,10 @@
                     "description": "Direction indicates the source of the most recent packet: \"RX\" (heard on air), \"TX\" (sent by us), or \"IS\" (APRS-IS).",
                     "type": "string"
                 },
+                "gated": {
+                    "description": "Gated is true when the most recent packet reached us as Internet-to-RF gated traffic (the inner packet of a third-party gate) rather than heard directly on RF.",
+                    "type": "boolean"
+                },
                 "hops": {
                     "description": "Hops is the APRS digipeater hop count (number of H-bit entries in Path).",
                     "type": "integer"
@@ -11086,6 +11090,10 @@
                 "direction": {
                     "description": "Direction indicates the source of this position packet: \"RX\", \"TX\", or \"IS\".",
                     "type": "string"
+                },
+                "gated": {
+                    "description": "Gated is true when this position fix reached us as Internet-to-RF gated traffic (the inner packet of a third-party gate) rather than heard directly on RF.",
+                    "type": "boolean"
                 },
                 "has_alt": {
                     "description": "HasAlt is true when the originating packet reported an altitude.",

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -2605,6 +2605,9 @@ definitions:
       direction:
         description: 'Direction indicates the source of the most recent packet: "RX" (heard on air), "TX" (sent by us), or "IS" (APRS-IS).'
         type: string
+      gated:
+        description: Gated is true when the most recent packet reached us as Internet-to-RF gated traffic (the inner packet of a third-party gate) rather than heard directly on RF.
+        type: boolean
       hops:
         description: Hops is the APRS digipeater hop count (number of H-bit entries in Path).
         type: integer
@@ -2662,6 +2665,9 @@ definitions:
       direction:
         description: 'Direction indicates the source of this position packet: "RX", "TX", or "IS".'
         type: string
+      gated:
+        description: Gated is true when this position fix reached us as Internet-to-RF gated traffic (the inner packet of a third-party gate) rather than heard directly on RF.
+        type: boolean
       has_alt:
         description: HasAlt is true when the originating packet reported an altitude.
         type: boolean

--- a/pkg/webapi/stations.go
+++ b/pkg/webapi/stations.go
@@ -42,6 +42,8 @@ type StationDTO struct {
 	PathPositions [][2]float64 `json:"path_positions,omitempty"`
 	// Hops is the APRS digipeater hop count (number of H-bit entries in Path).
 	Hops int `json:"hops,omitempty"`
+	// Gated is true when the most recent packet reached us as Internet-to-RF gated traffic (the inner packet of a third-party gate) rather than heard directly on RF.
+	Gated bool `json:"gated,omitempty"`
 	// Channel is the graywolf channel ID that received the most recent packet.
 	Channel uint32 `json:"channel"`
 	// Comment is the free-form comment field from the most recent packet.
@@ -74,6 +76,8 @@ type StationPosDTO struct {
 	PathPositions [][2]float64 `json:"path_positions,omitempty"`
 	// Hops is the APRS digipeater hop count (number of H-bit entries in Path) for this fix.
 	Hops int `json:"hops,omitempty"`
+	// Gated is true when this position fix reached us as Internet-to-RF gated traffic (the inner packet of a third-party gate) rather than heard directly on RF.
+	Gated bool `json:"gated,omitempty"`
 	// Direction indicates the source of this position packet: "RX", "TX", or "IS".
 	Direction string `json:"direction,omitempty"`
 	// Channel is the graywolf channel ID that received this position packet.
@@ -305,6 +309,7 @@ func stationToDTO(s stationcache.Station, isDelta, includeWeather bool, digiPos 
 		Path:          s.Path,
 		PathPositions: resolvePathPositions(s.Path, digiPos),
 		Hops:          s.Hops,
+		Gated:         s.Gated,
 		Channel:       s.Channel,
 		Comment:       s.Comment,
 	}
@@ -346,6 +351,7 @@ func positionToDTO(p stationcache.Position, digiPos map[string]stationcache.LatL
 		Path:          p.Path,
 		PathPositions: resolvePathPositions(p.Path, digiPos),
 		Hops:          p.Hops,
+		Gated:         p.Gated,
 		Direction:     p.Direction,
 		Channel:       p.Channel,
 		Comment:       p.Comment,

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -3393,6 +3393,8 @@ export interface components {
             comment?: string;
             /** @description Direction indicates the source of the most recent packet: "RX" (heard on air), "TX" (sent by us), or "IS" (APRS-IS). */
             direction?: string;
+            /** @description Gated is true when the most recent packet reached us as Internet-to-RF gated traffic (the inner packet of a third-party gate) rather than heard directly on RF. */
+            gated?: boolean;
             /** @description Hops is the APRS digipeater hop count (number of H-bit entries in Path). */
             hops?: number;
             /** @description IsObject is true for APRS objects and items; false for regular stations. */
@@ -3425,6 +3427,8 @@ export interface components {
             course?: number;
             /** @description Direction indicates the source of this position packet: "RX", "TX", or "IS". */
             direction?: string;
+            /** @description Gated is true when this position fix reached us as Internet-to-RF gated traffic (the inner packet of a third-party gate) rather than heard directly on RF. */
+            gated?: boolean;
             /** @description HasAlt is true when the originating packet reported an altitude. */
             has_alt?: boolean;
             /** @description Hops is the APRS digipeater hop count (number of H-bit entries in Path) for this fix. */

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -84,6 +84,7 @@
     myPosition: true,
     fixedPoints: true,
     directRxOnly: false,
+    rfOnly: false,
   });
 
   // Add-fixed-point dialog state. Opened from the context menu with the
@@ -98,6 +99,20 @@
     if (!Array.isArray(pts) || pts.length === 0) return false;
     for (const p of pts) {
       if (p.direction === 'RX' && (p.hops ?? 0) === 0) return true;
+    }
+    return false;
+  }
+
+  // RF Only predicate: a station qualifies if at least one position was
+  // heard over the air (RX) and did not arrive via Internet-to-RF gating
+  // (the `gated` flag, set on the inner packet of a third-party gate).
+  // Unlike Direct RX this keeps RF-digipeated stations; it only drops
+  // points that are merely Internet traffic some iGate pushed onto RF.
+  function isRfOnly(station) {
+    const pts = station?.positions;
+    if (!Array.isArray(pts) || pts.length === 0) return false;
+    for (const p of pts) {
+      if (p.direction === 'RX' && !p.gated) return true;
     }
     return false;
   }
@@ -497,12 +512,16 @@
     const v = layerToggles.fixedPoints;
     fixedPointsLayer?.setVisible(v);
   });
-  // Direct RX filter: predicate is shared across stations/trails/weather/
-  // wind-barbs so the layers stay in lockstep. my-position is the
-  // operator's own beacon and is intentionally exempt.
+  // RF reachability filter: predicate is shared across stations/trails/
+  // weather/wind-barbs so the layers stay in lockstep. my-position is the
+  // operator's own beacon and is intentionally exempt. Direct RX is the
+  // stricter of the two (a subset of RF Only), so it wins when both are on.
   $effect(() => {
-    const on = layerToggles.directRxOnly;
-    const pred = on ? isDirectRx : null;
+    const pred = layerToggles.directRxOnly
+      ? isDirectRx
+      : layerToggles.rfOnly
+        ? isRfOnly
+        : null;
     stationsLayer?.setFilter(pred);
     trailsLayer?.setFilter(pred);
     weatherLayer?.setFilter(pred);
@@ -569,6 +588,13 @@
     let n = 0;
     for (const s of dataStore.stations.values()) {
       if (isDirectRx(s)) n++;
+    }
+    return n;
+  });
+  let rfOnlyStationCount = $derived.by(() => {
+    let n = 0;
+    for (const s of dataStore.stations.values()) {
+      if (isRfOnly(s)) n++;
     }
     return n;
   });
@@ -697,6 +723,14 @@
           onchange={(e) => (layerToggles.directRxOnly = e.currentTarget.checked)}
         />
         <span>Direct RX</span>
+      </label>
+      <label class="toggle-row">
+        <input
+          type="checkbox"
+          checked={layerToggles.rfOnly}
+          onchange={(e) => (layerToggles.rfOnly = e.currentTarget.checked)}
+        />
+        <span>RF Only</span>
       </label>
       <label class="toggle-row">
         <input
@@ -835,6 +869,8 @@
     <span class="status-sep">&middot;</span>
     {#if layerToggles.directRxOnly}
       <span>{rfStationCount} heard direct / {stationCount} total</span>
+    {:else if layerToggles.rfOnly}
+      <span>{rfOnlyStationCount} RF reachable / {stationCount} total</span>
     {:else}
       <span>{stationCount} station{stationCount !== 1 ? 's' : ''}</span>
     {/if}


### PR DESCRIPTION
Implements the feature requested in #226: an optional Live Map filter, alongside the existing **Direct RX** toggle, that shows only stations reachable over RF and hides positions that only appeared because some other iGate gated them from the Internet onto RF.

Today, telling RF-reachable stations apart from Internet-gated ones means clicking each marker and eyeballing its path for `TCPIP`. This filter surfaces that boundary directly, making it easy to see the real edge of RF-digipeater coverage and to spot truly distant stations versus ones with bad coordinates.

### How it works
- The "Internet-to-RF" points are APRS third-party packets (`}SRC>DST,TCPIP*,...`) that our parser already unwraps. A new `Gated` flag is set in the station cache whenever a fix is the inner packet of a third-party gate (`decoded.ThirdParty != nil`).
- The flag is carried through `Station`/`Position`, the static-rebeacon merge, and the stations API DTO (`gated`), then consumed by a small frontend predicate: a station qualifies for **RF Only** if any position is `direction === 'RX'` and not `gated`.
- Unlike **Direct RX** (`RX && hops == 0`, which drops all digipeated traffic), **RF Only** keeps RF-digipeated stations and only removes gated points. Direct RX is the stricter subset, so it wins when both toggles are on.

### Changes
- `pkg/stationcache` — `Gated` on `CacheEntry`/`Station`/`Position`, set from the third-party wrapper and kept in lockstep with the existing most-direct-copy path metadata.
- `pkg/webapi/stations.go` (+ regenerated `swagger.json`/`swagger.yaml`, `api.d.ts`) — `gated` field on the station and position DTOs.
- `web/src/routes/LiveMapV2.svelte` — `RF Only` toggle, `isRfOnly` predicate, shared layer filter, and a status-bar count.

### Testing
- `go build ./...`, `go test ./pkg/stationcache/... ./pkg/webapi/` pass; added `TestExtractEntry_DirectRFNotGated` and extended the third-party unwrap test to assert `Gated`.
- `npm run build` and `npm test` pass (one unrelated pre-existing failure in `ptt/devices/methodOptions.test.js`, present on the base branch).
- API spec/`api.d.ts` edited surgically to add only `gated` — a full `make docs` regen in this environment introduces unrelated `format`/`x-enum` churn from a differently-built swag binary, so that noise was deliberately excluded.

Closes #226
