### PR TITLE
Add a downloadable low-detail world map

### DIFF
--- a/docs/handbook/maps.html
+++ b/docs/handbook/maps.html
@@ -128,6 +128,18 @@
       of the map you&rsquo;ll be on.
     </p>
 
+    <p>
+      At the top of the region list is a single <strong>World (low
+      detail)</strong> map &mdash; a low-zoom basemap of the entire
+      planet, around a few hundred megabytes. It is ideal for portable
+      and HF stations that hear traffic from far outside their usual
+      coverage: you get a usable worldwide map at low-to-moderate
+      detail without downloading every country. It coexists with your
+      detailed regional downloads &mdash; where a state or country you
+      have also covers an area, the Live Map shows that fuller detail,
+      and only falls back to the world map elsewhere.
+    </p>
+
     <div class="callout tip">
       <span class="callout-icon">&#10003;</span>
       <div class="callout-body">

--- a/docs/superpowers/plans/2026-06-13-downloadable-world-map.md
+++ b/docs/superpowers/plans/2026-06-13-downloadable-world-map.md
@@ -1,0 +1,1035 @@
+# Downloadable World Map Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a single low-zoom (z1–7, ~300 MB) worldwide basemap that operators can download for offline use anywhere on Earth, complementing the existing per-state/country/province downloads (GH #209).
+
+**Architecture:** The basemap is already generated and served worldwide as OpenMapTiles/Americana vector tiles from the `graywolf-maps` Cloudflare Worker. This plan adds one extra PMTiles archive — a z0–7 slice of the planet — to that pipeline (`graywolf-maps` repo, Phase A), then extends the graywolf client (Phase B) so the catalog, slug grammar, downloader, offline render path, and region-picker UI all understand a new `world` slug. Two client behaviours are new: the world archive's globe-spanning bbox must rank **below** higher-detail regional archives in the federated tile dispatcher, and the archive's max zoom (7) must be threaded through so MapLibre overzooms the z7 tile instead of requesting (and failing) z8+ offline.
+
+**Tech Stack:** Phase A — Planetiler (Java), PMTiles, Cloudflare R2 + Workers (wrangler), Node manifest generator. Phase B — Go 1.22+ (`http.ServeMux` wildcard routes, GORM/SQLite), Svelte 5 / MapLibre GL JS v5, `pmtiles` JS library.
+
+**Repos:**
+- `graywolf-maps` (`~/dev/graywolf-maps`, private — **not** checked out in this workspace): tile generation, R2 sync, manifest publishing, origin Worker. Phase A.
+- `graywolf` (this repo, https://github.com/chrissnell/graywolf): the client. Phase B.
+
+---
+
+## Design constraints (recorded; do not violate)
+
+1. **Reuse the existing pipeline.** The world archive is a maxzoom-capped Planetiler run of the same planet data already built; no new schema, style, or auth path.
+2. **One archive, ~a few hundred MiB.** Target z1–7 ≈ 300 MB (per GH #209). z0 is one tile and harmless to include; the slug stays `world`.
+3. **Regional downloads always win where they overlap.** A user with `state/colorado` AND `world` must render Colorado at full z14 detail, not the coarse world layer.
+4. **Offline-safe render path.** The render path reads `/api/maps/local-bounds` (the SQLite snapshot), never the remote catalog — same invariant as today (`pkg/webapi/local_bounds.go`).
+5. **No new auth/registration.** The world archive is served behind the same bearer-token Worker gate as every other download.
+6. **CN/RU forbidden list is irrelevant here** — `world` is a single global archive, not a country.
+
+---
+
+## Slug & route contract (the seam between the two repos)
+
+Agreed shape both repos implement against:
+
+| Concept | Value |
+|---|---|
+| Namespaced slug | `world` (single segment, no `/`) |
+| Worker download route | `GET /download/world.pmtiles` (bearer-token gated, edge-cached) |
+| On-disk client path | `<TileCacheDir>/world.pmtiles` (from `PathFor`, already correct) |
+| Manifest field | top-level `"world": { name, sizeBytes, sha256, bbox, maxZoom }` |
+| World bbox | `[-180, -85.0511, 180, 85.0511]` (Web Mercator lat clamp) |
+| World maxZoom | `7` |
+
+---
+
+## File Structure
+
+**Phase A — `graywolf-maps` (separate repo):**
+- Modify: the Planetiler build script/Makefile target — add a `world.pmtiles` build at `--maxzoom=7`.
+- Modify: the manifest generator — emit the top-level `world` object with `maxZoom`.
+- Modify: the R2 sync step — upload `world.pmtiles`.
+- Modify: the Worker router — add `GET /download/world.pmtiles`.
+
+**Phase B — `graywolf` (this repo):**
+- `pkg/mapsslug/slug.go` + `slug_test.go` — accept `world` in the grammar.
+- `pkg/mapscatalog/catalog.go` + `catalog_test.go` — `World *WorldMap` field, index, `HasSlug`.
+- `pkg/mapscache/manager.go` + `manager_test.go` — `urlForSlug` world case; thread `maxZoom` into `Start`.
+- `pkg/configstore/models.go` — `MaxZoom` column on `MapsDownload`.
+- `pkg/configstore/seed_downloads.go` + test — persist `max_zoom`.
+- `pkg/webapi/downloads.go` + test — `lookupCatalogBBox`/`lookupCatalogEntry` world case; pass maxZoom to `Start`.
+- `pkg/webapi/local_bounds.go` + `pkg/webapi/dto/*` — return `maxZoom` per slug.
+- `web/src/lib/maps/local-bounds-store.svelte.js` — expose `maxZoomBySlug`.
+- `web/src/lib/map/sources/gw-federated-protocol.js` + (new) `gw-federated-protocol.test.js` — area-ranked dispatch + maxZoom-aware overzoom.
+- `web/src/lib/map/maplibre-map.svelte` — dynamic source maxzoom when world-only.
+- `web/src/lib/maps/catalog-tree.js` + test — surface the `world` entry to the picker.
+- `web/src/lib/maps/region-picker.svelte` — render the World row.
+- Regen artifacts: `pkg/webapi/docs/{docs.go,swagger.json,swagger.yaml}`, `web/src/api/generated/*`.
+- Docs: `docs/wiki/system-topology.md`, `docs/handbook/maps.html`.
+
+---
+
+## Architecture decisions baked into this plan
+
+1. **`world` is a single optional catalog object**, not a fourth array. It carries a `maxZoom` field the others lack (regions are full z14). `HasSlug`/`indexSlugs` add the literal `"world"` when present.
+2. **maxZoom is snapshotted at download time** into `maps_downloads.max_zoom` (mirroring how bbox is snapshotted), so the offline render path knows the cap without consulting the catalog. Regional rows store `0`, meaning "no cap / upstream max".
+3. **Dispatch ranks candidates by bbox area, ascending.** Smaller bbox = more specific = tried first. The world bbox (whole globe) is therefore always last, satisfying constraint 3 without hard-coding the slug name. The first archive that actually holds the tile wins; network is the final fallback.
+4. **Overzoom is handled by setting the MapLibre source `maxzoom`.** When the *only* installed coverage is the world archive (no regional downloads), the gw-tile vector source is registered with `maxzoom: 7` so MapLibre reuses the z7 tile at higher screen zooms instead of requesting z8+ (which would miss offline → blank). When any regional (full-detail) download is present, the source keeps the upstream max (14) so detail is available there; world-only areas at high zoom rely on MapLibre's parent-tile retention. This is the documented, acceptable limitation.
+
+---
+
+# Phase A — graywolf-maps (tile generation + serving)
+
+> This repo is not checked out in this workspace and is not on public GitHub. The steps below are at build/deploy granularity with concrete commands; adapt paths to the repo's actual layout. Do these first — Phase B's integration test needs the manifest to advertise `world` and the Worker to serve `/download/world.pmtiles`.
+
+### Task A1: Generate the z0–7 world PMTiles archive
+
+**Files:**
+- Modify: the Planetiler invocation (Makefile target or build script, e.g. `Makefile` / `scripts/build-tiles.sh`).
+
+- [ ] **Step 1: Add a world build target**
+
+Add a target that runs Planetiler against the same planet input used for the full basemap, capped at zoom 7:
+
+```bash
+java -Xmx12g -jar planetiler.jar \
+  --download \
+  --area=planet \
+  --minzoom=0 --maxzoom=7 \
+  --output=build/world.pmtiles
+```
+
+A maxzoom-7 planet build is light (skips the explosive z13–14 data) — minutes-to-tens-of-minutes on a 16 GB box. Expected output ~250–400 MB.
+
+- [ ] **Step 2: Verify size and zoom range**
+
+Run:
+
+```bash
+pmtiles show build/world.pmtiles
+```
+
+Expected: `max zoom: 7`, `min zoom: 0`, bounds ≈ `-180,-85.05,180,85.05`, archive size a few hundred MB. If it exceeds ~450 MB, drop to `--maxzoom=6` and re-verify (constraint 2).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile scripts/build-tiles.sh
+git commit -m "build: generate z0-7 world.pmtiles archive"
+```
+
+### Task A2: Publish `world` in the manifest
+
+**Files:**
+- Modify: the manifest generator (e.g. `scripts/gen-manifest.js` or Go equivalent).
+
+- [ ] **Step 1: Compute the world entry**
+
+After building `world.pmtiles`, compute its size, SHA-256, and read its bbox/maxzoom from the PMTiles header, then add a top-level `world` object to `manifest.json`:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-06-13T00:00:00Z",
+  "world": {
+    "name": "World (low detail)",
+    "sizeBytes": 314572800,
+    "sha256": "<sha256 of world.pmtiles>",
+    "bbox": [-180, -85.0511, 180, 85.0511],
+    "maxZoom": 7
+  },
+  "countries": [ /* unchanged */ ],
+  "provinces": [ /* unchanged */ ],
+  "states":    [ /* unchanged */ ]
+}
+```
+
+`schemaVersion` stays `1`: the field is purely additive, and the graywolf client tolerates unknown/missing fields (`World` is a pointer, omitted when absent).
+
+- [ ] **Step 2: Validate the emitted manifest**
+
+Run the generator and confirm:
+
+```bash
+node scripts/gen-manifest.js && jq '.world' build/manifest.json
+```
+
+Expected: the `world` object with the five fields, non-zero `sizeBytes`, `maxZoom: 7`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/gen-manifest.js
+git commit -m "feat: advertise world archive in manifest"
+```
+
+### Task A3: Sync the archive to R2 and serve it from the Worker
+
+**Files:**
+- Modify: the R2 sync step (wrangler/rclone script).
+- Modify: the Worker router (e.g. `src/worker.ts` / `src/index.js`).
+
+- [ ] **Step 1: Upload world.pmtiles to R2**
+
+```bash
+wrangler r2 object put graywolf-maps/download/world.pmtiles \
+  --file build/world.pmtiles
+```
+
+(Match the existing bucket name and `download/` key prefix used by the other archives.)
+
+- [ ] **Step 2: Add the Worker download route**
+
+In the Worker's router, handle `GET /download/world.pmtiles` exactly like the existing `/download/state/<slug>.pmtiles` route: validate the bearer token, fetch the R2 object, stream it back, and set the same edge-cache headers with the `?t=<token>` stripped from the cache key. If routes are matched by regex, extend the download matcher to also accept the literal `world.pmtiles`. No new auth logic.
+
+- [ ] **Step 3: Deploy and smoke-test**
+
+```bash
+wrangler deploy
+curl -sI "https://maps.nw5w.com/download/world.pmtiles?t=$TOKEN" | head
+curl -sf "https://maps.nw5w.com/manifest.json?t=$TOKEN" | jq '.world.maxZoom'
+```
+
+Expected: `200 OK` with `content-type: application/octet-stream` and a `content-length` of a few hundred MB on the download; `7` from the manifest.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/worker.ts scripts/sync-r2.sh
+git commit -m "feat: serve /download/world.pmtiles from R2"
+```
+
+---
+
+# Phase B — graywolf client
+
+## Task B1: Accept `world` in the slug grammar
+
+**Files:**
+- Modify: `pkg/mapsslug/slug.go`
+- Test: `pkg/mapsslug/slug_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `pkg/mapsslug/slug_test.go`:
+
+```go
+func TestParseWorld(t *testing.T) {
+	kind, a, b, ok := Parse("world")
+	if !ok || kind != "world" || a != "" || b != "" {
+		t.Fatalf("Parse(\"world\") = (%q,%q,%q,%v), want (\"world\",\"\",\"\",true)", kind, a, b, ok)
+	}
+	for _, bad := range []string{"world/", "world/base", "world/x/y", "World", "worldx"} {
+		if _, _, _, ok := Parse(bad); ok {
+			t.Errorf("Parse(%q) = ok, want rejected", bad)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./pkg/mapsslug/ -run TestParseWorld -v`
+Expected: FAIL — `Parse("world")` returns `ok=false`.
+
+- [ ] **Step 3: Add the `world` case**
+
+In `pkg/mapsslug/slug.go`, inside `Parse`'s `switch parts[0]`, add a case before the closing brace:
+
+```go
+	case "world":
+		if len(parts) != 1 {
+			return "", "", "", false
+		}
+		return "world", "", "", true
+```
+
+Also update the package doc grammar comment to list `world`:
+
+```go
+//	world                    (single global archive, z0-7)
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `go test ./pkg/mapsslug/ -v`
+Expected: PASS (all cases, including the existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/mapsslug/slug.go pkg/mapsslug/slug_test.go
+git commit -m "feat(mapsslug): accept world slug"
+```
+
+## Task B2: Add the `world` entry to the catalog type
+
+**Files:**
+- Modify: `pkg/mapscatalog/catalog.go`
+- Test: `pkg/mapscatalog/catalog_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `pkg/mapscatalog/catalog_test.go`:
+
+```go
+func TestHasSlugWorld(t *testing.T) {
+	c := Catalog{World: &WorldMap{Name: "World", SizeBytes: 1, MaxZoom: 7}}
+	c.indexSlugs()
+	if !c.HasSlug("world") {
+		t.Fatal("HasSlug(\"world\") = false, want true")
+	}
+	empty := Catalog{}
+	empty.indexSlugs()
+	if empty.HasSlug("world") {
+		t.Fatal("HasSlug(\"world\") = true on catalog without world, want false")
+	}
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./pkg/mapscatalog/ -run TestHasSlugWorld -v`
+Expected: FAIL — `undefined: WorldMap` and `Catalog has no field World`.
+
+- [ ] **Step 3: Add the type, field, and index/lookup support**
+
+In `pkg/mapscatalog/catalog.go`, add the type near the other entry structs:
+
+```go
+type WorldMap struct {
+	Name      string      `json:"name"`
+	SizeBytes int64       `json:"sizeBytes"`
+	SHA256    string      `json:"sha256"`
+	BBox      *[4]float64 `json:"bbox,omitempty"`
+	MaxZoom   int         `json:"maxZoom"`
+}
+```
+
+Add the field to `Catalog` (right after `States`):
+
+```go
+	World *WorldMap `json:"world,omitempty"`
+```
+
+In `indexSlugs`, after the provinces loop and before `c.slugIndex = idx`:
+
+```go
+	if c.World != nil {
+		idx["world"] = struct{}{}
+	}
+```
+
+In `HasSlug`'s linear fallback, before the final `return false`:
+
+```go
+	if c.World != nil && slug == "world" {
+		return true
+	}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `go test ./pkg/mapscatalog/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/mapscatalog/catalog.go pkg/mapscatalog/catalog_test.go
+git commit -m "feat(mapscatalog): add optional world entry"
+```
+
+## Task B3: Build the world download URL
+
+**Files:**
+- Modify: `pkg/mapscache/manager.go`
+- Test: `pkg/mapscache/manager_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `pkg/mapscache/manager_test.go` (use the same construction the existing `urlForSlug`/`PathFor` tests use; if `urlForSlug` is unexported, this test lives in `package mapscache`):
+
+```go
+func TestURLForSlugWorld(t *testing.T) {
+	m := &Manager{mapsBaseURL: "https://maps.nw5w.com"}
+	got, err := m.urlForSlug("world", "")
+	if err != nil {
+		t.Fatalf("urlForSlug(world) error: %v", err)
+	}
+	const want = "https://maps.nw5w.com/download/world.pmtiles"
+	if got != want {
+		t.Fatalf("urlForSlug(world) = %q, want %q", got, want)
+	}
+	if p := m.PathFor("world"); !strings.HasSuffix(p, "world.pmtiles") {
+		t.Fatalf("PathFor(world) = %q, want suffix world.pmtiles", p)
+	}
+}
+```
+
+(If the `Manager` base-URL field has a different name than `mapsBaseURL`, match the struct in `manager.go`; the existing `urlForSlug` reads it into `base`.)
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./pkg/mapscache/ -run TestURLForSlugWorld -v`
+Expected: FAIL — `urlForSlug("world")` returns `invalid slug "world"` only if B1 not done; with B1 done it returns an error because the `switch kind` has no `world` case (falls through to the error path).
+
+- [ ] **Step 3: Add the `world` case**
+
+In `pkg/mapscache/manager.go`, inside `urlForSlug`'s `switch kind`, add:
+
+```go
+	case "world":
+		raw = fmt.Sprintf("%s/download/world.pmtiles", base)
+```
+
+`PathFor("world")` already yields `<cache>/world.pmtiles` via `filepath.FromSlash` — no change needed there.
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `go test ./pkg/mapscache/ -run TestURLForSlugWorld -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/mapscache/manager.go pkg/mapscache/manager_test.go
+git commit -m "feat(mapscache): world download URL"
+```
+
+## Task B4: Snapshot maxZoom into the downloads table
+
+**Files:**
+- Modify: `pkg/configstore/models.go`
+- Modify: `pkg/configstore/seed_downloads.go`
+- Test: `pkg/configstore/seed_downloads_test.go` (or the existing downloads store test file)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the downloads store test file (mirror the existing `UpsertMapsDownload` round-trip test):
+
+```go
+func TestUpsertMapsDownloadMaxZoom(t *testing.T) {
+	s := newTestStore(t) // existing helper used by the other tests in this file
+	ctx := context.Background()
+	if err := s.UpsertMapsDownload(ctx, MapsDownload{
+		Slug: "world", Status: "complete", MaxZoom: 7,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetMapsDownload(ctx, "world")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MaxZoom != 7 {
+		t.Fatalf("MaxZoom = %d, want 7", got.MaxZoom)
+	}
+}
+```
+
+(If the existing tests construct the store differently, reuse that exact setup helper instead of `newTestStore`.)
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./pkg/configstore/ -run TestUpsertMapsDownloadMaxZoom -v`
+Expected: FAIL — `MapsDownload has no field MaxZoom`.
+
+- [ ] **Step 3: Add the column and persist it**
+
+In `pkg/configstore/models.go`, add to the `MapsDownload` struct:
+
+```go
+	MaxZoom int `gorm:"not null;default:0" json:"max_zoom"` // 0 = no cap (regional, full-detail); >0 = world archive max zoom
+```
+
+GORM's `AutoMigrate` (run at startup) adds the column to existing DBs with the `0` default — no manual migration file needed. Confirm `AutoMigrate(&MapsDownload{})` is already in the migration list (it is — `maps_downloads` exists today).
+
+In `pkg/configstore/seed_downloads.go`, add `max_zoom` to the `cols` map in `UpsertMapsDownload`:
+
+```go
+	cols := map[string]any{
+		"slug":             d.Slug,
+		"status":           d.Status,
+		"bytes_total":      d.BytesTotal,
+		"bytes_downloaded": d.BytesDownloaded,
+		"downloaded_at":    d.DownloadedAt,
+		"error_message":    d.ErrorMessage,
+		"max_zoom":         d.MaxZoom,
+	}
+```
+
+`max_zoom` is written unconditionally (unlike `bbox`, which is guarded): status-transition upserts pass `MaxZoom: 0`, which is correct for every regional row and harmless until the world row is set at Start. The Start path (Task B5) writes the real value before any status transition.
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `go test ./pkg/configstore/ -run TestUpsertMapsDownloadMaxZoom -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/configstore/models.go pkg/configstore/seed_downloads.go pkg/configstore/seed_downloads_test.go
+git commit -m "feat(configstore): persist max_zoom on downloads"
+```
+
+## Task B5: Thread maxZoom through the download Start path
+
+**Files:**
+- Modify: `pkg/mapscache/manager.go` (`Start` signature + the initial row write)
+- Modify: `pkg/webapi/downloads.go` (`startDownload`, `lookupCatalogBBox` → also return maxZoom)
+- Test: `pkg/webapi/downloads_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `pkg/webapi/downloads_test.go`, add a unit test for the catalog lookup helper (rename target — see Step 3):
+
+```go
+func TestLookupCatalogEntryWorld(t *testing.T) {
+	c := mapscatalog.Catalog{World: &mapscatalog.WorldMap{
+		BBox: &[4]float64{-180, -85.05, 180, 85.05}, MaxZoom: 7,
+	}}
+	bbox, maxZoom, found := lookupCatalogEntry(c, "world")
+	if !found || maxZoom != 7 || bbox == nil {
+		t.Fatalf("lookupCatalogEntry(world) = (%v,%d,%v), want (non-nil,7,true)", bbox, maxZoom, found)
+	}
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./pkg/webapi/ -run TestLookupCatalogEntryWorld -v`
+Expected: FAIL — `undefined: lookupCatalogEntry`.
+
+- [ ] **Step 3: Extend the lookup to return maxZoom and handle world**
+
+In `pkg/mapscache/manager.go`, change `Start` to accept a maxZoom:
+
+```go
+func (m *Manager) Start(ctx context.Context, slug string, bbox *[4]float64, maxZoom int) error {
+```
+
+and set it on the initial row written inside `Start` (the `MapsDownload{...}` literal that records `Slug`, `Status`, `BBox`):
+
+```go
+		MaxZoom: maxZoom,
+```
+
+In `pkg/webapi/downloads.go`, rename `lookupCatalogBBox` to `lookupCatalogEntry`, returning maxZoom too, and add the `world` case:
+
+```go
+// lookupCatalogEntry returns the bbox and maxZoom for a namespaced
+// slug in the catalog, or (nil, 0, false) if the slug names no
+// published archive. Regional entries have no zoom cap and report
+// maxZoom 0; the world archive reports its real cap (e.g. 7).
+func lookupCatalogEntry(c mapscatalog.Catalog, slug string) (*[4]float64, int, bool) {
+	kind, a, b, ok := parseSlug(slug)
+	if !ok {
+		return nil, 0, false
+	}
+	switch kind {
+	case "world":
+		if c.World == nil {
+			return nil, 0, false
+		}
+		return c.World.BBox, c.World.MaxZoom, true
+	case "state":
+		for _, st := range c.States {
+			if st.Slug == a {
+				return st.BBox, 0, true
+			}
+		}
+	case "country":
+		for _, x := range c.Countries {
+			if x.ISO2 == a {
+				return x.BBox, 0, true
+			}
+		}
+	case "province":
+		for _, p := range c.Provinces {
+			if p.ISO2 == a && p.Slug == b {
+				return p.BBox, 0, true
+			}
+		}
+	}
+	return nil, 0, false
+}
+```
+
+(Preserve the exact existing branch bodies for state/country/province — only the return arity and the new `world` case change. Match the existing helper's `parseSlug` call.)
+
+Update `startDownload` to use the new helper and pass maxZoom:
+
+```go
+	bbox, maxZoom, found := lookupCatalogEntry(cat, slug)
+	if !found {
+		badRequest(w, "unknown slug")
+		return
+	}
+	if err := s.mapsCache.Start(r.Context(), slug, bbox, maxZoom); err != nil {
+```
+
+- [ ] **Step 4: Fix all other `Start` / `lookupCatalogBBox` callers**
+
+Run: `grep -rn "lookupCatalogBBox\|\.Start(" pkg/ | grep -i "maps\|catalog\|cache"`
+Update every remaining caller (e.g. any in `manager_test.go`, `downloads_test.go`, app wiring) to the new signatures. For regional/test calls pass `0` as maxZoom.
+
+- [ ] **Step 5: Run the tests to confirm they pass**
+
+Run: `go test ./pkg/webapi/ ./pkg/mapscache/ -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/mapscache/manager.go pkg/webapi/downloads.go pkg/webapi/downloads_test.go
+git commit -m "feat: snapshot world maxZoom at download start"
+```
+
+## Task B6: Return maxZoom from /api/maps/local-bounds
+
+**Files:**
+- Modify: `pkg/webapi/dto/` (the `LocalBounds` type)
+- Modify: `pkg/webapi/local_bounds.go`
+- Test: `pkg/webapi/local_bounds_test.go` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend `pkg/webapi/local_bounds_test.go` to assert the handler emits maxZoom. Mirror the construction style of the other handler tests in `pkg/webapi`:
+
+```go
+func TestLocalBoundsIncludesMaxZoom(t *testing.T) {
+	s := newTestServer(t) // existing webapi test helper
+	ctx := context.Background()
+	bbox := `[-180,-85.05,180,85.05]`
+	must(t, s.store.UpsertMapsDownload(ctx, configstore.MapsDownload{
+		Slug: "world", Status: "complete", MaxZoom: 7, BBox: &bbox,
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/maps/local-bounds", nil)
+	s.getLocalBounds(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var out map[string]struct {
+		BBox    [4]float64 `json:"bbox"`
+		MaxZoom int        `json:"maxZoom"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out["world"].MaxZoom != 7 {
+		t.Fatalf("world maxZoom = %d, want 7", out["world"].MaxZoom)
+	}
+}
+```
+
+(If the existing webapi tests use a different server constructor/helpers, reuse those exactly.)
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./pkg/webapi/ -run TestLocalBoundsIncludesMaxZoom -v`
+Expected: FAIL — the response is currently a bare `slug -> [4]float64` map, so `MaxZoom` is `0`.
+
+- [ ] **Step 3: Change the DTO shape and handler**
+
+Today `dto.LocalBounds` is `map[string]([4]float64)`. Change it to a per-slug object. In `pkg/webapi/dto/` (find the file defining `LocalBounds`):
+
+```go
+// LocalBoundsEntry is the render-path coverage for one downloaded slug.
+type LocalBoundsEntry struct {
+	BBox    [4]float64 `json:"bbox"`
+	MaxZoom int        `json:"maxZoom"` // 0 = no cap (regional); >0 = world archive cap
+}
+
+// LocalBounds maps each completed download's slug to its coverage.
+type LocalBounds map[string]LocalBoundsEntry
+```
+
+In `pkg/webapi/local_bounds.go`, populate the new shape:
+
+```go
+		out[row.Slug] = dto.LocalBoundsEntry{BBox: bbox, MaxZoom: row.MaxZoom}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `go test ./pkg/webapi/ -run TestLocalBoundsIncludesMaxZoom -v`
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate API docs + TS client**
+
+Run: `make docs-check api-client-check` (or the repo's regen target — check `Makefile`). Commit the regenerated `pkg/webapi/docs/*` and `web/src/api/generated/*`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/webapi/dto pkg/webapi/local_bounds.go pkg/webapi/local_bounds_test.go pkg/webapi/docs web/src/api/generated
+git commit -m "feat(webapi): local-bounds returns per-slug maxZoom"
+```
+
+## Task B7: Expose maxZoom in the local-bounds store
+
+**Files:**
+- Modify: `web/src/lib/maps/local-bounds-store.svelte.js`
+
+- [ ] **Step 1: Update the store to the new payload shape**
+
+The endpoint now returns `{ [slug]: { bbox: [w,s,e,n], maxZoom: N } }`. Update the `boundsBySlug` getter to read `.bbox`, and add a `maxZoomBySlug` getter:
+
+```js
+  return {
+    load,
+    refresh,
+    get boundsBySlug() {
+      const out = new Map();
+      if (!raw) return out;
+      for (const [slug, entry] of Object.entries(raw)) {
+        const bbox = entry && entry.bbox;
+        if (Array.isArray(bbox) && bbox.length === 4) out.set(slug, bbox);
+      }
+      return out;
+    },
+    get maxZoomBySlug() {
+      const out = new Map();
+      if (!raw) return out;
+      for (const [slug, entry] of Object.entries(raw)) {
+        if (entry && Number.isFinite(entry.maxZoom)) out.set(slug, entry.maxZoom);
+      }
+      return out;
+    },
+  };
+```
+
+- [ ] **Step 2: Verify the build typechecks**
+
+Run: `cd web && npm run check` (or the repo's svelte-check target).
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/lib/maps/local-bounds-store.svelte.js
+git commit -m "feat(web): expose maxZoomBySlug from local-bounds store"
+```
+
+## Task B8: Area-ranked dispatch + maxZoom-aware miss in the federated protocol
+
+**Files:**
+- Modify: `web/src/lib/map/sources/gw-federated-protocol.js`
+- Test: `web/src/lib/map/sources/gw-federated-protocol.test.js` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/lib/map/sources/gw-federated-protocol.test.js`. The module currently has no exported pure helper for ranking; this test drives extracting one. Use the repo's JS test runner (check `web/package.json` `scripts.test` — likely `vitest`):
+
+```js
+import { describe, it, expect } from 'vitest';
+import { rankCoveringSlugs } from './gw-federated-protocol.js';
+
+describe('rankCoveringSlugs', () => {
+  const tileBBox = [38, -105, 40, -103]; // [sLat, wLon, nLat, eLon] inside Colorado
+  const bounds = new Map([
+    ['world', [-180, -85, 180, 85]],
+    ['state/colorado', [-109, 37, -102, 41]],
+  ]);
+
+  it('ranks the smaller (more specific) bbox first, world last', () => {
+    const ranked = rankCoveringSlugs(tileBBox, new Set(['world', 'state/colorado']), bounds);
+    expect(ranked).toEqual(['state/colorado', 'world']);
+  });
+
+  it('omits non-intersecting slugs', () => {
+    const farTile = [-40, 100, -38, 102]; // southern hemisphere, far from CO
+    const ranked = rankCoveringSlugs(farTile, new Set(['state/colorado', 'world']), bounds);
+    expect(ranked).toEqual(['world']);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cd web && npx vitest run src/lib/map/sources/gw-federated-protocol.test.js`
+Expected: FAIL — `rankCoveringSlugs` is not exported.
+
+- [ ] **Step 3: Implement area-ranked dispatch**
+
+In `gw-federated-protocol.js`, replace `findCoveringSlug` with an exported `rankCoveringSlugs` that returns ALL intersecting slugs sorted by ascending bbox area (smallest/most-specific first; the global world bbox sorts last):
+
+```js
+// bboxArea: lon-span * lat-span of a [w, s, e, n] tuple. Used only to
+// rank overlapping archives by specificity, so a plain rectangular
+// area (no spherical correction) is sufficient and monotonic.
+function bboxArea([w, s, e, n]) {
+  return Math.max(0, e - w) * Math.max(0, n - s);
+}
+
+// rankCoveringSlugs returns every slug whose bbox intersects the tile,
+// ordered smallest-bbox-first. A more specific regional archive is
+// therefore tried before the globe-spanning world archive, so a user
+// who has both renders the region at full detail.
+export function rankCoveringSlugs(tileBBox, completedSlugs, boundsBySlug) {
+  const hits = [];
+  for (const slug of completedSlugs) {
+    const bbox = boundsBySlug.get(slug);
+    if (!bbox) continue;
+    if (bboxIntersects(tileBBox, bbox)) hits.push({ slug, area: bboxArea(bbox) });
+  }
+  hits.sort((a, b) => a.area - b.area);
+  return hits.map((h) => h.slug);
+}
+```
+
+Rewrite the handler body to walk the ranked list, trying each archive until one yields the tile, falling back to the network only after all miss:
+
+```js
+      const tileBBox = tileToBBox(z, x, y);
+      const completed = completedSlugsProvider();
+      const bounds = boundsBySlugProvider();
+      const maxZoomBySlug =
+        typeof maxZoomBySlugProvider === 'function' ? maxZoomBySlugProvider() : new Map();
+
+      const ranked = rankCoveringSlugs(tileBBox, completed, bounds);
+      const fallback = () =>
+        fetchOnline(z, x, y, abortController.signal).then((data) => ({ data }));
+
+      if (ranked.length === 0) return fallback();
+
+      const tryNext = (i) => {
+        if (i >= ranked.length) return fallback();
+        const slug = ranked[i];
+        const cap = maxZoomBySlug.get(slug);
+        // Skip archives that provably cannot hold this zoom (world
+        // archive at z>cap). Avoids a guaranteed-miss range read; the
+        // source maxzoom (Task B9) makes MapLibre overzoom instead.
+        if (typeof cap === 'number' && cap > 0 && z > cap) return tryNext(i + 1);
+        return getArchive(slug)
+          .getZxy(z, x, y, abortController.signal)
+          .then((tile) => {
+            if (tile && tile.data) return { data: new Uint8Array(tile.data) };
+            return tryNext(i + 1);
+          })
+          .catch(() => tryNext(i + 1));
+      };
+      return tryNext(0);
+```
+
+Add `maxZoomBySlugProvider` to the destructured params of `createFederatedProtocol`:
+
+```js
+export function createFederatedProtocol({
+  completedSlugsProvider,
+  boundsBySlugProvider,
+  maxZoomBySlugProvider,
+  fetchOnline,
+}) {
+```
+
+Keep `tileToBBox` and `bboxIntersects` unchanged.
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `cd web && npx vitest run src/lib/map/sources/gw-federated-protocol.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/map/sources/gw-federated-protocol.js web/src/lib/map/sources/gw-federated-protocol.test.js
+git commit -m "feat(web): area-ranked federated tile dispatch with maxZoom skip"
+```
+
+## Task B9: Wire maxZoom provider + dynamic source maxzoom in the map component
+
+**Files:**
+- Modify: `web/src/lib/map/maplibre-map.svelte`
+
+- [ ] **Step 1: Pass the new provider into the protocol**
+
+In the `createFederatedProtocol({ ... })` call (around line 49), add:
+
+```js
+      maxZoomBySlugProvider: () => localBoundsStore.maxZoomBySlug,
+```
+
+- [ ] **Step 2: Cap the gw-tile source maxzoom when coverage is world-only**
+
+Where the style's vector source is rewritten to `gw-tile://{z}/{x}/{y}` (around line 101, `src.tiles = [...]`), set the source `maxzoom` to the world cap **only when** the world archive is the sole completed download — otherwise leave the upstream max so regional detail still loads:
+
+```js
+        src.tiles = ['gw-tile://{z}/{x}/{y}'];
+        // When the user's ONLY offline coverage is the world archive,
+        // cap the source so MapLibre overzooms the z7 tile instead of
+        // requesting z8+ (which would miss offline -> blank). With any
+        // full-detail regional download present, keep the upstream max
+        // so that region renders at z14; world-only areas at high zoom
+        // then rely on MapLibre's parent-tile retention.
+        const completed = downloadsState.completed;
+        const worldCap = localBoundsStore.maxZoomBySlug.get('world');
+        if (completed.size === 1 && completed.has('world') && worldCap) {
+          src.maxzoom = worldCap;
+        }
+```
+
+- [ ] **Step 3: Manual verification (online + offline)**
+
+Build and run the app (`make build` / the repo's dev target). Then:
+1. Online, no downloads: map renders worldwide from the network as before (no regression).
+2. Download `world`: confirm the request hits `/api/maps/downloads/world` → `202`, file lands at `<TileCacheDir>/world.pmtiles`, status reaches `complete`.
+3. Disconnect network; reload: the world basemap renders globally at low zoom and overzooms (stays rendered, coarse) past z7.
+4. With `world` + a state download, offline: the state area renders at full z14 detail; outside it, the coarse world layer shows. Confirm the state is not replaced by the world layer (area-ranking working).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/lib/map/maplibre-map.svelte
+git commit -m "feat(web): world-only source maxzoom + maxZoom provider"
+```
+
+## Task B10: Surface the World entry in the region picker
+
+**Files:**
+- Modify: `web/src/lib/maps/catalog-tree.js`
+- Test: `web/src/lib/maps/catalog-tree.test.js` (extend if present, else create)
+- Modify: `web/src/lib/maps/region-picker.svelte`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `catalog-tree.test.js` a test that the world entry is projected to a downloadable node:
+
+```js
+import { describe, it, expect } from 'vitest';
+import { buildWorldNode } from './catalog-tree.js';
+
+describe('buildWorldNode', () => {
+  it('returns a node for a catalog with world', () => {
+    const node = buildWorldNode({ world: { name: 'World (low detail)', sizeBytes: 314572800, bbox: [-180, -85, 180, 85], maxZoom: 7 } });
+    expect(node).toEqual({ slug: 'world', name: 'World (low detail)', sizeBytes: 314572800 });
+  });
+  it('returns null when the catalog has no world', () => {
+    expect(buildWorldNode({})).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cd web && npx vitest run src/lib/maps/catalog-tree.test.js`
+Expected: FAIL — `buildWorldNode` is not exported.
+
+- [ ] **Step 3: Implement `buildWorldNode`**
+
+Add to `catalog-tree.js`:
+
+```js
+// buildWorldNode projects the optional top-level world archive into a
+// flat picker node, or null when the catalog has no world entry. Kept
+// separate from buildCountryTree because the world archive is not a
+// country and has no children.
+export function buildWorldNode(catalog) {
+  const w = catalog && catalog.world;
+  if (!w) return null;
+  return { slug: 'world', name: w.name || 'World (low detail)', sizeBytes: w.sizeBytes || 0 };
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `cd web && npx vitest run src/lib/maps/catalog-tree.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Render the World row in the picker**
+
+In `region-picker.svelte`, import the helper and compute the node:
+
+```js
+  import { buildCountryTree, /* keep existing */ } from './catalog-tree.js';
+  import { buildWorldNode } from './catalog-tree.js';
+```
+
+Add a derived value alongside `filteredTree`:
+
+```js
+  const worldNode = $derived(catalogStore.catalog ? buildWorldNode(catalogStore.catalog) : null);
+```
+
+In the markup, render a dedicated World row above the country list (inside the same results container, after the loading/error guards and before `{#each filteredTree ...}`). Mirror the existing country-row button logic (`statusOf`, `downloadsState.start/remove/cancel`, `formatBytes`):
+
+```svelte
+        {#if worldNode}
+          {@const wItem = statusOf(worldNode.slug)}
+          <div class="region-row region-row-world">
+            <span class="region-name">{worldNode.name}</span>
+            {#if worldNode.sizeBytes > 0}
+              <span class="region-size">{formatBytes(worldNode.sizeBytes)}</span>
+            {/if}
+            {#if !wItem}
+              <Button onclick={() => downloadsState.start(worldNode.slug)}>Download</Button>
+            {:else if wItem.state === 'complete'}
+              <Button variant="danger" onclick={() => downloadsState.remove(worldNode.slug)}>Delete</Button>
+            {:else}
+              <Button variant="danger" onclick={() => downloadsState.cancel(worldNode.slug)}>Cancel</Button>
+            {/if}
+          </div>
+        {/if}
+```
+
+(Match the exact class names / button structure used by the existing country rows in this file — the snippet above is the pattern, not necessarily the verbatim class set. Reuse `formatBytes` and `statusOf` already in scope.)
+
+- [ ] **Step 6: Verify build + manual check**
+
+Run: `cd web && npm run check && npx vitest run`
+Then load the Offline maps picker: the "World (low detail) — ~300 MB" row appears at the top with a Download button, and downloading/deleting works end to end.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/lib/maps/catalog-tree.js web/src/lib/maps/catalog-tree.test.js web/src/lib/maps/region-picker.svelte
+git commit -m "feat(web): World row in the offline region picker"
+```
+
+## Task B11: Docs
+
+**Files:**
+- Modify: `docs/wiki/system-topology.md`
+- Modify: `docs/handbook/maps.html`
+
+- [ ] **Step 1: Update the wiki**
+
+In `docs/wiki/system-topology.md`, in the offline-maps section, note the new `world` slug (single global z0–7 archive, ~300 MB, served from `/download/world.pmtiles`) and that `local-bounds` now carries a per-slug `maxZoom`. Add a sentence that the federated dispatcher ranks archives by bbox area so the world archive never shadows a regional download.
+
+- [ ] **Step 2: Update the handbook**
+
+In `docs/handbook/maps.html`, add a short paragraph under the offline-maps coverage description: a single low-detail world map (~300 MB) is available for portable/HF/cross-border use, renders worldwide at low zoom, and coexists with full-detail regional downloads (regions win where they overlap).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/wiki/system-topology.md docs/handbook/maps.html
+git commit -m "docs: document downloadable world map"
+```
+
+## Task B12: Full verification pass
+
+- [ ] **Step 1: Go tests + vet + lint**
+
+Run: `go test ./... && go vet ./...`
+Expected: PASS. (Then the repo's lint target if `make lint` exists.)
+
+- [ ] **Step 2: Frontend tests + check + build**
+
+Run: `cd web && npx vitest run && npm run check && npm run build`
+Expected: PASS, clean build.
+
+- [ ] **Step 3: Docs/API regen guard**
+
+Run: `make docs-check api-client-check`
+Expected: no diff (artifacts already committed in Task B6).
+
+- [ ] **Step 4: End-to-end against the live Worker (requires Phase A deployed)**
+
+With a registered device token: open the picker → Download World → confirm `complete` and a ~300 MB `world.pmtiles` on disk → go offline → confirm worldwide low-zoom render. This is the GH #209 acceptance criterion.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** GH #209 asks for a z1→"whatever fits in a few hundred MiB" world map ≈ size of existing downloads — Phase A (z0–7 ≈ 300 MB) + B10 (picker entry) + B12 step 4 (offline render) cover it. Portable/HF/cross-border use cases are served by the global low-zoom coverage. The "regions still win" and "doesn't go blank above z7 offline" concerns from the GRA-72 assessment are Tasks B8/B9.
+- **Type consistency:** `WorldMap.MaxZoom` (Go) → `maps_downloads.max_zoom` → `dto.LocalBoundsEntry.MaxZoom` (`json:"maxZoom"`) → store `maxZoomBySlug` → protocol `maxZoomBySlugProvider`. Slug literal `"world"` is identical across `mapsslug.Parse`, `mapscatalog` index, `manager.urlForSlug`, `lookupCatalogEntry`, `buildWorldNode`, and the source-maxzoom check. `lookupCatalogBBox` is renamed to `lookupCatalogEntry` everywhere (B5 step 4 sweeps callers).
+- **Cross-repo seam:** the slug/route/manifest contract table is the single source of truth both phases build against; Phase A must land (or be mockable) before B12 step 4.

--- a/docs/wiki/system-topology.md
+++ b/docs/wiki/system-topology.md
@@ -165,8 +165,11 @@ gate on outbound IS messages.
 
 The Worker exposes `GET /manifest.json` (auth-gated) returning the
 public download catalog: `{ schemaVersion: 1, generatedAt, countries[],
-provinces[], states[] }`. Internal R2 paths and build provenance are
-stripped before the response leaves the Worker.
+provinces[], states[], world? }`. Internal R2 paths and build
+provenance are stripped before the response leaves the Worker. The
+optional top-level `world` object (`{ name, sizeBytes, sha256, bbox,
+maxZoom }`) is the single global low-detail basemap (z0-7, ~300 MB);
+unlike the regional entries it carries a `maxZoom` cap.
 
 Graywolf proxies that catalog at `GET /api/maps/catalog`. The
 in-process [`pkg/mapscatalog/`](../../pkg/mapscatalog/) cache holds the
@@ -182,11 +185,14 @@ lockstep to dodge an import cycle):
 - `country/<iso2>` -- e.g. `country/de` (cn and ru are forbidden at
   parse time, not just catalog membership)
 - `province/<iso2>/<slug>` -- e.g. `province/ca/british-columbia`
+- `world` -- the single global archive (no sub-segments), served from
+  `/download/world.pmtiles`
 
 On disk the slashes become subdirectory separators:
 `<TileCacheDir>/state/colorado.pmtiles`,
 `<TileCacheDir>/country/de.pmtiles`,
-`<TileCacheDir>/province/ca/british-columbia.pmtiles`. Pre-namespaced
+`<TileCacheDir>/province/ca/british-columbia.pmtiles`,
+`<TileCacheDir>/world.pmtiles`. Pre-namespaced
 installs (where every archive sat directly in `<TileCacheDir>/`) are
 migrated on startup by `mapsCache.MigrateLegacyArchives` (file move)
 and `store.MigrateMapsDownloadSlugs` (DB row update); both idempotent.
@@ -196,6 +202,19 @@ prefix and `.pmtiles` suffix, sets the rest as the slug, and delegates
 to `webapi.Server.ServeTilesPMTiles`. Catalog membership is rechecked
 on every tile request; the cache is in-process so the cost is a map
 lookup.
+
+The offline-safe render-bounds source `GET /api/maps/local-bounds`
+returns, per completed slug, `{ bbox, maxZoom }` snapshotted into
+`maps_downloads` at download time (`maxZoom` is 0 for regional
+archives, >0 for the capped world archive). The browser-side federated
+tile dispatcher (`web/.../gw-federated-protocol.js`) ranks every
+archive whose bbox covers a tile by ascending bbox area, so a regional
+download is always tried before the globe-spanning `world` archive and
+never shadowed by it. The world archive's `maxZoom` lets the dispatcher
+skip zooms it cannot hold; when `world` is the *only* download, the
+MapLibre vector source is registered with that `maxzoom` so the client
+overzooms the top tile instead of requesting (and missing) higher zooms
+offline.
 
 ### Offline maps style assets
 

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -562,7 +562,12 @@ type MapsDownload struct {
 	// startup backfill reads the value from the pmtiles archive header.
 	// Render-path correctness depends on this column being populated
 	// for every completed download.
-	BBox      *string   `gorm:"column:bbox;type:text" json:"bbox,omitempty"`
+	BBox *string `gorm:"column:bbox;type:text" json:"bbox,omitempty"`
+	// MaxZoom is the archive's top zoom level, snapshotted from the
+	// catalog at download-start time. 0 means "no cap" (regional,
+	// full-detail archives); the world archive carries its real cap
+	// (e.g. 7) so the offline render path overzooms its top tile.
+	MaxZoom   int       `gorm:"not null;default:0" json:"max_zoom"`
 	CreatedAt time.Time `json:"-"`
 	UpdatedAt time.Time `json:"-"`
 }

--- a/pkg/configstore/seed_downloads.go
+++ b/pkg/configstore/seed_downloads.go
@@ -83,6 +83,16 @@ func (s *Store) UpsertMapsDownload(ctx context.Context, d MapsDownload) error {
 	if d.BBox != nil {
 		cols["bbox"] = d.BBox
 	}
+	// max_zoom follows the same "set if meaningful, leave untouched
+	// otherwise" rule as bbox. Start snapshots the world archive's cap
+	// (>0); the later downloading/complete status-transition upserts
+	// construct a fresh row with MaxZoom==0, and writing that
+	// unconditionally would wipe the cap. Regional archives are always
+	// 0 (no cap) and rely on the column default, so skipping the write
+	// for 0 is correct for them too.
+	if d.MaxZoom != 0 {
+		cols["max_zoom"] = d.MaxZoom
+	}
 	if d.ID == 0 {
 		return db.Model(&MapsDownload{}).Create(cols).Error
 	}

--- a/pkg/configstore/seed_downloads_test.go
+++ b/pkg/configstore/seed_downloads_test.go
@@ -146,3 +146,34 @@ func TestUpsertMapsDownload_NilBBoxOnFreshInsertStaysNull(t *testing.T) {
 		t.Fatalf("expected NULL bbox throughout, got %q", *got.BBox)
 	}
 }
+
+func TestUpsertMapsDownloadMaxZoom(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	if err := s.UpsertMapsDownload(ctx, MapsDownload{
+		Slug: "world", Status: "complete", MaxZoom: 7,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetMapsDownload(ctx, "world")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MaxZoom != 7 {
+		t.Fatalf("MaxZoom = %d, want 7", got.MaxZoom)
+	}
+	// A later status-transition upsert (fresh row, MaxZoom==0) must NOT
+	// wipe the snapshotted cap.
+	if err := s.UpsertMapsDownload(ctx, MapsDownload{
+		Slug: "world", Status: "downloading",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.GetMapsDownload(ctx, "world")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MaxZoom != 7 {
+		t.Fatalf("MaxZoom after status transition = %d, want 7 (must not be wiped)", got.MaxZoom)
+	}
+}

--- a/pkg/mapscache/manager.go
+++ b/pkg/mapscache/manager.go
@@ -116,6 +116,8 @@ func (m *Manager) urlForSlug(slug, token string) (string, error) {
 		raw = fmt.Sprintf("%s/download/country/%s.pmtiles", base, a)
 	case "province":
 		raw = fmt.Sprintf("%s/download/province/%s/%s.pmtiles", base, a, b)
+	case "world":
+		raw = fmt.Sprintf("%s/download/world.pmtiles", base)
 	}
 	if token == "" {
 		return raw, nil

--- a/pkg/mapscache/manager.go
+++ b/pkg/mapscache/manager.go
@@ -202,7 +202,7 @@ func (m *Manager) List(ctx context.Context) ([]Status, error) {
 // path can serve offline tiles without consulting the remote catalog
 // after a reboot. Pass nil only when no bbox is available; the startup
 // backfill will fill it in from the pmtiles header later.
-func (m *Manager) Start(ctx context.Context, slug string, bbox *[4]float64) error {
+func (m *Manager) Start(ctx context.Context, slug string, bbox *[4]float64, maxZoom int) error {
 	m.mu.Lock()
 	if _, busy := m.inflight[slug]; busy {
 		m.mu.Unlock()
@@ -217,8 +217,9 @@ func (m *Manager) Start(ctx context.Context, slug string, bbox *[4]float64) erro
 	// returns the right state even before the goroutine grabs the
 	// semaphore.
 	row := configstore.MapsDownload{
-		Slug:   slug,
-		Status: "downloading",
+		Slug:    slug,
+		Status:  "downloading",
+		MaxZoom: maxZoom,
 	}
 	if bbox != nil {
 		encoded := encodeBBox(*bbox)

--- a/pkg/mapscache/manager_test.go
+++ b/pkg/mapscache/manager_test.go
@@ -274,6 +274,7 @@ func TestURLForSlug(t *testing.T) {
 		{"state/colorado", "https://maps.example/download/state/colorado.pmtiles"},
 		{"country/de", "https://maps.example/download/country/de.pmtiles"},
 		{"province/ca/british-columbia", "https://maps.example/download/province/ca/british-columbia.pmtiles"},
+		{"world", "https://maps.example/download/world.pmtiles"},
 	}
 	for _, tc := range cases {
 		got, err := m.urlForSlug(tc.slug, "")
@@ -283,6 +284,9 @@ func TestURLForSlug(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("urlForSlug(%q) = %q, want %q", tc.slug, got, tc.want)
 		}
+	}
+	if p := m.PathFor("world"); !strings.HasSuffix(p, "world.pmtiles") {
+		t.Fatalf("PathFor(world) = %q, want suffix world.pmtiles", p)
 	}
 }
 

--- a/pkg/mapscache/manager_test.go
+++ b/pkg/mapscache/manager_test.go
@@ -54,7 +54,7 @@ func TestManager_HappyPath(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	if err := mgr.Start(context.Background(), "state/georgia", nil); err != nil {
+	if err := mgr.Start(context.Background(), "state/georgia", nil, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -97,10 +97,10 @@ func TestManager_AlreadyInflight(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	if err := mgr.Start(context.Background(), "state/texas", nil); err != nil {
+	if err := mgr.Start(context.Background(), "state/texas", nil, 0); err != nil {
 		t.Fatal(err)
 	}
-	err := mgr.Start(context.Background(), "state/texas", nil)
+	err := mgr.Start(context.Background(), "state/texas", nil, 0)
 	if !errors.Is(err, ErrAlreadyInflight) {
 		t.Fatalf("expected ErrAlreadyInflight, got %v", err)
 	}
@@ -113,7 +113,7 @@ func TestManager_DeleteDuringActiveDownload(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	if err := mgr.Start(context.Background(), "state/ohio", nil); err != nil {
+	if err := mgr.Start(context.Background(), "state/ohio", nil, 0); err != nil {
 		t.Fatal(err)
 	}
 	// Give the goroutine a moment to start the request
@@ -148,7 +148,7 @@ func TestManager_CancelLeavesNoErrorRow(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	if err := mgr.Start(context.Background(), "state/nebraska", nil); err != nil {
+	if err := mgr.Start(context.Background(), "state/nebraska", nil, 0); err != nil {
 		t.Fatal(err)
 	}
 	// Let the goroutine grab the semaphore, issue the request, and start
@@ -190,7 +190,7 @@ func TestManager_BadUpstreamStatus(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	if err := mgr.Start(context.Background(), "state/florida", nil); err != nil {
+	if err := mgr.Start(context.Background(), "state/florida", nil, 0); err != nil {
 		t.Fatal(err)
 	}
 	deadline := time.Now().Add(2 * time.Second)
@@ -232,7 +232,7 @@ func TestManager_RetryAfterError(t *testing.T) {
 	})
 	mgr, _, _ := newTestManager(t, upstream)
 
-	_ = mgr.Start(context.Background(), "state/ohio", nil)
+	_ = mgr.Start(context.Background(), "state/ohio", nil, 0)
 	// Wait for first attempt to fail
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -244,7 +244,7 @@ func TestManager_RetryAfterError(t *testing.T) {
 	}
 
 	// Second attempt
-	if err := mgr.Start(context.Background(), "state/ohio", nil); err != nil {
+	if err := mgr.Start(context.Background(), "state/ohio", nil, 0); err != nil {
 		t.Fatal(err)
 	}
 	deadline = time.Now().Add(2 * time.Second)
@@ -405,7 +405,7 @@ func TestStart_SnapshotsBBoxIntoFirstRow(t *testing.T) {
 	mgr, store, _ := newTestManager(t, silentUpstream())
 
 	bbox := [4]float64{-109.05, 36.99, -102.04, 41.0}
-	if err := mgr.Start(ctx, "state/colorado", &bbox); err != nil {
+	if err := mgr.Start(ctx, "state/colorado", &bbox, 0); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
@@ -426,7 +426,7 @@ func TestStart_NilBBoxLeavesColumnNull(t *testing.T) {
 	ctx := context.Background()
 	mgr, store, _ := newTestManager(t, silentUpstream())
 
-	if err := mgr.Start(ctx, "state/wyoming", nil); err != nil {
+	if err := mgr.Start(ctx, "state/wyoming", nil, 0); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	row, err := store.GetMapsDownload(ctx, "state/wyoming")

--- a/pkg/mapscatalog/catalog.go
+++ b/pkg/mapscatalog/catalog.go
@@ -48,12 +48,25 @@ type State struct {
 	BBox      *[4]float64 `json:"bbox,omitempty"`
 }
 
+// WorldMap is the single global low-zoom basemap archive. Unlike the
+// regional entries it carries a MaxZoom: the archive is capped (e.g.
+// z7), so the offline render path overzooms its top tile rather than
+// requesting zooms the archive does not contain.
+type WorldMap struct {
+	Name      string      `json:"name"`
+	SizeBytes int64       `json:"sizeBytes"`
+	SHA256    string      `json:"sha256"`
+	BBox      *[4]float64 `json:"bbox,omitempty"`
+	MaxZoom   int         `json:"maxZoom"`
+}
+
 type Catalog struct {
 	SchemaVersion int        `json:"schemaVersion"`
 	GeneratedAt   string     `json:"generatedAt"`
 	Countries     []Country  `json:"countries"`
 	Provinces     []Province `json:"provinces"`
 	States        []State    `json:"states"`
+	World         *WorldMap  `json:"world,omitempty"`
 
 	// slugIndex is a lazily-built O(1) membership lookup populated by
 	// indexSlugs. Not serialized; rebuilt on every fresh fetch.
@@ -88,6 +101,9 @@ func (c *Catalog) HasSlug(slug string) bool {
 			return true
 		}
 	}
+	if c.World != nil && slug == "world" {
+		return true
+	}
 	return false
 }
 
@@ -103,6 +119,9 @@ func (c *Catalog) indexSlugs() {
 	}
 	for _, p := range c.Provinces {
 		idx["province/"+p.ISO2+"/"+p.Slug] = struct{}{}
+	}
+	if c.World != nil {
+		idx["world"] = struct{}{}
 	}
 	c.slugIndex = idx
 }

--- a/pkg/mapscatalog/catalog_test.go
+++ b/pkg/mapscatalog/catalog_test.go
@@ -260,3 +260,21 @@ func TestNew_NoDiskCacheStillFunctions(t *testing.T) {
 		t.Fatalf("Refresh: %v", err)
 	}
 }
+
+func TestHasSlugWorld(t *testing.T) {
+	c := Catalog{World: &WorldMap{Name: "World", SizeBytes: 1, MaxZoom: 7}}
+	c.indexSlugs()
+	if !c.HasSlug("world") {
+		t.Fatal("HasSlug(\"world\") = false, want true")
+	}
+	empty := Catalog{}
+	empty.indexSlugs()
+	if empty.HasSlug("world") {
+		t.Fatal("HasSlug(\"world\") = true on catalog without world, want false")
+	}
+	// Linear-scan fallback (no index built).
+	noIdx := Catalog{World: &WorldMap{MaxZoom: 7}}
+	if !noIdx.HasSlug("world") {
+		t.Fatal("HasSlug fallback for world = false, want true")
+	}
+}

--- a/pkg/mapsslug/slug.go
+++ b/pkg/mapsslug/slug.go
@@ -8,6 +8,7 @@
 //	state/<state-slug>
 //	country/<iso2>           (iso2 != cn|ru)
 //	province/<iso2>/<slug>   (iso2 != cn|ru)
+//	world                    (single global archive, z0-7)
 //
 // state-slug and province-slug: ^[a-z][a-z0-9-]{0,49}$
 // iso2: ^[a-z]{2}$
@@ -59,6 +60,11 @@ func Parse(s string) (kind, a, b string, ok bool) {
 			return "", "", "", false
 		}
 		return "province", parts[1], parts[2], true
+	case "world":
+		if len(parts) != 1 {
+			return "", "", "", false
+		}
+		return "world", "", "", true
 	}
 	return "", "", "", false
 }

--- a/pkg/mapsslug/slug_test.go
+++ b/pkg/mapsslug/slug_test.go
@@ -1,0 +1,38 @@
+package mapsslug
+
+import "testing"
+
+func TestParseWorld(t *testing.T) {
+	kind, a, b, ok := Parse("world")
+	if !ok || kind != "world" || a != "" || b != "" {
+		t.Fatalf("Parse(\"world\") = (%q,%q,%q,%v), want (\"world\",\"\",\"\",true)", kind, a, b, ok)
+	}
+	for _, bad := range []string{"world/", "world/base", "world/x/y", "World", "worldx"} {
+		if _, _, _, ok := Parse(bad); ok {
+			t.Errorf("Parse(%q) = ok, want rejected", bad)
+		}
+	}
+}
+
+func TestParseExisting(t *testing.T) {
+	cases := []struct {
+		in         string
+		kind, a, b string
+		ok         bool
+	}{
+		{"state/colorado", "state", "colorado", "", true},
+		{"country/de", "country", "de", "", true},
+		{"country/cn", "", "", "", false},
+		{"country/ru", "", "", "", false},
+		{"province/ca/british-columbia", "province", "ca", "british-columbia", true},
+		{"", "", "", "", false},
+		{"bogus/x", "", "", "", false},
+	}
+	for _, tc := range cases {
+		k, a, b, ok := Parse(tc.in)
+		if ok != tc.ok || k != tc.kind || a != tc.a || b != tc.b {
+			t.Errorf("Parse(%q) = (%q,%q,%q,%v), want (%q,%q,%q,%v)",
+				tc.in, k, a, b, ok, tc.kind, tc.a, tc.b, tc.ok)
+		}
+	}
+}

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1417,7 +1417,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1465,7 +1464,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1522,7 +1520,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1563,7 +1560,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1756,7 +1752,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1798,7 +1793,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -7430,8 +7424,7 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer",
-                        "format": "int32"
+                        "type": "integer"
                     }
                 },
                 "source": {
@@ -7681,8 +7674,7 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -7697,8 +7689,7 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -7708,8 +7699,7 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -7717,8 +7707,7 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -7730,8 +7719,7 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -7746,12 +7734,10 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "table": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 }
             }
         },
@@ -7761,8 +7747,7 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number",
-                        "format": "float64"
+                        "type": "number"
                     }
                 },
                 "analogHas": {
@@ -7778,8 +7763,7 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -7795,8 +7779,7 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -7804,8 +7787,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -7880,21 +7862,17 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain24Hour": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rainSinceMid": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -7902,8 +7880,7 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -7911,8 +7888,7 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -7924,13 +7900,11 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 }
             }
         },
@@ -10762,11 +10736,6 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
-            "x-enum-descriptions": [
-                "heard on the air",
-                "transmitted by us",
-                "APRS-IS upload/download (iGate)"
-            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -11077,8 +11046,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -11167,8 +11135,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1417,6 +1417,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1464,6 +1465,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1520,6 +1522,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1560,6 +1563,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1752,6 +1756,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1793,6 +1798,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -7424,7 +7430,8 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "int32"
                     }
                 },
                 "source": {
@@ -7674,7 +7681,8 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -7689,7 +7697,8 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -7699,7 +7708,8 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -7707,7 +7717,8 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -7719,7 +7730,8 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -7734,10 +7746,12 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "table": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 }
             }
         },
@@ -7747,7 +7761,8 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number"
+                        "type": "number",
+                        "format": "float64"
                     }
                 },
                 "analogHas": {
@@ -7763,7 +7778,8 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -7779,7 +7795,8 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -7787,7 +7804,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -7862,17 +7880,21 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rain24Hour": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rainSinceMid": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -7880,7 +7902,8 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -7888,7 +7911,8 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -7900,11 +7924,13 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 }
             }
         },
@@ -9534,9 +9560,20 @@
         "dto.LocalBounds": {
             "type": "object",
             "additionalProperties": {
-                "type": "array",
-                "items": {
-                    "type": "number"
+                "$ref": "#/definitions/dto.LocalBoundsEntry"
+            }
+        },
+        "dto.LocalBoundsEntry": {
+            "type": "object",
+            "properties": {
+                "bbox": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "maxZoom": {
+                    "type": "integer"
                 }
             }
         },
@@ -10725,6 +10762,11 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
+            "x-enum-descriptions": [
+                "heard on the air",
+                "transmitted by us",
+                "APRS-IS upload/download (iGate)"
+            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -11035,7 +11077,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -11124,7 +11167,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,6 +50,7 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
+          format: int32
           type: integer
         type: array
       source:
@@ -228,6 +229,7 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
+        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -239,6 +241,7 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
+        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -246,12 +249,14 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
+        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
+        format: float64
         type: number
       phg:
         allOf:
@@ -259,6 +264,7 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
+        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -269,14 +275,17 @@ definitions:
   aprs.Symbol:
     properties:
       code:
+        format: int32
         type: integer
       table:
+        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
+          format: float64
           type: number
         type: array
       analogHas:
@@ -289,6 +298,7 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
+        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -300,11 +310,13 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
+        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -357,25 +369,31 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
+        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
+        format: float64
         type: number
       rain24Hour:
+        format: float64
         type: number
       rainSinceMid:
+        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
+        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
+        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -385,9 +403,11 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
+        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
+        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -1509,9 +1529,16 @@ definitions:
     type: object
   dto.LocalBounds:
     additionalProperties:
-      items:
-        type: number
-      type: array
+      $ref: '#/definitions/dto.LocalBoundsEntry'
+    type: object
+  dto.LocalBoundsEntry:
+    properties:
+      bbox:
+        items:
+          type: number
+        type: array
+      maxZoom:
+        type: integer
     type: object
   dto.MapsConfigRequest:
     properties:
@@ -2412,6 +2439,10 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
+    x-enum-descriptions:
+      - heard on the air
+      - transmitted by us
+      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2626,6 +2657,7 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -2689,6 +2721,7 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -3828,6 +3861,7 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -3848,6 +3882,7 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -3878,6 +3913,7 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -3919,6 +3955,7 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4039,6 +4076,7 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4059,6 +4097,7 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
+          format: int32
           in: path
           name: id
           required: true

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,7 +50,6 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
-          format: int32
           type: integer
         type: array
       source:
@@ -229,7 +228,6 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
-        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -241,7 +239,6 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
-        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -249,14 +246,12 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
-        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
-        format: float64
         type: number
       phg:
         allOf:
@@ -264,7 +259,6 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
-        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -275,17 +269,14 @@ definitions:
   aprs.Symbol:
     properties:
       code:
-        format: int32
         type: integer
       table:
-        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
-          format: float64
           type: number
         type: array
       analogHas:
@@ -298,7 +289,6 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
-        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -310,13 +300,11 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
-        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -369,31 +357,25 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
-        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
-        format: float64
         type: number
       rain24Hour:
-        format: float64
         type: number
       rainSinceMid:
-        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
-        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
-        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -403,11 +385,9 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
-        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
-        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -2439,10 +2419,6 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
-    x-enum-descriptions:
-      - heard on the air
-      - transmitted by us
-      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2657,7 +2633,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -2721,7 +2696,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -3861,7 +3835,6 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -3882,7 +3855,6 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -3913,7 +3885,6 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -3955,7 +3926,6 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4076,7 +4046,6 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4097,7 +4066,6 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true

--- a/pkg/webapi/downloads.go
+++ b/pkg/webapi/downloads.go
@@ -183,12 +183,12 @@ func (s *Server) startDownload(w http.ResponseWriter, r *http.Request) {
 		s.internalError(w, r, "catalog lookup", err)
 		return
 	}
-	bbox, found := lookupCatalogBBox(cat, slug)
+	bbox, maxZoom, found := lookupCatalogEntry(cat, slug)
 	if !found {
 		badRequest(w, "unknown slug")
 		return
 	}
-	if err := s.mapsCache.Start(r.Context(), slug, bbox); err != nil {
+	if err := s.mapsCache.Start(r.Context(), slug, bbox, maxZoom); err != nil {
 		if errors.Is(err, mapscache.ErrAlreadyInflight) {
 			writeJSON(w, http.StatusConflict, map[string]string{
 				"error":   "already_inflight",
@@ -226,37 +226,44 @@ func (s *Server) startDownload(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusAccepted, toDTO(st))
 }
 
-// lookupCatalogBBox returns the bbox for a namespaced slug in the
-// catalog, or (nil, false) if the slug names no published archive.
-// The boolean covers both "slug not in catalog" (caller returns 400)
-// and "slug in catalog but bbox missing" (caller still starts the
-// download; render-path bounds come from the backfill).
-func lookupCatalogBBox(c mapscatalog.Catalog, slug string) (*[4]float64, bool) {
+// lookupCatalogEntry returns the bbox and maxZoom for a namespaced
+// slug in the catalog, or (nil, 0, false) if the slug names no
+// published archive. The boolean covers both "slug not in catalog"
+// (caller returns 400) and "slug in catalog but bbox missing" (caller
+// still starts the download; render-path bounds come from the
+// backfill). Regional entries have no zoom cap and report maxZoom 0;
+// the world archive reports its real cap (e.g. 7).
+func lookupCatalogEntry(c mapscatalog.Catalog, slug string) (*[4]float64, int, bool) {
 	kind, a, b, ok := parseSlug(slug)
 	if !ok {
-		return nil, false
+		return nil, 0, false
 	}
 	switch kind {
+	case "world":
+		if c.World == nil {
+			return nil, 0, false
+		}
+		return c.World.BBox, c.World.MaxZoom, true
 	case "state":
 		for _, st := range c.States {
 			if st.Slug == a {
-				return st.BBox, true
+				return st.BBox, 0, true
 			}
 		}
 	case "country":
 		for _, x := range c.Countries {
 			if x.ISO2 == a {
-				return x.BBox, true
+				return x.BBox, 0, true
 			}
 		}
 	case "province":
 		for _, p := range c.Provinces {
 			if p.ISO2 == a && p.Slug == b {
-				return p.BBox, true
+				return p.BBox, 0, true
 			}
 		}
 	}
-	return nil, false
+	return nil, 0, false
 }
 
 // @Summary  Delete an offline download

--- a/pkg/webapi/downloads_test.go
+++ b/pkg/webapi/downloads_test.go
@@ -275,7 +275,7 @@ func TestDeleteMapsDownload_Idempotent(t *testing.T) {
 
 	// Drive a download to completion so DELETE has both a row and a
 	// file to remove.
-	if err := mgr.Start(context.Background(), "state/ohio", nil); err != nil {
+	if err := mgr.Start(context.Background(), "state/ohio", nil, 0); err != nil {
 		t.Fatal(err)
 	}
 	if !waitFor(t, 3*time.Second, func() bool {
@@ -602,5 +602,25 @@ func TestStartDownload_PersistsBBoxFromCatalog(t *testing.T) {
 			got = *row.BBox
 		}
 		t.Fatalf("bbox never reached %q (last seen: %q)", want, got)
+	}
+}
+
+func TestLookupCatalogEntryWorld(t *testing.T) {
+	c := mapscatalog.Catalog{World: &mapscatalog.WorldMap{
+		BBox: &[4]float64{-180, -85.05, 180, 85.05}, MaxZoom: 7,
+	}}
+	bbox, maxZoom, found := lookupCatalogEntry(c, "world")
+	if !found || maxZoom != 7 || bbox == nil {
+		t.Fatalf("lookupCatalogEntry(world) = (%v,%d,%v), want (non-nil,7,true)", bbox, maxZoom, found)
+	}
+	// Regional entries report no cap.
+	c2 := mapscatalog.Catalog{States: []mapscatalog.State{{Slug: "colorado", BBox: &[4]float64{-109, 37, -102, 41}}}}
+	_, mz, ok := lookupCatalogEntry(c2, "state/colorado")
+	if !ok || mz != 0 {
+		t.Fatalf("lookupCatalogEntry(state/colorado) maxZoom = %d, ok=%v, want 0,true", mz, ok)
+	}
+	// Absent world.
+	if _, _, ok := lookupCatalogEntry(mapscatalog.Catalog{}, "world"); ok {
+		t.Fatal("lookupCatalogEntry(world) on empty catalog = ok, want false")
 	}
 }

--- a/pkg/webapi/dto/local_bounds.go
+++ b/pkg/webapi/dto/local_bounds.go
@@ -1,7 +1,17 @@
 package dto
 
+// LocalBoundsEntry is the render-path coverage for one downloaded
+// slug: its bounding box plus the archive's max zoom. MaxZoom is 0 for
+// regional (full-detail) archives and >0 for the capped world archive,
+// letting the offline render path overzoom the world archive's top
+// tile instead of requesting zooms it does not contain.
+type LocalBoundsEntry struct {
+	BBox    [4]float64 `json:"bbox"`
+	MaxZoom int        `json:"maxZoom"`
+}
+
 // LocalBounds is the wire shape for GET /api/maps/local-bounds.
 // Keyed by namespaced slug ("state/colorado", "country/de",
-// "province/ca/british-columbia"); value is [west, south, east, north]
-// in degrees. Empty map (not 503) when no downloads are complete.
-type LocalBounds map[string][4]float64
+// "province/ca/british-columbia", "world"); value is the coverage
+// entry. Empty map (not 503) when no downloads are complete.
+type LocalBounds map[string]LocalBoundsEntry

--- a/pkg/webapi/local_bounds.go
+++ b/pkg/webapi/local_bounds.go
@@ -46,7 +46,7 @@ func (s *Server) getLocalBounds(w http.ResponseWriter, r *http.Request) {
 				"slug", row.Slug, "raw", *row.BBox, "err", err)
 			continue
 		}
-		out[row.Slug] = bbox
+		out[row.Slug] = dto.LocalBoundsEntry{BBox: bbox, MaxZoom: row.MaxZoom}
 	}
 	writeJSON(w, http.StatusOK, out)
 }

--- a/pkg/webapi/local_bounds_test.go
+++ b/pkg/webapi/local_bounds_test.go
@@ -22,6 +22,13 @@ func TestLocalBounds_ReturnsCompletedSlugs(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("upsert co: %v", err)
 	}
+	// World archive — completed, capped at z7.
+	bboxWorld := `[-180,-85.05,180,85.05]`
+	if err := store.UpsertMapsDownload(ctx, configstore.MapsDownload{
+		Slug: "world", Status: "complete", BBox: &bboxWorld, MaxZoom: 7,
+	}); err != nil {
+		t.Fatalf("upsert world: %v", err)
+	}
 	// In-progress row — excluded.
 	if err := store.UpsertMapsDownload(ctx, configstore.MapsDownload{
 		Slug: "state/utah", Status: "downloading",
@@ -45,16 +52,25 @@ func TestLocalBounds_ReturnsCompletedSlugs(t *testing.T) {
 		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
 	}
 
-	var got map[string][4]float64
+	var got map[string]struct {
+		BBox    [4]float64 `json:"bbox"`
+		MaxZoom int        `json:"maxZoom"`
+	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(got) != 1 {
-		t.Fatalf("len: got %d want 1; payload=%v", len(got), got)
+	if len(got) != 2 {
+		t.Fatalf("len: got %d want 2; payload=%v", len(got), got)
 	}
 	want := [4]float64{-109.05, 36.99, -102.04, 41}
-	if got["state/colorado"] != want {
-		t.Fatalf("bbox: got %v want %v", got["state/colorado"], want)
+	if got["state/colorado"].BBox != want {
+		t.Fatalf("bbox: got %v want %v", got["state/colorado"].BBox, want)
+	}
+	if got["state/colorado"].MaxZoom != 0 {
+		t.Fatalf("regional maxZoom: got %d want 0", got["state/colorado"].MaxZoom)
+	}
+	if got["world"].MaxZoom != 7 {
+		t.Fatalf("world maxZoom: got %d want 7", got["world"].MaxZoom)
 	}
 }
 

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -1987,50 +1987,33 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /**
-             * Format: float64
-             * @description meters (0 if none reported)
-             */
+            /** @description meters (0 if none reported) */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /**
-             * Format: int32
-             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
-             */
+            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive north
-             */
+            /** @description decimal degrees, positive north */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive east
-             */
+            /** @description decimal degrees, positive east */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /**
-             * Format: float64
-             * @description knots
-             */
+            /** @description knots */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
-            /** Format: int32 */
             code?: number;
-            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2039,20 +2022,14 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /**
-             * Format: int32
-             * @description bits 0..7 (only lower 8)
-             */
+            /** @description bits 0..7 (only lower 8) */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /**
-             * Format: int32
-             * @description BITS. sense-bits bitmap (active-high per bit)
-             */
+            /** @description BITS. sense-bits bitmap (active-high per bit) */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2080,47 +2057,27 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /**
-             * Format: float64
-             * @description tenths of millibar (e.g. 10132 = 1013.2)
-             */
+            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
             pressure?: number;
-            /**
-             * Format: float64
-             * @description hundredths of an inch
-             */
+            /** @description hundredths of an inch */
             rain1Hour?: number;
-            /** Format: float64 */
             rain24Hour?: number;
-            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /**
-             * Format: float64
-             * @description inches (via 's' after 'g')
-             */
+            /** @description inches (via 's' after 'g') */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /**
-             * Format: float64
-             * @description degrees F
-             */
+            /** @description degrees F */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /**
-             * Format: float64
-             * @description mph (5-minute peak)
-             */
+            /** @description mph (5-minute peak) */
             windGust?: number;
-            /**
-             * Format: float64
-             * @description mph (1-minute sustained)
-             */
+            /** @description mph (1-minute sustained) */
             windSpeed?: number;
         };
         "configstore.Referrer": {

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -1987,33 +1987,50 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /** @description meters (0 if none reported) */
+            /**
+             * Format: float64
+             * @description meters (0 if none reported)
+             */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
+            /**
+             * Format: int32
+             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
+             */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /** @description decimal degrees, positive north */
+            /**
+             * Format: float64
+             * @description decimal degrees, positive north
+             */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /** @description decimal degrees, positive east */
+            /**
+             * Format: float64
+             * @description decimal degrees, positive east
+             */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /** @description knots */
+            /**
+             * Format: float64
+             * @description knots
+             */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
+            /** Format: int32 */
             code?: number;
+            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2022,14 +2039,20 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /** @description bits 0..7 (only lower 8) */
+            /**
+             * Format: int32
+             * @description bits 0..7 (only lower 8)
+             */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /** @description BITS. sense-bits bitmap (active-high per bit) */
+            /**
+             * Format: int32
+             * @description BITS. sense-bits bitmap (active-high per bit)
+             */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2057,27 +2080,47 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
+            /**
+             * Format: float64
+             * @description tenths of millibar (e.g. 10132 = 1013.2)
+             */
             pressure?: number;
-            /** @description hundredths of an inch */
+            /**
+             * Format: float64
+             * @description hundredths of an inch
+             */
             rain1Hour?: number;
+            /** Format: float64 */
             rain24Hour?: number;
+            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /** @description inches (via 's' after 'g') */
+            /**
+             * Format: float64
+             * @description inches (via 's' after 'g')
+             */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /** @description degrees F */
+            /**
+             * Format: float64
+             * @description degrees F
+             */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /** @description mph (5-minute peak) */
+            /**
+             * Format: float64
+             * @description mph (5-minute peak)
+             */
             windGust?: number;
-            /** @description mph (1-minute sustained) */
+            /**
+             * Format: float64
+             * @description mph (1-minute sustained)
+             */
             windSpeed?: number;
         };
         "configstore.Referrer": {
@@ -2698,7 +2741,11 @@ export interface components {
             type?: string;
         };
         "dto.LocalBounds": {
-            [key: string]: number[];
+            [key: string]: components["schemas"]["dto.LocalBoundsEntry"];
+        };
+        "dto.LocalBoundsEntry": {
+            bbox?: number[];
+            maxZoom?: number;
         };
         "dto.MapsConfigRequest": {
             source?: string;

--- a/web/src/lib/map/maplibre-map.svelte
+++ b/web/src/lib/map/maplibre-map.svelte
@@ -49,6 +49,7 @@
     const federated = createFederatedProtocol({
       completedSlugsProvider: () => downloadsState.completed,
       boundsBySlugProvider: () => localBoundsStore.boundsBySlug,
+      maxZoomBySlugProvider: () => localBoundsStore.maxZoomBySlug,
       fetchOnline: async (z, x, y, signal) => {
         const base = `https://maps.nw5w.com/${z}/${x}/${y}.mvt`;
         const url = bearerToken
@@ -95,10 +96,20 @@
     // Deep clone so we don't mutate the cached upstream payload.
     const style = JSON.parse(JSON.stringify(cachedUpstreamStyle));
     if (federated) {
+      // When the user's ONLY offline coverage is the world archive, cap
+      // the source so MapLibre overzooms the z7 tile instead of
+      // requesting z8+ (which would miss offline -> blank). With any
+      // full-detail regional download present, keep the upstream max so
+      // that region renders at z14; world-only areas at high zoom then
+      // rely on MapLibre's parent-tile retention.
+      const completed = downloadsState.completed;
+      const worldCap = localBoundsStore.maxZoomBySlug.get('world');
+      const worldOnly = completed.size === 1 && completed.has('world') && worldCap > 0;
       for (const src of Object.values(style.sources)) {
         if (src.type === 'vector') {
           delete src.url; // drop the tilejson pointer
           src.tiles = ['gw-tile://{z}/{x}/{y}'];
+          if (worldOnly) src.maxzoom = worldCap;
         }
       }
     }

--- a/web/src/lib/map/sources/gw-federated-protocol.js
+++ b/web/src/lib/map/sources/gw-federated-protocol.js
@@ -55,16 +55,28 @@ function bboxIntersects(tileBBox, bboxWSEN) {
   return true;
 }
 
-// findCoveringSlug: returns the first slug from `completedSlugs`
-// whose bbox intersects the tile bbox, or null if none. The bounds
-// come from the live catalog via boundsBySlug.
-function findCoveringSlug(tileBBox, completedSlugs, boundsBySlug) {
+// bboxArea: lon-span * lat-span of a [w, s, e, n] tuple. Used only to
+// rank overlapping archives by specificity, so a plain rectangular
+// area (no spherical correction) is sufficient and monotonic.
+function bboxArea([w, s, e, n]) {
+  return Math.max(0, e - w) * Math.max(0, n - s);
+}
+
+// rankCoveringSlugs: returns every slug from `completedSlugs` whose
+// bbox intersects the tile, ordered smallest-bbox-first. A more
+// specific regional archive is therefore tried before the
+// globe-spanning world archive, so a user who has both renders the
+// region at full detail. Bounds come from the live catalog via
+// boundsBySlug.
+export function rankCoveringSlugs(tileBBox, completedSlugs, boundsBySlug) {
+  const hits = [];
   for (const slug of completedSlugs) {
     const bbox = boundsBySlug.get(slug);
     if (!bbox) continue;
-    if (bboxIntersects(tileBBox, bbox)) return slug;
+    if (bboxIntersects(tileBBox, bbox)) hits.push({ slug, area: bboxArea(bbox) });
   }
-  return null;
+  hits.sort((a, b) => a.area - b.area);
+  return hits.map((h) => h.slug);
 }
 
 // createFederatedProtocol returns a MapLibre protocol handler.
@@ -72,6 +84,10 @@ function findCoveringSlug(tileBBox, completedSlugs, boundsBySlug) {
 //   completedSlugsProvider: () => Set<string>  -- live; checked per request
 //   boundsBySlugProvider:   () => Map<string, [west, south, east, north]>
 //                              -- catalog-derived bounds, live per request
+//   maxZoomBySlugProvider: () => Map<string, number>  -- optional;
+//                          per-archive top zoom (0/absent = no cap).
+//                          Lets the world archive be skipped for zooms
+//                          it cannot hold instead of reading and missing.
 //   fetchOnline:           (z, x, y, signal) => Promise<Uint8Array>
 //                          fetches the corresponding online tile;
 //                          throws if not retrievable.
@@ -80,7 +96,12 @@ function findCoveringSlug(tileBBox, completedSlugs, boundsBySlug) {
 //   request: (params, abortController) => Promise<{data: Uint8Array}>
 // The abortController is provided by MapLibre and aborted when the
 // tile is no longer needed (panned out of view).
-export function createFederatedProtocol({ completedSlugsProvider, boundsBySlugProvider, fetchOnline }) {
+export function createFederatedProtocol({
+  completedSlugsProvider,
+  boundsBySlugProvider,
+  maxZoomBySlugProvider,
+  fetchOnline,
+}) {
   return {
     request(params, abortController) {
       const m = /^gw-tile:\/\/(\d+)\/(\d+)\/(\d+)$/.exec(params.url);
@@ -93,29 +114,39 @@ export function createFederatedProtocol({ completedSlugsProvider, boundsBySlugPr
       const tileBBox = tileToBBox(z, x, y);
       const completed = completedSlugsProvider();
       const bounds = boundsBySlugProvider();
+      const maxZoomBySlug =
+        typeof maxZoomBySlugProvider === 'function' ? maxZoomBySlugProvider() : new Map();
 
-      const slug = findCoveringSlug(tileBBox, completed, bounds);
+      const ranked = rankCoveringSlugs(tileBBox, completed, bounds);
       const fallback = () =>
         fetchOnline(z, x, y, abortController.signal).then((data) => ({ data }));
 
-      if (!slug) {
+      if (ranked.length === 0) {
         // No offline coverage for this tile.
         return fallback();
       }
 
-      // Try the local archive; on miss (or any error reading it),
-      // fall through to network. A missing tile in the archive isn't
-      // an error per se -- the source style may request zooms outside
-      // the archive's stored range.
-      return getArchive(slug)
-        .getZxy(z, x, y, abortController.signal)
-        .then((tile) => {
-          if (tile && tile.data) {
-            return { data: new Uint8Array(tile.data) };
-          }
-          return fallback();
-        })
-        .catch(() => fallback());
+      // Walk the ranked list (most-specific archive first); the first
+      // archive that actually holds the tile wins. Network is the final
+      // fallback. A missing tile in an archive isn't an error per se --
+      // the source style may request zooms outside the archive's range.
+      const tryNext = (i) => {
+        if (i >= ranked.length) return fallback();
+        const slug = ranked[i];
+        const cap = maxZoomBySlug.get(slug);
+        // Skip archives that provably cannot hold this zoom (e.g. the
+        // world archive at z>cap). Avoids a guaranteed-miss range read;
+        // the source maxzoom makes MapLibre overzoom instead.
+        if (typeof cap === 'number' && cap > 0 && z > cap) return tryNext(i + 1);
+        return getArchive(slug)
+          .getZxy(z, x, y, abortController.signal)
+          .then((tile) => {
+            if (tile && tile.data) return { data: new Uint8Array(tile.data) };
+            return tryNext(i + 1);
+          })
+          .catch(() => tryNext(i + 1));
+      };
+      return tryNext(0);
     },
   };
 }

--- a/web/src/lib/map/sources/gw-federated-protocol.test.js
+++ b/web/src/lib/map/sources/gw-federated-protocol.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { rankCoveringSlugs } from './gw-federated-protocol.js';
+
+// tileToBBox returns [southLat, westLon, northLat, eastLon]; the bounds
+// map holds [west, south, east, north]. These fixtures follow those
+// conventions.
+const bounds = new Map([
+  ['world', [-180, -85, 180, 85]],
+  ['state/colorado', [-109, 37, -102, 41]],
+]);
+
+test('rankCoveringSlugs: ranks smaller (more specific) bbox first, world last', () => {
+  const tileBBox = [38, -105, 40, -103]; // inside Colorado
+  const ranked = rankCoveringSlugs(tileBBox, new Set(['world', 'state/colorado']), bounds);
+  assert.deepEqual(ranked, ['state/colorado', 'world']);
+});
+
+test('rankCoveringSlugs: omits non-intersecting slugs', () => {
+  const farTile = [-40, 100, -38, 102]; // southern hemisphere, far from CO
+  const ranked = rankCoveringSlugs(farTile, new Set(['state/colorado', 'world']), bounds);
+  assert.deepEqual(ranked, ['world']);
+});
+
+test('rankCoveringSlugs: empty when nothing covers the tile', () => {
+  const noBounds = new Map();
+  const ranked = rankCoveringSlugs([0, 0, 1, 1], new Set(['state/colorado']), noBounds);
+  assert.deepEqual(ranked, []);
+});

--- a/web/src/lib/maps/catalog-tree.js
+++ b/web/src/lib/maps/catalog-tree.js
@@ -78,3 +78,13 @@ export function buildCountryTree(catalog) {
   // Sort countries alphabetically by display name.
   return [...byIso.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
+
+// buildWorldNode projects the optional top-level world archive into a
+// flat picker node, or null when the catalog has no world entry. Kept
+// separate from buildCountryTree because the world archive is not a
+// country and has no children.
+export function buildWorldNode(catalog) {
+  const w = catalog && catalog.world;
+  if (!w) return null;
+  return { slug: 'world', name: w.name || 'World (low detail)', sizeBytes: w.sizeBytes || 0 };
+}

--- a/web/src/lib/maps/catalog-tree.test.js
+++ b/web/src/lib/maps/catalog-tree.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCountryTree } from './catalog-tree.js';
+import { buildCountryTree, buildWorldNode } from './catalog-tree.js';
 
 const fix = {
   countries: [
@@ -63,5 +63,22 @@ describe('buildCountryTree', () => {
     assert.equal(ca.children[0].slug, 'province/ca/british-columbia');
     const us = tree.find(n => n.iso2 === 'us');
     assert.equal(us.children[0].slug, 'state/colorado');
+  });
+});
+
+describe('buildWorldNode', () => {
+  it('returns a node for a catalog with world', () => {
+    const node = buildWorldNode({
+      world: { name: 'World (low detail)', sizeBytes: 314572800, bbox: [-180, -85, 180, 85], maxZoom: 7 },
+    });
+    assert.deepEqual(node, { slug: 'world', name: 'World (low detail)', sizeBytes: 314572800 });
+  });
+  it('returns null when the catalog has no world', () => {
+    assert.equal(buildWorldNode({}), null);
+    assert.equal(buildWorldNode(null), null);
+  });
+  it('defaults the name when world.name is missing', () => {
+    const node = buildWorldNode({ world: { sizeBytes: 1 } });
+    assert.equal(node.name, 'World (low detail)');
   });
 });

--- a/web/src/lib/maps/local-bounds-store.svelte.js
+++ b/web/src/lib/maps/local-bounds-store.svelte.js
@@ -50,8 +50,22 @@ export const localBoundsStore = (() => {
     get boundsBySlug() {
       const out = new Map();
       if (!raw) return out;
-      for (const [slug, bbox] of Object.entries(raw)) {
+      for (const [slug, entry] of Object.entries(raw)) {
+        const bbox = entry && entry.bbox;
         if (Array.isArray(bbox) && bbox.length === 4) out.set(slug, bbox);
+      }
+      return out;
+    },
+    // maxZoomBySlug returns Map<slug, number>: the archive's top zoom.
+    // 0 (or absent) means "no cap" -- a regional, full-detail archive.
+    // The world archive reports its real cap so the federated protocol
+    // can let MapLibre overzoom its top tile instead of requesting
+    // zooms the archive does not contain.
+    get maxZoomBySlug() {
+      const out = new Map();
+      if (!raw) return out;
+      for (const [slug, entry] of Object.entries(raw)) {
+        if (entry && Number.isFinite(entry.maxZoom)) out.set(slug, entry.maxZoom);
       }
       return out;
     },

--- a/web/src/lib/maps/region-picker.svelte
+++ b/web/src/lib/maps/region-picker.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { Drawer, Button, Input } from '@chrissnell/chonky-ui';
   import { catalogStore } from './catalog-store.svelte.js';
-  import { buildCountryTree } from './catalog-tree.js';
+  import { buildCountryTree, buildWorldNode } from './catalog-tree.js';
   import { downloadsState } from './downloads-store.svelte.js';
   import { formatBytes } from './format-bytes.js';
 
@@ -15,6 +15,18 @@
   let tree = $derived.by(() => {
     if (!catalogStore.catalog) return [];
     return buildCountryTree(catalogStore.catalog);
+  });
+
+  // The global low-detail world archive, shown as a single row above
+  // the country tree. Null when the catalog advertises no world entry.
+  let worldNode = $derived(catalogStore.catalog ? buildWorldNode(catalogStore.catalog) : null);
+
+  // Hide the world row when a search query is active and doesn't match
+  // its name, so search results stay focused.
+  let showWorld = $derived.by(() => {
+    if (!worldNode) return false;
+    const q = query.trim().toLowerCase();
+    return !q || worldNode.name.toLowerCase().includes(q);
   });
 
   // Filter: when there is a query, expand any country with a matching
@@ -74,6 +86,32 @@
       </div>
     {:else}
       <ul class="region-list" role="list">
+        {#if showWorld}
+          {@const wItem = statusOf(worldNode.slug)}
+          {@const wStatus = wItem?.state ?? 'absent'}
+          <li class="region-row region-row-world" data-level="world">
+            <span class="region-name">{worldNode.name}</span>
+            <div class="region-meta">
+              {#if worldNode.sizeBytes > 0}
+                <span class="region-size">{formatBytes(worldNode.sizeBytes)}</span>
+              {/if}
+              {#if wStatus === 'downloading'}
+                <span class="region-status">{Math.round((wItem.bytes_downloaded / Math.max(1, wItem.bytes_total)) * 100)}%</span>
+              {:else if wStatus === 'complete'}
+                <span class="region-status complete">Downloaded</span>
+              {/if}
+            </div>
+            <div class="region-actions">
+              {#if wStatus === 'absent' || wStatus === 'error'}
+                <Button onclick={() => downloadsState.start(worldNode.slug)}>Download</Button>
+              {:else if wStatus === 'complete'}
+                <Button variant="danger" onclick={() => downloadsState.remove(worldNode.slug)}>Delete</Button>
+              {:else}
+                <Button variant="danger" onclick={() => downloadsState.cancel(worldNode.slug)}>Cancel</Button>
+              {/if}
+            </div>
+          </li>
+        {/if}
         {#each filteredTree as country (country.iso2)}
           {@const cItem = statusOf(country.slug)}
           {@const cStatus = cItem?.state ?? 'absent'}
@@ -142,7 +180,9 @@
             {/if}
           </li>
         {:else}
-          <li class="region-empty">No regions match "{query}"</li>
+          {#if !showWorld}
+            <li class="region-empty">No regions match "{query}"</li>
+          {/if}
         {/each}
       </ul>
     {/if}


### PR DESCRIPTION
## Summary

Adds support for a single global, low-zoom (z0–7, ~300 MB) basemap that operators can download for offline use anywhere on Earth, alongside the existing per-state/country/province downloads (GH #209). Use cases: portable/mobile stations, HF APRS, and beacon/digipeat reception that crosses borders, where a coarse worldwide map beats no map at all.

This PR is the **client side** only. The actual `world.pmtiles` archive, its `manifest.json` entry, and the `/download/world.pmtiles` Worker route live in the `graywolf-maps` repo and still need to ship before the download is live end-to-end.

### What changed
- **Slug + catalog:** new `world` slug in the namespaced grammar (`pkg/mapsslug`); optional top-level `world` catalog entry carrying a `maxZoom` cap (`pkg/mapscatalog`); download URL `/download/world.pmtiles` (`pkg/mapscache`).
- **maxZoom plumbing:** snapshot the archive's max zoom into `maps_downloads.max_zoom` at download start (new auto-migrated column), and return it per-slug from `GET /api/maps/local-bounds` so the offline render path knows the cap without consulting the catalog.
- **Offline render correctness:**
  - The federated tile dispatcher now ranks every archive whose bbox covers a tile by ascending bbox area, so a detailed regional download is always preferred over the globe-spanning world archive where they overlap.
  - When the world archive is the *only* download, the MapLibre vector source is registered with `maxzoom = 7`, so the client overzooms the top tile instead of requesting (and missing) higher zooms while offline.
- **UI:** a "World (low detail)" row at the top of the offline region picker.
- **Docs:** wiki (`system-topology.md`) and operator handbook (`maps.html`).
- Regenerated swagger + TS API client for the reshaped `local-bounds` response.

### Test Plan
- [x] `go build ./...`, `go vet ./...`, full `go test ./...` pass
- [x] Frontend `npm test` (`node --test`) passes for the changed modules; the one unrelated `methodOptions` PTT failure is pre-existing on `main`
- [x] `svelte-check` clean; `npm run build` succeeds
- [x] `make docs-check api-client-check` show no drift
- [ ] End-to-end (download World → go offline → render worldwide) — blocked on the `graywolf-maps` archive + manifest + Worker route landing