### PR TITLE
Radar loop: word buttons (Play/Pause, Stop) + manifest-fetch diagnostics

### DIFF
--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -80,6 +80,16 @@
   // same bearer token as the basemap (a plain fetch, so transformRequest does
   // not see it -- we append ?t= here). The token is revealed once and cached.
   let radarToken = null;
+  // De-dupe diagnostics: the manifest poll runs every ~15s while radar is on, so
+  // a persistent failure (e.g. the Worker/generator not yet deployed) would warn
+  // forever. Only log when the failure stage changes; clear on success so a
+  // later regression logs again.
+  let lastRadarLoadStatus = null;
+  function warnRadar(status, ...args) {
+    if (lastRadarLoadStatus === status) return;
+    lastRadarLoadStatus = status;
+    console.warn(...args);
+  }
   async function loadRadarFrames() {
     if (!mapsState.registered) return [];
     if (!radarToken) radarToken = await mapsState.revealToken();
@@ -89,42 +99,45 @@
     try {
       resp = await fetch(url);
     } catch (e) {
-      console.warn('[radar] manifest fetch failed (network/CORS)', e);
+      warnRadar('network', '[radar] manifest fetch failed (network/CORS)', e);
       return [];
     }
     if (resp.status === 401) {
       radarToken = null; // stale token -- re-reveal next poll
-      console.warn('[radar] manifest 401 -- token rejected; will re-reveal');
+      warnRadar(401, '[radar] manifest 401 -- token rejected; will re-reveal');
       return [];
     }
     if (resp.status === 404) {
       // The origin Worker has no /radar/manifest.json route -- it predates the
       // animated-loop deploy. Update the worker (wrangler deploy) so the overlay
-      // can load frames. Logged loudly because the overlay otherwise sits on
+      // can load frames. Logged because the overlay otherwise sits on
       // "waiting for frames…" with no other signal.
-      console.warn(
+      warnRadar(
+        404,
         '[radar] manifest 404 -- origin Worker is missing the /radar/manifest.json route. ' +
           'Deploy the animated-loop Worker (cd worker && npx wrangler deploy).',
       );
       return [];
     }
     if (resp.status === 503) {
-      console.warn(
+      warnRadar(
+        503,
         '[radar] manifest 503 -- Worker is up but radar/manifest.json is not in R2 yet. ' +
           'Deploy/run the radar-contour generator so it publishes the manifest.',
       );
       return [];
     }
     if (!resp.ok) {
-      console.warn(`[radar] manifest fetch HTTP ${resp.status}`);
+      warnRadar(resp.status, `[radar] manifest fetch HTTP ${resp.status}`);
       return [];
     }
     try {
       const frames = parseManifestFrames(await resp.json());
-      if (frames.length === 0) console.warn('[radar] manifest parsed but has 0 frames');
+      if (frames.length === 0) warnRadar('empty', '[radar] manifest parsed but has 0 frames');
+      else lastRadarLoadStatus = null; // recovered -- a later failure logs again
       return frames;
     } catch (e) {
-      console.warn('[radar] manifest JSON parse failed', e);
+      warnRadar('parse', '[radar] manifest JSON parse failed', e);
       return [];
     }
   }

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -34,9 +34,6 @@
   import MapPinPlus from 'lucide-svelte/icons/map-pin-plus';
   import MapPinned from 'lucide-svelte/icons/map-pinned';
   import Copy from 'lucide-svelte/icons/copy';
-  import Play from 'lucide-svelte/icons/play';
-  import Pause from 'lucide-svelte/icons/pause';
-  import Square from 'lucide-svelte/icons/square';
 
   // Values are seconds (data store wants ms; multiplied at dispatch).
   const TIMERANGES_S = [
@@ -87,20 +84,47 @@
     if (!mapsState.registered) return [];
     if (!radarToken) radarToken = await mapsState.revealToken();
     if (!radarToken) return [];
+    const url = `${radarManifestUrl()}?t=${encodeURIComponent(radarToken)}`;
     let resp;
     try {
-      resp = await fetch(`${radarManifestUrl()}?t=${encodeURIComponent(radarToken)}`);
-    } catch {
+      resp = await fetch(url);
+    } catch (e) {
+      console.warn('[radar] manifest fetch failed (network/CORS)', e);
       return [];
     }
     if (resp.status === 401) {
       radarToken = null; // stale token -- re-reveal next poll
+      console.warn('[radar] manifest 401 -- token rejected; will re-reveal');
       return [];
     }
-    if (!resp.ok) return []; // 503 pre-cutover, etc. -> no frames yet
+    if (resp.status === 404) {
+      // The origin Worker has no /radar/manifest.json route -- it predates the
+      // animated-loop deploy. Update the worker (wrangler deploy) so the overlay
+      // can load frames. Logged loudly because the overlay otherwise sits on
+      // "waiting for frames…" with no other signal.
+      console.warn(
+        '[radar] manifest 404 -- origin Worker is missing the /radar/manifest.json route. ' +
+          'Deploy the animated-loop Worker (cd worker && npx wrangler deploy).',
+      );
+      return [];
+    }
+    if (resp.status === 503) {
+      console.warn(
+        '[radar] manifest 503 -- Worker is up but radar/manifest.json is not in R2 yet. ' +
+          'Deploy/run the radar-contour generator so it publishes the manifest.',
+      );
+      return [];
+    }
+    if (!resp.ok) {
+      console.warn(`[radar] manifest fetch HTTP ${resp.status}`);
+      return [];
+    }
     try {
-      return parseManifestFrames(await resp.json());
-    } catch {
+      const frames = parseManifestFrames(await resp.json());
+      if (frames.length === 0) console.warn('[radar] manifest parsed but has 0 frames');
+      return frames;
+    } catch (e) {
+      console.warn('[radar] manifest JSON parse failed', e);
       return [];
     }
   }
@@ -827,7 +851,7 @@
     />
 
     {#if radarSettings.visible}
-      <!-- Radar loop animation: two square buttons [Play/Pause][Stop] and a
+      <!-- Radar loop animation: two text buttons [Play/Pause][Stop] and a
            frame-position slider. Disabled until the manifest yields >1 frame. -->
       <div class="radar-anim-buttons">
         <button
@@ -836,13 +860,8 @@
           onclick={() => radarFrames.toggle()}
           disabled={radarFrames.count <= 1}
           aria-label={radarFrames.playing ? 'Pause radar loop' : 'Play radar loop'}
-          title={radarFrames.playing ? 'Pause' : 'Play'}
         >
-          {#if radarFrames.playing}
-            <Pause size={18} aria-hidden="true" />
-          {:else}
-            <Play size={18} aria-hidden="true" />
-          {/if}
+          {radarFrames.playing ? 'Pause' : 'Play'}
         </button>
         <button
           type="button"
@@ -850,9 +869,8 @@
           onclick={() => radarFrames.stop()}
           disabled={radarFrames.count <= 1}
           aria-label="Stop radar loop and jump to the latest frame"
-          title="Stop (jump to latest)"
         >
-          <Square size={18} aria-hidden="true" />
+          Stop
         </button>
       </div>
       <label class="timerange-label" for="radar-frame-range">{radarFrameLabel}</label>
@@ -1121,22 +1139,24 @@
     cursor: pointer;
     accent-color: var(--color-accent, #4a9eff);
   }
-  /* Radar loop: two square buttons [Play][Stop] side by side. */
+  /* Radar loop: two text buttons [Play/Pause][Stop] side by side. */
   .radar-anim-buttons {
     display: flex;
     gap: 6px;
     margin-top: 14px;
   }
   .radar-anim-btn {
-    width: 34px;
-    height: 34px;
+    flex: 1;
+    min-height: 32px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    padding: 6px 12px;
     background: var(--color-surface);
     color: var(--color-text);
     border: 1px solid var(--color-border);
     border-radius: 4px;
+    font-size: 13px;
     cursor: pointer;
   }
   .radar-anim-btn:hover:not(:disabled) {


### PR DESCRIPTION
Follow-up to #281 (already merged), addressing operator feedback on the radar loop controls.

## Changes (`web/src/routes/LiveMapV2.svelte`)
- **Word buttons, not icons.** The Play/Stop controls rendered lucide glyphs; the operator wanted the words. The toggle button now reads **Play** (and **Pause** while running) and the second reads **Stop**, sized for text and still side by side. Drops the now-unused `Play`/`Pause`/`Square` icon imports.
- **Manifest-fetch diagnostics.** When the overlay couldn't load frames it sat silently on "waiting for frames…". `loadRadarFrames` now logs the precise failure stage to the console: `manifest 404` (origin Worker missing the `/radar/manifest.json` route -- not deployed), `manifest 503` (Worker up but `radar/manifest.json` not in R2 yet -- generator not deployed/run), 401, network/CORS, or a 0-frame parse.

## Context
The reported "radar never loads / waiting for frames…" turned out to be a **deploy gap, not a code bug**: production still runs the pre-#20 Worker, so the migrated client's `/radar/manifest.json` fetch 404s. (Confirmed externally: `GET /admin/radar/purge` returns 401 instead of 405, i.e. the new route isn't live.) These diagnostics make that failure mode legible instead of an endless silent wait; the actual fix is deploying the animated-loop Worker + generator.

## Verification
`vite build` green; `node --test` radar suites pass (34 tests). Diagnostics-only change to the load path; no behavior change to the playback/loop logic.