### PR TITLE
Source GitHub release notes from notes.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,20 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
+      # Render the GitHub release body from the curated notes.yaml entry so
+      # it matches the in-app "What's new" -- and so GoReleaser does not fall
+      # back to listing every commit when the previous release tag is not an
+      # ancestor of the tagged commit. Written to RUNNER_TEMP (outside the
+      # work tree) so it neither dirties git nor gets wiped by --clean.
+      - name: Render release notes from notes.yaml
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          v="${GITHUB_REF_NAME#v}"
+          go run ./cmd/release-notes -version "$v" -out "$RUNNER_TEMP/release-notes.md"
+          echo "---- release notes ----"
+          cat "$RUNNER_TEMP/release-notes.md"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -248,7 +262,7 @@ jobs:
           # On a tag push we cut a real release; on workflow_dispatch we
           # run in snapshot mode so the build pipeline executes end-to-end
           # without needing a tag context (no upload, no draft release).
-          args: ${{ github.event_name == 'workflow_dispatch' && 'release --snapshot --clean' || 'release --clean' }}
+          args: ${{ github.event_name == 'workflow_dispatch' && 'release --snapshot --clean' || format('release --clean --release-notes={0}/release-notes.md', runner.temp) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -26,30 +26,42 @@ import (
 )
 
 func main() {
-	version := flag.String("version", "", "release version (x.y.z, no leading v) to render notes for")
-	out := flag.String("out", "", "output file path (e.g. release-notes.md)")
-	flag.Parse()
+	os.Exit(run(os.Args[1:]))
+}
+
+// run parses args, renders the note, and writes it, returning the process
+// exit code. A non-zero return is what the Release workflow relies on to
+// fail loudly when notes.yaml has no entry for the tag version, rather than
+// publishing a blank release body.
+func run(args []string) int {
+	fs := flag.NewFlagSet("release-notes", flag.ContinueOnError)
+	version := fs.String("version", "", "release version (x.y.z, no leading v) to render notes for")
+	out := fs.String("out", "", "output file path (e.g. release-notes.md)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
 
 	if *version == "" || *out == "" {
 		fmt.Fprintln(os.Stderr, "usage: release-notes -version <x.y.z> -out <file>")
-		os.Exit(2)
+		return 2
 	}
 
 	text, err := releasenotes.PlainText(*version)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "release-notes: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	if dir := filepath.Dir(*out); dir != "" {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			fmt.Fprintf(os.Stderr, "release-notes: create %s: %v\n", dir, err)
-			os.Exit(1)
+			return 1
 		}
 	}
 	if err := os.WriteFile(*out, []byte(text+"\n"), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "release-notes: write %s: %v\n", *out, err)
-		os.Exit(1)
+		return 1
 	}
 	fmt.Fprintf(os.Stderr, "release-notes: wrote %d chars to %s\n", len([]rune(text)), *out)
+	return 0
 }

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -1,0 +1,55 @@
+// Command release-notes renders the operator-facing changelog for a given
+// release version from the embedded release notes (pkg/releasenotes/notes.yaml)
+// and writes it to a file, for use as the GitHub release body.
+//
+// The Release workflow runs this on a tag push and points GoReleaser's
+// --release-notes flag at the output, so the GitHub release description is
+// the same curated note that drives the in-app "What's new" popup -- not
+// GoReleaser's git-derived changelog, which lists every commit when the
+// previous release tag is not an ancestor of the tagged commit.
+//
+//	go run ./cmd/release-notes -version 0.14.0 -out release-notes.md
+//
+// Unlike play-whatsnew, the output is NOT truncated: the GitHub release
+// body has no tight length limit, so the full note ships. Exits non-zero
+// if no note exists for the version, so a release with a missing changelog
+// entry fails loudly rather than shipping a blank body.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/chrissnell/graywolf/pkg/releasenotes"
+)
+
+func main() {
+	version := flag.String("version", "", "release version (x.y.z, no leading v) to render notes for")
+	out := flag.String("out", "", "output file path (e.g. release-notes.md)")
+	flag.Parse()
+
+	if *version == "" || *out == "" {
+		fmt.Fprintln(os.Stderr, "usage: release-notes -version <x.y.z> -out <file>")
+		os.Exit(2)
+	}
+
+	text, err := releasenotes.PlainText(*version)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "release-notes: %v\n", err)
+		os.Exit(1)
+	}
+
+	if dir := filepath.Dir(*out); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "release-notes: create %s: %v\n", dir, err)
+			os.Exit(1)
+		}
+	}
+	if err := os.WriteFile(*out, []byte(text+"\n"), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "release-notes: write %s: %v\n", *out, err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "release-notes: wrote %d chars to %s\n", len([]rune(text)), *out)
+}

--- a/cmd/release-notes/main_test.go
+++ b/cmd/release-notes/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// An unknown version must fail the process. The Release workflow's
+// `set -euo pipefail` turns this non-zero exit into a release abort, which
+// is the whole point: a missing notes.yaml entry should fail loudly rather
+// than publish a blank GitHub release body.
+func TestRun_UnknownVersionExitsNonzero(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "notes.md")
+	if code := run([]string{"-version", "0.0.0-does-not-exist", "-out", out}); code == 0 {
+		t.Fatalf("expected non-zero exit for unknown version, got 0")
+	}
+	if _, err := os.Stat(out); err == nil {
+		t.Fatalf("output file should not be written when the version is unknown")
+	}
+}
+
+// Missing required flags is a usage error (exit 2), distinct from a render
+// failure (exit 1).
+func TestRun_MissingFlagsExitsTwo(t *testing.T) {
+	if code := run(nil); code != 2 {
+		t.Fatalf("expected exit 2 for missing flags, got %d", code)
+	}
+}
+
+// A version present in notes.yaml renders and writes a non-empty body.
+// 0.14.0 is permanent release history; the file is append-only.
+func TestRun_KnownVersionWritesNote(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "sub", "notes.md")
+	if code := run([]string{"-version", "0.14.0", "-out", out}); code != 0 {
+		t.Fatalf("expected exit 0 for known version, got %d", code)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if len(b) == 0 {
+		t.Fatalf("output file is empty")
+	}
+}


### PR DESCRIPTION
## Problem

The v0.14.0 GitHub release body was a 1200+ line dump of every commit in the project's history.

Root cause: GoReleaser derives its changelog from `<previous tag>..<current tag>`. The recent release tags (v0.13.x) are **not ancestors** of the v0.14.0 commit -- the most recent reachable tag is v0.11.4 -- so GoReleaser diffed v0.11.4..v0.14.0 and listed all 1214 commits.

## Fix

Source the GitHub release body from the curated `pkg/releasenotes/notes.yaml` entry instead of the git log -- the same note that drives the in-app "What's new" popup and the Play "What's new" text.

- **`cmd/release-notes`**: renders the note for a given version via the existing `releasenotes.PlainText`, untruncated (unlike `play-whatsnew`, which caps at Play's 500-char limit). Exits non-zero if no entry exists, so a missing changelog fails the release loudly.
- **`.github/workflows/release.yml`**: on a tag push, render the note to `$RUNNER_TEMP/release-notes.md` and pass it to GoReleaser via `--release-notes`. `--release-notes` overrides changelog generation entirely, so tag ancestry no longer matters. The file lives outside the work tree so it neither dirties git nor gets wiped by `--clean`. `workflow_dispatch` snapshot builds are unchanged (no release, no notes).

Output for 0.14.0 is the curated title + body paragraphs -- matching what the v0.14.0 release description was manually corrected to.

No change to the binaries, packaging, or the `changelog:` config (now simply unused for the release body).
