### PR TITLE
ci(android): auto-publish releases to Play Closed Testing

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -332,6 +332,8 @@ jobs:
   # this is the deliberate human step for graduating a vetted build to
   # open testing. Run from the Actions tab (or:
   #   gh workflow run android.yml --field version=X.Y.Z --field track=beta).
+  # Job id stays `promote-to-closed` for stability (external `gh`/Actions
+  # references); the job now promotes *from* closed onward, not into it.
   # ------------------------------------------------------------------
   promote-to-closed:
     name: Promote to another track

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -301,6 +301,22 @@ jobs:
           echo "::error::Release ${GITHUB_REF_NAME} never appeared; check goreleaser job."
           exit 1
 
+      # Render the Play "What's new" text from the same notes.yaml
+      # changelog that drives the in-app popup, so testers get an
+      # operator-facing release note. Output goes to a whatsNewDirectory
+      # the upload step reads (file naming: whatsnew-<locale>). The tool
+      # exits non-zero if notes.yaml has no entry for this version, so a
+      # missing changelog fails the release loudly rather than shipping a
+      # blank note.
+      - name: Generate Play "What's new" from release notes
+        if: env.HAVE_PLAY_SA == 'true'
+        run: |
+          set -euo pipefail
+          v="${{ steps.stage.outputs.version }}"
+          go run ./cmd/play-whatsnew -version "$v" -out staging/whatsnew/whatsnew-en-US
+          echo "---- whatsnew-en-US ----"
+          cat staging/whatsnew/whatsnew-en-US
+
       # Auto-publish the signed AAB to Play Closed Testing -- the `alpha`
       # track (Play's track IDs are fixed: internal, alpha=closed,
       # beta=open, production). Every v* tag now reaches the private beta
@@ -317,6 +333,8 @@ jobs:
           releaseFiles: staging/graywolf-*.aab
           track: alpha
           status: completed
+          # Per-locale release notes (whatsnew-en-US) generated above.
+          whatsNewDirectory: staging/whatsnew
 
       - name: Upload signed AAB as workflow artifact (manual fallback)
         uses: actions/upload-artifact@v5

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,9 +2,9 @@ name: Android
 
 # PR / push:main: build an unsigned debug APK and upload as an artifact.
 # Tag pushes (v*): also build a release-signed AAB + APK and attach them
-# to the GitHub Release (which goreleaser/release.yml creates in parallel).
-# Phase 5 of the plan will add a step that auto-uploads the AAB to the
-# Play Internal Testing track.
+# to the GitHub Release (which goreleaser/release.yml creates in parallel),
+# then auto-publish the AAB to the Play Closed Testing track (the `alpha`
+# track) so every tagged release reaches the private beta testers.
 
 on:
   push:
@@ -16,22 +16,24 @@ on:
     branches:
       - main
   # Manual trigger. Two uses: (a) re-run the build on transient network
-  # failures, and (b) promote an already-released version to the closed
-  # beta track via the promote-to-closed job (provide `version`).
+  # failures, and (b) promote an already-released version to a different
+  # track via the promote job (provide `version`). Closed testing (alpha)
+  # is auto-published on tag push, so the manual promote is mainly for
+  # graduating a build to open testing (beta).
   workflow_dispatch:
     inputs:
       version:
-        description: 'Released version to promote to a testing track (X.Y.Z, no v). Leave blank for a plain build re-run.'
+        description: 'Released version to promote to another track (X.Y.Z, no v). Leave blank for a plain build re-run.'
         required: false
         type: string
       track:
         description: 'Play track to promote into. alpha = closed testing (private beta); beta = open testing.'
         required: false
-        default: alpha
+        default: beta
         type: choice
         options:
-          - alpha
           - beta
+          - alpha
           - internal
 
 permissions:
@@ -299,20 +301,21 @@ jobs:
           echo "::error::Release ${GITHUB_REF_NAME} never appeared; check goreleaser job."
           exit 1
 
