### PR TITLE
Restyle station-click actions to match map context menu

### DIFF
--- a/web/src/lib/map/popup.js
+++ b/web/src/lib/map/popup.js
@@ -77,13 +77,40 @@ export function renderStationPopupHTML(s, { hasStation = null } = {}) {
   return html;
 }
 
+// Inline lucide-style icon. Mirrors the markup lucide-svelte emits so the
+// action rows visually match the map right-click menu (which uses the same
+// icons via lucide-svelte). 14px / strokeWidth 2 to match .menu-icon.
+function icon(body) {
+  return (
+    `<svg class="stn-action-icon" xmlns="http://www.w3.org/2000/svg" ` +
+    `width="14" height="14" viewBox="0 0 24 24" fill="none" ` +
+    `stroke="currentColor" stroke-width="2" stroke-linecap="round" ` +
+    `stroke-linejoin="round" aria-hidden="true">${body}</svg>`
+  );
+}
+
+const ICON_MESSAGE = icon(
+  '<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>'
+);
+const ICON_LOGS = icon(
+  '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/>' +
+    '<path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/>' +
+    '<path d="M16 13H8"/><path d="M16 17H8"/>'
+);
+const ICON_QRZ = icon(
+  '<path d="M15 3h6v6"/><path d="M10 14 21 3"/>' +
+    '<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>'
+);
+
 // renderStationActionsHTML(station) -> HTML string (or '' to suppress)
 //
-// Action links shown for a real heard station: QRZ database lookup,
-// open a direct message thread, and view the APRS packet log filtered
-// to this callsign. APRS objects/items aren't operators you can work,
-// so they get no actions. Messages and Logs are internal hash routes;
-// QRZ is the one external link (opens in a new tab).
+// Action rows shown for a real heard station: open a direct message thread,
+// view the APRS packet log filtered to this callsign, and a QRZ database
+// lookup. APRS objects/items aren't operators you can work, so they get no
+// actions. Messages and Logs are internal hash routes; QRZ is the one
+// external link (opens in a new tab). Styled to match the map right-click
+// context menu -- icon + label rows with a hover tint (see .stn-action in
+// LiveMapV2.svelte).
 export function renderStationActionsHTML(s) {
   const call = s.callsign;
   if (!call || s.is_object) return '';
@@ -93,10 +120,10 @@ export function renderStationActionsHTML(s) {
   const msgHref = `#/messages?thread=${encodeURIComponent('dm:' + upper)}`;
   const logHref = `#/logs?callsign=${encodeURIComponent(upper)}`;
 
-  let html = `<div class="stn-actions">`;
-  html += `<a class="stn-link stn-msg-link" href="${msgHref}">Message</a>`;
-  html += `<a class="stn-link stn-log-link" href="${logHref}">APRS logs</a>`;
-  html += `<a class="stn-link stn-qrz-link" href="${qrzHref}" target="_blank" rel="noopener noreferrer">QRZ</a>`;
+  let html = `<div class="stn-actions" role="menu">`;
+  html += `<a class="stn-action stn-msg-link" role="menuitem" href="${msgHref}">${ICON_MESSAGE}<span class="stn-action-label">Message</span></a>`;
+  html += `<a class="stn-action stn-log-link" role="menuitem" href="${logHref}">${ICON_LOGS}<span class="stn-action-label">APRS logs</span></a>`;
+  html += `<a class="stn-action stn-qrz-link" role="menuitem" href="${qrzHref}" target="_blank" rel="noopener noreferrer">${ICON_QRZ}<span class="stn-action-label">QRZ</span></a>`;
   html += `</div>`;
   return html;
 }

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1544,9 +1544,44 @@
   :global(.stn-path .path-link) { color: #6eb5ff; text-decoration: none; cursor: pointer; }
   :global(.stn-path .path-link:hover) { text-decoration: underline; }
   :global(.stn-comment) { color: var(--color-text-dim); font-style: italic; font-size: 12px; }
-  :global(.stn-actions) { font-size: 12px; display: flex; gap: 12px; flex-wrap: wrap; }
-  :global(.stn-link) { color: #6eb5ff; text-decoration: none; cursor: pointer; }
-  :global(.stn-link:hover) { text-decoration: underline; }
+  /* Station actions: styled to match the map right-click context menu
+     (.menu-item in map-context-menu.svelte) -- vertical icon+label rows
+     with a hover tint rather than inline text links. Negative side margin
+     lets each row's hover background extend toward the popup edges the way
+     menu items do. */
+  :global(.stn-actions) {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin: 2px -8px -4px;
+    font-size: 13px;
+  }
+  :global(.stn-action) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 5px;
+    color: var(--map-overlay-fg);
+    text-decoration: none;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  :global(.stn-action .stn-action-icon) {
+    flex: 0 0 auto;
+    color: var(--map-overlay-muted);
+  }
+  :global(.stn-action-label) { flex: 1 1 auto; }
+  :global(.stn-action:hover),
+  :global(.stn-action:focus-visible) {
+    background: var(
+      --color-surface-hover,
+      color-mix(in srgb, var(--color-text) 9%, transparent)
+    );
+    color: var(--color-text);
+    text-decoration: none;
+    outline: none;
+  }
   :global(.stn-weather) { font-size: 12px; }
   :global(.stn-weather-row) {
     display: flex;


### PR DESCRIPTION
The station popup actions (Message, APRS logs, QRZ) were inline blue text links that looked out of place. They now render as vertical icon+label rows with a hover tint, matching the right-click map context menu styling.

- `web/src/lib/map/popup.js`: actions now emit menu-style rows with inline lucide icons (message / file / external-link).
- `web/src/routes/LiveMapV2.svelte`: `.stn-action` CSS mirrors `.menu-item` from the context menu (overlay colors, hover tint, rounded rows).

Closes GRA-131.