### PR TITLE
Fix blank maps pane after switching radar region without reload

### DIFF
--- a/web/src/lib/map/layers/radar.js
+++ b/web/src/lib/map/layers/radar.js
@@ -105,10 +105,12 @@ export function mountRadarLayer(map, { visible, opacity, region = RADAR_REGION_U
   }
 
   function destroy() {
-    for (const layer of provider.layers) {
-      if (map.getLayer(layer.id)) map.removeLayer(layer.id);
-    }
-    if (map.getSource(provider.sourceId)) map.removeSource(provider.sourceId);
+    try {
+      for (const layer of provider.layers) {
+        if (map.getLayer(layer.id)) map.removeLayer(layer.id);
+      }
+      if (map.getSource(provider.sourceId)) map.removeSource(provider.sourceId);
+    } catch { /* map already removed */ }
   }
 
   return { refresh, setVisible, setOpacity, setRegion, destroy };

--- a/web/src/lib/map/layers/radar.test.js
+++ b/web/src/lib/map/layers/radar.test.js
@@ -62,3 +62,12 @@ test('setRegion tears down the US vector layer and rebuilds the world raster ove
   assert.ok(map._layers['radar-fill']);
   assert.equal(map._layers['radar-raster'], undefined);
 });
+
+test('destroy swallows errors when the map is already torn down', () => {
+  const map = fakeMap();
+  const layer = mountRadarLayer(map, { visible: true, opacity: 0.6, now: () => 0 });
+  // After map.remove(), MapLibre's getLayer throws because internal state is
+  // gone; teardown order can run a layer's destroy() against a removed map.
+  map.getLayer = () => { throw new TypeError("Cannot read properties of undefined (reading 'getLayer')"); };
+  assert.doesNotThrow(() => layer.destroy());
+});

--- a/web/src/lib/map/maplibre-map.svelte
+++ b/web/src/lib/map/maplibre-map.svelte
@@ -113,6 +113,35 @@
         }
       }
     }
+    return absolutizeStyleUrls(style);
+  }
+
+  // The backend rewrites upstream maps.nw5w.com URLs to root-relative
+  // /api/maps/style/... paths. MapLibre only resolves relative URLs when a
+  // style is loaded from a URL string; we hand it the style as an *object*
+  // (so federated mode can swap sources), and in that mode v5 rejects
+  // relative sprite/glyphs ("Invalid sprite URL ... must be absolute").
+  // Resolve the root-relative paths to absolute against the current origin
+  // (same host that serves /api/maps/style) before MapLibre sees the spec.
+  function absolutizeStyleUrls(style) {
+    if (typeof window === 'undefined' || !style) return style;
+    const abs = (u) =>
+      typeof u === 'string' && u.startsWith('/')
+        ? new URL(u, window.location.origin).href
+        : u;
+    if (typeof style.sprite === 'string') {
+      style.sprite = abs(style.sprite);
+    } else if (Array.isArray(style.sprite)) {
+      style.sprite = style.sprite.map((s) =>
+        s && typeof s.url === 'string' ? { ...s, url: abs(s.url) } : s,
+      );
+    }
+    if (typeof style.glyphs === 'string') style.glyphs = abs(style.glyphs);
+    if (style.sources) {
+      for (const src of Object.values(style.sources)) {
+        if (src && typeof src.url === 'string') src.url = abs(src.url);
+      }
+    }
     return style;
   }
 

--- a/web/src/lib/map/maplibre-map.svelte
+++ b/web/src/lib/map/maplibre-map.svelte
@@ -16,6 +16,7 @@
   import { catalogStore } from '../maps/catalog-store.svelte.js';
   import { localBoundsStore } from '../maps/local-bounds-store.svelte.js';
   import { createFederatedProtocol } from './sources/gw-federated-protocol.js';
+  import { absolutizeStyleUrls } from './style-urls.js';
 
   let { initialCenter = [-98, 39], initialZoom = 4, oncreate = null } = $props();
 
@@ -114,35 +115,6 @@
       }
     }
     return absolutizeStyleUrls(style);
