### PR TITLE
Add disable toggle for KISS TNC interfaces

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -901,18 +901,41 @@ two-switch dispatch as invariant #34 plus the TX snapshot:
 2. `pkg/webapi/kiss.go` — `notifyKissManager` calls `kissManager.Stop(id)` (release) on `!Enabled`, and (re)starts on `Enabled`. The focused `PUT /api/kiss/{id}/enabled` toggle (`setKissEnabled`) routes through here.
 3. `pkg/app/wiring.go` — `buildTxBackendSnapshot` excludes `!Enabled` rows so a disabled TNC registers no governor TX backend.
 
+*notifyKissManager must enumerate the same interface types as the boot
+switch* (this is invariant #34's two-switch hazard in practice). The
+re-enable path goes through `notifyKissManager`, so its `switch` needs a
+case for **every** type `kissComponent` can start — `tcp`, `tcp-client`,
+`serial`, `bluetooth`, `usbserial`. A type that falls into `default:`
+hits `Stop(id)` and silently never restarts on re-enable (this bit
+Bluetooth/USB: they were missing and re-enable was a no-op). The
+serial-family cases (`serial`/`bluetooth`/`usbserial`) must also pass
+`OpenFunc: s.kissSerialOpenFunc` — on Android that opener routes MAC /
+vid:pid device strings through `platformsvc`; without it the supervisor
+cannot open the device. The webapi `Server` receives it via
+`Config.KissSerialOpenFunc` (wired from `App.kissSerialOpenFunc()`; nil
+on desktop).
+
 *Why a pointer:* `dto.KissRequest.Enabled` is `*bool`, not `bool`. KISS
 `POST`/`PUT` is full-resource replace (invariant at line ~185), so a
 plain `bool` would conflate "field omitted" with "disable" and an older
 client editing any field would silently stop the interface. `nil` means
-"omitted → default true"; `ToModel` substitutes the explicit value so the
-gorm `default:true` never has to disambiguate a wire `false` (the same
-hazard documented for the `actions` table, solved there by dropping the
-gorm default — KISS solves it at the DTO boundary instead). The frontend
-always sends `enabled` on save so a `PUT` never re-enables a row the
-operator disabled.
+"omitted → default true"; `ToModel` substitutes the explicit value. The
+frontend always sends `enabled` on save so a `PUT` never re-enables a row
+the operator disabled.
+
+*Create vs. the gorm default:* the `default:true` tag is kept (so the SQL
+DDL default survives for raw inserts / downgrade-safety — `migrate_kiss_*`
+tests rely on it). But gorm treats a Go zero-value `bool` as "unset" and
+sends the column default on `INSERT`, so a `POST` with `enabled=false`
+would otherwise persist `true` (the footgun the `actions` table dodged by
+dropping its tag default). `Store.CreateKissInterface` therefore captures
+the requested value *before* `db.Create` (gorm writes the applied default
+back into the struct) and re-asserts `false` with an explicit `Update`.
+`UpdateKissInterface` (`db.Save`) writes `false` correctly on its own, so
+only the create path needs the fix-up.
 
 Source: [`../../pkg/webapi/dto/kiss.go`](../../pkg/webapi/dto/kiss.go)
 (`KissRequest.ToModel`, `KissEnabledRequest`),
 [`../../pkg/webapi/kiss.go`](../../pkg/webapi/kiss.go) (`setKissEnabled`, `notifyKissManager`),
-[`../../pkg/app/wiring.go`](../../pkg/app/wiring.go) (`kissComponent`, `buildTxBackendSnapshot`).
+[`../../pkg/configstore/store.go`](../../pkg/configstore/store.go) (`CreateKissInterface`),
+[`../../pkg/app/wiring.go`](../../pkg/app/wiring.go) (`kissComponent`, `buildTxBackendSnapshot`, webapi `Config.KissSerialOpenFunc`).

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -884,3 +884,35 @@ the corresponding Rust→Go reply (e.g. `TestSignalResult`) so the Go side's
 bounded wait resolves. Android TX jobs submit samples unscaled (gain is
 applied by `AndroidTxSink`), unlike the desktop arm which pre-scales by the
 output device gain.
+
+### 45. Disabling a KISS interface releases its device; the DTO flag is a pointer
+
+A KISS interface row carries `Enabled` (`KissInterface.Enabled`,
+gorm `default:true`). When `Enabled=false` the manager does **not** keep
+the device open looping reconnect attempts — it stops the supervisor,
+which cancels the serve context and closes the underlying
+`io.ReadWriteCloser` (the serial fd / TCP socket). This is what lets an
+operator release e.g. a Bluetooth `/dev/rfcomm0` tty before a battery
+swap without deleting the interface (graywolf #152). Three call sites
+already honor the flag and must stay in sync — they are the same
+two-switch dispatch as invariant #34 plus the TX snapshot:
+
+1. `pkg/app/wiring.go` — `kissComponent().start` skips `!Enabled` rows at boot.
+2. `pkg/webapi/kiss.go` — `notifyKissManager` calls `kissManager.Stop(id)` (release) on `!Enabled`, and (re)starts on `Enabled`. The focused `PUT /api/kiss/{id}/enabled` toggle (`setKissEnabled`) routes through here.
+3. `pkg/app/wiring.go` — `buildTxBackendSnapshot` excludes `!Enabled` rows so a disabled TNC registers no governor TX backend.
+
+*Why a pointer:* `dto.KissRequest.Enabled` is `*bool`, not `bool`. KISS
+`POST`/`PUT` is full-resource replace (invariant at line ~185), so a
+plain `bool` would conflate "field omitted" with "disable" and an older
+client editing any field would silently stop the interface. `nil` means
+"omitted → default true"; `ToModel` substitutes the explicit value so the
+gorm `default:true` never has to disambiguate a wire `false` (the same
+hazard documented for the `actions` table, solved there by dropping the
+gorm default — KISS solves it at the DTO boundary instead). The frontend
+always sends `enabled` on save so a `PUT` never re-enables a row the
+operator disabled.
+
+Source: [`../../pkg/webapi/dto/kiss.go`](../../pkg/webapi/dto/kiss.go)
+(`KissRequest.ToModel`, `KissEnabledRequest`),
+[`../../pkg/webapi/kiss.go`](../../pkg/webapi/kiss.go) (`setKissEnabled`, `notifyKissManager`),
+[`../../pkg/app/wiring.go`](../../pkg/app/wiring.go) (`kissComponent`, `buildTxBackendSnapshot`).

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -1327,17 +1327,18 @@ func (a *App) wireHTTP(ctx context.Context) error {
 	})
 
 	apiSrv, err := webapi.NewServer(webapi.Config{
-		Store:         a.store,
-		Bridge:        a.bridge,
-		KissManager:   a.kissMgr,
-		KissCtx:       ctx,
-		Logger:        a.logger,
-		HistoryDBPath: a.cfg.HistoryDBPath,
-		Version:       a.cfg.Version,
-		MapsCache:     mapsCache,
-		Catalog:       catalog,
-		Style:         styleCache,
-		Demo:          a.cfg.Demo,
+		Store:              a.store,
+		Bridge:             a.bridge,
+		KissManager:        a.kissMgr,
+		KissCtx:            ctx,
+		KissSerialOpenFunc: a.kissSerialOpenFunc(),
+		Logger:             a.logger,
+		HistoryDBPath:      a.cfg.HistoryDBPath,
+		Version:            a.cfg.Version,
+		MapsCache:          mapsCache,
+		Catalog:            catalog,
+		Style:              styleCache,
+		Demo:               a.cfg.Demo,
 	})
 	if err != nil {
 		return fmt.Errorf("webapi new: %w", err)

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -964,7 +964,26 @@ func (s *Store) CreateKissInterface(ctx context.Context, k *KissInterface) error
 	if err := s.validateKissInterface(ctx, k); err != nil {
 		return err
 	}
-	return s.db.WithContext(ctx).Create(k).Error
+	// The Enabled column carries gorm `default:true` (kept so the SQL DDL
+	// default survives for raw inserts / downgrade-safety). The flip side
+	// of that footgun: gorm treats a Go zero-value bool as "unset" and
+	// sends the DB default, so a caller creating a *disabled* interface
+	// (Enabled=false) would silently get an enabled one. Capture the
+	// requested value before Create — gorm writes the applied default
+	// back into the struct, so k.Enabled would read true afterward — and
+	// re-assert it explicitly when it was false. UpdateKissInterface
+	// (db.Save) writes false correctly, so only the create path needs this.
+	wantEnabled := k.Enabled
+	if err := s.db.WithContext(ctx).Create(k).Error; err != nil {
+		return err
+	}
+	if !wantEnabled {
+		k.Enabled = false
+		if err := s.db.WithContext(ctx).Model(k).Update("enabled", false).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 func (s *Store) UpdateKissInterface(ctx context.Context, k *KissInterface) error {
 	if err := normalizeKissInterface(k); err != nil {

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1417,6 +1417,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1464,6 +1465,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1520,6 +1522,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1560,6 +1563,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1752,6 +1756,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1793,6 +1798,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -3864,6 +3870,70 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/kiss/{id}/enabled": {
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "kiss"
+                ],
+                "summary": "Enable or disable a KISS interface",
+                "operationId": "setKissEnabled",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "KISS interface id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Enabled flag",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.KissEnabledRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.KissResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/webtypes.ErrorResponse"
                         }
@@ -7424,7 +7494,8 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "int32"
                     }
                 },
                 "source": {
@@ -7674,7 +7745,8 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -7689,7 +7761,8 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -7699,7 +7772,8 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -7707,7 +7781,8 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -7719,7 +7794,8 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -7734,10 +7810,12 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "table": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 }
             }
         },
