### PR TITLE
fix(modem): populate per-packet audio level for Profile B demod

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -939,3 +939,26 @@ Source: [`../../pkg/webapi/dto/kiss.go`](../../pkg/webapi/dto/kiss.go)
 [`../../pkg/webapi/kiss.go`](../../pkg/webapi/kiss.go) (`setKissEnabled`, `notifyKissManager`),
 [`../../pkg/configstore/store.go`](../../pkg/configstore/store.go) (`CreateKissInterface`),
 [`../../pkg/app/wiring.go`](../../pkg/app/wiring.go) (`kissComponent`, `buildTxBackendSnapshot`, webapi `Config.KissSerialOpenFunc`).
+
+### 46. Per-frame metadata must be populated by every demod profile, not just Profile A
+
+The default AFSK RX path is the `RECOMMENDED_3DEMOD` ensemble (Profile A,
+Profile A + hard-limiter, Profile B / FM-discriminator). The ensemble dedups
+identical frames across sub-demods and keeps the *first* emitter within a
+~110-sample window; in practice **Profile B usually wins** because its
+pipeline detects the closing flag a few samples earlier. So any per-frame
+field stamped onto `DecodedFrame` (e.g. `audio_level_mark`/`space`) must be
+produced by *all three* profiles -- a field tracked only in
+`process_profile_a` will be the `-1.0`/zero init on the frames that actually
+reach the application, even though Profile A "also" decoded the packet.
+
+This bit the per-packet audio level (GRA-84): Profile B never called
+`track_level`, so nearly every logged packet showed no level (a dash) until
+Profile B was taught to track its center-frequency envelope. When adding a
+new per-frame measurement, populate it in `process_profile_a` **and**
+`process_profile_b`, or compute it profile-independently.
+
+Source: [`../../graywolf-modem/src/demod_afsk.rs`](../../graywolf-modem/src/demod_afsk.rs)
+(`process_profile_a`, `process_profile_b`, `track_level`),
+[`../../graywolf-modem/src/demod_afsk_multi.rs`](../../graywolf-modem/src/demod_afsk_multi.rs)
+(dedup in `process_sample`).