-  }
-
-  // The backend rewrites upstream maps.nw5w.com URLs to root-relative
-  // /api/maps/style/... paths. MapLibre only resolves relative URLs when a
-  // style is loaded from a URL string; we hand it the style as an *object*
-  // (so federated mode can swap sources), and in that mode v5 rejects
-  // relative sprite/glyphs ("Invalid sprite URL ... must be absolute").
-  // Resolve the root-relative paths to absolute against the current origin
-  // (same host that serves /api/maps/style) before MapLibre sees the spec.
-  function absolutizeStyleUrls(style) {
-    if (typeof window === 'undefined' || !style) return style;
-    const abs = (u) =>
-      typeof u === 'string' && u.startsWith('/')
-        ? new URL(u, window.location.origin).href
-        : u;
-    if (typeof style.sprite === 'string') {
-      style.sprite = abs(style.sprite);
-    } else if (Array.isArray(style.sprite)) {
-      style.sprite = style.sprite.map((s) =>
-        s && typeof s.url === 'string' ? { ...s, url: abs(s.url) } : s,
-      );
-    }
-    if (typeof style.glyphs === 'string') style.glyphs = abs(style.glyphs);
-    if (style.sources) {
-      for (const src of Object.values(style.sources)) {
-        if (src && typeof src.url === 'string') src.url = abs(src.url);
-      }
-    }
-    return style;
   }
 
   async function buildStyle() {

--- a/web/src/lib/map/style-urls.js
+++ b/web/src/lib/map/style-urls.js
@@ -1,0 +1,37 @@
+// Resolve root-relative style URLs to absolute.
+//
+// The backend (pkg/mapsstyle) rewrites upstream maps.nw5w.com URLs to
+// root-relative /api/maps/style/... paths. MapLibre only resolves relative
+// URLs when a style is loaded from a URL string; we hand it the style as an
+// *object* (so federated mode can swap sources), and in that mode v5 rejects
+// relative sprite/glyphs ("Invalid sprite URL ... must be absolute"). Resolve
+// the root-relative paths to absolute against the current origin (the same
+// host that serves /api/maps/style) before MapLibre sees the spec.
+//
+// Mutates `style` in place and returns it. Callers must pass a style they own
+// (a fresh clone or freshly built object), never a shared/cached spec.
+//
+// The backend always emits root-absolute paths ("/api/..."), so prefixing the
+// origin is enough -- and unlike `new URL()` it leaves the {fontstack}/{range}
+// glyph placeholders intact instead of percent-encoding them.
+export function absolutizeStyleUrls(style) {
+  if (typeof window === 'undefined' || !style) return style;
+  const abs = (u) =>
+    typeof u === 'string' && u.startsWith('/')
+      ? window.location.origin + u
+      : u;
+  if (typeof style.sprite === 'string') {
+    style.sprite = abs(style.sprite);
+  } else if (Array.isArray(style.sprite)) {
+    style.sprite = style.sprite.map((s) =>
+      s && typeof s.url === 'string' ? { ...s, url: abs(s.url) } : s,
+    );
+  }
+  if (typeof style.glyphs === 'string') style.glyphs = abs(style.glyphs);
+  if (style.sources) {
+    for (const src of Object.values(style.sources)) {
+      if (src && typeof src.url === 'string') src.url = abs(src.url);
+    }
+  }
+  return style;
+}

--- a/web/src/lib/map/style-urls.test.js
+++ b/web/src/lib/map/style-urls.test.js
@@ -1,0 +1,74 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { absolutizeStyleUrls } from './style-urls.js';
+
+const ORIGIN = 'https://gw.example.com';
+
+beforeEach(() => {
+  globalThis.window = { location: { origin: ORIGIN } };
+});
+
+afterEach(() => {
+  delete globalThis.window;
+});
+
+test('resolves a root-relative string sprite and glyphs to absolute', () => {
+  const style = {
+    sprite: '/api/maps/style/americana/sprites/sprite',
+    glyphs: '/api/maps/style/americana/glyphs/{fontstack}/{range}.pbf',
+  };
+  absolutizeStyleUrls(style);
+  assert.equal(style.sprite, `${ORIGIN}/api/maps/style/americana/sprites/sprite`);
+  assert.equal(
+    style.glyphs,
+    `${ORIGIN}/api/maps/style/americana/glyphs/{fontstack}/{range}.pbf`,
+  );
+});
+
+test('resolves the array form of sprite', () => {
+  const style = {
+    sprite: [
+      { id: 'default', url: '/api/maps/style/americana/sprites/sprite' },
+      { id: 'other', url: '/api/maps/style/other/sprites/sprite' },
+    ],
+  };
+  absolutizeStyleUrls(style);
+  assert.deepEqual(style.sprite, [
+    { id: 'default', url: `${ORIGIN}/api/maps/style/americana/sprites/sprite` },
+    { id: 'other', url: `${ORIGIN}/api/maps/style/other/sprites/sprite` },
+  ]);
+});
+
+test('resolves source tilejson urls', () => {
+  const style = {
+    sources: {
+      basemap: { type: 'vector', url: '/api/maps/style/tiles.json' },
+      dem: { type: 'raster-dem', url: 'https://s3.amazonaws.com/dem.json' },
+      tiled: { type: 'vector', tiles: ['gw-tile://{z}/{x}/{y}'] },
+    },
+  };
+  absolutizeStyleUrls(style);
+  assert.equal(style.sources.basemap.url, `${ORIGIN}/api/maps/style/tiles.json`);
+  // Already-absolute and tiles-only sources are left untouched.
+  assert.equal(style.sources.dem.url, 'https://s3.amazonaws.com/dem.json');
+  assert.deepEqual(style.sources.tiled.tiles, ['gw-tile://{z}/{x}/{y}']);
+});
+
+test('leaves already-absolute and non-string fields untouched', () => {
+  const style = {
+    sprite: 'https://maps.nw5w.com/style/americana/sprites/sprite',
+    glyphs: undefined,
+    sources: { osm: { type: 'raster', tiles: ['https://tile/{z}/{x}/{y}.png'] } },
+  };
+  absolutizeStyleUrls(style);
+  assert.equal(style.sprite, 'https://maps.nw5w.com/style/americana/sprites/sprite');
+  assert.equal(style.glyphs, undefined);
+});
+
+test('is a no-op without a window (SSR) and tolerates null', () => {
+  delete globalThis.window;
+  const style = { sprite: '/api/maps/style/americana/sprites/sprite' };
+  const out = absolutizeStyleUrls(style);
+  assert.equal(out.sprite, '/api/maps/style/americana/sprites/sprite');
+  assert.equal(absolutizeStyleUrls(null), null);
+});


### PR DESCRIPTION
## Problem

Switching radar region (RainViewer -> US NEXRAD) in the maps settings tab and navigating back to the maps page without a full reload left the maps pane blank, with two console errors:

1. `Invalid sprite URL "/api/maps/style/americana/sprites/sprite", must be absolute`
2. `Uncaught TypeError: Cannot read properties of undefined (reading 'getLayer')` during teardown.

A full page reload (Cmd-R) recovered, which pointed at the re-mount path.

## Root causes & fixes

**Sprite/glyphs (the blank pane).** The basemap style is handed to MapLibre as a JS *object* so federated/offline mode can rewrite sources. MapLibre v5 only resolves relative URLs when a style is loaded from a URL string; with an object it rejects the backend-rewritten root-relative `sprite`/`glyphs` paths. `buildStyle()` now resolves `sprite`, `glyphs`, and source `url`s to absolute against `window.location.origin` (the same host that serves `/api/maps/style/...`) before MapLibre sees the spec.

**getLayer TypeError (teardown).** `radar.js` `destroy()` was the only layer teardown missing the `try/catch` guard its siblings (`trails.js`, `hover-path.js`) carry. A `destroy()` running against an already-removed map threw uncaught. Guarded to match the established pattern, plus a regression test.

## Verification

- `npm test` — radar suite passes including the new `destroy swallows errors when the map is already torn down` test. The one remaining failure (`DESKTOP_METHODS includes all six PTT methods`) is pre-existing and unrelated to maps.
- `npm run build` — succeeds.
