### PR TITLE
Persist Live Map layer toggles across sessions

### DIFF
--- a/web/src/lib/map/layer-toggles-core.js
+++ b/web/src/lib/map/layer-toggles-core.js
@@ -1,0 +1,38 @@
+// Pure load/merge logic for the Live Map layer toggles. No runes, no DOM, no
+// localStorage -- so it is unit-testable under `node --test`. LiveMapV2.svelte
+// wraps this with $state and the actual localStorage read/write (mirrors the
+// radar-frames-core.js / radar-frames.svelte.js split).
+//
+// The toggles are a per-browser preference persisted as one JSON blob under the
+// gw_map_layer_toggles key, so unchecking e.g. Trails or Fixed Points survives
+// navigating away and back.
+
+// Default visibility for every Live Map layer toggle. All display layers start
+// on; the RF reachability filters start off.
+export const LAYER_TOGGLES_DEFAULTS = {
+  stations: true,
+  trails: true,
+  weather: true,
+  myPosition: true,
+  fixedPoints: true,
+  directRxOnly: false,
+  rfOnly: false,
+};
+
+export const LAYER_TOGGLES_KEY = 'gw_map_layer_toggles';
+
+// Parse a persisted toggle blob into a complete toggle set. Saved values are
+// merged OVER the defaults so a toggle added in a later version picks up its
+// default instead of becoming undefined, and a stale key from an old version is
+// harmlessly ignored by consumers. Missing or corrupt input yields a fresh copy
+// of the defaults. Always returns a new object (never the shared defaults).
+export function parseLayerToggles(raw) {
+  if (!raw) return { ...LAYER_TOGGLES_DEFAULTS };
+  try {
+    const saved = JSON.parse(raw);
+    if (saved == null || typeof saved !== 'object') return { ...LAYER_TOGGLES_DEFAULTS };
+    return { ...LAYER_TOGGLES_DEFAULTS, ...saved };
+  } catch {
+    return { ...LAYER_TOGGLES_DEFAULTS };
+  }
+}

--- a/web/src/lib/map/layer-toggles-core.test.js
+++ b/web/src/lib/map/layer-toggles-core.test.js
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  LAYER_TOGGLES_DEFAULTS,
+  parseLayerToggles,
+} from './layer-toggles-core.js';
+
+test('parseLayerToggles returns defaults for missing/empty input', () => {
+  assert.deepEqual(parseLayerToggles(null), LAYER_TOGGLES_DEFAULTS);
+  assert.deepEqual(parseLayerToggles(undefined), LAYER_TOGGLES_DEFAULTS);
+  assert.deepEqual(parseLayerToggles(''), LAYER_TOGGLES_DEFAULTS);
+});
+
+test('parseLayerToggles returns defaults for corrupt JSON', () => {
+  assert.deepEqual(parseLayerToggles('{not valid'), LAYER_TOGGLES_DEFAULTS);
+  assert.deepEqual(parseLayerToggles('null'), LAYER_TOGGLES_DEFAULTS);
+  assert.deepEqual(parseLayerToggles('42'), LAYER_TOGGLES_DEFAULTS);
+  assert.deepEqual(parseLayerToggles('"trails"'), LAYER_TOGGLES_DEFAULTS);
+});
+
+test('parseLayerToggles preserves saved values', () => {
+  const raw = JSON.stringify({ ...LAYER_TOGGLES_DEFAULTS, trails: false, fixedPoints: false });
+  const got = parseLayerToggles(raw);
+  assert.equal(got.trails, false);
+  assert.equal(got.fixedPoints, false);
+  assert.equal(got.stations, true);
+});
+
+test('parseLayerToggles merges a partial blob over defaults (forward compat)', () => {
+  // An old blob predating the fixedPoints toggle: the missing key must fall
+  // back to its default rather than becoming undefined.
+  const raw = JSON.stringify({ stations: true, trails: false });
+  const got = parseLayerToggles(raw);
+  assert.equal(got.trails, false);
+  assert.equal(got.fixedPoints, LAYER_TOGGLES_DEFAULTS.fixedPoints);
+  assert.equal(got.rfOnly, LAYER_TOGGLES_DEFAULTS.rfOnly);
+});
+
+test('parseLayerToggles ignores stale extra keys harmlessly', () => {
+  const raw = JSON.stringify({ trails: false, removedLegacyToggle: true });
+  const got = parseLayerToggles(raw);
+  assert.equal(got.trails, false);
+  assert.equal(got.removedLegacyToggle, true); // carried but unread by consumers
+  assert.equal(got.stations, true);
+});
+
+test('parseLayerToggles never returns the shared defaults object', () => {
+  const got = parseLayerToggles(null);
+  got.trails = false;
+  assert.equal(LAYER_TOGGLES_DEFAULTS.trails, true);
+});