-      # Auto-upload the signed AAB to Play Internal Testing. Gated on the
-      # service-account secret so it safely skips (not fails) until the
-      # Google Cloud service account is created and stored as
-      # GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON. Lands in the Internal track
-      # only; humans promote to the closed beta track separately, so a
-      # CI tag never reaches external testers automatically.
-      - name: Upload AAB to Play Internal Testing
+      # Auto-publish the signed AAB to Play Closed Testing -- the `alpha`
+      # track (Play's track IDs are fixed: internal, alpha=closed,
+      # beta=open, production). Every v* tag now reaches the private beta
+      # testers. Gated on the service-account secret so it safely skips
+      # (not fails) when GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON is absent. The
+      # service account still lacks production permission, so a CI tag can
+      # never reach production.
+      - name: Upload AAB to Play Closed Testing (alpha)
         if: env.HAVE_PLAY_SA == 'true'
         uses: r0adkll/upload-google-play@v1.1.3
         with:
           serviceAccountJsonPlainText: ${{ secrets.GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.nw5w.graywolf
           releaseFiles: staging/graywolf-*.aab
-          track: internal
+          track: alpha
           status: completed
 
       - name: Upload signed AAB as workflow artifact (manual fallback)
@@ -323,15 +326,15 @@ jobs:
           retention-days: 30
 
   # ------------------------------------------------------------------
-  # promote-to-closed — manual (workflow_dispatch) promotion of an
-  # already-released version to a Play testing track (default: alpha =
-  # closed testing, the private beta). Keeping this a deliberate human
-  # action means a CI tag never auto-ships to external beta testers; you
-  # choose which build they get. Run from the Actions tab (or:
-  #   gh workflow run android.yml --field version=X.Y.Z --field track=alpha).
+  # promote — manual (workflow_dispatch) promotion of an already-released
+  # version from closed testing (alpha) to another Play track (default:
+  # beta = open testing). Closed testing is auto-published on tag push, so
+  # this is the deliberate human step for graduating a vetted build to
+  # open testing. Run from the Actions tab (or:
+  #   gh workflow run android.yml --field version=X.Y.Z --field track=beta).
   # ------------------------------------------------------------------
   promote-to-closed:
-    name: Promote to testing track
+    name: Promote to another track
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
     env:
@@ -360,11 +363,11 @@ jobs:
           bundler-cache: true
 
       # Promote (not re-upload): the version is already in Play (from the
-      # Phase 5 auto-upload to internal). fastlane supply moves that
-      # versionCode to the chosen track. Re-uploading the AAB would fail
-      # with "version code already used", which is why this isn't an
-      # upload action. versionCode is derived from X.Y.Z the same way
-      # android/app/build.gradle.kts derives it (M*1e6 + m*1e4 + p*100).
+      # tag-push auto-publish to closed testing / alpha). fastlane supply
+      # moves that versionCode to the chosen track. Re-uploading the AAB
+      # would fail with "version code already used", which is why this
+      # isn't an upload action. versionCode is derived from X.Y.Z the same
+      # way android/app/build.gradle.kts derives it (M*1e6 + m*1e4 + p*100).
       - name: Promote to the chosen track via fastlane
         if: env.HAVE_PLAY_SA == 'true'
         env:
@@ -376,5 +379,5 @@ jobs:
           echo "Promoting versionCode $VC -> track '${{ github.event.inputs.track }}'"
           bundle exec fastlane promote \
             version_code:"$VC" \
-            from:internal \
+            from:alpha \
             to:"${{ github.event.inputs.track }}"

--- a/Makefile
+++ b/Makefile
@@ -249,11 +249,11 @@ android-play-check:
 # (no re-upload -- Play rejects a duplicate versionCode). CI does this
 # from the Android workflow's promote-to-closed job; this is the local
 # equivalent.
-#   make android-promote VC=130800 TO=alpha JSON=path/to/service-account.json
+#   make android-promote VC=130800 TO=beta JSON=path/to/service-account.json
 android-promote:
 	@test -n "$(VC)" || { echo "usage: make android-promote VC=<versionCode> TO=<track> JSON=<sa.json>" >&2; exit 2; }
 	@test -n "$(JSON)" || { echo "error: JSON=<service-account.json> required" >&2; exit 2; }
-	SUPPLY_JSON_KEY="$(JSON)" fastlane promote version_code:$(VC) to:$(or $(TO),alpha) from:$(or $(FROM),internal)
+	SUPPLY_JSON_KEY="$(JSON)" fastlane promote version_code:$(VC) to:$(or $(TO),beta) from:$(or $(FROM),alpha)
 
 # Upload the Play store-listing images (icon, feature graphic, phone +
 # tablet screenshots). Run `make android-screenshots` first to generate

--- a/Makefile
+++ b/Makefile
@@ -247,8 +247,8 @@ android-play-check:
 
 # Promote an already-uploaded build between Play tracks via fastlane
 # (no re-upload -- Play rejects a duplicate versionCode). CI does this
-# from the Android workflow's promote-to-closed job; this is the local
-# equivalent.
+# from the Android workflow's promote job (graduating closed/alpha onward
+# to open/beta); this is the local equivalent.
 #   make android-promote VC=130800 TO=beta JSON=path/to/service-account.json
 android-promote:
 	@test -n "$(VC)" || { echo "usage: make android-promote VC=<versionCode> TO=<track> JSON=<sa.json>" >&2; exit 2; }

--- a/cmd/play-whatsnew/main.go
+++ b/cmd/play-whatsnew/main.go
@@ -1,0 +1,57 @@
+// Command play-whatsnew renders the Google Play "What's new" text for a
+// given release version from the embedded release-notes changelog
+// (pkg/releasenotes/notes.yaml) and writes it to a file.
+//
+// The Android release workflow runs this before uploading the AAB to the
+// Play Closed Testing track and points the upload's whatsNewDirectory at
+// the output, so each tagged release ships an operator-facing changelog
+// derived from the same notes that drive the in-app "What's new" popup.
+//
+//	go run ./cmd/play-whatsnew -version 0.13.16 -out staging/whatsnew/whatsnew-en-US
+//
+// Output is truncated to Play's 500-character per-language limit at a
+// sentence or word boundary. Exits non-zero if no note exists for the
+// version, so a release with a missing changelog entry fails loudly.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/chrissnell/graywolf/pkg/releasenotes"
+)
+
+func main() {
+	version := flag.String("version", "", "release version (x.y.z, no leading v) to render notes for")
+	out := flag.String("out", "", "output file path (e.g. whatsnew/whatsnew-en-US)")
+	max := flag.Int("max", releasenotes.PlayWhatsNewMax, "maximum characters (Play caps the field at 500)")
+	flag.Parse()
+
+	if *version == "" || *out == "" {
+		fmt.Fprintln(os.Stderr, "usage: play-whatsnew -version <x.y.z> -out <file> [-max N]")
+		os.Exit(2)
+	}
+
+	text, err := releasenotes.PlainText(*version)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "play-whatsnew: %v\n", err)
+		os.Exit(1)
+	}
+	text = releasenotes.Truncate(text, *max)
+
+	if dir := filepath.Dir(*out); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "play-whatsnew: create %s: %v\n", dir, err)
+			os.Exit(1)
+		}
+	}
+	// Trailing newline keeps the file POSIX-clean; Play trims surrounding
+	// whitespace on ingest.
+	if err := os.WriteFile(*out, []byte(text+"\n"), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "play-whatsnew: write %s: %v\n", *out, err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "play-whatsnew: wrote %d chars to %s\n", len([]rune(text)), *out)
+}

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -20,7 +20,7 @@ roles.
 - [`system-topology.md`](system-topology.md) -- processes, ports, persistence, hardware surface, and deployment targets.
 - [`code-map.md`](code-map.md) -- feature/concern -> file lookup, one table per component.
 - [`build-pipelines.md`](build-pipelines.md) -- per-artifact build recipes (Go binary, Rust modem, web UI, proto codegen, OpenAPI, goreleaser, packages, in-app release notes).
