### PR TITLE
Disable serial flow control (RTS/DTR) for GPS connections to fix persistent PTT

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -962,3 +962,19 @@ Source: [`../../graywolf-modem/src/demod_afsk.rs`](../../graywolf-modem/src/demo
 (`process_profile_a`, `process_profile_b`, `track_level`),
 [`../../graywolf-modem/src/demod_afsk_multi.rs`](../../graywolf-modem/src/demod_afsk_multi.rs)
 (dedup in `process_sample`).
+
+### 47. The GPS serial reader must deassert RTS/DTR on open
+
+`gps.RunSerial` opens its NMEA port with
+`InitialStatusBits: &serial.ModemOutputBits{RTS: false, DTR: false}`. This is
+not optional cosmetics: opening a tty otherwise leaves RTS and DTR raised
+(`go.bug.st/serial` only touches the modem bits when `InitialStatusBits` is
+non-nil, and the kernel asserts both on open by default). On shared serial
+rigs where RTS drives PTT -- the Digirig Mobile RS232 is the canonical case --
+raised RTS keys the transmitter the instant GPS connects, producing a
+persistent PTT that can't be toggled off (issue #305). GPS only consumes RX,
+so it holds the control lines low and leaves RTS for the PTT driver to assert
+when it keys. macOS does not exhibit this because its tty open does not raise
+the lines the same way, which is why the bug was Linux-only.
+
+Source: [`../../pkg/gps/serial.go`](../../pkg/gps/serial.go) (`RunSerial`).

--- a/pkg/gps/serial.go
+++ b/pkg/gps/serial.go
@@ -45,7 +45,15 @@ func RunSerial(ctx context.Context, cfg SerialConfig, cache PositionCache, logge
 			"device", cfg.Device, "suggested", alt)
 	}
 
-	mode := &serial.Mode{BaudRate: baud}
+	// Deassert RTS and DTR on open. Opening a tty otherwise raises both lines
+	// (the library leaves them untouched unless InitialStatusBits is set, and
+	// the kernel asserts them by default), which keys PTT on shared serial
+	// rigs like the Digirig where RTS drives PTT. GPS only needs RX, so hold
+	// the control lines low and let the PTT driver assert RTS when it keys.
+	mode := &serial.Mode{
+		BaudRate:          baud,
+		InitialStatusBits: &serial.ModemOutputBits{RTS: false, DTR: false},
+	}
 	port, err := serial.Open(cfg.Device, mode)
 	if err != nil {
 		return fmt.Errorf("gps: open %s: %w", cfg.Device, err)


### PR DESCRIPTION
## Summary

On Linux, configuring a GPS connection to a serial port shared with PTT (e.g. the Digirig Mobile RS232, where RTS drives PTT) keyed the transmitter the instant GPS connected, producing a persistent PTT that couldn't be toggled off.

The cause: `gps.RunSerial` opened the NMEA port without setting `InitialStatusBits`. `go.bug.st/serial` only touches the modem control bits when that field is non-nil, and the kernel asserts RTS and DTR on tty open by default — so both lines came up high and stayed high. macOS doesn't raise the lines the same way, which is why the bug was Linux-only.

## Fix

Open the GPS reader with `InitialStatusBits: &serial.ModemOutputBits{RTS: false, DTR: false}` so the control lines are held low. GPS only consumes RX; RTS is left for the PTT driver to assert when it keys. This matches how flrig/fldigi let you ignore RTS/CTS on the GPS path.

## Notes

- One-line behavioral change in `pkg/gps/serial.go` plus a wiki invariant documenting why GPS must deassert RTS/DTR on open.
- `go build` / `go vet` / `go test ./pkg/gps/...` pass.

Fixes #305