### PR TITLE
Don't crash on launch on devices without a GPS provider

### DIFF
--- a/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt
@@ -381,7 +381,16 @@ class GraywolfService : Service() {
             stopSelf()
             return
         }
-        gpsAdapter = GpsAdapter(this, platformServer!!).also { it.start() }
+        // GPS is optional — the radio path is the point. start() already guards
+        // the known no-provider/no-permission cases, but keep the whole adapter
+        // init non-fatal so no future GPS-subsystem surprise can take the service
+        // down on launch (issue #338).
+        gpsAdapter = GpsAdapter(this, platformServer!!)
+        try {
+            gpsAdapter!!.start()
+        } catch (e: Throwable) {
+            Log.w(TAG, "GpsAdapter init failed; continuing without GPS", e)
+        }
 
         // Bluetooth-classic KISS TNC adapter. Wired AFTER PlatformServer.start()
         // because its sendMessage callback closes over platformServer.broadcastBt.

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/gps/GpsAdapter.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/gps/GpsAdapter.kt
@@ -72,6 +72,15 @@ class GpsAdapter(
             Log.i(TAG, "GpsAdapter.start skipped — ACCESS_FINE_LOCATION not granted")
             return
         }
+        // Devices without a GPS HAL (Facebook Portal, Android TV boxes, the
+        // emulator) have no GPS_PROVIDER, and requestLocationUpdates throws
+        // IllegalArgumentException("provider doesn't exist: gps"). Skip cleanly,
+        // same posture as the missing-permission case above: the app runs
+        // without GPS rather than crashing onCreate (issue #338).
+        if (LocationManager.GPS_PROVIDER !in locationManager.allProviders) {
+            Log.i(TAG, "GpsAdapter.start skipped — no GPS provider on this device")
+            return
+        }
         try {
             locationManager.requestLocationUpdates(
                 LocationManager.GPS_PROVIDER,
@@ -82,7 +91,21 @@ class GpsAdapter(
             Log.i(TAG, "GpsAdapter started: GPS_PROVIDER 10s/0m + GNSS status callback")
         } catch (se: SecurityException) {
             Log.w(TAG, "GpsAdapter start hit SecurityException: $se")
+            rollbackPartialStart()
+        } catch (iae: IllegalArgumentException) {
+            // Belt-and-suspenders for the no-provider race or a device where
+            // registerGnssStatusCallback rejects the request after the guard.
+            Log.w(TAG, "GpsAdapter start hit IllegalArgumentException: $iae")
+            rollbackPartialStart()
         }
+    }
+
+    // requestLocationUpdates may have registered the listener before a later
+    // call in start() threw; started stays false, so stop() (which only cleans
+    // up when started) would leak it. Tear down whatever did register.
+    private fun rollbackPartialStart() {
+        try { locationManager.removeUpdates(locationListener) } catch (_: Throwable) {}
+        try { locationManager.unregisterGnssStatusCallback(gnssStatusCallback) } catch (_: Throwable) {}
     }
 
     fun stop() {

--- a/android/app/src/test/kotlin/com/nw5w/graywolf/gps/GpsAdapterTest.kt
+++ b/android/app/src/test/kotlin/com/nw5w/graywolf/gps/GpsAdapterTest.kt
@@ -2,6 +2,8 @@ package com.nw5w.graywolf.gps
 
 import android.content.Context
 import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
 import com.nw5w.graywolf.platformproto.GpsSource
 import com.nw5w.graywolf.platformsvc.PlatformServer
 import org.junit.Test
@@ -10,6 +12,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class GpsAdapterTest {
     // Android framework classes are stubbed under the host JVM; we mock
@@ -68,5 +76,42 @@ class GpsAdapterTest {
         assertFalse(fix.hasAlt)
         assertFalse(fix.hasSpeed)
         assertFalse(fix.hasCourse)
+    }
+
+    // unitTests.isReturnDefaultValues makes the host-JVM permission check
+    // return GRANTED (0), so start() runs past the permission gate and we can
+    // drive its provider handling with a mocked LocationManager.
+
+    @Test fun start_isNoOp_whenDeviceHasNoGpsProvider() {
+        // Regression for #338: Facebook Portal / Android TV have no GPS_PROVIDER,
+        // so requestLocationUpdates would throw IllegalArgumentException and crash
+        // GraywolfService.onCreate. start() must skip cleanly instead.
+        val lm = mock(LocationManager::class.java)
+        `when`(lm.allProviders).thenReturn(listOf(LocationManager.NETWORK_PROVIDER))
+        val ctx = mock(Context::class.java)
+        `when`(ctx.getSystemService(Context.LOCATION_SERVICE)).thenReturn(lm)
+
+        val adapter = GpsAdapter(ctx, mock(PlatformServer::class.java))
+        adapter.start() // must not throw
+
+        verify(lm, never()).requestLocationUpdates(
+            any<String>(), any<Long>(), any<Float>(), any<LocationListener>()
+        )
+    }
+
+    @Test fun start_swallowsIllegalArgument_whenProviderVanishesAfterCheck() {
+        // Belt-and-suspenders: even if the provider is listed, a device may still
+        // reject the request. start() must catch IllegalArgumentException, not crash.
+        val lm = mock(LocationManager::class.java)
+        `when`(lm.allProviders).thenReturn(listOf(LocationManager.GPS_PROVIDER))
+        doThrow(IllegalArgumentException("provider doesn't exist: gps"))
+            .whenever(lm).requestLocationUpdates(
+                eq(LocationManager.GPS_PROVIDER), any<Long>(), any<Float>(), any<LocationListener>()
+            )
+        val ctx = mock(Context::class.java)
+        `when`(ctx.getSystemService(Context.LOCATION_SERVICE)).thenReturn(lm)
+
+        val adapter = GpsAdapter(ctx, mock(PlatformServer::class.java))
+        adapter.start() // must not throw
     }
 }


### PR DESCRIPTION
## Problem

`GpsAdapter.start()` requested `GPS_PROVIDER` unconditionally and only caught `SecurityException`. On devices with no GPS HAL (Facebook Portal, Android TV boxes, the emulator), `requestLocationUpdates` throws `IllegalArgumentException: provider doesn't exist: gps`. That exception propagated out of `GraywolfService.onCreate` and killed the foreground service on launch -- white screen, then crash.

Fixes #338.

## Fix

- **Guard on provider existence** in `start()`: if `GPS_PROVIDER` isn't in `locationManager.allProviders`, log and skip cleanly -- same posture as the existing missing-permission no-op. The app runs without GPS instead of crashing.
- **Catch `IllegalArgumentException`** in the request block as a backstop (covers the no-provider race and devices where `registerGnssStatusCallback` rejects after the guard).
- **Keep the `gpsAdapter` init in `onCreate` non-fatal** so no future GPS-subsystem surprise can take the service down on launch. GPS is optional; the radio path is the point.

## Tests

Added two regression tests to `GpsAdapterTest` (host-JVM, `unitTests.isReturnDefaultValues` lets `start()` run past the permission gate with a mocked `LocationManager`):

- `start_isNoOp_whenDeviceHasNoGpsProvider` -- no GPS in `allProviders`, `start()` doesn't throw and never calls `requestLocationUpdates`.
- `start_swallowsIllegalArgument_whenProviderVanishesAfterCheck` -- provider listed but request throws; `start()` swallows it.

`./gradlew :app:testDebugUnitTest --tests GpsAdapterTest` passes.
