### PR TITLE
Strip SSID for QRZ lookup; tighten station action row padding

### DIFF
--- a/web/src/lib/map/popup.js
+++ b/web/src/lib/map/popup.js
@@ -152,7 +152,10 @@ export function renderStationActionsHTML(s) {
   if (!call || s.is_object) return '';
 
   const upper = call.toUpperCase();
-  const qrzHref = `https://www.qrz.com/db/${encodeURIComponent(upper)}`;
+  // QRZ indexes operators by base callsign, not by APRS SSID, so strip any
+  // "-N" suffix (e.g. W1ABC-9 -> W1ABC) before building the lookup URL.
+  const qrzCall = upper.split('-')[0];
+  const qrzHref = `https://www.qrz.com/db/${encodeURIComponent(qrzCall)}`;
   const msgHref = `#/messages?thread=${encodeURIComponent('dm:' + upper)}`;
   const logHref = `#/logs?callsign=${encodeURIComponent(upper)}`;
 

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1577,7 +1577,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 6px 10px;
+    padding: 4px 10px;
     border-radius: 5px;
     color: var(--map-overlay-fg);
     text-decoration: none;


### PR DESCRIPTION
Follow-up to the station-action restyle (#325, merged). Those two tweaks were pushed after #325 merged, so they never landed on main; this re-applies them on top of current main.

- `web/src/lib/map/popup.js`: QRZ now strips the APRS -N SSID suffix (W1ABC-9 -> W1ABC), since QRZ indexes operators by base callsign.
- `web/src/routes/LiveMapV2.svelte`: reduce the action rows' vertical padding (6px -> 4px).

Closes GRA-131.