-- [`android-play-store.md`](android-play-store.md) -- Android release pipeline: signing, Play App Signing, the service account, tracks (Internal auto / closed beta promote), version derivation, screenshots, and what's hidden on Android.
+- [`android-play-store.md`](android-play-store.md) -- Android release pipeline: signing, Play App Signing, the service account, tracks (closed testing auto / open testing promote), version derivation, screenshots, and what's hidden on Android.
 - [`invariants.md`](invariants.md) -- cross-cutting "if X then also Y" rules with reasons.
 - [`glossary.md`](glossary.md) -- domain terms as graywolf uses them, with source pointers.
 - [`actions.md`](actions.md) -- the `@@`-prefixed APRS Actions subsystem: trigger surface, classifier topology, source-aware reply, lifecycle, schema.

--- a/docs/wiki/android-play-store.md
+++ b/docs/wiki/android-play-store.md
@@ -14,10 +14,12 @@ push fires two workflows in parallel: `release.yml` (goreleaser:
 Linux/macOS/Windows binaries, Docker, `.deb`/`.rpm`, NSIS) and
 `android.yml`. The Android workflow builds a release-signed `.aab` +
 `.apk`, attaches both to the GitHub Release goreleaser created, and
-auto-uploads the `.aab` to the Play **Internal Testing** track. Promotion
-from Internal to the **closed beta** track is a separate, deliberate
-manual step (`gh workflow run android.yml --field version=X.Y.Z`) so a CI
-tag never auto-ships to external testers.
+auto-publishes the `.aab` to the Play **Closed Testing** track (Play's
+`alpha` track), so every tagged release reaches the ~15-person private
+beta. Promotion onward to **Open Testing** (the `beta` track) is a
+separate, deliberate manual step (`gh workflow run android.yml --field
+version=X.Y.Z --field track=beta`). Production is never targeted -- the
+service account lacks the permission.
 
 ## Workflow triggers and jobs (`android.yml`)
 
