### PR TITLE
Fix radar overlay staying blank until Play is pressed

### DIFF
--- a/web/src/lib/map/layers/radar.js
+++ b/web/src/lib/map/layers/radar.js
@@ -18,7 +18,7 @@
 
 import { radarProviderForRegion, frameBucket, RADAR_REGION_US } from '../sources/radar-source.js';
 
-export function mountRadarLayer(map, { visible, opacity, region = RADAR_REGION_US, now = () => Date.now() }) {
+export function mountRadarLayer(map, { visible, opacity, region = RADAR_REGION_US, frameTs = null, now = () => Date.now() }) {
   // Region (US vs rest-of-world) is operator-selectable, so the provider is
   // mutable: setRegion() tears down and rebuilds it. Everything below reads the
   // current `provider`, so the same add/remove logic serves either region.
@@ -31,9 +31,11 @@ export function mountRadarLayer(map, { visible, opacity, region = RADAR_REGION_U
   // Current frame cache-bust bucket (RainViewer raster only). The source is
   // added already pointing at this bucket's URL; refresh() bumps it on rollover.
   let curBucket = provider.cacheBust ? frameBucket(now()) : null;
-  // Current frame ts (per-frame vector loop only). Null until the manifest
-  // yields a frame; setFrameTs() advances it.
-  let curFrameTs = null;
+  // Current frame ts (per-frame vector loop only). Seeded from the mount option
+  // when the manifest poll already resolved before the layer mounted (so the
+  // overlay paints immediately rather than waiting for the next index change);
+  // null otherwise. setFrameTs() advances it.
+  let curFrameTs = frameTs;
 
   // Idempotent add: safe to call repeatedly (initial mount + every refresh).
   function ensure() {

--- a/web/src/lib/map/layers/radar.test.js
+++ b/web/src/lib/map/layers/radar.test.js
@@ -31,6 +31,18 @@ test('per-frame vector overlay adds no source until a frame ts is set', () => {
   assert.equal(map._layers['radar-fill'], undefined);
 });
 
+test('an initial frameTs seeds the per-frame source at mount (no setFrameTs needed)', () => {
+  // The manifest poll can resolve before the basemap style loads, so a frame ts
+  // is often known by the time the layer mounts. Passing it as a mount option
+  // (like visible/opacity) must render the overlay immediately -- otherwise it
+  // stays blank until the next index change (e.g. pressing Play).
+  const map = fakeMap();
+  mountRadarLayer(map, { visible: true, opacity: 0.6, frameTs: 1750020000 });
+  assert.equal(map._sources['radar-tiles'].type, 'vector');
+  assert.deepEqual(map._sources['radar-tiles'].tiles, [frameUrl(1750020000)]);
+  assert.equal(map._layers['radar-fill'].type, 'fill');
+});
+
 test('setFrameTs adds the per-frame source then swaps the template on advance', () => {
   const map = fakeMap();
   const layer = mountRadarLayer(map, { visible: true, opacity: 0.6 });

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -409,6 +409,12 @@
       visible: radarSettings.visible,
       opacity: radarSettings.opacity,
       region: mapState.radarRegion,
+      // The manifest poll often resolves before the basemap style loads (tiny
+      // edge-cached JSON vs a heavy basemap), so a frame ts may already be
+      // known. The currentTs effect won't re-fire for an unchanged ts once the
+      // layer exists, so seed the current frame here or the overlay stays blank
+      // until the index changes (e.g. pressing Play).
+      frameTs: radarFrames.currentTs,
     });
     // Trails first so the line sits beneath the (DOM) station markers
     // and below the weather labels in symbol-layer order.


### PR DESCRIPTION
## Symptom

On the Live Map, with the radar layer checked, the overlay shows nothing on load. Pressing **Play** makes it appear and animate correctly.

## Root cause

The frame ts reaches the radar layer only through an `$effect` keyed on `radarFrames.currentTs` (LiveMapV2). But `radarLayer` is a non-reactive `let`, assigned later in `onMapReady` (the async `style.load` callback). The loop manifest is tiny and edge-cached while the basemap is heavy, so the manifest poll usually resolves **before** the layer exists: the effect runs with `radarLayer` still null (no-op), and because the layer reference isn't reactive, it never re-pushes the already-known ts. Pressing Play advances the index → `currentTs` changes → the effect re-fires (layer now exists) → radar appears.

Unlike `visible`/`opacity`, the frame ts was never seeded at mount.

## Fix

Add a `frameTs` mount option to `mountRadarLayer` (mirroring `visible`/`opacity`) and seed it from `radarFrames.currentTs` in `onMapReady`. The overlay now paints immediately regardless of whether the poll or the style load wins the race; the existing effect still handles later frame changes.

## Tests

- New `radar.test.js` case: mounting with an initial `frameTs` adds the per-frame vector source immediately (red before the fix, green after).
- Full suite: 317/318 (the one failure is the pre-existing, unrelated `DESKTOP_METHODS` PTT test). `npm run build` clean.
