### PR TITLE
Add beacon slot input and object altitude support

### DIFF
--- a/pkg/beacon/builder.go
+++ b/pkg/beacon/builder.go
@@ -117,7 +117,7 @@ func (s *Scheduler) buildInfo(ctx context.Context, b Config) (string, error) {
 		if b.ObjectName == "" {
 			return "", fmt.Errorf("object beacon missing object_name")
 		}
-		lat, lon := b.Lat, b.Lon
+		lat, lon, altM := b.Lat, b.Lon, b.AltFt/3.28084
 		if b.UseGps {
 			if s.cache == nil {
 				return "", fmt.Errorf("object beacon: use_gps set but no GPS cache configured")
@@ -127,10 +127,16 @@ func (s *Scheduler) buildInfo(ctx context.Context, b Config) (string, error) {
 				return "", fmt.Errorf("object beacon: use_gps set but no GPS fix available")
 			}
 			lat, lon = fix.Latitude, fix.Longitude
+			if fix.HasAlt {
+				altM = fix.Altitude
+			} else {
+				// Never mix GPS lat/lon with a stale fixed AltFt.
+				altM = 0
+			}
 		} else if lat == 0 && lon == 0 {
 			return "", fmt.Errorf("object beacon: fixed coordinates are 0/0 (configure lat/lon or enable use_gps)")
 		}
-		return ObjectInfo(b.ObjectName, true, "", lat, lon, b.SymbolTable, b.SymbolCode, phg, comment), nil
+		return ObjectInfo(b.ObjectName, true, "", lat, lon, altM, b.SymbolTable, b.SymbolCode, phg, comment), nil
 
 	case TypeCustom:
 		if b.CustomInfo == "" {

--- a/pkg/beacon/encoder.go
+++ b/pkg/beacon/encoder.go
@@ -172,13 +172,16 @@ func CompressedPositionInfo(lat, lon float64, course int, speedKt float64, altM 
 
 // ObjectInfo builds an APRS object report info-field.
 //
-//	;NAME     *DDHHMMzDDMM.hhN/DDDMM.hhW>[PHGphgd]comment
+//	;NAME     *DDHHMMzDDMM.hhN/DDDMM.hhW>[PHGphgd][/A=NNNNNN]comment
 //
 // objectName is padded/truncated to 9 characters. live=true sets '*'
 // (live) rather than '_' (killed). timestampDHM is a 6-char "DDHHMMz"
 // string; if empty, "111111z" is used (APRS wildcard). phg is the
 // already-encoded "PHGphgd" 7-byte string (or "" for no extension).
-func ObjectInfo(objectName string, live bool, timestampDHM string, lat, lon float64, symbolTable, symbolCode byte, phg string, comment string) string {
+// altM is metres; when non-zero it is appended as "/A=NNNNNN" feet per
+// APRS101 ch 6 (the /A= extension is valid anywhere in an object's
+// comment text), matching the position-report encoders.
+func ObjectInfo(objectName string, live bool, timestampDHM string, lat, lon, altM float64, symbolTable, symbolCode byte, phg string, comment string) string {
 	if symbolTable == 0 {
 		symbolTable = '/'
 	}
@@ -211,6 +214,10 @@ func ObjectInfo(objectName string, live bool, timestampDHM string, lat, lon floa
 	sb.WriteByte(symbolCode)
 	if phg != "" {
 		sb.WriteString(phg)
+	}
+	if altM != 0 {
+		ft := altM * 3.28084
+		fmt.Fprintf(&sb, "/A=%06d", int(math.Round(ft)))
 	}
 	sb.WriteString(comment)
 	return sb.String()

--- a/pkg/beacon/encoder_test.go
+++ b/pkg/beacon/encoder_test.go
@@ -132,7 +132,7 @@ func TestCompressedPositionInfoWithPHG(t *testing.T) {
 // TestObjectInfoWithPHG verifies object reports carry PHG between the
 // symbol code and the comment.
 func TestObjectInfoWithPHG(t *testing.T) {
-	info := ObjectInfo("W6REPEATR", true, "", 37.5, -122.5, '/', '#', "PHG7700", "146.520")
+	info := ObjectInfo("W6REPEATR", true, "", 37.5, -122.5, 0, '/', '#', "PHG7700", "146.520")
 	pkt, err := aprs.ParseInfo([]byte(info))
 	if err != nil {
 		t.Fatalf("parse: %v (%q)", err, info)
@@ -145,6 +145,34 @@ func TestObjectInfoWithPHG(t *testing.T) {
 	}
 	if pkt.Object.Comment != "146.520" {
 		t.Errorf("object comment %q", pkt.Object.Comment)
+	}
+}
+
+// TestObjectInfoWithAltitude verifies object reports carry a /A=
+// altitude extension (feet) that round-trips through the parser, and
+// that zero altitude omits it entirely.
+func TestObjectInfoWithAltitude(t *testing.T) {
+	// 152.4 m == 500 ft.
+	info := ObjectInfo("HILLTOP", true, "", 37.5, -122.5, 152.4, '/', '#', "", "repeater")
+	if !strings.Contains(info, "/A=000500") {
+		t.Fatalf("expected /A=000500 in %q", info)
+	}
+	pkt, err := aprs.ParseInfo([]byte(info))
+	if err != nil {
+		t.Fatalf("parse: %v (%q)", err, info)
+	}
+	if pkt.Object == nil || pkt.Object.Position == nil {
+		t.Fatalf("object not decoded: %+v", pkt.Object)
+	}
+	if got := pkt.Object.Position.Altitude; got < 152 || got > 153 {
+		t.Errorf("object altitude: got %v want ~152.4 m", got)
+	}
+	if pkt.Object.Comment != "repeater" {
+		t.Errorf("object comment %q", pkt.Object.Comment)
+	}
+
+	if strings.Contains(ObjectInfo("HILLTOP", true, "", 37.5, -122.5, 0, '/', '#', "", ""), "/A=") {
+		t.Error("expected no /A= extension when altitude is zero")
 	}
 }
 

--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -97,7 +97,7 @@
     symbol_table: '/', symbol: '-', overlay: '',
     position_format: 'compressed', ambiguity: 0,
     pos_source: 'gps', latitude: '', longitude: '', alt_ft: '',
-    comment: '', interval: '600', send_to_aprs_is: false, enabled: true,
+    comment: '', interval: '600', slot: '', send_to_aprs_is: false, enabled: true,
   });
 
   let callsignError = $state('');
@@ -293,6 +293,7 @@
     altError = '';
     form.comment = defaultComment;
     form.interval = '600';
+    form.slot = '';
     form.send_to_aprs_is = false;
     form.enabled = true;
     modalOpen = true;
@@ -324,6 +325,7 @@
       longitude: row.longitude != null ? String(row.longitude) : '',
       alt_ft: row.alt_ft != null ? String(row.alt_ft) : '',
       interval: String(row.interval),
+      slot: row.slot_seconds != null && row.slot_seconds >= 0 ? String(row.slot_seconds) : '',
     });
     altInput = altInputFromFeet(form.alt_ft);
     altError = '';
@@ -373,11 +375,11 @@
     const lonStr = form.longitude.trim();
     const lat = latStr === '' ? 0 : parseFloat(latStr);
     const lon = lonStr === '' ? 0 : parseFloat(lonStr);
-    // Convert altitude input to feet for the API. Object reports don't
-    // carry altitude (the ObjectInfo encoder has no /A= field), so skip it.
+    // Convert altitude input to feet for the API. Objects carry it via
+    // the /A= comment extension, same as position reports.
     const altNorm = altInput.replace(',', '.').trim();
     let altFt = null;
-    if (form.type !== 'object' && altNorm !== '') {
+    if (altNorm !== '') {
       const altVal = parseFloat(altNorm);
       if (Number.isNaN(altVal)) {
         altError = 'Altitude must be a number';
@@ -394,18 +396,31 @@
       toasts.error('Latitude/longitude required when not using GPS');
       return;
     }
+    // Slot: seconds past the hour (0..3599); blank means unset (-1).
+    const slotNorm = String(form.slot).trim();
+    let slotSeconds = -1;
+    if (slotNorm !== '') {
+      const slotVal = parseInt(slotNorm, 10);
+      if (Number.isNaN(slotVal) || slotVal < 0 || slotVal > 3599) {
+        toasts.error('Slot must be 0–3599 seconds past the hour (or blank)');
+        return;
+      }
+      slotSeconds = slotVal;
+    }
     const data = {
       ...form,
       callsign: callsignToSend,
       channel: channelId,
       use_gps: useGps,
       interval: parseInt(form.interval),
+      slot_seconds: slotSeconds,
       latitude: lat,
       longitude: lon,
       alt_ft: altFt,
     };
     delete data.pos_source;
     delete data.callsign_override;
+    delete data.slot;
     delete data.id;
     try {
       if (editing) {
@@ -567,6 +582,12 @@
             <span class="detail-label">Interval</span>
             <span class="detail-value">{formatInterval(b.interval)}</span>
           </div>
+          {#if b.slot_seconds != null && b.slot_seconds >= 0}
+            <div class="detail-row">
+              <span class="detail-label">Slot</span>
+              <span class="detail-value">{b.slot_seconds}s past the hour</span>
+            </div>
+          {/if}
           {#if b.comment}
             <div class="detail-row">
               <span class="detail-label">Comment</span>
@@ -793,24 +814,28 @@
           hint="Decimal degrees, east positive (e.g. -122.4 for San Francisco; 151.2 for Sydney).">
           <Input id="bcn-lon" bind:value={form.longitude} placeholder="-122.4" />
         </FormField>
-        {#if form.type !== 'object'}
-          <FormField label="Altitude" id="bcn-alt"
-            hint="Antenna height above sea level in {altUnit}. Optional; leave blank or 0 to omit.">
-            <div class="alt-row">
-              <Input id="bcn-alt" bind:value={altInput} placeholder={altUnit === 'feet' ? '0 ft' : '0 m'}
-                type="text" inputmode="decimal" error={altError} oninput={() => altError = ''} />
-              <div class="unit-toggle" role="group" aria-label="Altitude unit">
-                <button type="button" class="unit-btn" class:unit-active={altUnit === 'feet'}
-                  onclick={() => toggleAltUnit('feet')}>ft</button>
-                <button type="button" class="unit-btn" class:unit-active={altUnit === 'meters'}
-                  onclick={() => toggleAltUnit('meters')}>m</button>
-              </div>
+        <FormField label="Altitude" id="bcn-alt"
+          hint={form.type === 'object'
+            ? `Object altitude above sea level in ${altUnit}. Optional; leave blank or 0 to omit.`
+            : `Antenna height above sea level in ${altUnit}. Optional; leave blank or 0 to omit.`}>
+          <div class="alt-row">
+            <Input id="bcn-alt" bind:value={altInput} placeholder={altUnit === 'feet' ? '0 ft' : '0 m'}
+              type="text" inputmode="decimal" error={altError} oninput={() => altError = ''} />
+            <div class="unit-toggle" role="group" aria-label="Altitude unit">
+              <button type="button" class="unit-btn" class:unit-active={altUnit === 'feet'}
+                onclick={() => toggleAltUnit('feet')}>ft</button>
+              <button type="button" class="unit-btn" class:unit-active={altUnit === 'meters'}
+                onclick={() => toggleAltUnit('meters')}>m</button>
             </div>
-          </FormField>
-        {/if}
+          </div>
+        </FormField>
       {/if}
       <FormField label="Interval (seconds)" id="bcn-interval">
         <Input id="bcn-interval" bind:value={form.interval} type="number" placeholder="600" />
+      </FormField>
+      <FormField label="Slot (seconds past the hour)" id="bcn-slot"
+        hint="Optional. Aligns each transmission to a fixed second past the top of the hour so multiple beacons stagger instead of flooding. E.g. 0 fires at :00/:30 with a 1800 s interval; 900 fires at :15/:45. Leave blank to fire on a plain interval.">
+        <Input id="bcn-slot" bind:value={form.slot} type="number" min="0" max="3599" placeholder="e.g. 0" />
       </FormField>
       <Toggle bind:checked={form.send_to_aprs_is} label="Also send to APRS-IS" />
     </div>


### PR DESCRIPTION
Fixes the missing settings reported in #333.

## Slot
The scheduler already honored `slot_seconds` (seconds past the hour, -1 = unset), but the beacon edit dialog never rendered a control for it — operators could only set a plain interval and had no way to stagger transmissions, causing network floods. Adds a **Slot** input (0–3599, blank = unset) to the dialog, wired through create/edit/save with client-side validation, plus a slot row on the beacon card. Applies to all beacon types.

## Object altitude
Object beacons previously hid the altitude field, and `ObjectInfo()` dropped altitude entirely. APRS101 ch 6 allows the `/A=NNNNNN` extension anywhere in an object's comment text (our own parser already reads it), so:
- `ObjectInfo()` now appends `/A=` when altitude is non-zero, matching the position-report encoders.
- The dialog's altitude field is unhidden for objects (fixed coords use the entered value; GPS-sourced objects pull altitude from the live fix).

## Tests
- New `TestObjectInfoWithAltitude` covers the `/A=` round-trip and the zero-altitude omission.
- `go build ./...`, `go test ./pkg/beacon/... ./pkg/webapi/... ./pkg/app/...`, and `vite build` all pass.
- The one failing web unit test (`ptt/devices/methodOptions.test.js`) is pre-existing and unrelated to this change.
