### PR TITLE
web(maps): match World row font + separate it from the country list

### DIFF
--- a/web/src/lib/maps/region-picker.svelte
+++ b/web/src/lib/maps/region-picker.svelte
@@ -209,7 +209,22 @@
     border-radius: 6px;
     background: var(--bg-secondary);
   }
-  .region-row[data-level="country"] { background: var(--bg-tertiary, var(--bg-secondary)); font-weight: 600; }
+  .region-row[data-level="country"],
+  .region-row[data-level="world"] { background: var(--bg-tertiary, var(--bg-secondary)); font-weight: 600; }
+
+  /* The single global archive sits above the alphabetical country list.
+     It shares the country rows' card styling and weight so the typography
+     is consistent; the extra bottom margin plus a hairline divider set it
+     apart as a distinct, standalone entry rather than the first country. */
+  .region-row-world { position: relative; margin-bottom: 16px; }
+  .region-row-world::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -8px;
+    border-bottom: 1px solid var(--border-color);
+  }
 
   .region-toggle {
     display: flex; align-items: center; gap: 8px;


### PR DESCRIPTION
## Problem

In the Offline Maps picker, **World (low detail)** rendered in a lighter weight than the country rows (Argentina, Australia, ...), so it looked like a different font, and it sat flush against the top of the alphabetical country list with no separation.

Cause: country rows get `font-weight: 600` + the `--bg-tertiary` card background via `.region-row[data-level="country"]`, but the world row (`data-level="world"`) only got the base `.region-row` styling.

## Fix (CSS-only, `region-picker.svelte`)

- Share the country rows' weight + background with `.region-row[data-level="world"]` so the World row matches the other top-level entries.
- Add `margin-bottom` + a hairline divider (`.region-row-world::after`) so the single global archive reads as a distinct, standalone entry above the country list.

The world row already carried the `.region-row-world` / `data-level="world"` hooks, so no markup change was needed.

## Verification

- `npm run build` compiles clean.
- `buildWorldNode` tests pass. (The one unrelated failing web test — `DESKTOP_METHODS ... PTT methods` — is pre-existing on `main` and untouched by this CSS change.)