--- a/graywolf-modem/src/demod_afsk.rs
+++ b/graywolf-modem/src/demod_afsk.rs
@@ -565,6 +565,27 @@ impl AfskDemodulator {
         let c_i = convolve(&self.state.afsk.c_i_buf.as_slice()[..taps], lp);
         let c_q = convolve(&self.state.afsk.c_q_buf.as_slice()[..taps], lp);
 
+        // Track the center-frequency envelope as the received signal level.
+        // Profile B is an FM discriminator with no separate mark/space tones,
+        // so both level peaks follow the same envelope. Without this the peaks
+        // stay at their -1.0 init, and because Profile B usually wins the
+        // cross-demod dedup, the emitted frame would report no audio level —
+        // every packet rendered as a dash in the log (issue GRA-84). Uses the
+        // same attack/decay envelope tracker as Profile A so the scale matches.
+        let c_amp = (c_i * c_i + c_q * c_q).sqrt();
+        Self::track_level(
+            c_amp,
+            &mut self.state.alevel_mark_peak,
+            self.state.quick_attack,
+            self.state.sluggish_decay,
+        );
+        Self::track_level(
+            c_amp,
+            &mut self.state.alevel_space_peak,
+            self.state.quick_attack,
+            self.state.sluggish_decay,
+        );
+
         // FM discriminator: instantaneous frequency ≈ d(phase)/dt
         let phase = c_q.atan2(c_i);
         let mut rate = phase - self.state.afsk.prev_phase;

--- a/graywolf-modem/tests/audio_level.rs
+++ b/graywolf-modem/tests/audio_level.rs
@@ -1,0 +1,59 @@
+// Regression test for GRA-84: every frame the default RECOMMENDED_3DEMOD
+// ensemble emits must carry a valid (positive) per-packet audio level.
+//
+// The bug: Profile B (FM discriminator) never tracked an audio level, leaving
+// its mark/space peaks at the -1.0 init. Profile B usually wins the cross-demod
+// dedup, so the emitted frame reported no level and the packet log rendered a
+// dash for nearly every packet. This decodes a real 1200-baud AFSK recording
+// through the production ensemble and asserts no frame comes out level-less.
+use std::fs::File;
+use std::io::{BufReader, Read};
+
+use graywolfmodem::demod_afsk_multi::{MultiAfskDemodulator, RECOMMENDED_3DEMOD};
+
+fn read_wav_mono16(path: &str) -> (Vec<i16>, u32) {
+    let mut r = BufReader::new(File::open(path).unwrap());
+    let mut all = Vec::new();
+    r.read_to_end(&mut all).unwrap();
+    let mut i = 12;
+    let mut sr = 44100u32;
+    let mut data: Vec<i16> = Vec::new();
+    while i + 8 <= all.len() {
+        let id = &all[i..i + 4];
+        let size = u32::from_le_bytes([all[i + 4], all[i + 5], all[i + 6], all[i + 7]]) as usize;
+        let body = i + 8;
+        if id == b"fmt " {
+            sr = u32::from_le_bytes([all[body + 4], all[body + 5], all[body + 6], all[body + 7]]);
+        } else if id == b"data" {
+            for c in all[body..(body + size).min(all.len())].chunks_exact(2) {
+                data.push(i16::from_le_bytes([c[0], c[1]]));
+            }
+        }
+        i = body + size + (size & 1);
+    }
+    (data, sr)
+}
+
+#[test]
+fn ensemble_frames_carry_audio_level() {
+    let (samples, sr) = read_wav_mono16("testdata/wav/afsk_1200.wav");
+    let mut demod = MultiAfskDemodulator::new(sr, 1200, 1200, 2200, 0, &RECOMMENDED_3DEMOD);
+    let mut frames = Vec::new();
+    for s in samples {
+        demod.process_sample(s as i32);
+        frames.extend(demod.take_frames());
+    }
+    frames.extend(demod.take_frames());
+
+    assert!(!frames.is_empty(), "expected to decode at least one frame");
+    let dashed = frames
+        .iter()
+        .filter(|f| f.audio_level_mark <= 0.0 && f.audio_level_space <= 0.0)
+        .count();
+    assert_eq!(
+        dashed, 0,
+        "{}/{} decoded frames carry no audio level (would render as a dash in the packet log)",
+        dashed,
+        frames.len()
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up fix for GRA-84. After #291 merged, the per-packet audio level was blank (a dash) for nearly every packet in the log, even on raw modem-RX entries.

## Root cause

The default RX path uses the 3-demodulator ensemble (`RECOMMENDED_3DEMOD`: Profile A, Profile A + hard-limit, Profile B). Only Profile A tracked an audio level; the **Profile B (FM-discriminator) sub-demod never called `track_level`**, so its `alevel_mark_peak` / `alevel_space_peak` stayed at the `-1.0` init. Profile B wins the cross-demod dedup for the large majority of frames (it detects the closing flag a few samples earlier), so the emitted frame carried `-1.0` levels -- which the Go side maps to "no level" and the UI renders as a dash.

## Fix

Track the center-frequency envelope (`sqrt(c_i^2 + c_q^2)`) in Profile B using the same attack/decay tracker Profile A already uses, writing both level peaks. Profile B has no separate mark/space tones, so both peaks follow the single envelope (the UI shows the mean, which equals it).

## Verification

Reproduced and fixed against `testdata/wav/afsk_1200.wav` driven through the production ensemble (new regression test `graywolf-modem/tests/audio_level.rs`):

- Before: 15/16 deduped frames came out level-less (mark = space = -1.0).
- After: 0/16 -- every frame carries a positive level.
- Decode correctness suite unchanged: `correctness` 19/19 pass.

## Deploy note

This is a **modem** change. Operators must rebuild + restart from a build that includes this commit; rebuilding only the web UI or the Go daemon won't pick it up.
