### PR TITLE
Live Map: drive radar frame cache-bust from the 1s clock

### DIFF
--- a/web/src/lib/map/layers/radar.js
+++ b/web/src/lib/map/layers/radar.js
@@ -1,9 +1,13 @@
 // NEXRAD radar overlay layer for the Live Map.
 //
 // Backend-agnostic: it asks radar-source.js for a provider descriptor and
-// performs the MapLibre source/layer calls. Raster today, GRA-48 vector
-// tomorrow -- this file does not change when the backend flips; only
-// ACTIVE_RADAR_BACKEND in radar-source.js does.
+// performs the MapLibre source/layer calls. The active backend is the
+// GRA-48 vector contours, selected by ACTIVE_RADAR_BACKEND in
+// radar-source.js. For the vector backend this layer also drives a
+// cadence-aligned frame cache-bust (the route always serves the latest
+// frame, so refresh() bumps the tile URL on a time-bucket rollover to make
+// MapLibre refetch); the raster backend has no cache-bust and refresh()
+// is purely idempotent re-adds.
 //
 // Mirrors the other layer modules (stations.js, trails.js): mount returns
 // control methods; LiveMapV2 persists settings and drives them via effects,

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -454,11 +454,15 @@
   // Drive layer refresh from data-store reactivity. Touching .size
   // ensures Svelte tracks Map mutations even if the proxy short-circuits
   // a reassignment. unitsState.isMetric is read so the weather layer
-  // re-renders when the operator toggles metric/imperial.
+  // re-renders when the operator toggles metric/imperial. tickNow is read
+  // so the 1s clock drives this effect even when the station roster is
+  // stable -- the radar layer's frame cache-bust rolls over on a time
+  // bucket, and refresh() no-ops when the bucket hasn't changed.
   $effect(() => {
     const _size = dataStore.stations.size;
     const _isMetric = unitsState.isMetric;
     const _myPos = dataStore.myPosition; // track
+    const _tick = tickNow; // drive radar frame rollover on the clock
     if (radarLayer) radarLayer.refresh();
     if (stationsLayer) stationsLayer.refresh();
     if (trailsLayer) trailsLayer.refresh();


### PR DESCRIPTION
The vector radar overlay rolls its frame cache-bust on a 5-min time bucket, but the layer-refresh $effect tracked only stations.size, isMetric, and myPosition. With a stable station roster the effect would not re-run, so the bucket rollover went unevaluated and frames only advanced incidentally. Read tickNow in the effect so the existing 1s tick drives it; refresh() already no-ops when the bucket is unchanged.

Also refresh the stale radar.js header comment, which still described the raster backend as active and claimed the file does not change when the backend flips.