### PR TITLE
Fix false 'mixed build' version warning (short SHA length mismatch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,12 @@ jobs:
         run: |
           ref="${{ github.ref_name }}"
           echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
-          echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          # Pin the short-SHA length: git's default abbreviation grows with
+          # the repo's object count and clone depth, so this shallow-checkout
+          # job and the full-clone GoReleaser job would otherwise stamp the
+          # same commit at different lengths (e.g. 7c309d4 vs 7c309d4e),
+          # tripping the startup "versions disagree" check (graywolf#310).
+          echo "commit=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
 
       # Run cargo/cross from the workspace root so cross-rs mounts the
       # whole repo (it needs access to ../proto/graywolf.proto, which is
@@ -193,6 +198,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Stamp the Go binary with the same fixed-length short SHA the Rust
+      # modem build uses. GoReleaser's {{.ShortCommit}} is git's default
+      # abbreviation, whose length tracks clone depth -- pinning it here
+      # keeps both binaries' version strings byte-identical (graywolf#310).
+      - name: Compute version metadata
+        id: ver
+        shell: bash
+        run: echo "commit=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Download frontend dist
         uses: actions/download-artifact@v5
         with:
@@ -265,6 +279,7 @@ jobs:
           args: ${{ github.event_name == 'workflow_dispatch' && 'release --snapshot --clean' || format('release --clean --release-notes={0}/release-notes.md', runner.temp) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GRAYWOLF_GIT_COMMIT: ${{ steps.ver.outputs.commit }}
 
       - name: Upload Windows binary for installer
         uses: actions/upload-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,12 +92,14 @@ jobs:
         run: |
           ref="${{ github.ref_name }}"
           echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
-          # Pin the short-SHA length: git's default abbreviation grows with
-          # the repo's object count and clone depth, so this shallow-checkout
-          # job and the full-clone GoReleaser job would otherwise stamp the
-          # same commit at different lengths (e.g. 7c309d4 vs 7c309d4e),
-          # tripping the startup "versions disagree" check (graywolf#310).
-          echo "commit=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+          # Use a fixed 8-char prefix of the full SHA. `git rev-parse --short`
+          # (and --short=N, which is only a *minimum*) lengthens the hash for
+          # uniqueness based on object count and clone depth, so this
+          # shallow-checkout job and the full-clone GoReleaser job could stamp
+          # the same commit at different lengths (e.g. 7c309d4 vs 7c309d4e),
+          # tripping the startup "versions disagree" check. A fixed prefix is a
+          # pure function of the commit, independent of depth (graywolf#310).
+          echo "commit=$(git rev-parse HEAD | cut -c1-8)" >> "$GITHUB_OUTPUT"
 
       # Run cargo/cross from the workspace root so cross-rs mounts the
       # whole repo (it needs access to ../proto/graywolf.proto, which is
@@ -198,14 +200,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Stamp the Go binary with the same fixed-length short SHA the Rust
-      # modem build uses. GoReleaser's {{.ShortCommit}} is git's default
-      # abbreviation, whose length tracks clone depth -- pinning it here
+      # Stamp the Go binary with the same fixed 8-char SHA prefix the Rust
+      # modem build uses. GoReleaser's {{.ShortCommit}} is git's variable
+      # abbreviation, whose length tracks clone depth -- a fixed prefix here
       # keeps both binaries' version strings byte-identical (graywolf#310).
       - name: Compute version metadata
         id: ver
         shell: bash
-        run: echo "commit=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+        run: echo "commit=$(git rev-parse HEAD | cut -c1-8)" >> "$GITHUB_OUTPUT"
 
       - name: Download frontend dist
         uses: actions/download-artifact@v5

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,10 @@ builds:
       - -w
       - -s
       - -X main.Version={{.Version}}
-      - -X main.GitCommit={{.ShortCommit}}
+      # Prefer the fixed-length short SHA computed by the release workflow so
+      # this binary and the Rust modem agree; fall back to GoReleaser's own
+      # (variable-length) ShortCommit for local/snapshot builds (graywolf#310).
+      - -X main.GitCommit={{ envOrDefault "GRAYWOLF_GIT_COMMIT" .ShortCommit }}
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ RUSTFLAGS_NATIVE := -C target-cpu=native
 # flag come from git. The two are joined into v<VERSION>-<COMMIT>[-dirty]
 # at display time by both the Go and Rust sides, so keep them separate here.
 VERSION     ?= $(shell cat VERSION 2>/dev/null || echo dev)
-GIT_COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+GIT_COMMIT  ?= $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo unknown)
 GIT_DIRTY   := $(shell git diff-index --quiet HEAD -- 2>/dev/null || echo -dirty)
 FULL_COMMIT := $(GIT_COMMIT)$(GIT_DIRTY)
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,11 @@ RUSTFLAGS_NATIVE := -C target-cpu=native
 # flag come from git. The two are joined into v<VERSION>-<COMMIT>[-dirty]
 # at display time by both the Go and Rust sides, so keep them separate here.
 VERSION     ?= $(shell cat VERSION 2>/dev/null || echo dev)
-GIT_COMMIT  ?= $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo unknown)
+# Fixed 8-char prefix of the full SHA, not `git rev-parse --short`: the latter
+# lengthens for uniqueness based on clone depth and would desync the Go and
+# Rust version stamps (graywolf#310). A prefix is a pure function of the commit.
+GIT_SHA     := $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+GIT_COMMIT  ?= $(shell printf '%.8s' '$(GIT_SHA)')
 GIT_DIRTY   := $(shell git diff-index --quiet HEAD -- 2>/dev/null || echo -dirty)
 FULL_COMMIT := $(GIT_COMMIT)$(GIT_DIRTY)
 

--- a/graywolf-modem/build.rs
+++ b/graywolf-modem/build.rs
@@ -45,10 +45,11 @@ fn main() {
 }
 
 fn derive_commit(repo_root: &Path) -> String {
-    // --short=8 pins the abbreviation length so it matches the Go side's
-    // stamping; git's default length varies with clone depth (graywolf#310).
-    let short = Command::new("git")
-        .args(["rev-parse", "--short=8", "HEAD"])
+    // Fixed 8-char prefix of the full SHA, not `git rev-parse --short`, whose
+    // length varies with clone depth and would desync the Go side's stamping
+    // (graywolf#310). A prefix is a pure function of the commit.
+    let full = Command::new("git")
+        .args(["rev-parse", "HEAD"])
         .current_dir(repo_root)
         .output()
         .ok()
@@ -56,6 +57,7 @@ fn derive_commit(repo_root: &Path) -> String {
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "unknown".to_string());
+    let short: String = full.chars().take(8).collect();
 
     let dirty = Command::new("git")
         .args(["diff-index", "--quiet", "HEAD", "--"])

--- a/graywolf-modem/build.rs
+++ b/graywolf-modem/build.rs
@@ -45,8 +45,10 @@ fn main() {
 }
 
 fn derive_commit(repo_root: &Path) -> String {
+    // --short=8 pins the abbreviation length so it matches the Go side's
+    // stamping; git's default length varies with clone depth (graywolf#310).
     let short = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short=8", "HEAD"])
         .current_dir(repo_root)
         .output()
         .ok()


### PR DESCRIPTION
## Summary

Closes #310.

The startup banner logs `graywolf and graywolf-modem versions disagree -- possibly a mixed build` even when both binaries come from the same commit, because the embedded short commit SHAs have different lengths (e.g. `v0.14.0-7c309d4e` vs `v0.14.0-7c309d4`).

## Root cause

Both binaries stamp their version from git's *default* short-SHA abbreviation (`git rev-parse --short HEAD` / GoReleaser's `{{.ShortCommit}}`). That length is not fixed -- git grows it as needed for uniqueness, which depends on the repo's object count and clone depth. In the release workflow:

- the **Rust modem** job uses a shallow checkout -> 7-char abbreviation
- the **GoReleaser** job uses `fetch-depth: 0` (full clone) -> 8-char abbreviation

Same commit, different lengths, so the equality check in `pkg/app/wiring.go` failed.

## Fix

Pin the abbreviation to a fixed 8 characters across every build path:

- `.github/workflows/release.yml` -- both the Rust job and a new `ver` step in the GoReleaser job use `git rev-parse --short=8 HEAD`
- `.goreleaser.yml` -- stamps from `GRAYWOLF_GIT_COMMIT` (the workflow-computed value), falling back to `.ShortCommit` for local/snapshot builds
- `Makefile` -- `--short=8` so local `make` builds stay consistent
- `graywolf-modem/build.rs` -- `--short=8` in the no-env fallback

Cosmetic-only bug; no operational impact. Existing `pkg/app` tests pass.