@@ -25,9 +27,9 @@ tag never auto-ships to external testers.
 |---|---|---|
 | `pull_request` -> main | `build` | Unsigned debug APK artifact (sanity check) |
 | `push` -> main | `build` | Same; catches breakage before a tag |
-| `push` tag `v*` | `build` + `release-sign` | Signed `.aab`+`.apk` on the GH Release; `.aab` auto-uploaded to Play Internal |
+| `push` tag `v*` | `build` + `release-sign` | Signed `.aab`+`.apk` on the GH Release; `.aab` auto-published to Play Closed Testing (`alpha`) |
 | `workflow_dispatch` (no `version`) | `build` | Manual build re-run |
-| `workflow_dispatch` (`version=X.Y.Z`) | `promote-to-closed` | Promotes that release's `.aab` from Internal to the closed beta track |
+| `workflow_dispatch` (`version=X.Y.Z`) | `promote-to-closed` | Promotes that release's `.aab` from Closed Testing (`alpha`) to the chosen track (default `beta` = open testing) |
 
 `build` is skipped on `workflow_dispatch` (a promote run doesn't need a
 fresh APK). `release-sign` only runs on tags. `promote-to-closed` only
@@ -88,11 +90,20 @@ configure time, so `make bump-*` cascades into Android automatically:
 
 ## Tracks
 
-- **Internal** -- auto-uploaded on every `v*` tag. Dev/team loop.
-- **Closed (`graywolf-beta`)** -- the ~15-person private beta. Builds
-  reach it only via the manual `promote-to-closed` workflow. Add testers
-  in Play Console -> Closed testing -> graywolf-beta -> Testers (email
-  list); they install via the track's opt-in URL.
+Play's track IDs are fixed: `internal`, `alpha` (closed testing), `beta`
+(open testing), `production`. A custom Console display name (e.g.
+"graywolf-beta") does not change the API id -- the closed track is still
+addressed as `alpha` by `supply` / `upload-google-play`.
+
+- **Closed testing (`alpha`)** -- auto-published on every `v*` tag; this
+  is where the ~15-person private beta lives. Add testers in Play Console
+  -> Closed testing -> Testers (email list); they install via the track's
+  opt-in URL.
+- **Open testing (`beta`)** -- public opt-in. A vetted closed build is
+  promoted here with the manual `promote-to-closed` workflow
+  (`--field track=beta`).
+- **Internal** -- no longer auto-populated. Still reachable manually for a
+  quick dev/team smoke check (`--field track=internal`).
 - **Production** -- not enabled. The service account lacks the permission
   and the workflow never targets it.
 
@@ -103,9 +114,9 @@ in [`../../CLAUDE.md`](../../CLAUDE.md): fix the cause, delete and re-tag
 the same version (`git tag -d vX.Y.Z && git push origin :refs/tags/vX.Y.Z`,
 commit fix, re-tag, push), and **do not rewrite the release note**. A
 re-tag re-runs both workflows. Note Play rejects a duplicate
-`versionCode`, so if the `.aab` already uploaded to Internal before the
-failure, a plain re-tag's upload step will conflict -- in that case bump
-to a new patch instead.
+`versionCode`, so if the `.aab` already uploaded to Closed Testing
+(`alpha`) before the failure, a plain re-tag's upload step will conflict
+-- in that case bump to a new patch instead.
 
 ## armv6 (Pi 1 / Pi Zero) -- temporarily dropped
 

--- a/docs/wiki/android-play-store.md
+++ b/docs/wiki/android-play-store.md
@@ -88,6 +88,27 @@ configure time, so `make bump-*` cascades into Android automatically:
   `130800`), leaving 100 slots per patch for hotfix re-uploads. Play
   requires `versionCode` to increase monotonically across uploads.
 
