### PR TITLE
map: guard hover-path clear() against post-teardown map.remove()

### DIFF
--- a/web/src/lib/map/layers/hover-path.js
+++ b/web/src/lib/map/layers/hover-path.js
@@ -136,10 +136,13 @@ export function mountHoverPathLayer(map, getOwnPosition = () => null) {
   }
 
   function clear() {
-    const pathSrc = map.getSource(PATH_SRC);
-    const nodesSrc = map.getSource(NODES_SRC);
-    if (pathSrc) pathSrc.setData(EMPTY_FC);
-    if (nodesSrc) nodesSrc.setData(EMPTY_FC);
+    // Guard: map.remove() deletes map.style; getSource() would throw.
+    try {
+      const pathSrc = map.getSource(PATH_SRC);
+      const nodesSrc = map.getSource(NODES_SRC);
+      if (pathSrc) pathSrc.setData(EMPTY_FC);
+      if (nodesSrc) nodesSrc.setData(EMPTY_FC);
+    } catch { /* map already removed */ }
   }
 
   function destroy() {


### PR DESCRIPTION
## Bug

MapLibre GL JS v5 crash on map teardown when a station popup is open.

`map.remove()` synchronously deletes `map.style`, so a subsequent `map.getSource()` throws a `TypeError` (it dereferences the now-null `this.style`).

During teardown the ordering is:

1. The child map component's `onDestroy` (`maplibre-map.svelte`) runs `map.remove()`, nulling `map.style`.
2. The parent `LiveMapV2.svelte` `onDestroy` then runs `closePopup()` → `activePopup.remove()`, which synchronously fires the popup's `close` handler.
3. That handler calls `hoverPathLayer.clear()`, which calls `map.getSource()` against the deleted style → `TypeError`.

(In Svelte 5, a child's `onDestroy` fires before its parent's, so the map is already gone by the time the popup close handler runs.)

`destroy()` already carried this try/catch guard; `clear()` did not, because it's invoked from the popup close handler — outside the component lifecycle.

## Fix

Wrap `clear()`'s body in the same try/catch used by `destroy()`. Single-file, behavior-preserving change.

This PR is the isolated bug fix extracted from #302. The other changes in #302 (popup action links, `esc()` double-quote escaping) are out of scope here.