--- a/web/src/lib/map/map-store.svelte.js
+++ b/web/src/lib/map/map-store.svelte.js
@@ -42,14 +42,6 @@ const hasSavedView = hasSavedCenter && hasSavedZoom;
 export const mapState = (() => {
   let selectedStation = $state(null);
 
-  let layerToggles = $state({
-    stations: true,
-    aprsIs: true,
-    trails: true,
-    weather: false,
-    myPosition: false,
-  });
-
   let highContrastLabels = $state(localStorage.getItem('map-high-contrast-labels') === '1');
 
   let timerange = $state(loadInt('map-timerange', 3600));
@@ -63,9 +55,6 @@ export const mapState = (() => {
   return {
     get selectedStation() { return selectedStation; },
     set selectedStation(v) { selectedStation = v; },
-
-    get layerToggles() { return layerToggles; },
-    set layerToggles(v) { layerToggles = v; },
 
     get highContrastLabels() { return highContrastLabels; },
     set highContrastLabels(v) {

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -31,6 +31,10 @@
   import { renderStationPopupHTML } from '../lib/map/popup.js';
   import { unitsState } from '../lib/settings/units-store.svelte.js';
   import { mapState, MY_POSITION_ZOOM } from '../lib/map/map-store.svelte.js';
+  import {
+    LAYER_TOGGLES_KEY,
+    parseLayerToggles,
+  } from '../lib/map/layer-toggles-core.js';
   import { toMaidenhead } from '../lib/map/maidenhead.js';
   import { fmtLat, fmtLon, timeAgo } from '../lib/map/popup-helpers.js';
   import { clockOffset, formatOffsetMagnitude } from '../lib/map/clock-offset.svelte.js';
@@ -175,29 +179,9 @@
   let layerCardCollapsed = $state(false);
   // Layer toggles are a per-browser preference (like the radar settings
   // above): persisted to localStorage so unchecking e.g. Trails or Fixed
-  // Points survives navigating away and back. Stored as one JSON blob and
-  // merged over the defaults on load so toggles added in later versions
-  // pick up their default instead of becoming undefined.
-  const LAYER_TOGGLES_KEY = 'gw_map_layer_toggles';
-  const LAYER_TOGGLES_DEFAULTS = {
-    stations: true,
-    trails: true,
-    weather: true,
-    myPosition: true,
-    fixedPoints: true,
-    directRxOnly: false,
-    rfOnly: false,
-  };
-  function loadLayerToggles() {
-    try {
-      const raw = localStorage.getItem(LAYER_TOGGLES_KEY);
-      if (!raw) return { ...LAYER_TOGGLES_DEFAULTS };
-      return { ...LAYER_TOGGLES_DEFAULTS, ...JSON.parse(raw) };
-    } catch {
-      return { ...LAYER_TOGGLES_DEFAULTS };
-    }
-  }
-  let layerToggles = $state(loadLayerToggles());
+  // Points survives navigating away and back. The load/merge logic lives in
+  // layer-toggles-core.js (pure, unit-tested); here we only read/write storage.
+  let layerToggles = $state(parseLayerToggles(localStorage.getItem(LAYER_TOGGLES_KEY)));
 
   // Add-fixed-point dialog state. Opened from the context menu with the
   // clicked coordinates; onConfirm drops the point into the store.

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -173,7 +173,13 @@
   let isMobile = $state(false);
   let panelOpen = $state(false);
   let layerCardCollapsed = $state(false);
-  let layerToggles = $state({
+  // Layer toggles are a per-browser preference (like the radar settings
+  // above): persisted to localStorage so unchecking e.g. Trails or Fixed
+  // Points survives navigating away and back. Stored as one JSON blob and
+  // merged over the defaults on load so toggles added in later versions
+  // pick up their default instead of becoming undefined.
+  const LAYER_TOGGLES_KEY = 'gw_map_layer_toggles';
+  const LAYER_TOGGLES_DEFAULTS = {
     stations: true,
     trails: true,
     weather: true,
@@ -181,7 +187,17 @@
     fixedPoints: true,
     directRxOnly: false,
     rfOnly: false,
-  });
+  };
+  function loadLayerToggles() {
+    try {
+      const raw = localStorage.getItem(LAYER_TOGGLES_KEY);
+      if (!raw) return { ...LAYER_TOGGLES_DEFAULTS };
+      return { ...LAYER_TOGGLES_DEFAULTS, ...JSON.parse(raw) };
+    } catch {
+      return { ...LAYER_TOGGLES_DEFAULTS };
+    }
+  }
+  let layerToggles = $state(loadLayerToggles());
 
   // Add-fixed-point dialog state. Opened from the context menu with the
   // clicked coordinates; onConfirm drops the point into the store.
@@ -585,6 +601,11 @@
     fixedPointsLayer?.refresh();
   });
 
+  // Persist the whole toggle set on any change. JSON.stringify reads every
+  // property, so Svelte tracks each one as a dependency.
+  $effect(() => {
+    localStorage.setItem(LAYER_TOGGLES_KEY, JSON.stringify(layerToggles));
+  });
   // Push the layer toggles into the layer modules. We MUST read the
   // reactive value before the optional-chain so Svelte 5 tracks it as a
   // dependency on the initial run. With `layer?.setVisible(toggle)`, if


### PR DESCRIPTION
## Summary

Fixes #340. On the Live Map, unchecking display options like **Trails** and **Fixed Points** did not survive navigating away and back -- they reverted to checked. Only **Radar** persisted, which is why the behavior looked inconsistent.

## Root cause

`layerToggles` in `LiveMapV2.svelte` was component-local `$state` with no localStorage backing, so every visit reset it to the defaults (all on). Radar was the exception because it had its own `gw_radar_visible` / `gw_radar_opacity` keys. A separate, never-read `layerToggles` also lived in the shared map store, which made it look like persistence existed there when it didn't.

## Fix

- Load the toggle set from a single `gw_map_layer_toggles` JSON key, merged over the defaults so toggles added in future versions pick up their default rather than becoming `undefined`.
- Write the set back to localStorage on every change via an `$effect`.
- Remove the dead `layerToggles` state/getter/setter from the shared map store.

This covers all toggles (Stations, Trails, Weather, My Position, Fixed Points, and the Direct RX / RF Only filters), matching the per-browser persistence model already used for Radar.

## Testing

- `npm run build` succeeds.
- `npm test` passes (the one unrelated failure in `ptt/devices/methodOptions` predates this change).