+## Release notes ("What's new")
+
+The closed-testing upload ships a per-locale "What's new" note so testers
+see what changed. It is derived from the same
+[`pkg/releasenotes/notes.yaml`](../../pkg/releasenotes/notes.yaml)
+changelog that drives the in-app popup -- no second place to edit.
+
+- `cmd/play-whatsnew` renders the note for the release version to plain
+  text: title first, then the body with markdown links flattened to their
+  text and bold/italic markers stripped, truncated to Play's 500-char
+  per-locale limit at a sentence (else word) boundary.
+- The `release-sign` job runs it into `staging/whatsnew/whatsnew-en-US`
+  and points the upload's `whatsNewDirectory` there.
+- It exits non-zero if `notes.yaml` has no entry for the tagged version,
+  so a missing changelog fails the release loudly rather than shipping a
+  blank note. (The `make bump-*` flow already refuses to tag without an
+  entry, so this is a backstop.)
+- Promotions (`promote-to-closed`) carry the existing release's notes
+  forward; `fastlane supply` runs with `skip_upload_changelogs`, so the
+  note is set once at the closed-testing upload.
+
 ## Tracks
 
 Play's track IDs are fixed: `internal`, `alpha` (closed testing), `beta`

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,11 +14,11 @@ PACKAGE = "com.nw5w.graywolf".freeze
 
 platform :android do
   desc "Promote an existing versionCode from one track to another (no re-upload)"
-  desc "Params: version_code (required), from (default internal), to (default alpha)"
+  desc "Params: version_code (required), from (default alpha), to (default beta)"
   lane :promote do |options|
     version_code = (options[:version_code] || ENV["VERSION_CODE"]).to_i
-    from_track   = options[:from] || ENV["FROM_TRACK"] || "internal"
-    to_track     = options[:to]   || ENV["TO_TRACK"]   || "alpha"
+    from_track   = options[:from] || ENV["FROM_TRACK"] || "alpha"
+    to_track     = options[:to]   || ENV["TO_TRACK"]   || "beta"
     UI.user_error!("version_code is required (e.g. version_code:130800)") if version_code.zero?
 
     UI.message("Promoting versionCode #{version_code}: #{from_track} -> #{to_track}")