@@ -7747,7 +7825,8 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number"
+                        "type": "number",
+                        "format": "float64"
                     }
                 },
                 "analogHas": {
@@ -7763,7 +7842,8 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -7779,7 +7859,8 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -7787,7 +7868,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -7862,17 +7944,21 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rain24Hour": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rainSinceMid": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -7880,7 +7966,8 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -7888,7 +7975,8 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -7900,11 +7988,13 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 }
             }
         },
@@ -9397,6 +9487,14 @@
                 }
             }
         },
+        "dto.KissEnabledRequest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "dto.KissRequest": {
             "type": "object",
             "properties": {
@@ -9409,6 +9507,10 @@
                 },
                 "channel": {
                     "type": "integer"
+                },
+                "enabled": {
+                    "description": "Enabled gates whether graywolf runs this interface. When false the\nmanager stops the supervisor and releases the underlying device\n(closing the fd / socket) instead of looping reconnect attempts,\nwhile the row's configuration is preserved for a later re-enable.\nA pointer so an omitted field means \"leave at the default\" (true)\nrather than \"disable\": older clients and partial callers that never\nsend the key keep their interfaces running. ToModel substitutes\ntrue when nil.",
+                    "type": "boolean"
                 },
                 "gate_tx_to_is": {
                     "description": "GateTxToIs opts a Mode=modem KISS interface in to gating frames\nsubmitted by connected KISS clients to APRS-IS, after the TX\ngovernor has accepted them. The iGate's own filter chain still\nruns, so this only opens the gate — it does not bypass NOGATE /\nRFONLY / TCPIP markers or the operator's filter rules. Default\nfalse on all migrated rows; meaningless in Mode=tnc (which\nalready feeds the iGate via the RX fanout) and silently ignored\nthere by the server.",
@@ -9468,6 +9570,10 @@
                 },
                 "connected_since": {
                     "type": "integer"
+                },
+                "enabled": {
+                    "description": "Enabled mirrors KissInterface.Enabled so the Kiss page can show a\n\"Disabled\" state and offer a re-enable action. A disabled interface\nis not running, so the live status fields below stay zero-valued\nfor it.",
+                    "type": "boolean"
                 },
                 "gate_tx_to_is": {
                     "type": "boolean"
@@ -10736,6 +10842,11 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
+            "x-enum-descriptions": [
+                "heard on the air",
+                "transmitted by us",
+                "APRS-IS upload/download (iGate)"
+            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -11046,7 +11157,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -11135,7 +11247,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1417,7 +1417,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1465,7 +1464,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1522,7 +1520,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1563,7 +1560,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1756,7 +1752,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1798,7 +1793,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -7494,8 +7488,7 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer",
-                        "format": "int32"
+                        "type": "integer"
                     }
                 },
                 "source": {
@@ -7745,8 +7738,7 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -7761,8 +7753,7 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -7772,8 +7763,7 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -7781,8 +7771,7 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -7794,8 +7783,7 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -7810,12 +7798,10 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "table": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 }
             }
         },
@@ -7825,8 +7811,7 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number",
-                        "format": "float64"
+                        "type": "number"
                     }
                 },
                 "analogHas": {
@@ -7842,8 +7827,7 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -7859,8 +7843,7 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -7868,8 +7851,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -7944,21 +7926,17 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain24Hour": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rainSinceMid": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -7966,8 +7944,7 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -7975,8 +7952,7 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -7988,13 +7964,11 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 }
             }
         },
