### PR TITLE
Add High Contrast and High Contrast Night themes

### DIFF
--- a/web/themes/high-contrast-night.css
+++ b/web/themes/high-contrast-night.css
@@ -1,0 +1,78 @@
+/*
+ * High Contrast Night -- dark, maximum-legibility palette (graywolf
+ * #274). Pure-white body copy on pure-black surfaces fixes the "faded,
+ * barely visible" dark-mode text the reporter saw: secondary/tertiary
+ * text stay bright, borders are clearly visible, and packet badges use
+ * SOLID bright fills with black text instead of the low-alpha tints the
+ * default night theme uses.
+ *
+ * Top-level rule is doubled (`:root:root[data-theme="..."]`) so the
+ * theme's vars win against chonky-ui's
+ * `@media (prefers-color-scheme: dark) :root:not([data-theme="light"])`
+ * fallback regardless of bundle source order. See graywolf.css for the
+ * full explanation.
+ */
+:root:root[data-theme="high-contrast-night"] {
+  --color-bg: #000000;
+  --color-surface: #0d0d0d;
+  --color-surface-raised: #1a1a1a;
+  --color-border: #8a8a8a;
+  --color-border-subtle: #444444;
+  --color-text: #ffffff;
+  --color-text-muted: #d0d0d0;
+  --color-text-dim: #a8a8a8;
+  --color-text-inverse: #000000;
+  --color-accent: #5fd75f;
+  --color-primary: #ffb000;
+  --color-primary-hover: #ffc640;
+  --color-primary-muted: rgba(255, 176, 0, 0.22);
+  --color-primary-fg: #000000;
+  --color-danger: #ff5c5c;
+  --color-danger-hover: #ff7a7a;
+  --color-danger-muted: rgba(255, 92, 92, 0.22);
+  --color-danger-fg: #000000;
+  --color-success: #5fd75f;
+  --color-success-fill: #5fd75f;
+  --color-success-muted: rgba(95, 215, 95, 0.22);
+  --color-success-fg: #000000;
+  --color-warning: #ffd24a;
+  --color-warning-muted: rgba(255, 210, 74, 0.22);
+  --color-warning-fg: #000000;
+  --color-info: #5cc8ff;
+  --color-info-muted: rgba(92, 200, 255, 0.22);
+  --color-info-fg: #000000;
+  --color-btn-bg: #1a1a1a;
+  --color-btn-bg-hover: #2a2a2a;
+  --color-btn-border: #8a8a8a;
+  --font-mono: 'Inconsolata', 'Courier New', monospace;
+  --radius: 2px;
+  /* Map overlay tokens (used by MapLibre Live Map rebuild) */
+  --map-overlay-bg: var(--color-surface);
+  --map-overlay-fg: var(--color-text);
+  --map-overlay-muted: var(--color-text-muted);
+  --map-overlay-border: var(--color-border);
+  --map-overlay-shadow: 0 4px 16px rgba(0, 0, 0, 0.7);
+  --map-attribution-bg: color-mix(in srgb, var(--color-surface) 92%, transparent);
+}
+
+/* Packet-log type badges: solid bright fills + black text for crisp,
+   high-contrast scanning against the black surface. */
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='position']     { background: #58a6ff; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='weather']      { background: #56d364; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='telemetry']    { background: #e3b341; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='message']      { background: #39d0db; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='object']       { background: #bc8cff; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='item']         { background: #7ee787; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='mic-e']        { background: #f778ba; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='status']       { background: #c9d1d9; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='capabilities'] { background: #d2a8ff; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='df-report'],
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='query']        { background: #ffa657; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='third-party'],
+:root[data-theme="high-contrast-night"] .pkt-b-type[data-type='unknown']      { background: #b0b0b0; color: #000000; }
+
+:root[data-theme="high-contrast-night"] .pkt-b-origin[data-origin='bcn']          { background: #ffa657; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-origin[data-origin='digi']         { background: #a5d6ff; color: #000000; }
+:root[data-theme="high-contrast-night"] .pkt-b-origin[data-origin='igate'],
+:root[data-theme="high-contrast-night"] .pkt-b-origin[data-origin='igate-is2rf'],
+:root[data-theme="high-contrast-night"] .pkt-b-origin[data-origin='igate-rf2is'] { background: #d2a8ff; color: #000000; }

--- a/web/themes/high-contrast.css
+++ b/web/themes/high-contrast.css
@@ -1,0 +1,88 @@
+/*
+ * High Contrast -- light, maximum-legibility palette built for bright
+ * sunlight and low-vision operators (graywolf #274). Pure-black body
+ * copy on pure-white surfaces, darkened secondary/tertiary text that
+ * still clears WCAG AA, and visibly bordered controls. Primary is a
+ * deep blue so links and buttons read at high contrast rather than the
+ * default orange, which is hard to see as text on white.
+ *
+ * Top-level rule is doubled (`:root:root[data-theme="..."]`) so the
+ * theme's vars win against chonky-ui's
+ * `@media (prefers-color-scheme: dark) :root:not([data-theme="light"])`
+ * fallback regardless of bundle source order. See graywolf.css for the
+ * full explanation.
+ */
+:root:root[data-theme="high-contrast"] {
+  --color-bg: #ffffff;
+  --color-surface: #f4f4f4;
+  --color-surface-raised: #eaeaea;
+  --color-border: #595959;
+  --color-border-subtle: #c0c0c0;
+  --color-text: #000000;
+  --color-text-muted: #404040;
+  --color-text-dim: #595959;
+  --color-text-inverse: #ffffff;
+  --color-accent: #0b5d0b;
+  --color-primary: #0b4fb3;
+  --color-primary-hover: #06347a;
+  --color-primary-muted: rgba(11, 79, 179, 0.14);
+  --color-primary-fg: #ffffff;
+  --color-danger: #b00000;
+  --color-danger-hover: #8a0000;
+  --color-danger-muted: rgba(176, 0, 0, 0.14);
+  --color-danger-fg: #ffffff;
+  --color-success: #0b6b0b;
+  --color-success-fill: #0b6b0b;
+  --color-success-muted: rgba(11, 107, 11, 0.15);
+  --color-success-fg: #ffffff;
+  --color-warning: #8a4b00;
+  --color-warning-muted: rgba(138, 75, 0, 0.15);
+  --color-warning-fg: #ffffff;
+  --color-info: #00557a;
+  --color-info-muted: rgba(0, 85, 122, 0.15);
+  --color-info-fg: #ffffff;
+  --color-btn-bg: #eaeaea;
+  --color-btn-bg-hover: #dcdcdc;
+  --color-btn-border: #595959;
+  --font-mono: 'Inconsolata', 'Courier New', monospace;
+  --radius: 2px;
+  /* Map overlay tokens (used by MapLibre Live Map rebuild) */
+  --map-overlay-bg: var(--color-surface);
+  --map-overlay-fg: var(--color-text);
+  --map-overlay-muted: var(--color-text-muted);
+  --map-overlay-border: var(--color-border);
+  --map-overlay-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  --map-attribution-bg: color-mix(in srgb, var(--color-surface) 92%, transparent);
+}
+
+/* chonky-ui <Badge variant="..."> overrides: solid fills + white text. */
+:root[data-theme="high-contrast"] .badge {
+  border-color: transparent;
+}
+:root[data-theme="high-contrast"] .badge-success { background: var(--color-success); color: #ffffff; border-color: var(--color-success); }
+:root[data-theme="high-contrast"] .badge-warning { background: var(--color-warning); color: #ffffff; border-color: var(--color-warning); }
+:root[data-theme="high-contrast"] .badge-danger  { background: var(--color-danger);  color: #ffffff; border-color: var(--color-danger); }
+:root[data-theme="high-contrast"] .badge-info    { background: var(--color-info);    color: #ffffff; border-color: var(--color-info); }
+
+/* Packet-log type badges: darkened saturated fills + white text so each
+   label clears AA against the white surface in direct sunlight. */
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='position']     { background: #15639c; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='weather']      { background: #1f6b1f; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='telemetry']    { background: #8a5d00; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='message']      { background: #00697a; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='object']       { background: #5a2d96; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='item']         { background: #2f7d2f; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='mic-e']        { background: #a31e6e; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='status']       { background: #44505c; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='capabilities'] { background: #6a35a0; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='df-report'],
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='query']        { background: #9a5000; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='third-party'],
+:root[data-theme="high-contrast"] .pkt-b-type[data-type='unknown']      { background: #5a5a5a; color: #ffffff; }
+
+/* Origin badges (bcn / digi / igate): solid + white. */
+:root[data-theme="high-contrast"] .pkt-b-origin[data-origin='bcn']          { background: #9a5000; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-origin[data-origin='digi']         { background: #15639c; color: #ffffff; }
+:root[data-theme="high-contrast"] .pkt-b-origin[data-origin='igate'],
+:root[data-theme="high-contrast"] .pkt-b-origin[data-origin='igate-is2rf'],
+:root[data-theme="high-contrast"] .pkt-b-origin[data-origin='igate-rf2is'] { background: #6a35a0; color: #ffffff; }

--- a/web/themes/themes.json
+++ b/web/themes/themes.json
@@ -20,6 +20,16 @@
       "id": "grayscale-night",
       "name": "Grayscale Night",
       "description": "Dark, monochrome. No chromatic accents."
+    },
+    {
+      "id": "high-contrast",
+      "name": "High Contrast",
+      "description": "Light, maximum-legibility. Pure-black text on white for bright sunlight and low vision."
+    },
+    {
+      "id": "high-contrast-night",
+      "name": "High Contrast Night",
+      "description": "Dark, maximum-legibility. Pure-white text on black; no faded dark-mode copy."
     }
   ]
 }


### PR DESCRIPTION
Addresses #274 (higher-contrast fonts).

The reporter found both default themes hard to read: the Light theme's font is gray rather than pure black ("almost impossible to see in bright sunlight"), and the Dark theme's font looks "faded" and is barely visible. Rather than alter the existing palettes (which other operators rely on), this adds two new opt-in themes selectable from Preferences:

- **High Contrast** — light, maximum-legibility. Pure-black body copy (`#000`) on white, with darkened secondary/tertiary text that still clears WCAG AA, visibly bordered controls, and a deep-blue primary so links/buttons read at high contrast instead of the default orange (poor as text on white).
- **High Contrast Night** — dark, maximum-legibility. Pure-white body copy (`#fff`) on black, bright non-faded secondary text, visible borders, and solid bright packet badges with black text (instead of the default night theme's low-alpha tints, which is the source of the "faded" look).

Each is a drop-in `web/themes/*.css` file plus one `themes.json` entry — no Go, OpenAPI, or build-config changes, per the documented theme-contribution flow. `npm run build` succeeds and both selectors land in the bundle; the theme-registry tests pass.