### PR TITLE
Add interface display-size scaling to Preferences

### DIFF
--- a/docs/handbook/preferences.html
+++ b/docs/handbook/preferences.html
@@ -66,7 +66,7 @@
 
   <main class="content">
     <h1>Preferences</h1>
-    <p class="subtitle">Theme, units, update checks, and message length</p>
+    <p class="subtitle">Theme, display size, units, update checks, and message length</p>
 
     <p>
       The Preferences page collects the small per-station knobs that
@@ -83,6 +83,24 @@
       strong solid badges). Want your own colour scheme? See
       <code>graywolf/web/themes/README.md</code> in the source tree for
       how to drop one in via pull request.
+    </p>
+
+    <h2>Display size</h2>
+
+    <p>
+      The <strong>Display size</strong> selector scales the entire
+      interface &mdash; text, buttons, switches, and spacing &mdash; from
+      90% up to 200%. It&rsquo;s most useful on Android, where the app
+      runs in a full-screen WebView that has no pinch-zoom or
+      browser-style zoom of its own. On the desktop you can also use your
+      browser&rsquo;s built-in zoom.
+    </p>
+
+    <p>
+      Unlike the other preferences, display size is saved on the
+      <em>current device only</em> &mdash; bumping it up on your phone
+      won&rsquo;t enlarge the UI on your desktop. It takes effect
+      immediately and persists across restarts.
     </p>
 
     <h2>Updates</h2>

--- a/web/index.html
+++ b/web/index.html
@@ -28,6 +28,20 @@
         }
       })();
     </script>