--- a/pkg/releasenotes/plaintext.go
+++ b/pkg/releasenotes/plaintext.go
@@ -1,0 +1,116 @@
+package releasenotes
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PlayWhatsNewMax is Google Play's hard limit on the per-language
+// "What's new" / release-notes field: 500 characters. The generator
+// truncates to this so the Publishing API never rejects an over-long
+// note.
+const PlayWhatsNewMax = 500
+
+var (
+	// [text](href) -> text. The hrefs in notes.yaml are internal #/...
+	// app routes that mean nothing in a store listing, so only the
+	// visible text survives.
+	mdLink = regexp.MustCompile(`\[([^\]]*)\]\([^)]*\)`)
+	// **bold** then *italic* markers -- store "What's new" text is
+	// unstyled plain text. Bold runs first so a leftover single star
+	// from the bold pass can't confuse the italic pass.
+	mdBold   = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+	mdItalic = regexp.MustCompile(`\*([^*]+)\*`)
+)
+
+// PlainText renders the release note for version as plain UTF-8 text
+// suitable for an app-store "What's new" field. The title is the first
+// line, separated from the body by a blank line. Markdown links collapse
+// to their visible text and bold/italic markers are stripped. Soft-
+// wrapped lines within a paragraph join into one line; paragraphs are
+// separated by a blank line (mirroring the in-app renderer's paragraph
+// model). Returns an error if no note matches version.
+//
+// The result is NOT length-capped; pass it through Truncate for stores
+// with a character limit (see PlayWhatsNewMax).
+func PlainText(version string) (string, error) {
+	var raws []rawNote
+	if err := yaml.Unmarshal(source, &raws); err != nil {
+		return "", fmt.Errorf("releasenotes: parse yaml: %w", err)
+	}
+	for _, r := range raws {
+		if r.Version != version {
+			continue
+		}
+		title := strings.TrimSpace(r.Title)
+		paras := splitParagraphs(r.Body)
+		for i, p := range paras {
+			paras[i] = flattenInline(p)
+		}
+		body := strings.Join(paras, "\n\n")
+		switch {
+		case title == "":
+			return body, nil
+		case body == "":
+			return title, nil
+		default:
+			return title + "\n\n" + body, nil
+		}
+	}
+	return "", fmt.Errorf("releasenotes: no note for version %q", version)
+}
+
+// flattenInline strips the restricted markdown subset (links, bold,
+// italic) down to plain text. Links resolve first so any bold/italic
+// inside link text is then handled by the marker passes.
+func flattenInline(s string) string {
+	s = mdLink.ReplaceAllString(s, "$1")
+	s = mdBold.ReplaceAllString(s, "$1")
+	s = mdItalic.ReplaceAllString(s, "$1")
+	return strings.TrimSpace(s)
+}
+
+// Truncate shortens s to at most max characters, backing off to the
+// nearest sentence end (a '.' followed by space, newline, or end of
+// string) and then to a word boundary so the result never ends mid-word.
+// A word-boundary or hard cut appends an ellipsis to signal there's
+// more; a clean sentence end does not. max <= 0 or s already within the
+// limit returns s unchanged. Length is measured in characters (runes).
+func Truncate(s string, max int) string {
+	r := []rune(s)
+	if max <= 0 || len(r) <= max {
+		return s
+	}
+	const ell = "..."
+	budget := max - len([]rune(ell))
+	if budget <= 0 {
+		return string(r[:max])
+	}
+	head := string(r[:budget])
+	// A complete sentence reads cleanly; prefer it when it keeps at
+	// least half the budget (avoids cutting back to a tiny fragment).
+	if i := lastSentenceEnd(head); i >= budget/2 {
+		return strings.TrimRight(head[:i+1], " \n")
+	}
+	if i := strings.LastIndexByte(head, ' '); i > 0 {
+		return strings.TrimRight(head[:i], " \n") + " " + ell
+	}
+	return head + ell
+}
+
+// lastSentenceEnd returns the index of the last '.' that ends a sentence
+// (followed by a space, newline, or the end of the string), or -1.
+func lastSentenceEnd(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] != '.' {
+			continue
+		}
+		if i+1 >= len(s) || s[i+1] == ' ' || s[i+1] == '\n' {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/releasenotes/plaintext.go
+++ b/pkg/releasenotes/plaintext.go
@@ -2,6 +2,7 @@ package releasenotes
 
 import (
 	"fmt"
+	"html"
 	"regexp"
 	"strings"
 
@@ -14,25 +15,22 @@ import (
 // note.
 const PlayWhatsNewMax = 500
 
-var (
-	// [text](href) -> text. The hrefs in notes.yaml are internal #/...
-	// app routes that mean nothing in a store listing, so only the
-	// visible text survives.
-	mdLink = regexp.MustCompile(`\[([^\]]*)\]\([^)]*\)`)
-	// **bold** then *italic* markers -- store "What's new" text is
-	// unstyled plain text. Bold runs first so a leftover single star
-	// from the bold pass can't confuse the italic pass.
-	mdBold   = regexp.MustCompile(`\*\*([^*]+)\*\*`)
-	mdItalic = regexp.MustCompile(`\*([^*]+)\*`)
-)
+// htmlTag matches a single tag emitted by the release-note renderer
+// (<p>, <strong>, <em>, <a ...>). Their attribute values are
+// HTML-escaped, so a literal '>' never appears inside a tag.
+var htmlTag = regexp.MustCompile(`<[^>]+>`)
 
 // PlainText renders the release note for version as plain UTF-8 text
 // suitable for an app-store "What's new" field. The title is the first
-// line, separated from the body by a blank line. Markdown links collapse
-// to their visible text and bold/italic markers are stripped. Soft-
-// wrapped lines within a paragraph join into one line; paragraphs are
-// separated by a blank line (mirroring the in-app renderer's paragraph
-// model). Returns an error if no note matches version.
+// line, separated from the body by a blank line.
+//
+// The body is produced by the in-app renderer (renderMarkdown) and then
+// stripped to text, so the result is exactly what the in-app "What's
+// new" popup shows minus styling and link targets: bold/italic markers
+// and links collapse to their visible text (nested markers included),
+// paragraphs are separated by a blank line, and a deliberate literal
+// such as the CALL-* wildcard is preserved. Reusing the renderer means
+// there is no second markdown implementation to drift from the popup.
 //
 // The result is NOT length-capped; pass it through Truncate for stores
 // with a character limit (see PlayWhatsNewMax).
@@ -45,12 +43,12 @@ func PlainText(version string) (string, error) {
 		if r.Version != version {
 			continue
 		}
-		title := strings.TrimSpace(r.Title)
-		paras := splitParagraphs(r.Body)
-		for i, p := range paras {
-			paras[i] = flattenInline(p)
+		htmlBody, err := renderMarkdown(r.Body)
+		if err != nil {
+			return "", fmt.Errorf("releasenotes: render %q: %w", version, err)
 		}
-		body := strings.Join(paras, "\n\n")
+		body := htmlToText(htmlBody)
+		title := strings.TrimSpace(r.Title)
 		switch {
 		case title == "":
 			return body, nil
@@ -63,14 +61,15 @@ func PlainText(version string) (string, error) {
 	return "", fmt.Errorf("releasenotes: no note for version %q", version)
 }
 
-// flattenInline strips the restricted markdown subset (links, bold,
-// italic) down to plain text. Links resolve first so any bold/italic
-// inside link text is then handled by the marker passes.
-func flattenInline(s string) string {
-	s = mdLink.ReplaceAllString(s, "$1")
-	s = mdBold.ReplaceAllString(s, "$1")
-	s = mdItalic.ReplaceAllString(s, "$1")
-	return strings.TrimSpace(s)
+// htmlToText converts the renderer's sanitized HTML to plain text:
+// paragraph breaks become blank lines, all tags are removed, and HTML
+// entities are decoded. Tags are stripped BEFORE unescaping so escaped
+// text like "&lt;script&gt;" is never resurrected into a real tag.
+func htmlToText(h string) string {
+	h = strings.ReplaceAll(h, "</p>", "\n\n")
+	h = htmlTag.ReplaceAllString(h, "")
+	h = html.UnescapeString(h)
+	return strings.TrimSpace(h)
 }
 
 // Truncate shortens s to at most max characters, backing off to the
@@ -89,6 +88,10 @@ func Truncate(s string, max int) string {
 	if budget <= 0 {
 		return string(r[:max])
 	}
+	// head is rune-correct. The boundary searches below return BYTE
+	// offsets, but every boundary char ('.', ' ', '\n') is single-byte
+	// ASCII, so slicing head at those offsets is safe. notes.yaml is
+	// ASCII-only by convention; this is the one spot that relies on it.
 	head := string(r[:budget])
 	// A complete sentence reads cleanly; prefer it when it keeps at
 	// least half the budget (avoids cutting back to a tiny fragment).

--- a/pkg/releasenotes/plaintext_test.go
+++ b/pkg/releasenotes/plaintext_test.go
@@ -33,6 +33,44 @@ func TestPlainText_FlattensAndJoins(t *testing.T) {
 	}
 }
 
+// TestPlainText_MarkdownSubset exercises the flattening of the full
+// markdown subset, including the nested and literal cases a naive regex
+// flattener gets wrong. PlainText delegates to the in-app renderer, so
+// these assert parity with what the popup shows minus styling.
+func TestPlainText_MarkdownSubset(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string // body portion only (after the title + blank line)
+	}{
+		{"italic inside bold", "**really *very* important** today", "really very important today"},
+		{"bold inside link text", "see [**Settings**](#/settings) now", "see Settings now"},
+		{"literal wildcard star kept", "use a CALL-* wildcard to match all SSIDs", "use a CALL-* wildcard to match all SSIDs"},
+		{"entities round-trip", "filter & sort; speeds < 5 and it's fine", "filter & sort; speeds < 5 and it's fine"},
+		{"unclosed bold literal", "this ** is not bold", "this ** is not bold"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(`
+- version: "0.12.0"
+  date: "2026-05-01"
+  style: info
+  title: "T"
+  body: ` + "\"" + tc.body + "\"\n")
+			restore := forceParse(src)
+			defer restore()
+			got, err := PlainText("0.12.0")
+			if err != nil {
+				t.Fatalf("PlainText: %v", err)
+			}
+			want := "T\n\n" + tc.want
+			if got != want {
+				t.Fatalf("got:\n%q\nwant:\n%q", got, want)
+			}
+		})
+	}
+}
+
 func TestPlainText_MissingVersion(t *testing.T) {
 	src := []byte(`
 - version: "0.12.0"

--- a/pkg/releasenotes/plaintext_test.go
+++ b/pkg/releasenotes/plaintext_test.go
@@ -1,0 +1,115 @@
+package releasenotes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPlainText_FlattensAndJoins(t *testing.T) {
+	src := []byte(`
+- version: "0.12.0"
+  date: "2026-05-01"
+  style: info
+  title: "Shiny new thing"
+  body: |
+    First paragraph that is soft
+    wrapped across two lines.
+
+    See **bold** and *italic* and a
+    [link to messages](#/messages) here.
+`)
+	restore := forceParse(src)
+	defer restore()
+
+	got, err := PlainText("0.12.0")
+	if err != nil {
+		t.Fatalf("PlainText: %v", err)
+	}
+	want := "Shiny new thing\n\n" +
+		"First paragraph that is soft wrapped across two lines.\n\n" +
+		"See bold and italic and a link to messages here."
+	if got != want {
+		t.Fatalf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestPlainText_MissingVersion(t *testing.T) {
+	src := []byte(`
+- version: "0.12.0"
+  date: "2026-05-01"
+  style: info
+  title: "T"
+  body: "B"
+`)
+	restore := forceParse(src)
+	defer restore()
+
+	if _, err := PlainText("9.9.9"); err == nil {
+		t.Fatal("expected error for missing version, got nil")
+	}
+}
+
+// TestPlainText_EmbeddedLatest renders the newest real changelog entry
+// and confirms it fits Play's limit after truncation -- a guard that the
+// release workflow's whatsnew step won't be rejected by the API.
+func TestPlainText_EmbeddedLatest(t *testing.T) {
+	notes, err := All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	// All() sorts CTA-first; find the newest version regardless of style.
+	latest := notes[0].Version
+	for _, n := range notes {
+		if Compare(n.Version, latest) > 0 {
+			latest = n.Version
+		}
+	}
+	text, err := PlainText(latest)
+	if err != nil {
+		t.Fatalf("PlainText(%q): %v", latest, err)
+	}
+	if strings.TrimSpace(text) == "" {
+		t.Fatalf("empty whatsnew for %q", latest)
+	}
+	out := Truncate(text, PlayWhatsNewMax)
+	if n := len([]rune(out)); n > PlayWhatsNewMax {
+		t.Fatalf("truncated text is %d chars, exceeds %d", n, PlayWhatsNewMax)
+	}
+}
+
+func TestTruncate_UnderLimitUnchanged(t *testing.T) {
+	s := "short and sweet."
+	if got := Truncate(s, 100); got != s {
+		t.Fatalf("got %q, want unchanged %q", got, s)
+	}
+}
+
+func TestTruncate_SentenceBoundaryNoEllipsis(t *testing.T) {
+	s := "First sentence here. Second sentence runs much longer and pushes well past the cap so it must be dropped entirely."
+	got := Truncate(s, 30)
+	if got != "First sentence here." {
+		t.Fatalf("got %q, want clean sentence cut", got)
+	}
+	if len([]rune(got)) > 30 {
+		t.Fatalf("got %d chars, exceeds 30", len([]rune(got)))
+	}
+}
+
+func TestTruncate_WordBoundaryEllipsis(t *testing.T) {
+	s := "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda"
+	got := Truncate(s, 20)
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("expected ellipsis, got %q", got)
+	}
+	if strings.Contains(got, "  ") {
+		t.Fatalf("double space in %q", got)
+	}
+	if len([]rune(got)) > 20 {
+		t.Fatalf("got %d chars, exceeds 20", len([]rune(got)))
+	}
+	// Must end on a whole word, never mid-word.
+	body := strings.TrimSuffix(strings.TrimSpace(got), "...")
+	if last := strings.Fields(body); len(last) > 0 && last[len(last)-1] == "epsil" {
+		t.Fatalf("truncated mid-word: %q", got)
+	}
+}


### PR DESCRIPTION
## What

Switches the Android release pipeline to publish tagged releases directly to the Play **Closed Testing** track instead of Internal, so the next (and every future) `v*` tag reaches the private beta testers automatically.

## Why

Per the request: the next Graywolf release needs to land in Closed Testing. Previously a tag auto-uploaded only to Internal, and reaching Closed Testing required a separate manual `workflow_dispatch` promote.

## Changes

- **`.github/workflows/android.yml`** — the `release-sign` auto-upload now targets `track: alpha` (Play's fixed track id for Closed Testing) rather than `internal`. The manual `promote` job is repurposed to graduate a vetted build from closed (`alpha`) to open testing (`beta`), with the dispatch `track` input defaulting to `beta`.
- **`fastlane/Fastfile`, `Makefile`** — `promote` defaults follow suit (`from:alpha`, `to:beta`).
- **`docs/wiki/`** — updated to match, and corrected the stale claim that the closed track is a custom `graywolf-beta` track. Play's track ids are fixed (`internal`, `alpha`=closed, `beta`=open, `production`); the closed track is addressed as `alpha`.

Production is still never targeted — the service account lacks the permission. The Play steps remain gated on the `GRAYWOLF_PLAY_SERVICE_ACCOUNT_JSON` secret, so they skip (not fail) when it is absent.

## Note

This updates the process only; it does not cut a release. The next `make bump-point`/`bump-minor` tag will publish to Closed Testing.
