### PR TITLE
Skip adjtimex clock-sync check on Android to avoid SIGSYS crash

### DIFF
--- a/pkg/clocksync/clocksync_android.go
+++ b/pkg/clocksync/clocksync_android.go
@@ -1,0 +1,11 @@
+//go:build android
+
+package clocksync
+
+// Check is a no-op on Android. Android is Linux, but its seccomp-bpf
+// policy forbids adjtimex(2) for app processes: invoking it delivers
+// SIGSYS and kills the process, even for the read-only zero-Modes query
+// that needs no privileges elsewhere (graywolf#315). With no usable
+// query API we report Unknown and the caller stays silent, matching the
+// non-Linux behavior in clocksync_other.go.
+func Check() Status { return Unknown }

--- a/pkg/clocksync/clocksync_linux.go
+++ b/pkg/clocksync/clocksync_linux.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !android
 
 package clocksync
 

--- a/pkg/clocksync/clocksync_linux_test.go
+++ b/pkg/clocksync/clocksync_linux_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !android
 
 package clocksync
 


### PR DESCRIPTION
## Problem

On Android (Samsung, Android 11, unrooted) the native Graywolf backend crashes on launch with `SIGSYS: bad system call`, producing the white-screen-then-disappears symptom in graywolf#315. A user-supplied logcat shows:

```
SIGSYS: bad system call
goroutine 1 ... [syscall]:
syscall.Syscall(0xab, ...)            # 0xab = 171 = adjtimex(2)
golang.org/x/sys/unix.Adjtimex(...)
pkg/clocksync/clocksync_linux.go:20   # clocksync.Check()
pkg/app.(*App).wireServicesInner      # wiring.go:207
main.main                             # main_android.go:89
```

Android is Linux, so the build selected `clocksync_linux.go`, whose `Check()` calls `adjtimex(2)` during service wiring. Android's seccomp-bpf policy forbids `adjtimex` for app processes and delivers SIGSYS — killing the whole process — even for the read-only zero-Modes query that needs no privileges on a normal Linux host.

## Fix

- Add `clocksync_android.go` (`//go:build android`) whose `Check()` returns `Unknown`, matching the existing non-Linux behavior in `clocksync_other.go` (caller stays silent).
- Restrict the `adjtimex` path to `//go:build linux && !android` (source + test file).

Desktop/server Linux keeps the real clock-sync warning (graywolf#234); Android no longer issues the forbidden syscall.

## Verification

- `go build ./pkg/clocksync/` (linux) and `GOOS=android GOARCH=arm64 CGO_ENABLED=0 go build ./pkg/clocksync/` both succeed.
- `go list` confirms Android compiles `[clocksync.go clocksync_android.go]` (no adjtimex) and linux compiles `[clocksync.go clocksync_linux.go]`.
- `go test ./pkg/clocksync/` passes; `go vet -tags android` clean.

Fixes #315
