### PR TITLE
Speed up radar loop playback to ~4 fps

### DIFF
--- a/web/src/lib/map/radar-frames.svelte.js
+++ b/web/src/lib/map/radar-frames.svelte.js
@@ -11,8 +11,8 @@ import { applyManifest, shouldApply, nextIndex, newestIndex, clampIndex } from '
 export function createRadarFrames({
   load,
   pollMs = 15000, // manifest refresh cadence (matches the worker's manifest TTL)
-  frameMs = 500, // ~2 fps playback
-  holdMs = 1000, // dwell on the newest frame before looping
+  frameMs = 250, // ~4 fps playback
+  holdMs = 750, // dwell on the newest frame before looping
 }) {
   let frames = $state([]); // oldest -> newest
   let index = $state(0);


### PR DESCRIPTION
## What

The animated radar loop played at ~2 fps (`frameMs = 500`), which feels slow over the 3h/36-frame window. This halves the per-frame interval to 250ms (~4 fps) and trims the newest-frame dwell from 1000ms to 750ms.

Both are `createRadarFrames` options, so they remain trivially tunable if a different speed is preferred.

## Note

This is the playback-speed half of the user's request. The separate "frames every 5 min, not 10" half is the generator **CronJob schedule** (`*/10` deployed vs the chart default `*/5`), an infra change — not in this PR.

## Tests
Build clean; suite unchanged (the lone failure is the pre-existing, unrelated `DESKTOP_METHODS` PTT test). The frame-timing constants aren't logic, so no unit test applies; `radar-frames-core` math tests are untouched.
