### PR TITLE
Improve map temperature chip contrast (incl. night mode)

### DIFF
--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1392,20 +1392,20 @@
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
   }
   /* Temperature chip: sits just below the callsign, right-justified to
-     it. Filled by the weather layer. Uses fixed light-on-dark colors
-     (not a theme variable) so it stays legible over any basemap and in
-     night mode — the callsign chip above it follows the same approach.
-     A touch dimmer than the callsign's pure white so the callsign stays
-     the primary label. */
+     it. Filled by the weather layer. Themeable via the --map-temp-*
+     tokens (defined per theme in web/themes/*.css); the fallbacks here
+     are light-on-dark so it stays legible over any basemap and in night
+     mode even if a theme omits them. Kept a touch dimmer than the
+     callsign's pure white so the callsign stays the primary label. */
   :global(.gw-station-aside .wx-temp) {
     padding: 0 4px;
     line-height: 13px;
     font-family: var(--font-mono);
     font-size: 10px;
     font-weight: 600;
-    color: #e6edf3;
-    background: rgba(14, 14, 14, 0.82);
-    border: 1px solid rgba(255, 255, 255, 0.45);
+    color: var(--map-temp-fg, #e6edf3);
+    background: var(--map-temp-bg, rgba(14, 14, 14, 0.82));
+    border: 1px solid var(--map-temp-border, rgba(255, 255, 255, 0.45));
     border-radius: 2px;
     white-space: nowrap;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1392,20 +1392,23 @@
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
   }
   /* Temperature chip: sits just below the callsign, right-justified to
-     it. Filled by the weather layer; dimmer than the callsign so the
-     callsign stays the primary label. */
+     it. Filled by the weather layer. Uses fixed light-on-dark colors
+     (not a theme variable) so it stays legible over any basemap and in
+     night mode — the callsign chip above it follows the same approach.
+     A touch dimmer than the callsign's pure white so the callsign stays
+     the primary label. */
   :global(.gw-station-aside .wx-temp) {
     padding: 0 4px;
     line-height: 13px;
     font-family: var(--font-mono);
     font-size: 10px;
     font-weight: 600;
-    color: var(--color-text-dim, #c9d1d9);
-    background: rgba(22, 27, 34, 0.85);
-    border: 1px solid rgba(255, 255, 255, 0.22);
+    color: #e6edf3;
+    background: rgba(14, 14, 14, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.45);
     border-radius: 2px;
     white-space: nowrap;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
   }
 
   /* Fixed-point markers: same footprint as station markers (APRS icon +

--- a/web/themes/README.md
+++ b/web/themes/README.md
@@ -84,6 +84,15 @@ Each of `danger`, `success`, `warning`, `info` has a trio:
 - `--radius` — corner radius in px. Most shipped themes use 2px;
   Graywolf Night bumps it to 6px for a softer feel at low contrast.
 
+### Map overlay (optional)
+Tokens consumed by the MapLibre Live Map. These render *over the
+basemap*, not over a theme surface, so default to light-on-dark in
+every theme regardless of light/dark mode.
+- `--map-temp-fg` / `--map-temp-bg` / `--map-temp-border` — the
+  temperature chip beside each station marker. Keep the text legible
+  on the chip's own background, not on the page surface; the chip can
+  sit over any basemap tile.
+
 ## Contrast and legibility
 
 Please eyeball these before submitting:

--- a/web/themes/grayscale-night.css
+++ b/web/themes/grayscale-night.css
@@ -49,6 +49,11 @@
   --map-overlay-border: var(--color-border);
   --map-overlay-shadow: 0 4px 16px rgba(0, 0, 0, 0.55);
   --map-attribution-bg: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  /* Station marker temperature chip. Light-on-dark so it stays legible
+     over any basemap; override per theme to retune contrast. */
+  --map-temp-fg: #e6edf3;
+  --map-temp-bg: rgba(14, 14, 14, 0.82);
+  --map-temp-border: rgba(255, 255, 255, 0.45);
 }
 
 /* Single-tone packet and origin badges. */

--- a/web/themes/grayscale.css
+++ b/web/themes/grayscale.css
@@ -50,6 +50,11 @@
   --map-overlay-border: var(--color-border);
   --map-overlay-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
   --map-attribution-bg: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  /* Station marker temperature chip. Light-on-dark so it stays legible
+     over any basemap; override per theme to retune contrast. */
+  --map-temp-fg: #e6edf3;
+  --map-temp-bg: rgba(14, 14, 14, 0.82);
+  --map-temp-border: rgba(255, 255, 255, 0.45);
 }
 
 /* Single-tone packet and origin badges. */

--- a/web/themes/graywolf-night.css
+++ b/web/themes/graywolf-night.css
@@ -51,6 +51,11 @@
   --map-overlay-border: var(--color-border);
   --map-overlay-shadow: 0 4px 16px rgba(0, 0, 0, 0.55);
   --map-attribution-bg: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  /* Station marker temperature chip. Light-on-dark so it stays legible
+     over any basemap; override per theme to retune contrast. */
+  --map-temp-fg: #e6edf3;
+  --map-temp-bg: rgba(14, 14, 14, 0.82);
+  --map-temp-border: rgba(255, 255, 255, 0.45);
 }
 
 /* Packet-log badges: muted tint backgrounds + bright text. */