+    <script>
+      // Apply the stored UI scale before the first frame paints so the
+      // interface doesn't visibly jump from 100% to the operator's chosen
+      // size on load. Mirrors ui-scale-store.svelte.js; clamps to the same
+      // [0.5, 3] range. Default (1) is a no-op so we leave `zoom` unset.
+      (function () {
+        try {
+          var n = parseFloat(localStorage.getItem('ui-scale'));
+          if (isFinite(n) && n >= 0.5 && n <= 3 && n !== 1) {
+            document.documentElement.style.zoom = String(n);
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/web/index.html
+++ b/web/index.html
@@ -31,12 +31,14 @@
     <script>
       // Apply the stored UI scale before the first frame paints so the
       // interface doesn't visibly jump from 100% to the operator's chosen
-      // size on load. Mirrors ui-scale-store.svelte.js; clamps to the same
-      // [0.5, 3] range. Default (1) is a no-op so we leave `zoom` unset.
+      // size on load. Mirrors ui-scale-store.svelte.js; accepts the same
+      // [0.9, 2] range. The store snaps to discrete steps after mount, so a
+      // raw in-range value here is fine. Default (1) is a no-op, so we leave
+      // `zoom` unset.
       (function () {
         try {
           var n = parseFloat(localStorage.getItem('ui-scale'));
-          if (isFinite(n) && n >= 0.5 && n <= 3 && n !== 1) {
+          if (isFinite(n) && n >= 0.9 && n <= 2 && n !== 1) {
             document.documentElement.style.zoom = String(n);
           }
         } catch (e) {}

--- a/web/src/lib/settings/ui-scale-store.svelte.js
+++ b/web/src/lib/settings/ui-scale-store.svelte.js
@@ -12,13 +12,14 @@
 
 const LS_KEY = 'ui-scale';
 
-const MIN = 0.5;
-const MAX = 3;
 const DEFAULT = 1;
 
-// Discrete steps offered in Preferences. The inline boot script in
-// index.html applies whatever is stored (clamped to [MIN, MAX]); keep the
-// bounds here in sync with it.
+// Discrete steps offered in Preferences, in ascending order. These are the
+// ONLY values the store will ever hold: reads and writes snap to the nearest
+// step (see snap()), so the Select always has an exact match to display and
+// the applied zoom is always a known-good size. MIN/MAX below are derived
+// from this list and must stay in sync with the inline boot script in
+// index.html, which clamps to the same [0.9, 2] range.
 export const UI_SCALE_OPTIONS = [
   { value: '0.9', label: 'Small (90%)' },
   { value: '1', label: 'Default (100%)' },
@@ -29,15 +30,24 @@ export const UI_SCALE_OPTIONS = [
   { value: '2', label: 'Maximum (200%)' },
 ];
 
-function clamp(n) {
+const STEPS = UI_SCALE_OPTIONS.map((o) => parseFloat(o.value));
+const MIN = STEPS[0];
+const MAX = STEPS[STEPS.length - 1];
+
+// Clamp into range, then snap to the nearest offered step. A hand-edited or
+// legacy localStorage value (e.g. 1.2) thus resolves to a real option (1.25)
+// instead of leaving the Select rendering its empty placeholder.
+function snap(n) {
   if (!Number.isFinite(n)) return DEFAULT;
-  return Math.min(MAX, Math.max(MIN, n));
+  const c = Math.min(MAX, Math.max(MIN, n));
+  return STEPS.reduce((best, s) =>
+    Math.abs(s - c) < Math.abs(best - c) ? s : best, STEPS[0]);
 }
 
 function readStored() {
   try {
     const n = parseFloat(localStorage.getItem(LS_KEY));
-    return Number.isFinite(n) ? clamp(n) : DEFAULT;
+    return Number.isFinite(n) ? snap(n) : DEFAULT;
   } catch {
     return DEFAULT;
   }
@@ -63,7 +73,7 @@ export const uiScaleState = (() => {
   applyDOM(initial);
 
   function setScale(next) {
-    const n = clamp(parseFloat(next));
+    const n = snap(parseFloat(next));
     scale = n;
     writeStored(n);
     applyDOM(n);

--- a/web/src/lib/settings/ui-scale-store.svelte.js
+++ b/web/src/lib/settings/ui-scale-store.svelte.js
@@ -1,0 +1,76 @@
+// Device-local UI scale preference. Unlike theme/units, this is
+// intentionally NOT synced to the server: an operator who needs a larger
+// interface on their phone doesn't want their desktop blown up to match,
+// so the value lives only in this device's localStorage.
+//
+// It's applied as a CSS `zoom` on the document root, which reflows the
+// whole layout and scales every interface element uniformly — text,
+// buttons, switches, spacing — the way the browser's own page-zoom would.
+// That matters most on Android, where the WebView disables pinch-zoom and
+// the page-zoom shortcut, leaving the operator no built-in way to enlarge
+// the UI (graywolf #275).
+
+const LS_KEY = 'ui-scale';
+
+const MIN = 0.5;
+const MAX = 3;
+const DEFAULT = 1;
+
+// Discrete steps offered in Preferences. The inline boot script in
+// index.html applies whatever is stored (clamped to [MIN, MAX]); keep the
+// bounds here in sync with it.
+export const UI_SCALE_OPTIONS = [
+  { value: '0.9', label: 'Small (90%)' },
+  { value: '1', label: 'Default (100%)' },
+  { value: '1.1', label: 'Large (110%)' },
+  { value: '1.25', label: 'Larger (125%)' },
+  { value: '1.5', label: 'Huge (150%)' },
+  { value: '1.75', label: 'Extra (175%)' },
+  { value: '2', label: 'Maximum (200%)' },
+];
+
+function clamp(n) {
+  if (!Number.isFinite(n)) return DEFAULT;
+  return Math.min(MAX, Math.max(MIN, n));
+}
+
+function readStored() {
+  try {
+    const n = parseFloat(localStorage.getItem(LS_KEY));
+    return Number.isFinite(n) ? clamp(n) : DEFAULT;
+  } catch {
+    return DEFAULT;
+  }
+}
+
+function writeStored(n) {
+  try { localStorage.setItem(LS_KEY, String(n)); } catch {}
+}
+
+function applyDOM(n) {
+  // `zoom` on the root element behaves like page-zoom in Chromium (the
+  // Android WebView engine): `vh`, fixed positioning, and the map all
+  // recompute against the zoomed viewport, so nothing clips the way a
+  // `transform: scale()` would.
+  try { document.documentElement.style.zoom = String(n); } catch {}
+}
+
+export const uiScaleState = (() => {
+  const initial = readStored();
+  let scale = $state(initial);
+  // The inline boot script already applied this before first paint; re-apply
+  // so the rune and the DOM are guaranteed to agree. Cheap and idempotent.
+  applyDOM(initial);
+
+  function setScale(next) {
+    const n = clamp(parseFloat(next));
+    scale = n;
+    writeStored(n);
+    applyDOM(n);
+  }
+
+  return {
+    get scale() { return scale; },
+    setScale,
+  };
+})();

--- a/web/src/routes/Preferences.svelte
+++ b/web/src/routes/Preferences.svelte
@@ -4,6 +4,7 @@
   import { unitsState } from '../lib/settings/units-store.svelte.js';
   import { updates } from '../lib/updatesStore.svelte.js';
   import { themeState } from '../lib/settings/theme-store.svelte.js';
+  import { uiScaleState, UI_SCALE_OPTIONS } from '../lib/settings/ui-scale-store.svelte.js';
   import { THEMES } from '../lib/themes/registry.js';
   import PageHeader from '../components/PageHeader.svelte';
 
@@ -36,6 +37,18 @@
   </p>
 </Box>
 
+<Box title="Display size">
+  <Select
+    value={String(uiScaleState.scale)}
+    onValueChange={(v) => uiScaleState.setScale(v)}
+    options={UI_SCALE_OPTIONS}
+  />
+  <p class="scale-hint">
+    Scales the whole interface — text, buttons, and switches. Saved on this
+    device only, so it won't change the size on your other screens.
+  </p>
+</Box>
+
 <Box title="Units">
   <Toggle
     checked={unitsState.isMetric}
@@ -65,6 +78,7 @@
 
 <style>
   .theme-hint,
+  .scale-hint,
   .unit-hint,
   .update-hint {
     margin-top: 12px;


### PR DESCRIPTION
Closes #275.

## What
Adds a **Display size** selector to Preferences that scales the entire interface -- text, buttons, switches, and spacing -- from 90% up to 200%.

## Why
The Android app runs the Svelte UI in a full-screen WebView that explicitly disables pinch-zoom and the browser zoom shortcut (`setSupportZoom(false)` in `MainActivity`), so an Android operator had no way to enlarge the UI. This gives them an in-app control. Desktop users benefit too, though they also have browser zoom.

## How
- Applies a CSS `zoom` on the document root, which reflows the whole layout and scales every element uniformly -- the way page-zoom would. Unlike `transform: scale()`, it doesn't clip fixed/full-bleed surfaces (sidebar, map), and the map keeps working since the zoomed viewport behaves like browser page-zoom.
- The preference is **device-local** (localStorage only, deliberately not synced to the server) so bumping the size on a phone doesn't enlarge the UI on a desktop.
- An inline boot script in `index.html` applies the stored value before first paint to avoid a visible jump on load, mirroring the existing theme boot script.

## Files
- `web/src/lib/settings/ui-scale-store.svelte.js` -- new device-local store
- `web/src/routes/Preferences.svelte` -- Display size selector
- `web/index.html` -- pre-paint boot apply
- `docs/handbook/preferences.html` -- documents the setting

Verified with `npm run build`.