### PR TITLE
webapi: surface the World Map in the maps download catalog

### DIFF
--- a/pkg/webapi/catalog.go
+++ b/pkg/webapi/catalog.go
@@ -55,5 +55,14 @@ func toCatalogDTO(c mapscatalog.Catalog) dto.Catalog {
 	for i, x := range c.States {
 		out.States[i] = dto.CatalogState{Slug: x.Slug, Name: x.Name, Code: x.Code, SizeBytes: x.SizeBytes, SHA256: x.SHA256, BBox: x.BBox}
 	}
+	if c.World != nil {
+		out.World = &dto.CatalogWorld{
+			Name:      c.World.Name,
+			SizeBytes: c.World.SizeBytes,
+			SHA256:    c.World.SHA256,
+			BBox:      c.World.BBox,
+			MaxZoom:   c.World.MaxZoom,
+		}
+	}
 	return out
 }

--- a/pkg/webapi/catalog_test.go
+++ b/pkg/webapi/catalog_test.go
@@ -86,3 +86,41 @@ func TestGetCatalog_Demo(t *testing.T) {
 		t.Fatalf("expected empty states, got %d", len(out.States))
 	}
 }
+
+// TestGetCatalog_World guards the world archive surviving the DTO
+// projection: the Worker advertises it as a top-level `world` object and
+// the region picker renders it as a standalone node, so toCatalogDTO must
+// carry it through (it previously dropped it, hiding the World Map).
+func TestGetCatalog_World(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(mapscatalog.Catalog{
+			SchemaVersion: 1,
+			GeneratedAt:   "2026-04-30T00:00:00Z",
+			World:         &mapscatalog.WorldMap{Name: "World (low detail)", SizeBytes: 206424864, SHA256: "w", MaxZoom: 7},
+		})
+	}))
+	defer upstream.Close()
+
+	srv, _ := newTestServer(t)
+	srv.catalog = mapscatalog.New(upstream.URL, func(_ context.Context) string { return "tok" }, time.Hour)
+
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/maps/catalog", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var out dto.Catalog
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.World == nil {
+		t.Fatal("world dropped from catalog DTO")
+	}
+	if out.World.Name != "World (low detail)" || out.World.MaxZoom != 7 || out.World.SizeBytes != 206424864 {
+		t.Fatalf("unexpected world entry: %+v", out.World)
+	}
+}

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -8833,6 +8833,9 @@
                     "items": {
                         "$ref": "#/definitions/dto.CatalogState"
                     }
+                },
+                "world": {
+                    "$ref": "#/definitions/dto.CatalogWorld"
                 }
             }
         },
@@ -8911,6 +8914,29 @@
                 },
                 "slug": {
                     "type": "string"
+                }
+            }
+        },
+        "dto.CatalogWorld": {
+            "type": "object",
+            "properties": {
+                "bbox": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "maxZoom": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "sha256": {
+                    "type": "string"
+                },
+                "sizeBytes": {
+                    "type": "integer"
                 }
             }
         },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -969,6 +969,8 @@ definitions:
         items:
           $ref: '#/definitions/dto.CatalogState'
         type: array
+      world:
+        $ref: '#/definitions/dto.CatalogWorld'
     type: object
   dto.CatalogCountry:
     properties:
@@ -1020,6 +1022,21 @@ definitions:
         type: integer
       slug:
         type: string
+    type: object
+  dto.CatalogWorld:
+    properties:
+      bbox:
+        items:
+          type: number
+        type: array
+      maxZoom:
+        type: integer
+      name:
+        type: string
+      sha256:
+        type: string
+      sizeBytes:
+        type: integer
     type: object
   dto.ChannelBacking:
     properties:

--- a/pkg/webapi/dto/catalog.go
+++ b/pkg/webapi/dto/catalog.go
@@ -10,6 +10,19 @@ type Catalog struct {
 	Countries     []CatalogCountry  `json:"countries"`
 	Provinces     []CatalogProvince `json:"provinces"`
 	States        []CatalogState    `json:"states"`
+	World         *CatalogWorld     `json:"world,omitempty"`
+}
+
+// CatalogWorld is the optional single global low-zoom basemap archive.
+// Unlike the regional entries it carries a MaxZoom (the archive is
+// capped, e.g. z7) and is surfaced as a standalone picker node, not a
+// member of any region array. Omitted until the Worker advertises one.
+type CatalogWorld struct {
+	Name      string      `json:"name"`
+	SizeBytes int64       `json:"sizeBytes"`
+	SHA256    string      `json:"sha256"`
+	BBox      *[4]float64 `json:"bbox,omitempty"`
+	MaxZoom   int         `json:"maxZoom"`
 }
 
 type CatalogCountry struct {

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2406,6 +2406,7 @@ export interface components {
             provinces?: components["schemas"]["dto.CatalogProvince"][];
             schemaVersion?: number;
             states?: components["schemas"]["dto.CatalogState"][];
+            world?: components["schemas"]["dto.CatalogWorld"];
         };
         "dto.CatalogCountry": {
             bbox?: number[];
@@ -2430,6 +2431,13 @@ export interface components {
             sha256?: string;
             sizeBytes?: number;
             slug?: string;
+        };
+        "dto.CatalogWorld": {
+            bbox?: number[];
+            maxZoom?: number;
+            name?: string;
+            sha256?: string;
+            sizeBytes?: number;
         };
         "dto.ChannelBacking": {
             health?: string;


### PR DESCRIPTION
## Problem

Users on graywolf 0.14.0 can't find the World Map in **Download maps** even though the Worker publishes it and `/manifest.json` advertises it. Traced to the client's catalog DTO:

`GET /api/maps/catalog` is built by `toCatalogDTO`, but `dto.Catalog` had **no `World` field** and the projection only copied `countries`/`provinces`/`states`. So `c.World` (parsed correctly by `mapscatalog`) was silently dropped before reaching the SPA. The region picker already calls `buildWorldNode(catalogStore.catalog.world)` (`region-picker.svelte:22`), so the moment the DTO carries `world`, the picker renders it — no UI change needed.

## Fix

- Add `CatalogWorld` to `dto.Catalog` (`world,omitempty`) mirroring `mapscatalog.WorldMap` (name, sizeBytes, sha256, bbox, maxZoom).
- Project `c.World` in `toCatalogDTO`.
- New test `TestGetCatalog_World` asserting the entry survives projection.
- Regenerated `swagger.json` / `swagger.yaml` / `api.d.ts` so generated artifacts match the struct.

The DTO comment's "mirrors the Worker's `/manifest.json` output 1:1" is now actually true.

## Verification

- `go test ./pkg/webapi/ ./pkg/mapscatalog/` — green (incl. new test); `go vet` clean.
- `buildWorldNode` JS test still passes.
- Backend already serves it: `GET https://maps.nw5w.com/manifest.json` has the `world` key and `GET /download/world.pmtiles` → 200. With this change the entry flows through to the picker.