--- a/web/themes/graywolf.css
+++ b/web/themes/graywolf.css
@@ -55,6 +55,11 @@
   --map-overlay-border: var(--color-border);
   --map-overlay-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
   --map-attribution-bg: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  /* Station marker temperature chip. Light-on-dark so it stays legible
+     over any basemap; override per theme to retune contrast. */
+  --map-temp-fg: #e6edf3;
+  --map-temp-bg: rgba(14, 14, 14, 0.82);
+  --map-temp-border: rgba(255, 255, 255, 0.45);
 }
 
 /* chonky-ui <Badge variant="..."> overrides: chonky-ui's defaults are

--- a/web/themes/high-contrast-night.css
+++ b/web/themes/high-contrast-night.css
@@ -53,6 +53,11 @@
   --map-overlay-border: var(--color-border);
   --map-overlay-shadow: 0 4px 16px rgba(0, 0, 0, 0.7);
   --map-attribution-bg: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  /* Station marker temperature chip. Maximum contrast for this theme:
+     pure white on solid black with a bright border. */
+  --map-temp-fg: #ffffff;
+  --map-temp-bg: rgba(0, 0, 0, 0.92);
+  --map-temp-border: rgba(255, 255, 255, 0.85);
 }
 
 /* Packet-log type badges: solid bright fills + black text for crisp,

--- a/web/themes/high-contrast.css
+++ b/web/themes/high-contrast.css
@@ -53,6 +53,11 @@
   --map-overlay-border: var(--color-border);
   --map-overlay-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
   --map-attribution-bg: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  /* Station marker temperature chip. Maximum contrast for this theme:
+     pure white on solid black with a bright border. */
+  --map-temp-fg: #ffffff;
+  --map-temp-bg: rgba(0, 0, 0, 0.92);
+  --map-temp-border: rgba(255, 255, 255, 0.85);
 }
 
 /* chonky-ui <Badge variant="..."> overrides: solid fills + white text. */


### PR DESCRIPTION
## Summary

The temperature chip shown beside each station on the live map was hard to read, especially in night mode (GitHub #304).

**Cause:** the chip's text color was `var(--color-text-dim)`, which resolves to `#5a5a5a` in night mode (and `#999999` in day) over a dark chip background — far too low-contrast.

**Fix:** use fixed light-on-dark colors (`#e6edf3` on `rgba(14,14,14,0.82)`) so the chip stays legible across every theme and basemap, mirroring how the callsign chip directly above it already pins `#ffffff`. The temp is kept a touch dimmer than the callsign's pure white so the callsign remains the primary label, and the border/shadow are firmed up for definition.

CSS-only change in `web/src/routes/LiveMapV2.svelte`.

Closes #304