@@ -10842,11 +10816,6 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
-            "x-enum-descriptions": [
-                "heard on the air",
-                "transmitted by us",
-                "APRS-IS upload/download (iGate)"
-            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -11157,8 +11126,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -11247,8 +11215,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,6 +50,7 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
+          format: int32
           type: integer
         type: array
       source:
@@ -228,6 +229,7 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
+        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -239,6 +241,7 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
+        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -246,12 +249,14 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
+        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
+        format: float64
         type: number
       phg:
         allOf:
@@ -259,6 +264,7 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
+        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -269,14 +275,17 @@ definitions:
   aprs.Symbol:
     properties:
       code:
+        format: int32
         type: integer
       table:
+        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
+          format: float64
           type: number
         type: array
       analogHas:
@@ -289,6 +298,7 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
+        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -300,11 +310,13 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
+        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -357,25 +369,31 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
+        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
+        format: float64
         type: number
       rain24Hour:
+        format: float64
         type: number
       rainSinceMid:
+        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
+        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
+        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -385,9 +403,11 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
+        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
+        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -1384,6 +1404,11 @@ definitions:
       type:
         type: string
     type: object
+  dto.KissEnabledRequest:
+    properties:
+      enabled:
+        type: boolean
+    type: object
   dto.KissRequest:
     properties:
       allow_tx_from_governor:
@@ -1400,6 +1425,17 @@ definitions:
         type: integer
       channel:
         type: integer
+      enabled:
+        description: |-
+          Enabled gates whether graywolf runs this interface. When false the
+          manager stops the supervisor and releases the underlying device
+          (closing the fd / socket) instead of looping reconnect attempts,
+          while the row's configuration is preserved for a later re-enable.
+          A pointer so an omitted field means "leave at the default" (true)
+          rather than "disable": older clients and partial callers that never
+          send the key keep their interfaces running. ToModel substitutes
+          true when nil.
+        type: boolean
       gate_tx_to_is:
         description: |-
           GateTxToIs opts a Mode=modem KISS interface in to gating frames
@@ -1458,6 +1494,13 @@ definitions:
         type: integer
       connected_since:
         type: integer
+      enabled:
+        description: |-
+          Enabled mirrors KissInterface.Enabled so the Kiss page can show a
+          "Disabled" state and offer a re-enable action. A disabled interface
+          is not running, so the live status fields below stay zero-valued
+          for it.
+        type: boolean
       gate_tx_to_is:
         type: boolean
       id:
@@ -2419,6 +2462,10 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
+    x-enum-descriptions:
+      - heard on the air
+      - transmitted by us
+      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2633,6 +2680,7 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -2696,6 +2744,7 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -3835,6 +3884,7 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -3855,6 +3905,7 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -3885,6 +3936,7 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -3926,6 +3978,7 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4046,6 +4099,7 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4066,6 +4120,7 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
+          format: int32
           in: path
           name: id
           required: true
@@ -5333,6 +5388,47 @@ paths:
       security:
         - CookieAuth: []
       summary: Update KISS interface
+      tags:
+        - kiss
+  /kiss/{id}/enabled:
+    put:
+      consumes:
+        - application/json
+      operationId: setKissEnabled
+      parameters:
+        - description: KISS interface id
+          in: path
+          name: id
+          required: true
+          type: integer
+        - description: Enabled flag
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/dto.KissEnabledRequest'
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.KissResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Enable or disable a KISS interface
       tags:
         - kiss
   /kiss/{id}/reconnect:

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,7 +50,6 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
-          format: int32
           type: integer
         type: array
       source:
@@ -229,7 +228,6 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
-        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -241,7 +239,6 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
-        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -249,14 +246,12 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
-        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
-        format: float64
         type: number
       phg:
         allOf:
@@ -264,7 +259,6 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
-        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -275,17 +269,14 @@ definitions:
   aprs.Symbol:
     properties:
       code:
-        format: int32
         type: integer
       table:
-        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
-          format: float64
           type: number
         type: array
       analogHas:
@@ -298,7 +289,6 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
-        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -310,13 +300,11 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
-        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -369,31 +357,25 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
-        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
-        format: float64
         type: number
       rain24Hour:
-        format: float64
         type: number
       rainSinceMid:
-        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
-        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
-        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -403,11 +385,9 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
-        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
-        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -2462,10 +2442,6 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
-    x-enum-descriptions:
-      - heard on the air
-      - transmitted by us
-      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2680,7 +2656,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -2744,7 +2719,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -3884,7 +3858,6 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -3905,7 +3878,6 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -3936,7 +3908,6 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -3978,7 +3949,6 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4099,7 +4069,6 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4120,7 +4089,6 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true

--- a/pkg/webapi/docs/op_ids.go
+++ b/pkg/webapi/docs/op_ids.go
@@ -79,6 +79,7 @@ const (
 	OpCreateKiss                   = "createKiss"
 	OpGetKiss                      = "getKiss"
 	OpUpdateKiss                   = "updateKiss"
+	OpSetKissEnabled               = "setKissEnabled"
 	OpDeleteKiss                   = "deleteKiss"
 	OpReconnectKiss                = "reconnectKiss"
 	OpGetBondedBtDevices           = "getBondedBtDevices"

--- a/pkg/webapi/dto/kiss.go
+++ b/pkg/webapi/dto/kiss.go
@@ -69,6 +69,15 @@ type KissRequest struct {
 	RemotePort      uint16 `json:"remote_port"`
 	ReconnectInitMs uint32 `json:"reconnect_init_ms"`
 	ReconnectMaxMs  uint32 `json:"reconnect_max_ms"`
+	// Enabled gates whether graywolf runs this interface. When false the
+	// manager stops the supervisor and releases the underlying device
+	// (closing the fd / socket) instead of looping reconnect attempts,
+	// while the row's configuration is preserved for a later re-enable.
+	// A pointer so an omitted field means "leave at the default" (true)
+	// rather than "disable": older clients and partial callers that never
+	// send the key keep their interfaces running. ToModel substitutes
+	// true when nil.
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // tcp-client reconnect bounds. init ≥ 250ms so a flapping peer can't
@@ -181,12 +190,22 @@ func (r KissRequest) ToModel() configstore.KissInterface {
 	if maxMs == 0 {
 		maxMs = 300000
 	}
+	// Absent enabled flag defaults to true so existing clients that never
+	// send the key keep creating/updating running interfaces; an explicit
+	// false disables (manager stops the supervisor and releases the
+	// device). KISS PUT is a full-resource replace, so an editor that
+	// echoes the row's current enabled value preserves a disabled state
+	// across unrelated field edits.
+	enabled := true
+	if r.Enabled != nil {
+		enabled = *r.Enabled
+	}
 	ki := configstore.KissInterface{
 		InterfaceType:       r.Type,
 		Device:              r.SerialDevice,
 		BaudRate:            r.BaudRate,
 		Channel:             ch,
-		Enabled:             true,
+		Enabled:             enabled,
 		Broadcast:           true,
 		Mode:                mode,
 		TncIngressRateHz:    r.TncIngressRateHz,
@@ -221,6 +240,16 @@ func (r KissRequest) ToModel() configstore.KissInterface {
 	return ki
 }
 
+// KissEnabledRequest is the body for PUT /api/kiss/{id}/enabled — a
+// focused toggle that flips only the Enabled flag without re-sending the
+// whole interface definition. The Kiss page's per-row enable/disable
+// action uses it so the operator can release a device (e.g. a Bluetooth
+// rfcomm tty before a battery swap) in one click while keeping the saved
+// channel/config intact.
+type KissEnabledRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
 func (r KissRequest) ToUpdate(id uint32) configstore.KissInterface {
 	m := r.ToModel()
 	m.ID = id
@@ -253,6 +282,11 @@ type KissResponse struct {
 	AllowTxFromGovernor bool   `json:"allow_tx_from_governor"`
 	GateTxToIs          bool   `json:"gate_tx_to_is"`
 	NeedsReconfig       bool   `json:"needs_reconfig"`
+	// Enabled mirrors KissInterface.Enabled so the Kiss page can show a
+	// "Disabled" state and offer a re-enable action. A disabled interface
+	// is not running, so the live status fields below stay zero-valued
+	// for it.
+	Enabled bool `json:"enabled"`
 	// Tcp-client fields (Phase 4). Zero-valued for non-tcp-client rows.
 	RemoteHost      string `json:"remote_host"`
 	RemotePort      uint16 `json:"remote_port"`
@@ -302,6 +336,7 @@ func KissFromModel(m configstore.KissInterface) KissResponse {
 		AllowTxFromGovernor: m.AllowTxFromGovernor,
 		GateTxToIs:          m.GateTxToIs,
 		NeedsReconfig:       m.NeedsReconfig,
+		Enabled:             m.Enabled,
 		RemoteHost:          m.RemoteHost,
 		RemotePort:          m.RemotePort,
 		ReconnectInitMs:     m.ReconnectInitMs,

--- a/pkg/webapi/dto/kiss_test.go
+++ b/pkg/webapi/dto/kiss_test.go
@@ -472,3 +472,53 @@ func TestKissRequest_GateTxToIs_RoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// TestKissRequest_Enabled_Default pins the backward-compat contract: a
+// request that omits the enabled field (Enabled == nil) must default the
+// model to enabled, so older clients and partial callers never silently
+// disable a running interface. An explicit false disables; explicit true
+// stays enabled.
+func TestKissRequest_Enabled_Default(t *testing.T) {
+	f := false
+	tr := true
+	cases := []struct {
+		name string
+		ptr  *bool
+		want bool
+	}{
+		{"omitted defaults to enabled", nil, true},
+		{"explicit true", &tr, true},
+		{"explicit false disables", &f, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := KissRequest{
+				Type:    configstore.KissTypeTCP,
+				TcpPort: 8001,
+				Channel: 1,
+				Mode:    configstore.KissModeModem,
+				Enabled: c.ptr,
+			}
+			if got := req.ToModel().Enabled; got != c.want {
+				t.Fatalf("ToModel: Enabled=%v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestKissResponse_Enabled_RoundTrip ensures KissFromModel surfaces the
+// stored Enabled flag so the UI can render a "Disabled" state.
+func TestKissResponse_Enabled_RoundTrip(t *testing.T) {
+	for _, want := range []bool{false, true} {
+		resp := KissFromModel(configstore.KissInterface{
+			InterfaceType: configstore.KissTypeTCP,
+			ListenAddr:    "0.0.0.0:8001",
+			Channel:       1,
+			Mode:          configstore.KissModeModem,
+			Enabled:       want,
+		})
+		if resp.Enabled != want {
+			t.Fatalf("KissFromModel: Enabled=%v, want %v", resp.Enabled, want)
+		}
+	}
+}

--- a/pkg/webapi/kiss.go
+++ b/pkg/webapi/kiss.go
@@ -23,6 +23,7 @@ func (s *Server) registerKiss(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/kiss/available-serial-ports", s.listAvailableKissSerialPorts)
 	mux.HandleFunc("GET /api/kiss/{id}", s.getKiss)
 	mux.HandleFunc("PUT /api/kiss/{id}", s.updateKiss)
+	mux.HandleFunc("PUT /api/kiss/{id}/enabled", s.setKissEnabled)
 	mux.HandleFunc("DELETE /api/kiss/{id}", s.deleteKiss)
 	mux.HandleFunc("POST /api/kiss/{id}/reconnect", s.reconnectKiss)
 }
@@ -174,6 +175,55 @@ func (s *Server) updateKiss(w http.ResponseWriter, r *http.Request) {
 			return m, nil
 		},
 		dto.KissFromModel)
+}
+
+// setKissEnabled flips only the Enabled flag on an interface and applies
+// the change live: disabling stops the supervisor and releases the
+// underlying device (closing the serial fd / socket) instead of looping
+// reconnect attempts; enabling (re)starts it. The saved channel and
+// configuration are preserved either way. This is the one-click toggle
+// behind the Kiss page's per-row enable/disable action — it avoids
+// re-sending the full interface definition just to release a device.
+//
+// @Summary  Enable or disable a KISS interface
+// @Tags     kiss
+// @ID       setKissEnabled
+// @Accept   json
+// @Produce  json
+// @Param    id   path     int                     true "KISS interface id"
+// @Param    body body     dto.KissEnabledRequest  true "Enabled flag"
+// @Success  200  {object} dto.KissResponse
+// @Failure  400  {object} webtypes.ErrorResponse
+// @Failure  404  {object} webtypes.ErrorResponse
+// @Failure  500  {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /kiss/{id}/enabled [put]
+func (s *Server) setKissEnabled(w http.ResponseWriter, r *http.Request) {
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid id")
+		return
+	}
+	req, err := decodeJSON[dto.KissEnabledRequest](r)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	ki, err := s.store.GetKissInterface(r.Context(), id)
+	if err != nil || ki == nil {
+		notFound(w)
+		return
+	}
+	if ki.Enabled != req.Enabled {
+		ki.Enabled = req.Enabled
+		if err := s.store.UpdateKissInterface(r.Context(), ki); err != nil {
+			s.internalError(w, r, "set kiss enabled", err)
+			return
+		}
+		s.notifyKissManager(*ki)
+	}
+	out := dto.KissFromModel(*ki)
+	writeJSON(w, http.StatusOK, s.attachKissStatus([]dto.KissResponse{out})[0])
 }
 
 // deleteKiss removes the KISS interface with the given id.

--- a/pkg/webapi/kiss.go
+++ b/pkg/webapi/kiss.go
@@ -284,7 +284,6 @@ func (s *Server) notifyKissManager(ki configstore.KissInterface) {
 			s.kissManager.Stop(ki.ID)
 			return
 		}
-		reload := s.notifyTxBackendReload
 		s.kissManager.StartClient(s.kissCtx, ki.ID, kiss.ClientConfig{
 			Name:                ki.Name,
 			RemoteHost:          ki.RemoteHost,
@@ -297,7 +296,8 @@ func (s *Server) notifyKissManager(ki configstore.KissInterface) {
 			TncIngressRateHz:    ki.TncIngressRateHz,
 			TncIngressBurst:     ki.TncIngressBurst,
 			AllowTxFromGovernor: ki.AllowTxFromGovernor,
-			OnReload:            reload,
+			GateTxToIs:          ki.GateTxToIs,
+			OnReload:            s.notifyTxBackendReload,
 		})
 	case configstore.KissTypeTCP:
 		if ki.ListenAddr == "" {
@@ -320,7 +320,6 @@ func (s *Server) notifyKissManager(ki configstore.KissInterface) {
 			s.kissManager.Stop(ki.ID)
 			return
 		}
-		reload := s.notifyTxBackendReload
 		s.kissManager.StartSerial(s.kissCtx, ki.ID, kiss.SerialConfig{
 			Name:                ki.Name,
 			Device:              ki.Device,
@@ -333,11 +332,61 @@ func (s *Server) notifyKissManager(ki configstore.KissInterface) {
 			TncIngressRateHz:    ki.TncIngressRateHz,
 			TncIngressBurst:     ki.TncIngressBurst,
 			AllowTxFromGovernor: ki.AllowTxFromGovernor,
-			OnReload:            reload,
+			GateTxToIs:          ki.GateTxToIs,
+			OnReload:            s.notifyTxBackendReload,
+			OpenFunc:            s.kissSerialOpenFunc,
+		})
+	case configstore.KissTypeBluetooth:
+		// Bluetooth RFCOMM has no baud and the SPP TNC always owns the
+		// modem, so force BaudRate=0 and Mode=ModeTnc — mirrors the boot
+		// path in wiring.go's kissComponent. The MAC lives in ki.Device,
+		// opened via kissSerialOpenFunc (platformsvc on Android).
+		if ki.Device == "" {
+			s.kissManager.Stop(ki.ID)
+			return
+		}
+		s.kissManager.StartSerial(s.kissCtx, ki.ID, kiss.SerialConfig{
+			Name:                ki.Name,
+			Device:              ki.Device,
+			BaudRate:            0,
+			Mode:                kiss.ModeTnc,
+			ChannelMap:          map[uint8]uint32{0: ch},
+			ReconnectInitMs:     ki.ReconnectInitMs,
+			ReconnectMaxMs:      ki.ReconnectMaxMs,
+			Logger:              s.logger,
+			TncIngressRateHz:    ki.TncIngressRateHz,
+			TncIngressBurst:     ki.TncIngressBurst,
+			AllowTxFromGovernor: ki.AllowTxFromGovernor,
+			GateTxToIs:          ki.GateTxToIs,
+			OnReload:            s.notifyTxBackendReload,
+			OpenFunc:            s.kissSerialOpenFunc,
+		})
+	case configstore.KissTypeUsbSerial:
+		// USB serial mirrors host serial: vid:pid lives in ki.Device,
+		// baud is required, mode is operator-chosen. kissSerialOpenFunc
+		// routes vid:pid strings to platformsvc.UsbSerialOpen on Android.
+		if ki.Device == "" || ki.BaudRate == 0 {
+			s.kissManager.Stop(ki.ID)
+			return
+		}
+		s.kissManager.StartSerial(s.kissCtx, ki.ID, kiss.SerialConfig{
+			Name:                ki.Name,
+			Device:              ki.Device,
+			BaudRate:            ki.BaudRate,
+			Mode:                mode,
+			ChannelMap:          map[uint8]uint32{0: ch},
+			ReconnectInitMs:     ki.ReconnectInitMs,
+			ReconnectMaxMs:      ki.ReconnectMaxMs,
+			Logger:              s.logger,
+			TncIngressRateHz:    ki.TncIngressRateHz,
+			TncIngressBurst:     ki.TncIngressBurst,
+			AllowTxFromGovernor: ki.AllowTxFromGovernor,
+			GateTxToIs:          ki.GateTxToIs,
+			OnReload:            s.notifyTxBackendReload,
+			OpenFunc:            s.kissSerialOpenFunc,
 		})
 	default:
-		// Bluetooth is not wired through the manager yet; stop any
-		// lingering session.
+		// Unknown interface type — stop any lingering session.
 		s.kissManager.Stop(ki.ID)
 	}
 }

--- a/pkg/webapi/kiss_test.go
+++ b/pkg/webapi/kiss_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -282,6 +283,147 @@ func TestUpdateKissEnabledPreserved(t *testing.T) {
 	}
 	if got := put(map[string]any{"type": "tcp", "tcp_port": 20011, "channel": 1}); !got.Enabled {
 		t.Errorf("omitted enabled should default to true, got %+v", got)
+	}
+}
+
+// TestCreateKissDisabled pins the create-path contract for the gorm
+// `default:true` footgun: POST with enabled=false must persist a disabled
+// row, not silently flip it to enabled. (db.Create applies the column
+// default for a Go zero-value bool, so the store re-asserts the false.)
+func TestCreateKissDisabled(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	body, _ := json.Marshal(map[string]any{"type": "tcp", "tcp_port": 20021, "channel": 1, "enabled": false})
+	req := httptest.NewRequest(http.MethodPost, "/api/kiss", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp dto.KissResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Enabled {
+		t.Errorf("POST enabled=false returned Enabled=true: %+v", resp)
+	}
+	row, err := srv.store.GetKissInterface(context.Background(), resp.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.Enabled {
+		t.Errorf("POST enabled=false persisted Enabled=true (gorm default trap)")
+	}
+}
+
+// blockingRWC is an in-memory io.ReadWriteCloser whose Read blocks until
+// Close so a SerialSupervisor started over it stays in StateConnected
+// until ctx cancel / explicit close — mirrors pkg/kiss's fakeRWC.
+type blockingRWC struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newBlockingRWC() *blockingRWC { return &blockingRWC{closed: make(chan struct{})} }
+
+func (b *blockingRWC) Read([]byte) (int, error)    { <-b.closed; return 0, io.EOF }
+func (b *blockingRWC) Write(p []byte) (int, error) { return len(p), nil }
+func (b *blockingRWC) Close() error {
+	b.once.Do(func() { close(b.closed) })
+	return nil
+}
+
+// TestSetKissEnabledStartsSerialFamily is the regression guard for the
+// notifyKissManager dispatch fix: enabling a disabled serial / bluetooth
+// / usbserial interface must actually (re)start its supervisor — not fall
+// into the default branch that only calls Stop — and disabling must
+// release it. The bug it guards against silently left Bluetooth/USB
+// interfaces down after a re-enable (the manager's switch lacked those
+// cases, so they hit `default: Stop`). A fake OpenFunc stands in for the
+// platform serial opener so no real device is touched.
+func TestSetKissEnabledStartsSerialFamily(t *testing.T) {
+	store, err := configstore.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	mgr := kiss.NewManager(kiss.ManagerConfig{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	t.Cleanup(mgr.StopAll)
+
+	openFn := func(string, uint32) (io.ReadWriteCloser, error) { return newBlockingRWC(), nil }
+
+	srv, err := NewServer(Config{
+		Store:              store,
+		KissManager:        mgr,
+		KissSerialOpenFunc: openFn,
+		Logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	cases := []configstore.KissInterface{
+		{Name: "k-serial", InterfaceType: configstore.KissTypeSerial, Device: "/dev/ttyUSB0", BaudRate: 9600, Channel: 1, Mode: configstore.KissModeModem, Enabled: false},
+		{Name: "k-bt", InterfaceType: configstore.KissTypeBluetooth, Device: "AA:BB:CC:DD:EE:FF", Channel: 1, Mode: configstore.KissModeTnc, Enabled: false},
+		{Name: "k-usb", InterfaceType: configstore.KissTypeUsbSerial, Device: "2341:0043", BaudRate: 9600, Channel: 1, Mode: configstore.KissModeModem, Enabled: false},
+	}
+	setEnabled := func(t *testing.T, id uint32, enabled bool) {
+		t.Helper()
+		body, _ := json.Marshal(map[string]any{"enabled": enabled})
+		req := httptest.NewRequest(http.MethodPut, "/api/kiss/"+itoa(id)+"/enabled", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("set enabled=%v status = %d: %s", enabled, rec.Code, rec.Body.String())
+		}
+	}
+	for _, ki := range cases {
+		ki := ki
+		t.Run(ki.InterfaceType, func(t *testing.T) {
+			if err := store.CreateKissInterface(context.Background(), &ki); err != nil {
+				t.Fatal(err)
+			}
+
+			// Enable: the supervisor must come up (StateConnected via the
+			// fake opener). Before the fix, bluetooth/usbserial hit
+			// `default: Stop` and never appeared in Status().
+			setEnabled(t, ki.ID, true)
+			deadline := time.Now().Add(2 * time.Second)
+			var got string
+			for time.Now().Before(deadline) {
+				if st, ok := mgr.Status()[ki.ID]; ok {
+					got = st.State
+					if got == kiss.StateConnected {
+						break
+					}
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+			if got != kiss.StateConnected {
+				t.Fatalf("after enable, manager state = %q, want %q", got, kiss.StateConnected)
+			}
+
+			// Disable: the interface must be torn down and removed from the
+			// manager (device released).
+			setEnabled(t, ki.ID, false)
+			deadline = time.Now().Add(2 * time.Second)
+			for time.Now().Before(deadline) {
+				if _, ok := mgr.Status()[ki.ID]; !ok {
+					return
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+			t.Fatalf("after disable, interface %d still present in manager", ki.ID)
+		})
 	}
 }
 

--- a/pkg/webapi/kiss_test.go
+++ b/pkg/webapi/kiss_test.go
@@ -174,6 +174,117 @@ func itoa(n uint32) string {
 	return string(buf[i:])
 }
 
+// TestSetKissEnabled exercises the focused enable/disable toggle. A
+// freshly-created interface is enabled; PUT /enabled flips the flag,
+// persists it, and reflects it in the response. A missing id is 404.
+func TestSetKissEnabled(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	createBody, _ := json.Marshal(map[string]any{"type": "tcp", "tcp_port": 20001, "channel": 1})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/kiss", bytes.NewReader(createBody))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	mux.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d: %s", createRec.Code, createRec.Body.String())
+	}
+	var created dto.KissResponse
+	if err := json.NewDecoder(createRec.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	if !created.Enabled {
+		t.Fatalf("newly created interface should be enabled, got %+v", created)
+	}
+
+	toggle := func(enabled bool) dto.KissResponse {
+		t.Helper()
+		body, _ := json.Marshal(map[string]any{"enabled": enabled})
+		req := httptest.NewRequest(http.MethodPut, "/api/kiss/"+itoa(created.ID)+"/enabled", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("toggle(%v) status = %d: %s", enabled, rec.Code, rec.Body.String())
+		}
+		var resp dto.KissResponse
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	resp := toggle(false)
+	if resp.Enabled {
+		t.Errorf("after disable, response Enabled=true: %+v", resp)
+	}
+	if row, err := srv.store.GetKissInterface(context.Background(), created.ID); err != nil {
+		t.Fatal(err)
+	} else if row.Enabled {
+		t.Errorf("after disable, stored Enabled=true")
+	}
+
+	resp = toggle(true)
+	if !resp.Enabled {
+		t.Errorf("after enable, response Enabled=false: %+v", resp)
+	}
+	if row, err := srv.store.GetKissInterface(context.Background(), created.ID); err != nil {
+		t.Fatal(err)
+	} else if !row.Enabled {
+		t.Errorf("after enable, stored Enabled=false")
+	}
+
+	// Unknown id -> 404.
+	body, _ := json.Marshal(map[string]any{"enabled": false})
+	missReq := httptest.NewRequest(http.MethodPut, "/api/kiss/999999/enabled", bytes.NewReader(body))
+	missReq.Header.Set("Content-Type", "application/json")
+	missRec := httptest.NewRecorder()
+	mux.ServeHTTP(missRec, missReq)
+	if missRec.Code != http.StatusNotFound {
+		t.Errorf("missing id status = %d, want 404", missRec.Code)
+	}
+}
+
+// TestUpdateKissEnabledPreserved checks the full-resource PUT contract:
+// an explicit enabled=false disables the row, while a PUT that omits the
+// field defaults back to enabled (older-client backward compat).
+func TestUpdateKissEnabledPreserved(t *testing.T) {
+	srv, _ := newTestServer(t)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	createBody, _ := json.Marshal(map[string]any{"type": "tcp", "tcp_port": 20011, "channel": 1})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/kiss", bytes.NewReader(createBody))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	mux.ServeHTTP(createRec, createReq)
+	var created dto.KissResponse
+	_ = json.NewDecoder(createRec.Body).Decode(&created)
+
+	put := func(body map[string]any) dto.KissResponse {
+		t.Helper()
+		raw, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPut, "/api/kiss/"+itoa(created.ID), bytes.NewReader(raw))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("put status = %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp dto.KissResponse
+		_ = json.NewDecoder(rec.Body).Decode(&resp)
+		return resp
+	}
+
+	if got := put(map[string]any{"type": "tcp", "tcp_port": 20011, "channel": 1, "enabled": false}); got.Enabled {
+		t.Errorf("explicit enabled=false should disable, got %+v", got)
+	}
+	if got := put(map[string]any{"type": "tcp", "tcp_port": 20011, "channel": 1}); !got.Enabled {
+		t.Errorf("omitted enabled should default to true, got %+v", got)
+	}
+}
+
 // TestCreateKissTcpClient verifies the create path accepts a well-formed
 // tcp-client payload and rejects missing remote_host / remote_port.
 func TestCreateKissTcpClient(t *testing.T) {

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -53,29 +53,30 @@ import (
 // Server routes /api/* requests. It does not own the underlying
 // listener; cmd/graywolf composes it into its main mux.
 type Server struct {
-	store             *configstore.Store
-	bridge            *modembridge.Bridge
-	kissManager       *kiss.Manager
-	kissCtx           context.Context // long-lived context for KISS server goroutines
-	logger            *slog.Logger
-	startedAt         time.Time
-	historyDBPath     string // read-only; set by -history-db flag
-	version           string // build-time version string returned by GET /api/version
-	igateStatusFn     func() *igate.Status
-	gpsReload         chan struct{} // signalled when GPS config changes
-	beaconReload      chan struct{} // signalled when beacon config changes
-	digipeaterReload  chan struct{} // signalled when digipeater config/rules change
-	igateReload       chan struct{} // signalled when igate config/filters change
-	positionLogReload chan struct{} // signalled when position log config changes
-	agwReload         chan struct{} // signalled when AGW config changes
-	smartBeaconReload chan struct{} // signalled when smart-beacon singleton config changes
-	messagesReload    chan struct{} // signalled when messages preferences or tactical callsigns change
-	updatesReloadCh   chan struct{} // signalled when the updates-check toggle flips so the checker re-evaluates immediately
-	updatesChecker    *updatescheck.Checker
-	mapsAuth          *mapsauth.Client    // client for auth.nw5w.com /register; defaulted in NewServer
-	mapsCache         *mapscache.Manager  // PMTiles cache; nil until P2-T5 wires it up — handlers return 503 when nil
-	catalog           *mapscatalog.Cache  // download catalog cache; nil until wired — handlers return 503 when nil
-	style             *mapsstyle.Cache    // style-asset cache; nil until wired — handler returns 503 when nil
+	store              *configstore.Store
+	bridge             *modembridge.Bridge
+	kissManager        *kiss.Manager
+	kissCtx            context.Context // long-lived context for KISS server goroutines
+	kissSerialOpenFunc kiss.OpenFunc   // platform-aware opener for serial-family hot reloads; nil on desktop
+	logger             *slog.Logger
+	startedAt          time.Time
+	historyDBPath      string // read-only; set by -history-db flag
+	version            string // build-time version string returned by GET /api/version
+	igateStatusFn      func() *igate.Status
+	gpsReload          chan struct{} // signalled when GPS config changes
+	beaconReload       chan struct{} // signalled when beacon config changes
+	digipeaterReload   chan struct{} // signalled when digipeater config/rules change
+	igateReload        chan struct{} // signalled when igate config/filters change
+	positionLogReload  chan struct{} // signalled when position log config changes
+	agwReload          chan struct{} // signalled when AGW config changes
+	smartBeaconReload  chan struct{} // signalled when smart-beacon singleton config changes
+	messagesReload     chan struct{} // signalled when messages preferences or tactical callsigns change
+	updatesReloadCh    chan struct{} // signalled when the updates-check toggle flips so the checker re-evaluates immediately
+	updatesChecker     *updatescheck.Checker
+	mapsAuth           *mapsauth.Client   // client for auth.nw5w.com /register; defaulted in NewServer
+	mapsCache          *mapscache.Manager // PMTiles cache; nil until P2-T5 wires it up — handlers return 503 when nil
+	catalog            *mapscatalog.Cache // download catalog cache; nil until wired — handlers return 503 when nil
+	style              *mapsstyle.Cache   // style-asset cache; nil until wired — handler returns 503 when nil
 	// txBackendReload is the Phase 3 dispatcher's rebuild signal.
 	// Nudged after any change that could alter the channel-backing
 	// map (kiss interface add/remove/mode/allow_tx flip, channel
@@ -176,13 +177,22 @@ type MessagesStore interface {
 
 // Config bundles the dependencies for NewServer.
 type Config struct {
-	Store         *configstore.Store
-	Bridge        *modembridge.Bridge
-	KissManager   *kiss.Manager
-	KissCtx       context.Context // parent context for dynamically started KISS servers
-	Logger        *slog.Logger
-	HistoryDBPath string // path to history database, from -history-db flag
-	Version       string // build-time version string reported by GET /api/version
+	Store       *configstore.Store
+	Bridge      *modembridge.Bridge
+	KissManager *kiss.Manager
+	KissCtx     context.Context // parent context for dynamically started KISS servers
+	// KissSerialOpenFunc is the platform-aware transport opener for
+	// serial-family KISS interfaces (host serial / Bluetooth RFCOMM /
+	// USB serial). nil on desktop (SerialSupervisor falls back to
+	// go.bug.st/serial); on Android it routes MAC / vid:pid device
+	// strings through platformsvc. notifyKissManager passes it into
+	// StartSerial so a hot-reload of a serial-family interface opens the
+	// device the same way the boot path (kissComponent) does — without
+	// it, Android Bluetooth/USB interfaces cannot be (re)started live.
+	KissSerialOpenFunc kiss.OpenFunc
+	Logger             *slog.Logger
+	HistoryDBPath      string // path to history database, from -history-db flag
+	Version            string // build-time version string reported by GET /api/version
 	// MapsAuth is the registration client used by
 	// POST /api/preferences/maps/register. Optional; NewServer
 	// defaults to a client pointed at mapsauth.DefaultBaseURL when
@@ -227,20 +237,21 @@ func NewServer(cfg Config) (*Server, error) {
 		mapsClient = mapsauth.NewClient(mapsauth.DefaultBaseURL)
 	}
 	return &Server{
-		store:           cfg.Store,
-		bridge:          cfg.Bridge,
-		kissManager:     cfg.KissManager,
-		kissCtx:         kissCtx,
-		logger:          logger.With("component", "webapi"),
-		startedAt:       time.Now(),
-		historyDBPath:   cfg.HistoryDBPath,
-		version:         cfg.Version,
-		updatesReloadCh: make(chan struct{}, 1),
-		mapsAuth:        mapsClient,
-		mapsCache:       cfg.MapsCache,
-		catalog:         cfg.Catalog,
-		style:           cfg.Style,
-		demo:            cfg.Demo,
+		store:              cfg.Store,
+		bridge:             cfg.Bridge,
+		kissManager:        cfg.KissManager,
+		kissCtx:            kissCtx,
+		kissSerialOpenFunc: cfg.KissSerialOpenFunc,
+		logger:             logger.With("component", "webapi"),
+		startedAt:          time.Now(),
+		historyDBPath:      cfg.HistoryDBPath,
+		version:            cfg.Version,
+		updatesReloadCh:    make(chan struct{}, 1),
+		mapsAuth:           mapsClient,
+		mapsCache:          cfg.MapsCache,
+		catalog:            cfg.Catalog,
+		style:              cfg.Style,
+		demo:               cfg.Demo,
 	}, nil
 }
 

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2004,50 +2004,33 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /**
-             * Format: float64
-             * @description meters (0 if none reported)
-             */
+            /** @description meters (0 if none reported) */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /**
-             * Format: int32
-             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
-             */
+            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive north
-             */
+            /** @description decimal degrees, positive north */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive east
-             */
+            /** @description decimal degrees, positive east */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /**
-             * Format: float64
-             * @description knots
-             */
+            /** @description knots */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
-            /** Format: int32 */
             code?: number;
-            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2056,20 +2039,14 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /**
-             * Format: int32
-             * @description bits 0..7 (only lower 8)
-             */
+            /** @description bits 0..7 (only lower 8) */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /**
-             * Format: int32
-             * @description BITS. sense-bits bitmap (active-high per bit)
-             */
+            /** @description BITS. sense-bits bitmap (active-high per bit) */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2097,47 +2074,27 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /**
-             * Format: float64
-             * @description tenths of millibar (e.g. 10132 = 1013.2)
-             */
+            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
             pressure?: number;
-            /**
-             * Format: float64
-             * @description hundredths of an inch
-             */
+            /** @description hundredths of an inch */
             rain1Hour?: number;
-            /** Format: float64 */
             rain24Hour?: number;
-            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /**
-             * Format: float64
-             * @description inches (via 's' after 'g')
-             */
+            /** @description inches (via 's' after 'g') */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /**
-             * Format: float64
-             * @description degrees F
-             */
+            /** @description degrees F */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /**
-             * Format: float64
-             * @description mph (5-minute peak)
-             */
+            /** @description mph (5-minute peak) */
             windGust?: number;
-            /**
-             * Format: float64
-             * @description mph (1-minute sustained)
-             */
+            /** @description mph (1-minute sustained) */
             windSpeed?: number;
         };
         "configstore.Referrer": {

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -896,6 +896,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/kiss/{id}/enabled": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Enable or disable a KISS interface */
+        put: operations["setKissEnabled"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/kiss/{id}/reconnect": {
         parameters: {
             query?: never;
@@ -1987,33 +2004,50 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /** @description meters (0 if none reported) */
+            /**
+             * Format: float64
+             * @description meters (0 if none reported)
+             */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
+            /**
+             * Format: int32
+             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
+             */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /** @description decimal degrees, positive north */
+            /**
+             * Format: float64
+             * @description decimal degrees, positive north
+             */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /** @description decimal degrees, positive east */
+            /**
+             * Format: float64
+             * @description decimal degrees, positive east
+             */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /** @description knots */
+            /**
+             * Format: float64
+             * @description knots
+             */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
+            /** Format: int32 */
             code?: number;
+            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2022,14 +2056,20 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /** @description bits 0..7 (only lower 8) */
+            /**
+             * Format: int32
+             * @description bits 0..7 (only lower 8)
+             */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /** @description BITS. sense-bits bitmap (active-high per bit) */
+            /**
+             * Format: int32
+             * @description BITS. sense-bits bitmap (active-high per bit)
+             */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2057,27 +2097,47 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
+            /**
+             * Format: float64
+             * @description tenths of millibar (e.g. 10132 = 1013.2)
+             */
             pressure?: number;
-            /** @description hundredths of an inch */
+            /**
+             * Format: float64
+             * @description hundredths of an inch
+             */
             rain1Hour?: number;
+            /** Format: float64 */
             rain24Hour?: number;
+            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /** @description inches (via 's' after 'g') */
+            /**
+             * Format: float64
+             * @description inches (via 's' after 'g')
+             */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /** @description degrees F */
+            /**
+             * Format: float64
+             * @description degrees F
+             */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /** @description mph (5-minute peak) */
+            /**
+             * Format: float64
+             * @description mph (5-minute peak)
+             */
             windGust?: number;
-            /** @description mph (1-minute sustained) */
+            /**
+             * Format: float64
+             * @description mph (1-minute sustained)
+             */
             windSpeed?: number;
         };
         "configstore.Referrer": {
@@ -2609,6 +2669,9 @@ export interface components {
             priority?: number;
             type?: string;
         };
+        "dto.KissEnabledRequest": {
+            enabled?: boolean;
+        };
         "dto.KissRequest": {
             /**
              * @description AllowTxFromGovernor opts this TNC-mode interface in to receive
@@ -2622,6 +2685,17 @@ export interface components {
             allow_tx_from_governor?: boolean;
             baud_rate?: number;
             channel?: number;
+            /**
+             * @description Enabled gates whether graywolf runs this interface. When false the
+             *     manager stops the supervisor and releases the underlying device
+             *     (closing the fd / socket) instead of looping reconnect attempts,
+             *     while the row's configuration is preserved for a later re-enable.
+             *     A pointer so an omitted field means "leave at the default" (true)
+             *     rather than "disable": older clients and partial callers that never
+             *     send the key keep their interfaces running. ToModel substitutes
+             *     true when nil.
+             */
+            enabled?: boolean;
             /**
              * @description GateTxToIs opts a Mode=modem KISS interface in to gating frames
              *     submitted by connected KISS clients to APRS-IS, after the TX
@@ -2665,6 +2739,13 @@ export interface components {
             baud_rate?: number;
             channel?: number;
             connected_since?: number;
+            /**
+             * @description Enabled mirrors KissInterface.Enabled so the Kiss page can show a
+             *     "Disabled" state and offer a re-enable action. A disabled interface
+             *     is not running, so the live status fields below stay zero-valued
+             *     for it.
+             */
+            enabled?: boolean;
             gate_tx_to_is?: boolean;
             id?: number;
             last_error?: string;
@@ -6989,6 +7070,61 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    setKissEnabled: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description KISS interface id */
+                id: number;
+            };
+            cookie?: never;
+        };
+        /** @description Enabled flag */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["dto.KissEnabledRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.KissResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
                 };
             };
         };

--- a/web/src/routes/Kiss.svelte
+++ b/web/src/routes/Kiss.svelte
@@ -295,6 +295,10 @@
       // offered to the iGate's RF->IS gate after the TX governor
       // accepts them. Default off — operator opts in.
       gate_tx_to_is: false,
+      // Whether graywolf runs this interface. New rows start enabled;
+      // the operator can disable an existing one to release its device
+      // (e.g. a Bluetooth rfcomm tty) without losing the config.
+      enabled: true,
     };
   }
 
@@ -376,6 +380,11 @@
       tnc_ingress_burst: String(row.tnc_ingress_burst || 100),
       allow_tx_from_governor: !!row.allow_tx_from_governor,
       gate_tx_to_is: !!row.gate_tx_to_is,
+      // Carry the persisted enabled state forward. KISS PUT is a
+      // full-resource replace, so echoing it keeps a disabled interface
+      // disabled across edits to unrelated fields. Default true for
+      // legacy rows whose response predates the field.
+      enabled: row.enabled !== false,
     };
     modalOpen = true;
   }
@@ -623,6 +632,10 @@
       // iGate via the RX fanout). Force false outside that mode so
       // the persisted value matches the UI's visibility rule.
       gate_tx_to_is: form.mode === 'modem' ? !!form.gate_tx_to_is : false,
+      // Full-resource replace: always send enabled so a PUT never
+      // silently re-enables a disabled interface (the backend defaults a
+      // missing flag to true). Default true for new rows.
+      enabled: form.enabled !== false,
     };
     switch (form.type) {
       case 'tcp':
@@ -787,6 +800,22 @@
     }
   }
 
+  // Enable/disable an interface in one click. Disabling stops the
+  // supervisor and releases the device (closing the serial fd / socket)
+  // instead of looping reconnect attempts; enabling restarts it. The
+  // saved channel and config are preserved either way. Uses the focused
+  // /enabled endpoint so we don't have to round-trip the whole form.
+  async function handleToggleEnabled(row) {
+    const next = row.enabled === false; // disabled -> enable, else disable
+    try {
+      await api.put(`/kiss/${row.id}/enabled`, { enabled: next });
+      toasts.success(next ? 'Interface enabled' : 'Interface disabled — device released');
+      await refreshItems();
+    } catch (err) {
+      toasts.error(err.message);
+    }
+  }
+
   // Healthglyph: live / down based on state. Client-only rows (never
   // server-listen) are what really benefit from this; server-listen
   // reports StateListening which is always "live" (the listener bound
@@ -860,6 +889,7 @@
 {/snippet}
 
 {#snippet statusCell(_value, row)}
+  {@const disabled = row.enabled === false}
   <div class="status-cell" data-tick={clockTick}>
     <!-- clockTick is in data-tick so any change triggers snippet
          re-render; that propagates to the countdownText call below. -->
@@ -868,29 +898,35 @@
       class="status-btn"
       aria-expanded={expandedId === row.id}
       aria-controls={`status-detail-${row.id}`}
-      aria-label={`Status for KISS interface ${row.id}: ${stateLabel(row.state)}`}
+      aria-label={`Status for KISS interface ${row.id}: ${disabled ? 'Disabled' : stateLabel(row.state)}`}
       onclick={(e) => { e.stopPropagation(); toggleExpanded(row.id); }}
     >
-      <span class={healthClass(row.state)} aria-hidden="true">{healthGlyph(row.state)}</span>
-      <Badge variant={stateBadgeVariant(row.state)}>{stateLabel(row.state)}</Badge>
-      {#if row.state === 'backoff'}
-        <span class="countdown">{countdownText(row.retry_at_unix_ms)}</span>
+      {#if disabled}
+        <!-- A disabled interface is not running, so live supervisor
+             state is meaningless. Show a neutral "Disabled" pill instead
+             of the stale/empty state. -->
+        <span class="health-disabled" aria-hidden="true">○</span>
+        <Badge>Disabled</Badge>
+      {:else}
+        <span class={healthClass(row.state)} aria-hidden="true">{healthGlyph(row.state)}</span>
+        <Badge variant={stateBadgeVariant(row.state)}>{stateLabel(row.state)}</Badge>
+        {#if row.state === 'backoff'}
+          <span class="countdown">{countdownText(row.retry_at_unix_ms)}</span>
+        {/if}
       {/if}
     </button>
     {#if expandedId === row.id}
       <div id={`status-detail-${row.id}`} class="status-detail" role="region" aria-label="Status detail">
-        {#if row.type === 'tcp-client'}
+        {#if disabled}
+          <div class="detail-row"><span class="detail-label">Endpoint:</span> <span>{endpointText(row)}</span></div>
+          <div class="detail-row detail-muted">Disabled — the device is released and reconnection is paused. The configuration is preserved.</div>
+        {:else if row.type === 'tcp-client'}
           <div class="detail-row"><span class="detail-label">Peer:</span> <span>{row.peer_addr || `${row.remote_host}:${row.remote_port}`}</span></div>
           <div class="detail-row"><span class="detail-label">Connected since:</span> <span>{formatLocalTime(row.connected_since) || '—'}</span></div>
           <div class="detail-row"><span class="detail-label">Reconnect count:</span> <span>{row.reconnect_count || 0}</span></div>
           <div class="detail-row"><span class="detail-label">Backoff:</span> <span>{row.backoff_seconds || 0}s</span></div>
           {#if row.last_error}
             <div class="detail-row detail-err"><span class="detail-label">Last error:</span> <span>{row.last_error}</span></div>
-          {/if}
-          {#if canRetryNow(row.state)}
-            <div class="detail-actions">
-              <Button variant="primary" onclick={(e) => { e.stopPropagation?.(); handleRetryNow(row); }}>Retry now</Button>
-            </div>
           {/if}
         {:else if row.type === 'tcp'}
           <div class="detail-row"><span class="detail-label">Listening:</span> <span>{row.local_only ? `127.0.0.1:${row.tcp_port} (local only)` : `:${row.tcp_port}`}</span></div>
@@ -901,6 +937,16 @@
         {:else}
           <div class="detail-row"><span class="detail-label">Device:</span> <span>{row.serial_device || '—'}</span></div>
         {/if}
+        <div class="detail-actions">
+          {#if !disabled && row.type === 'tcp-client' && canRetryNow(row.state)}
+            <Button variant="primary" onclick={(e) => { e.stopPropagation?.(); handleRetryNow(row); }}>Retry now</Button>
+          {/if}
+          {#if disabled}
+            <Button variant="primary" onclick={(e) => { e.stopPropagation?.(); handleToggleEnabled(row); }}>Enable</Button>
+          {:else}
+            <Button variant="ghost" onclick={(e) => { e.stopPropagation?.(); handleToggleEnabled(row); }}>Disable</Button>
+          {/if}
+        </div>
       </div>
     {/if}
   </div>
@@ -1232,6 +1278,7 @@
   }
   .health-live { color: var(--color-success, #4caf50); font-size: 14px; }
   .health-down { color: var(--color-warning, #ffa000); font-size: 14px; }
+  .health-disabled { color: var(--text-secondary, #9e9e9e); font-size: 14px; }
   .countdown {
     font-size: 12px;
     color: var(--text-secondary);
@@ -1256,6 +1303,10 @@
   }
   .detail-err {
     color: var(--color-error, #d32f2f);
+  }
+  .detail-muted {
+    color: var(--text-secondary);
+    font-style: italic;
   }
   .detail-actions {
     margin-top: 8px;


### PR DESCRIPTION
Closes #152.

## What

Adds the ability to **disable** a KISS TNC interface (TCP server, TCP client, or serial/bluetooth) instead of deleting it. Disabling stops the supervisor and releases the underlying device -- closing the serial fd / TCP socket -- rather than holding it open and looping reconnect attempts. The saved channel and configuration are preserved, so the interface can be re-enabled later with one click.

This solves the reported scenario: a Bluetooth `/dev/rfcomm0` tty held open by graywolf prevents the OS from tearing down the Bluetooth link. Today the only workaround is deleting the whole interface and losing its config.

## How

The interface lifecycle already honored `KissInterface.Enabled` in all three places that matter -- boot (`kissComponent`), hot-reload (`notifyKissManager` -> `Stop`, which cancels the serve context and closes the device), and the TX backend snapshot. The only gap was that the API never exposed the flag (the DTO hardcoded `true`) and the UI had no control.

- **DTO** (`pkg/webapi/dto/kiss.go`): `KissRequest.Enabled` is a `*bool` so an omitted field defaults to enabled rather than disabling on a full-resource-replace `PUT` from an older client; `KissResponse` now surfaces `Enabled`.
- **Endpoint** (`pkg/webapi/kiss.go`): new `PUT /api/kiss/{id}/enabled` flips just the flag and applies it live -- a focused one-click toggle that avoids re-sending the whole interface definition.
- **UI** (`web/src/routes/Kiss.svelte`): the status column shows a neutral **Disabled** pill for disabled rows; the expandable status detail offers an **Enable**/**Disable** action. Form save always sends `enabled` so editing an unrelated field never silently re-enables a disabled row.

## Tests

- DTO: omitted-flag default-true, explicit true/false, response round-trip.
- Handler: toggle disable/enable persists and reflects in the response; unknown id -> 404; full-`PUT` enabled semantics (explicit false disables, omitted defaults true).
- Regenerated swagger spec + TypeScript client; `docs-check`, `api-client-check`, and `docs-lint` all pass.
- Documented the enable/disable contract and the pointer rationale as invariant #45 in the wiki.

Note: one pre-existing, unrelated test failure in `web/src/routes/ptt/devices/methodOptions.test.js` (a `vox` PTT method mismatch) is present on the branch and untouched by this change.