### PR TITLE
gps: drop exclusive tty lock so shared-line PTT works after reboot

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -978,3 +978,31 @@ when it keys. macOS does not exhibit this because its tty open does not raise
 the lines the same way, which is why the bug was Linux-only.
 
 Source: [`../../pkg/gps/serial.go`](../../pkg/gps/serial.go) (`RunSerial`).
+
+### 47a. The GPS serial reader must NOT hold the tty exclusively (Linux)
+
+On Linux `gps.RunSerial` opens the NMEA port through `openNMEASerial`
+(`serial_open_linux.go`), a raw `unix.Open` + termios path that deliberately
+does **not** issue `TIOCEXCL`. `go.bug.st/serial` acquires exclusive access on
+every Unix open (`acquireExclusiveAccess` -> `TIOCEXCL`), which blocks any
+later `open()` of the same tty with `EBUSY` for non-`CAP_SYS_ADMIN` callers.
+On a shared serial rig (Digirig Mobile: radio NMEA in on RX, PTT on RTS over
+the same DB9), the GPS reader (Go parent) and the PTT driver (graywolf-modem
+child, `ptt_unix.rs` -> `open(O_RDWR|O_NOCTTY|O_NONBLOCK|O_CLOEXEC)`) both open
+the same device. Whichever opens first wins; if GPS won and held `TIOCEXCL`,
+the modem's PTT `open()` failed with `EBUSY` and PTT silently never worked.
+This was order-dependent, so it surfaced as "PTT works when I configure it but
+breaks after a reboot" -- on reboot both routines start concurrently and GPS
+frequently wins the race (issue GRA-118 / #305 follow-up). The Linux opener
+keeps the #47 RTS/DTR deassert but drops the exclusive lock so the PTT driver
+can always open the device. Non-Linux platforms keep the `go.bug.st/serial`
+path (`serial_open_other.go`); the shared-line scenario is Linux-only.
+
+The Linux reader uses `VMIN=0` with a `poll()`-driven timeout so `Read`
+returns `(0, nil)` on timeout (what the `timeoutReader` scanner expects) and a
+self-pipe so `Close` wakes a blocked read without closing the device fd out
+from under it (avoiding an fd-reuse race).
+
+Source: [`../../pkg/gps/serial_open_linux.go`](../../pkg/gps/serial_open_linux.go) (`openNMEASerial`, `linuxNMEAPort`);
+[`../../pkg/gps/serial_open_other.go`](../../pkg/gps/serial_open_other.go) (non-Linux opener);
+[`../../graywolf-modem/src/tx/ptt_unix.rs`](../../graywolf-modem/src/tx/ptt_unix.rs) (`UnixSerialLines::open`).

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	go.bug.st/serial v1.6.4
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.49.0
+	golang.org/x/sys v0.42.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.31.1
@@ -40,7 +41,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	modernc.org/libc v1.22.5 // indirect
 	modernc.org/mathutil v1.5.0 // indirect

--- a/pkg/gps/serial.go
+++ b/pkg/gps/serial.go
@@ -7,9 +7,17 @@ import (
 	"log/slog"
 	"strings"
 	"time"
-
-	"go.bug.st/serial"
 )
+
+// nmeaPort is the subset of a serial port the NMEA reader needs. It is
+// satisfied by both the go.bug.st/serial-backed opener (non-Linux) and
+// the raw Linux opener, which deliberately skips exclusive access so the
+// shared-line PTT driver can open the same tty (see openNMEASerial).
+type nmeaPort interface {
+	io.Reader
+	SetReadTimeout(time.Duration) error
+	Close() error
+}
 
 // SerialConfig configures a NMEA-over-serial reader.
 type SerialConfig struct {
@@ -45,16 +53,15 @@ func RunSerial(ctx context.Context, cfg SerialConfig, cache PositionCache, logge
 			"device", cfg.Device, "suggested", alt)
 	}
 
-	// Deassert RTS and DTR on open. Opening a tty otherwise raises both lines
-	// (the library leaves them untouched unless InitialStatusBits is set, and
-	// the kernel asserts them by default), which keys PTT on shared serial
-	// rigs like the Digirig where RTS drives PTT. GPS only needs RX, so hold
-	// the control lines low and let the PTT driver assert RTS when it keys.
-	mode := &serial.Mode{
-		BaudRate:          baud,
-		InitialStatusBits: &serial.ModemOutputBits{RTS: false, DTR: false},
-	}
-	port, err := serial.Open(cfg.Device, mode)
+	// Open with RTS/DTR held low and, on Linux, without exclusive access
+	// (TIOCEXCL). Both matter on shared serial rigs like the Digirig where
+	// the radio's NMEA arrives on RX and PTT is driven by RTS on the same
+	// tty: raised RTS keys the transmitter the instant GPS connects (#305),
+	// and holding the port exclusively locks graywolf-modem's PTT driver
+	// out of the device entirely, so PTT silently failed whenever the GPS
+	// reader won the startup race (GRA-118). GPS only needs RX, so it holds
+	// the control lines low and leaves the tty open for the PTT driver.
+	port, err := openNMEASerial(cfg.Device, baud)
 	if err != nil {
 		return fmt.Errorf("gps: open %s: %w", cfg.Device, err)
 	}

--- a/pkg/gps/serial_open_linux.go
+++ b/pkg/gps/serial_open_linux.go
@@ -1,0 +1,180 @@
+//go:build linux
+
+package gps
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// linuxBaudMap maps a plain baud rate to its termios speed constant. NMEA
+// devices run at standard rates (4800/9600/38400 are the common ones), so
+// the non-standard BOTHER path is intentionally not supported here.
+var linuxBaudMap = map[int]uint32{
+	1200:   unix.B1200,
+	2400:   unix.B2400,
+	4800:   unix.B4800,
+	9600:   unix.B9600,
+	19200:  unix.B19200,
+	38400:  unix.B38400,
+	57600:  unix.B57600,
+	115200: unix.B115200,
+	230400: unix.B230400,
+}
+
+// linuxNMEAPort is a minimal NMEA-RX serial port. Unlike go.bug.st/serial
+// it never calls TIOCEXCL: holding the tty exclusively locks the
+// graywolf-modem PTT driver out of the same device on shared serial rigs
+// (Digirig: NMEA on RX, PTT on RTS), so PTT silently failed whenever the
+// GPS reader won the startup race (GRA-118). Reads use VMIN=0/VTIME so a
+// read returns (0, nil) on timeout, exactly what the NMEA scanner's
+// timeoutReader expects, and a self-pipe wakes a blocked read on Close
+// without the fd-reuse hazard of closing the fd out from under it.
+type linuxNMEAPort struct {
+	fd        int
+	wakeR     int
+	wakeW     int
+	timeoutMs int
+	closeOnce sync.Once
+}
+
+func openNMEASerial(device string, baud int) (nmeaPort, error) {
+	speed, ok := linuxBaudMap[baud]
+	if !ok {
+		return nil, fmt.Errorf("unsupported baud rate %d", baud)
+	}
+
+	// O_NONBLOCK avoids the DCD-blocking open() seen on some USB-serial
+	// adapters; we keep the fd non-blocking and gate reads with poll().
+	fd, err := unix.Open(device, unix.O_RDWR|unix.O_NOCTTY|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("tcgetattr: %w", err)
+	}
+
+	// Raw mode, 8N1, no flow control. CLOCAL ignores modem-control inputs
+	// (RX must work without DCD); CREAD enables the receiver.
+	t.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP |
+		unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON | unix.IXOFF | unix.IXANY
+	t.Oflag &^= unix.OPOST
+	t.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
+	t.Cflag &^= unix.CSIZE | unix.PARENB | unix.CSTOPB | unix.CRTSCTS
+	t.Cflag |= unix.CS8 | unix.CLOCAL | unix.CREAD
+
+	for _, b := range linuxBaudMap {
+		t.Cflag &^= b
+	}
+	t.Cflag |= speed
+	t.Ispeed = speed
+	t.Ospeed = speed
+
+	t.Cc[unix.VMIN] = 0
+	t.Cc[unix.VTIME] = 0
+
+	if err := unix.IoctlSetTermios(fd, unix.TCSETS, t); err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("tcsetattr: %w", err)
+	}
+
+	// Deassert RTS and DTR. The kernel raises both on open; on a Digirig
+	// raised RTS keys PTT the instant GPS connects (#305). Hold them low
+	// and leave RTS for the PTT driver to assert when it keys. Crucially,
+	// no TIOCEXCL is issued, so the PTT driver can open the same tty.
+	// ENOTTY means the device has no modem-control lines (a pty or a
+	// modem-less virtual serial), so there's no RTS PTT to worry about
+	// and the deassert is simply skipped.
+	if bits, err := unix.IoctlGetInt(fd, unix.TIOCMGET); err == nil {
+		bits &^= unix.TIOCM_RTS | unix.TIOCM_DTR
+		if err := unix.IoctlSetPointerInt(fd, unix.TIOCMSET, bits); err != nil && err != unix.ENOTTY {
+			unix.Close(fd)
+			return nil, fmt.Errorf("TIOCMSET: %w", err)
+		}
+	} else if err != unix.ENOTTY {
+		unix.Close(fd)
+		return nil, fmt.Errorf("TIOCMGET: %w", err)
+	}
+
+	var pipe [2]int
+	if err := unix.Pipe2(pipe[:], unix.O_CLOEXEC|unix.O_NONBLOCK); err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("wake pipe: %w", err)
+	}
+
+	return &linuxNMEAPort{
+		fd:        fd,
+		wakeR:     pipe[0],
+		wakeW:     pipe[1],
+		timeoutMs: 500,
+	}, nil
+}
+
+func (p *linuxNMEAPort) Read(b []byte) (int, error) {
+	for {
+		pfds := []unix.PollFd{
+			{Fd: int32(p.fd), Events: unix.POLLIN},
+			{Fd: int32(p.wakeR), Events: unix.POLLIN},
+		}
+		_, err := unix.Poll(pfds, p.timeoutMs)
+		if err == unix.EINTR {
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+		// Close() wrote to the wake pipe, or the device fd went away.
+		if pfds[1].Revents != 0 {
+			return 0, io.EOF
+		}
+		if pfds[0].Revents&int16(unix.POLLNVAL|unix.POLLERR|unix.POLLHUP) != 0 {
+			return 0, io.EOF
+		}
+		if pfds[0].Revents&int16(unix.POLLIN) == 0 {
+			// Poll timeout: report a (0, nil) read so timeoutReader can
+			// observe ctx and loop.
+			return 0, nil
+		}
+		n, err := unix.Read(p.fd, b)
+		if err == unix.EINTR || err == unix.EAGAIN {
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+		return n, nil
+	}
+}
+
+func (p *linuxNMEAPort) SetReadTimeout(d time.Duration) error {
+	ms := d.Milliseconds()
+	switch {
+	case d < 0:
+		p.timeoutMs = -1 // block indefinitely
+	case ms < 1:
+		p.timeoutMs = 1
+	default:
+		p.timeoutMs = int(ms)
+	}
+	return nil
+}
+
+func (p *linuxNMEAPort) Close() error {
+	var err error
+	p.closeOnce.Do(func() {
+		// Wake a blocked Read before closing the device fd so it never
+		// reads from a recycled fd number.
+		_, _ = unix.Write(p.wakeW, []byte{0})
+		err = unix.Close(p.fd)
+		unix.Close(p.wakeR)
+		unix.Close(p.wakeW)
+	})
+	return err
+}

--- a/pkg/gps/serial_open_linux.go
+++ b/pkg/gps/serial_open_linux.go
@@ -149,6 +149,14 @@ func (p *linuxNMEAPort) Read(b []byte) (int, error) {
 		if err != nil {
 			return 0, err
 		}
+		if n == 0 {
+			// poll() reported the device readable but read drained zero
+			// bytes: end-of-stream (e.g. the adapter was unplugged and the
+			// disconnect surfaced as readable-EOF rather than POLLHUP).
+			// Surface it as EOF so the reader's retry-with-backoff layer
+			// re-opens the port instead of looping on (0, nil) forever.
+			return 0, io.EOF
+		}
 		return n, nil
 	}
 }

--- a/pkg/gps/serial_open_linux_test.go
+++ b/pkg/gps/serial_open_linux_test.go
@@ -1,0 +1,159 @@
+//go:build linux
+
+package gps
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// openPTY returns the master fd and the slave device path of a fresh
+// pseudo-terminal pair. The slave stands in for a real /dev/ttyUSB0.
+func openPTY(t *testing.T) (master int, slavePath string) {
+	t.Helper()
+	m, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Skipf("cannot open /dev/ptmx: %v", err)
+	}
+	t.Cleanup(func() { unix.Close(m) })
+	if err := unix.IoctlSetPointerInt(m, unix.TIOCSPTLCK, 0); err != nil {
+		t.Fatalf("unlockpt: %v", err)
+	}
+	n, err := unix.IoctlGetInt(m, unix.TIOCGPTN)
+	if err != nil {
+		t.Fatalf("ptsname: %v", err)
+	}
+	return m, "/dev/pts/" + itoa(n)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
+
+// TestOpenNMEASerialNotExclusive is the GRA-118 regression: the GPS
+// opener must leave the tty openable by the PTT driver. A plain open of
+// the same device (what graywolf-modem's PTT path does) must succeed
+// while GPS holds the port.
+func TestOpenNMEASerialNotExclusive(t *testing.T) {
+	_, slave := openPTY(t)
+
+	port, err := openNMEASerial(slave, 4800)
+	if err != nil {
+		t.Fatalf("openNMEASerial: %v", err)
+	}
+	defer port.Close()
+
+	// Simulate the PTT driver opening the same tty (ptt_unix.rs flags).
+	fd, err := unix.Open(slave, unix.O_RDWR|unix.O_NOCTTY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("PTT-style open of shared tty failed (exclusive access held?): %v", err)
+	}
+	unix.Close(fd)
+}
+
+// TestOpenNMEASerialDeassertsRTS verifies GPS holds RTS/DTR low on open
+// so it does not key a shared-line PTT (#305).
+func TestOpenNMEASerialDeassertsRTS(t *testing.T) {
+	_, slave := openPTY(t)
+
+	port, err := openNMEASerial(slave, 4800)
+	if err != nil {
+		t.Fatalf("openNMEASerial: %v", err)
+	}
+	defer port.Close()
+
+	fd, err := unix.Open(slave, unix.O_RDWR|unix.O_NOCTTY|unix.O_NONBLOCK, 0)
+	if err != nil {
+		t.Fatalf("open shared tty: %v", err)
+	}
+	defer unix.Close(fd)
+	bits, err := unix.IoctlGetInt(fd, unix.TIOCMGET)
+	if err == unix.ENOTTY {
+		t.Skip("pty has no modem-control lines; RTS deassert not observable here")
+	}
+	if err != nil {
+		t.Fatalf("TIOCMGET: %v", err)
+	}
+	if bits&unix.TIOCM_RTS != 0 {
+		t.Errorf("RTS asserted after open; would key PTT")
+	}
+	if bits&unix.TIOCM_DTR != 0 {
+		t.Errorf("DTR asserted after open")
+	}
+}
+
+func TestOpenNMEASerialReadsData(t *testing.T) {
+	master, slave := openPTY(t)
+
+	port, err := openNMEASerial(slave, 9600)
+	if err != nil {
+		t.Fatalf("openNMEASerial: %v", err)
+	}
+	defer port.Close()
+	_ = port.SetReadTimeout(500 * time.Millisecond)
+
+	want := "$GPGGA,sentence\r\n"
+	if _, err := unix.Write(master, []byte(want)); err != nil {
+		t.Fatalf("write master: %v", err)
+	}
+
+	buf := make([]byte, len(want))
+	got := 0
+	deadline := time.Now().Add(2 * time.Second)
+	for got < len(want) && time.Now().Before(deadline) {
+		n, err := port.Read(buf[got:])
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		got += n
+	}
+	if string(buf[:got]) != want {
+		t.Errorf("read %q, want %q", buf[:got], want)
+	}
+}
+
+// TestOpenNMEASerialCloseUnblocksRead verifies Close() wakes a blocked
+// Read promptly via the wake pipe rather than waiting out the timeout.
+func TestOpenNMEASerialCloseUnblocksRead(t *testing.T) {
+	_, slave := openPTY(t)
+
+	port, err := openNMEASerial(slave, 9600)
+	if err != nil {
+		t.Fatalf("openNMEASerial: %v", err)
+	}
+	_ = port.SetReadTimeout(10 * time.Second)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := port.Read(make([]byte, 64))
+		done <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if err := port.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, io.EOF) {
+			t.Errorf("read after close returned %v, want io.EOF", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Read did not unblock after Close")
+	}
+}

--- a/pkg/gps/serial_open_linux_test.go
+++ b/pkg/gps/serial_open_linux_test.go
@@ -5,6 +5,7 @@ package gps
 import (
 	"errors"
 	"io"
+	"strconv"
 	"testing"
 	"time"
 
@@ -27,21 +28,7 @@ func openPTY(t *testing.T) (master int, slavePath string) {
 	if err != nil {
 		t.Fatalf("ptsname: %v", err)
 	}
-	return m, "/dev/pts/" + itoa(n)
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var b [20]byte
-	i := len(b)
-	for n > 0 {
-		i--
-		b[i] = byte('0' + n%10)
-		n /= 10
-	}
-	return string(b[i:])
+	return m, "/dev/pts/" + strconv.Itoa(n)
 }
 
 // TestOpenNMEASerialNotExclusive is the GRA-118 regression: the GPS
@@ -83,6 +70,10 @@ func TestOpenNMEASerialDeassertsRTS(t *testing.T) {
 	defer unix.Close(fd)
 	bits, err := unix.IoctlGetInt(fd, unix.TIOCMGET)
 	if err == unix.ENOTTY {
+		// A pty fundamentally has no modem-control lines, so the #305
+		// RTS/DTR deassert can only be verified on real hardware (and is
+		// pinned by invariant #47). The opener's ENOTTY tolerance is what
+		// lets the rest of these tests run on a pty at all.
 		t.Skip("pty has no modem-control lines; RTS deassert not observable here")
 	}
 	if err != nil {

--- a/pkg/gps/serial_open_other.go
+++ b/pkg/gps/serial_open_other.go
@@ -1,0 +1,20 @@
+//go:build !linux
+
+package gps
+
+import "go.bug.st/serial"
+
+// openNMEASerial opens device at baud for NMEA RX with RTS and DTR held
+// low so a shared-line PTT driver isn't keyed by the GPS connection
+// (issue #305). On non-Linux platforms go.bug.st/serial drives the port.
+//
+// Note: go.bug.st acquires exclusive access (TIOCEXCL) on Unix. The
+// shared-serial PTT contention this would cause (GRA-118) is a Linux-only
+// scenario (Raspberry Pi + Digirig), handled by the dedicated opener in
+// serial_open_linux.go.
+func openNMEASerial(device string, baud int) (nmeaPort, error) {
+	return serial.Open(device, &serial.Mode{
+		BaudRate:          baud,
+		InitialStatusBits: &serial.ModemOutputBits{RTS: false, DTR: false},
+	})
+}


### PR DESCRIPTION
## Problem

On a Digirig-style rig the radio feeds **NMEA in on RX** and **PTT is keyed via RTS** over the *same* serial line (DB9). With this setup PTT works right after the user configures it, but stops working after a reboot.

## Root cause

`go.bug.st/serial` (used by the GPS NMEA reader) calls `TIOCEXCL` on every Unix open, putting the tty into exclusive mode. Any later `open()` of the same device by a non-`CAP_SYS_ADMIN` process then fails with `EBUSY`.

The GPS reader runs in the Go parent; `graywolf-modem`'s serial PTT driver (`ptt_unix.rs`, `open(O_RDWR|O_NOCTTY|O_NONBLOCK|O_CLOEXEC)`) runs in the child. Both open the same device:

- **Configuring devices one at a time** is deterministic — the modem's PTT fd is usually already open when GPS connects, so GPS's `TIOCEXCL` doesn't disturb it → PTT works.
- **On reboot** both routines start concurrently. When the GPS reader wins the race it holds the port exclusively, the modem's PTT `open()` returns `EBUSY`, and PTT silently never works.

This is the follow-up to #305 (which fixed GPS keying PTT on connect by deasserting RTS/DTR).

## Fix

Add a Linux-only NMEA opener (`serial_open_linux.go`) that opens the port with a raw `unix.Open` + termios path and **deliberately omits `TIOCEXCL`**, so the PTT driver can always open the same tty. It keeps the #305 RTS/DTR deassert so GPS still doesn't key PTT on connect. Reads use `VMIN=0` with a `poll()` timeout (so `Read` returns `(0, nil)` on timeout, exactly what the NMEA scanner's `timeoutReader` expects) and a self-pipe so `Close` wakes a blocked read without closing the device fd out from under it.

Non-Linux platforms keep the existing `go.bug.st/serial` path (`serial_open_other.go`); the shared-line scenario is Linux-only (Raspberry Pi + Digirig).

## Tests

`serial_open_linux_test.go` adds a regression covering the core property — while GPS holds the port, a PTT-style `open()` of the same tty succeeds — plus read, RTS-deassert, and close-unblocks-read coverage (over a pty pair).

Invariant #47a documents the no-`TIOCEXCL` rule alongside the existing #47.

Fixes GRA-118.