### PR TITLE
fix(android): Test TX failed: modembridge: test signal timeout (#267)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -854,3 +854,33 @@ process roughly every 90 seconds so the UI never observed a healthy session.
 `atomic.Uint64`/`atomic.Int64` and use the method API (`.Add(1)`, `.Load()`,
 `.Store()`). Do not reintroduce bare `uint64` + `atomic.AddUint64`, and do not
 rely on field ordering for alignment.
+
+### 44. Every Go→Rust IPC payload must be dispatched in BOTH modem loops
+
+The desktop/server modem and the Android modem read the same
+`graywolf.proto` IPC stream through **two independent dispatch matches**,
+and a Go→Rust payload only works on a platform whose match has an arm for
+it:
+
+1. `graywolf-modem/src/modem/mod.rs` — `handle_message` (desktop, server, the cdylib's non-Android path)
+2. `graywolf-modem/src/android/mod.rs` — the inbound `while let` in `run_demod` (Android)
+
+Both end in a catch-all (`_ => {}` / the grouped Rust→Go ignore arm), so a
+new payload added to one loop but not the other is **silently dropped** on
+the platform that missed it — no error, no log, just a Go-side request that
+never gets its reply and times out.
+
+*Why:* this has bitten twice. 5d6b75ad wired `ConfigurePtt` / `ManualPtt` /
+`TransmitFrame` into `run_demod` after they were found dropped on Android
+(PTT stayed silent); then `TransmitTestSignal` (the Channel TX test-signal
+feature, #193) shipped to the desktop loop only and fell into the Android
+catch-all, so **Test TX** returned `modembridge: test signal timeout` on
+Android (#267). Same failure mode as invariant #34 (KISS dispatch in two
+places), but across the Go↔Rust boundary.
+
+*How to apply:* when you add a Go→Rust `Payload` variant, add a matching
+arm to **both** loops in the same change — and on Android remember to send
+the corresponding Rust→Go reply (e.g. `TestSignalResult`) so the Go side's
+bounded wait resolves. Android TX jobs submit samples unscaled (gain is
+applied by `AndroidTxSink`), unlike the desktop arm which pre-scales by the
+output device gain.

--- a/graywolf-modem/src/android/mod.rs
+++ b/graywolf-modem/src/android/mod.rs
@@ -587,6 +587,11 @@ fn run_demod(
                                                 audio_channel: 0,
                                             },
                                     };
+                                    // Ok here means "enqueued on the TX
+                                    // worker", not "played out" -- PTT keying
+                                    // and audio happen async in process_job.
+                                    // Matches the desktop handler's reply
+                                    // semantics (modem::handle_transmit_test_signal).
                                     match tx_worker.transmit(job) {
                                         Ok(()) => {
                                             config_state::increment_tx_frames();

--- a/graywolf-modem/src/android/mod.rs
+++ b/graywolf-modem/src/android/mod.rs
@@ -19,7 +19,9 @@ use jni::{JNIEnv, JavaVM};
 use log::{error, info, warn};
 
 use crate::demod_afsk_multi::{MultiAfskDemodulator, RECOMMENDED_3DEMOD};
-use crate::ipc::proto::{ipc_message, DeviceLevelUpdate, IpcMessage, ReceivedFrame, StatusUpdate};
+use crate::ipc::proto::{
+    ipc_message, DeviceLevelUpdate, IpcMessage, ReceivedFrame, StatusUpdate, TestSignalResult,
+};
 use crate::ipc::server::{IpcInbound, IpcServer};
 use crate::modem::tx_worker::{TxJob, TxWorker};
 use crate::rxonly::feed_chunk;
@@ -430,6 +432,9 @@ fn run_demod(
 
             // Drain inbound IPC messages from the Go side. Previously only
             // ConfigureChannel was handled; now the full TX dispatch is wired.
+            // Set when a reply send fails so we break to await reconnect after
+            // the drain loop (a `while let` can't `break` with a value).
+            let mut reply_send_failed = false;
             while let Ok(inbound) = ipc_rx.try_recv() {
                 if let IpcInbound::Message(msg) = inbound {
                     match msg.payload {
@@ -527,6 +532,83 @@ fn run_demod(
                                 }
                             }
                         }
+                        Some(ipc_message::Payload::TransmitTestSignal(req)) => {
+                            // Build test-signal PCM the same way the desktop
+                            // modem does (modem::handle_transmit_test_signal),
+                            // then submit it through the shared TxWorker and
+                            // reply with TestSignalResult. Without this arm the
+                            // payload hit the catch-all below and was dropped,
+                            // so the Go side's 5s wait expired -- the "test
+                            // signal timeout" operators saw on Android
+                            // (graywolf#267). Gain is applied by AndroidTxSink,
+                            // so samples are submitted unscaled like TransmitFrame.
+                            let built = match req.kind {
+                                0 => {
+                                    let s = crate::txtest::cw_samples(
+                                        &req.callsign,
+                                        TARGET_SAMPLE_RATE,
+                                        req.cw_wpm.max(1),
+                                        req.freq_a_hz as f32,
+                                    );
+                                    if s.is_empty() {
+                                        Err("callsign produced no CW symbols".to_string())
+                                    } else {
+                                        Ok(s)
+                                    }
+                                }
+                                1 => Ok(crate::txtest::tone_samples(
+                                    TARGET_SAMPLE_RATE,
+                                    req.freq_a_hz as f32,
+                                    req.duration_ms,
+                                )),
+                                2 => Ok(crate::txtest::alternating_samples(
+                                    TARGET_SAMPLE_RATE,
+                                    req.freq_a_hz as f32,
+                                    req.freq_b_hz as f32,
+                                    req.duration_ms,
+                                    req.alt_period_ms,
+                                )),
+                                other => Err(format!("unknown test signal kind {}", other)),
+                            };
+
+                            let (success, error) = match built {
+                                Ok(samples) => {
+                                    let job = TxJob {
+                                        channel: req.channel,
+                                        samples,
+                                        sample_rate: TARGET_SAMPLE_RATE,
+                                        // unused by the Android arm of process_job
+                                        output_device_id: 0,
+                                        sink_config:
+                                            crate::audio::soundcard::SoundcardOutputConfig {
+                                                device_name: String::new(),
+                                                sample_rate: TARGET_SAMPLE_RATE,
+                                                channels: 1,
+                                                audio_channel: 0,
+                                            },
+                                    };
+                                    match tx_worker.transmit(job) {
+                                        Ok(()) => {
+                                            config_state::increment_tx_frames();
+                                            (true, String::new())
+                                        }
+                                        Err(e) => (false, e),
+                                    }
+                                }
+                                Err(e) => (false, e),
+                            };
+
+                            if let Err(e) = handle.send(&IpcMessage::test_signal_result(
+                                TestSignalResult { request_id: req.request_id, success, error },
+                            )) {
+                                warn!(
+                                    "ipc send (test signal result): {}; awaiting reconnect",
+                                    e
+                                );
+                                reply_send_failed = true;
+                                break;
+                            }
+                        }
                         Some(ipc_message::Payload::SetDeviceGain(sg)) => {
                             // Live gain from the operator slider. Without this
                             // arm it was a silent no-op on Android (gain frozen
@@ -542,6 +624,9 @@ fn run_demod(
                         _ => {}
                     }
                 }
+            }
+            if reply_send_failed {
+                break true;
             }
         };
 


### PR DESCRIPTION
## What

On Android, clicking **Test TX** on a channel failed with:

> Test TX failed: modembridge: test signal timeout

## Root cause

The Android Rust modem runs its own IPC dispatch loop in `run_demod` (`graywolf-modem/src/android/mod.rs`), separate from the desktop modem's loop. That loop handled `ConfigureChannel`, `ConfigurePtt`, `ManualPtt`, `TransmitFrame` and `SetDeviceGain`, but the `TransmitTestSignal` payload -- added later with the Channel TX test-signal feature (#193) -- fell through to the `_ => {}` catch-all and was silently dropped.

Because no `TestSignalResult` was ever sent back, the Go side's 5s wait in `Bridge.TransmitTestSignal` expired and returned `modembridge: test signal timeout`, which the SPA surfaced verbatim. This is the same class of bug that 5d6b75ad fixed for the other TX payloads; Test TX was simply never wired into the Android dispatch.

## Fix

Add the missing `TransmitTestSignal` arm, mirroring the desktop modem's `handle_transmit_test_signal`:

- build CW / steady-tone / alternating-tone PCM via `txtest`
- submit it through the shared `TxWorker` (samples go in unscaled -- `AndroidTxSink` applies gain, same as the `TransmitFrame` arm)
- reply with `TestSignalResult` so the operator gets a real success or error instead of a timeout

A reply-send failure drops to await reconnect via a flag, since the inbound `while let` drain loop can't `break` with a value.

## Verification

- `cargo ndk -t arm64-v8a check --lib` (the exact flags the Gradle `cargoNdkBuild` task uses): compiles clean.

The fix is fully contained within the `#![cfg(target_os = "android")]` module, so desktop builds are unaffected.