### PR TITLE
Move radar region selector to the maps settings tab

### DIFF
--- a/web/src/lib/map/map-store.svelte.js
+++ b/web/src/lib/map/map-store.svelte.js
@@ -7,6 +7,8 @@
 // (when available from /api/position) is applied by LiveMapV2 as a
 // one-shot recentering after the data store first reports it.
 
+import { RADAR_REGION_US, RADAR_REGION_WORLD } from './sources/radar-source.js';
+
 // Slightly above the equator so the world view shows more land than ocean.
 const WORLD_CENTER = [20, 0];
 const WORLD_ZOOM = 2;
@@ -21,6 +23,13 @@ function loadFloat(key, fallback) {
 function loadInt(key, fallback) {
   const v = localStorage.getItem(key);
   return v != null ? parseInt(v, 10) : fallback;
+}
+
+// Radar coverage region -- a per-browser map preference chosen on the maps
+// settings tab and consumed by the radar layer on the live map. Only two
+// values are valid; anything else falls back to US.
+function normalizeRadarRegion(v) {
+  return v === RADAR_REGION_WORLD ? RADAR_REGION_WORLD : RADAR_REGION_US;
 }
 
 const hasSavedCenter = localStorage.getItem('map-center-lat') != null;
@@ -49,6 +58,7 @@ export const mapState = (() => {
     loadFloat('map-center-lon', WORLD_CENTER[1]),
   ]);
   let mapZoom = $state(loadInt('map-zoom', WORLD_ZOOM));
+  let radarRegion = $state(normalizeRadarRegion(localStorage.getItem('gw_radar_region')));
 
   return {
     get selectedStation() { return selectedStation; },
@@ -80,6 +90,13 @@ export const mapState = (() => {
     set mapZoom(v) {
       mapZoom = v;
       localStorage.setItem('map-zoom', String(v));
+    },
+
+    get radarRegion() { return radarRegion; },
+    set radarRegion(v) {
+      const next = normalizeRadarRegion(v);
+      radarRegion = next;
+      localStorage.setItem('gw_radar_region', next);
     },
 
     hasSavedView,

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -18,7 +18,6 @@
   import { mountHoverPathLayer } from '../lib/map/layers/hover-path.js';
   import { mountMyPositionLayer } from '../lib/map/layers/my-position.js';
   import { mountRadarLayer } from '../lib/map/layers/radar.js';
-  import { RADAR_REGION_US, RADAR_REGION_WORLD } from '../lib/map/sources/radar-source.js';
   import { mountFixedPointsLayer } from '../lib/map/layers/fixed-points.js';
   import { fixedPointsStore } from '../lib/map/fixed-points-store.svelte.js';
   import FixedPointDialog from '../lib/map/fixed-point-dialog.svelte';
@@ -68,9 +67,10 @@
   const radarSettings = $state({
     visible: localStorage.getItem('gw_radar_visible') === '1',
     opacity: parseFloat(localStorage.getItem('gw_radar_opacity') ?? '0.6'),
-    // Coverage region: 'us' = NEXRAD overlay, 'world' = RainViewer global.
-    region: localStorage.getItem('gw_radar_region') ?? RADAR_REGION_US,
   });
+  // Coverage region ('us' = NEXRAD, 'world' = RainViewer) lives in the shared
+  // map store so the maps settings tab owns the selector; the live map only
+  // reflects the operator's choice here.
   let mapRef = null;
   let activePopup = null;
 
@@ -326,7 +326,11 @@
     // Radar first so the raster/fill sits below trails and station markers in
     // the GL stack. DOM layers (stations, weather) always render above the
     // canvas regardless, but GL line layers (trails) would otherwise cover it.
-    radarLayer = mountRadarLayer(map, radarSettings);
+    radarLayer = mountRadarLayer(map, {
+      visible: radarSettings.visible,
+      opacity: radarSettings.opacity,
+      region: mapState.radarRegion,
+    });
     // Trails first so the line sits beneath the (DOM) station markers
     // and below the weather labels in symbol-layer order.
     trailsLayer = mountTrailsLayer(map, () => dataStore.stations, {
@@ -512,9 +516,7 @@
     radarLayer?.setOpacity(v);
   });
   $effect(() => {
-    const v = radarSettings.region;
-    localStorage.setItem('gw_radar_region', v);
-    radarLayer?.setRegion(v);
+    radarLayer?.setRegion(mapState.radarRegion);
   });
   $effect(() => {
     const v = layerToggles.fixedPoints;
@@ -762,16 +764,6 @@
       class="radar-opacity-range"
       bind:value={radarSettings.opacity}
     />
-
-    <label class="timerange-label" for="radar-region-select">Radar region</label>
-    <select
-      id="radar-region-select"
-      class="map-timerange-select"
-      bind:value={radarSettings.region}
-    >
-      <option value={RADAR_REGION_US}>United States (NEXRAD)</option>
-      <option value={RADAR_REGION_WORLD}>Rest of world (RainViewer)</option>
-    </select>
 
     <label class="timerange-label" for="map-timerange-select">Time range</label>
     <select

--- a/web/src/routes/MapsSettings.svelte
+++ b/web/src/routes/MapsSettings.svelte
@@ -2,6 +2,8 @@
   import { onMount } from 'svelte';
   import { Box, Button, Input, Toggle, Radio, RadioGroup } from '@chrissnell/chonky-ui';
   import { mapsState, ISSUES_URL } from '../lib/settings/maps-store.svelte.js';
+  import { mapState } from '../lib/map/map-store.svelte.js';
+  import { RADAR_REGION_US, RADAR_REGION_WORLD } from '../lib/map/sources/radar-source.js';
   import { validateCallsign } from '../lib/maps/callsign.js';
   import { downloadsState } from '../lib/maps/downloads-store.svelte.js';
   import { catalogStore } from '../lib/maps/catalog-store.svelte.js';
@@ -110,6 +112,25 @@
 
   function onSourceChange(v) {
     mapsState.setSource(v);
+  }
+
+  // Radar coverage region. Per-browser preference (mapState persists it to
+  // localStorage); the live map's radar layer reflects the choice immediately.
+  const radarRegions = [
+    {
+      value: RADAR_REGION_US,
+      label: 'United States (NEXRAD)',
+      sublabel: 'High-resolution NEXRAD reflectivity contours.',
+    },
+    {
+      value: RADAR_REGION_WORLD,
+      label: 'Rest of world (RainViewer)',
+      sublabel: 'Global RainViewer composite for coverage outside the US.',
+    },
+  ];
+
+  function onRadarRegionChange(v) {
+    mapState.radarRegion = v;
   }
 </script>
 
@@ -271,6 +292,27 @@
           Areas without offline coverage fall back to online.
         </p>
       {/if}
+    {/each}
+  </RadioGroup>
+</Box>
+
+<Box title="Radar region">
+  <p class="prose">
+    Choose which radar overlay the live map shows. NEXRAD covers the United
+    States; RainViewer covers the rest of the world.
+  </p>
+  <RadioGroup
+    value={mapState.radarRegion}
+    onValueChange={onRadarRegionChange}
+    name="radar-region"
+    class="source-radio-group"
+    aria-label="Choose a radar region"
+  >
+    {#each radarRegions as region}
+      <div class="source-radio-row">
+        <Radio value={region.value} label={region.label} />
+        <p class="source-sublabel">{region.sublabel}</p>
+      </div>
     {/each}
   </RadioGroup>
 </Box>


### PR DESCRIPTION
## Summary

Addresses the two problems reported against PR #269's radar region feature.

### 1. Region selector moved to the maps settings tab (fixed here)
The "Radar region" selector was rendered in the live map's layer pane. It now lives on the **Maps** settings tab next to the basemap "Map source" control, as a two-option radio (United States / Rest of world).

- The coverage region now lives in the shared map store as `mapState.radarRegion` (persisted per-browser to `gw_radar_region`).
- `MapsSettings.svelte` owns the selector; `LiveMapV2.svelte` drops the inline `<select>` and just drives `radarLayer.setRegion()` from the store.
- `radar.js` / `radar-source.js` are unchanged, so their unit tests are untouched and still pass (20/20).

### 2. RainViewer overlay not rendering (root cause is server-side, not in this repo)
I traced the full client render path (provider descriptor, source/layer add, region teardown/rebuild, cache-bust + bearer-token query composition, z-order) and an independent review reached the same conclusion: **the client wiring is correct.** The world raster provider is structurally identical to the US raster overlay that shipped in #256 and rendered fine; the only deltas (URL path, `maxzoom 7`, presence of `cacheBust`) are not render-fatal.

The no-overlay symptom is consistent with the origin Worker's `/radar/rainviewer/*` route not serving tiles. The worker's auth gate returns `401` for every path before routing, so the route can't be confirmed from outside without a valid token. This needs verification/fix on the graywolf-maps Worker (separate repo), not in the web client.

## Testing
- `npm run build` succeeds.
- `npm test`: all radar tests pass; the one unrelated pre-existing failure (`ptt/devices/methodOptions.test.js`) also fails on the clean base.