### PR TITLE
igate: fix 32-bit ARM atomic misalignment panic (Pi Zero shows iGate Disabled)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -830,3 +830,27 @@ of truth for which path entries are real hops. The map's `hops` field is
 computed once in [`pkg/stationcache/extract.go`](../../pkg/stationcache/extract.go)
 and consumed verbatim by the frontend popup; do not recompute it from
 `path.length` client-side.
+
+### 43. 64-bit atomic counters must be `atomic.Uint64`, not bare `uint64`
+
+Any struct field touched by a 64-bit atomic operation must use the
+`atomic.Uint64` / `atomic.Int64` types, never a plain `uint64` accessed via
+`atomic.AddUint64`/`atomic.LoadUint64`. On 32-bit platforms (notably ARMv6 --
+the Raspberry Pi Zero), a 64-bit atomic op requires the address to be 8-byte
+aligned; a bare `uint64` sitting mid-struct on a 4-byte boundary is not
+guaranteed to be, and the op panics with `unaligned 64-bit atomic operation`.
+The `atomic.Uint64` wrapper carries an alignment guarantee, so the compiler
+places it correctly regardless of field order. The iGate's four packet
+counters (`statGated`, `statDownlinked`, `statFiltered`, `statDropped` in
+[`pkg/igate/igate.go`](../../pkg/igate/igate.go)) are the canonical example.
+
+*Why:* graywolf issue #262 -- on a Pi Zero the iGate connected to APRS-IS fine
+but the web UI showed "Disabled" because `handleISLine`'s first
+`atomic.AddUint64` panicked on the misaligned `statFiltered`, crash-looping the
+process roughly every 90 seconds so the UI never observed a healthy session.
+64-bit hosts are unaffected, which is why it slipped through.
+
+*How to apply:* declare any atomically-accessed 64-bit counter as
+`atomic.Uint64`/`atomic.Int64` and use the method API (`.Add(1)`, `.Load()`,
+`.Store()`). Do not reintroduce bare `uint64` + `atomic.AddUint64`, and do not
+rely on field ordering for alignment.

--- a/pkg/igate/igate.go
+++ b/pkg/igate/igate.go
@@ -212,11 +212,14 @@ type Igate struct {
 	mSubmitDropped  prometheus.Counter
 	mFanoutDropped  prometheus.Counter
 
-	// Stats snapshot for Status().
-	statGated      uint64
-	statDownlinked uint64
-	statFiltered   uint64
-	statDropped    uint64
+	// Stats snapshot for Status(). atomic.Uint64 guarantees 8-byte
+	// alignment, which bare uint64 fields do not on 32-bit platforms
+	// (e.g. ARMv6 Raspberry Pi Zero); a misaligned 64-bit atomic op
+	// there panics with "unaligned 64-bit atomic operation".
+	statGated      atomic.Uint64
+	statDownlinked atomic.Uint64
+	statFiltered   atomic.Uint64
+	statDropped    atomic.Uint64
 
 	// session plumbing
 	//
@@ -478,12 +481,12 @@ func (ig *Igate) handleISLine(line string) {
 	// echoed onto RF (e.g. their own internet-connected weather
 	// station). See shouldForwardISToRF for the full rules.
 	if !ig.shouldForwardISToRF(pkt) {
-		atomic.AddUint64(&ig.statFiltered, 1)
+		ig.statFiltered.Add(1)
 		ig.mFilteredTotal.Inc()
 		return
 	}
 	if !ig.filter.Load().Allow(pkt) {
-		atomic.AddUint64(&ig.statFiltered, 1)
+		ig.statFiltered.Add(1)
 		ig.mFilteredTotal.Inc()
 		return
 	}
@@ -527,7 +530,7 @@ func (ig *Igate) handleISLine(line string) {
 		ig.logSubmitDrop(wrapped, err)
 		return
 	}
-	atomic.AddUint64(&ig.statDownlinked, 1)
+	ig.statDownlinked.Add(1)
 	ig.mGatedTotal.WithLabelValues("is_to_rf").Inc()
 
 	// Also publish into the PacketInput fan-out for any listeners.
@@ -731,7 +734,7 @@ func (ig *Igate) gateRFToIS(pkt *aprs.DecodedAPRSPacket) GateReason {
 	connected := ig.connected
 	ig.mu.Unlock()
 	if !connected {
-		atomic.AddUint64(&ig.statDropped, 1)
+		ig.statDropped.Add(1)
 		ig.mDroppedOffline.Inc()
 		return GateReasonOffline
 	}
@@ -742,7 +745,7 @@ func (ig *Igate) gateRFToIS(pkt *aprs.DecodedAPRSPacket) GateReason {
 	}
 	if ig.simulation.Load() {
 		ig.logger.Info("igate simulation send", "line", line)
-		atomic.AddUint64(&ig.statGated, 1)
+		ig.statGated.Add(1)
 		ig.mGatedTotal.WithLabelValues("rf_to_is").Inc()
 		if ig.cfg.RfToIsHook != nil {
 			ig.cfg.RfToIsHook(pkt, line)
@@ -753,7 +756,7 @@ func (ig *Igate) gateRFToIS(pkt *aprs.DecodedAPRSPacket) GateReason {
 		ig.logger.Warn("igate: aprs-is write failed", "err", err)
 		return GateReasonWriteFail
 	}
-	atomic.AddUint64(&ig.statGated, 1)
+	ig.statGated.Add(1)
 	ig.mGatedTotal.WithLabelValues("rf_to_is").Inc()
 	if ig.cfg.RfToIsHook != nil {
 		ig.cfg.RfToIsHook(pkt, line)
@@ -852,9 +855,9 @@ func (ig *Igate) Status() Status {
 		Callsign:       ig.stationCallsign,
 		SimulationMode: ig.simulation.Load(),
 		LastConnected:  ig.lastConnected,
-		Gated:          atomic.LoadUint64(&ig.statGated),
-		Downlinked:     atomic.LoadUint64(&ig.statDownlinked),
-		Filtered:       atomic.LoadUint64(&ig.statFiltered),
-		DroppedOffline: atomic.LoadUint64(&ig.statDropped),
+		Gated:          ig.statGated.Load(),
+		Downlinked:     ig.statDownlinked.Load(),
+		Filtered:       ig.statFiltered.Load(),
+		DroppedOffline: ig.statDropped.Load(),
 	}
 }

--- a/pkg/igate/is_to_rf_test.go
+++ b/pkg/igate/is_to_rf_test.go
@@ -310,7 +310,7 @@ func TestIsRxHookFiresEvenWhenFilterRejects(t *testing.T) {
 	if got := atomic.LoadInt32(&hookCalls); got != 1 {
 		t.Fatalf("IsRxHook calls = %d, want 1 (must fire regardless of filter)", got)
 	}
-	if got := atomic.LoadUint64(&ig.statFiltered); got != 1 {
+	if got := ig.statFiltered.Load(); got != 1 {
 		t.Fatalf("statFiltered = %d, want 1 (filter still counts the reject)", got)
 	}
 }


### PR DESCRIPTION
## Problem

On 32-bit ARM hardware (Raspberry Pi Zero, ARMv6), the iGate web UI shows a "Disabled" status despite successful APRS-IS connections. The real cause is a panic-and-restart loop roughly every 90 seconds, so the web UI never observes a healthy connection.

The iGate struct's four `uint64` packet counters (`statGated`, `statDownlinked`, `statFiltered`, `statDropped`) sit mid-struct on 4-byte boundaries. 64-bit atomic operations on 32-bit ARM require 8-byte alignment, so the first `atomic.AddUint64` in `handleISLine` hits a misaligned address and panics with `unaligned 64-bit atomic operation`. 64-bit hosts are unaffected.

## Fix

Replace the bare `uint64` fields with Go's `atomic.Uint64`, which carries an 8-byte alignment guarantee regardless of field placement. Counter writes move from `atomic.AddUint64(&ig.statX, 1)` to `ig.statX.Add(1)` and reads from `atomic.LoadUint64(&ig.statX)` to `ig.statX.Load()`.

## Verification

- `go build ./...` and `go vet ./pkg/igate/...` clean
- Cross-compile sanity check: `GOARCH=arm GOARM=6 go build ./pkg/igate/...` succeeds
- `go test ./pkg/igate/...` passes

Also documented as invariant #43 in `docs/wiki/invariants.md`.

Fixes #262