### PR TITLE
Allow APRS-IS-only beacons to be created without a channel

### DIFF
--- a/docs/handbook/beacons.html
+++ b/docs/handbook/beacons.html
@@ -134,7 +134,7 @@
             <tr>
               <td><code>channel</code></td>
               <td>&mdash;</td>
-              <td>Radio channel to transmit on</td>
+              <td>Radio channel to transmit on. Not required when <em>Send to</em> is <em>APRS-IS only</em>.</td>
             </tr>
             <tr>
               <td><code>callsign</code></td>
@@ -169,24 +169,100 @@
             <tr>
               <td><code>send_path</code></td>
               <td><code>rf</code></td>
-              <td>Where the beacon is sent: <code>rf</code> (radio only), <code>both</code> (radio and APRS-IS), or <code>is_only</code> (APRS-IS only, no radio)</td>
+              <td>Where the beacon is sent &mdash; see <a href="#where-a-beacon-is-sent">Where a beacon is sent</a> below</td>
             </tr>
           </tbody>
         </table>
       </div>
     </div>
 
+    <h2 id="where-a-beacon-is-sent">Where a beacon is sent</h2>
+
+    <p>
+      Every beacon has a <strong>Send to</strong> setting that controls
+      where it is transmitted:
+    </p>
+
+    <div class="box">
+      <div class="box-body">
+        <table>
+          <thead>
+            <tr><th>Send to</th><th><code>send_path</code></th><th>What happens</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>RF only</td>
+              <td><code>rf</code></td>
+              <td>Transmitted over the radio on the selected channel. Other igates may relay it to APRS-IS.</td>
+            </tr>
+            <tr>
+              <td>RF + APRS-IS</td>
+              <td><code>both</code></td>
+              <td>Transmitted over the radio <em>and</em> sent straight to APRS-IS.</td>
+            </tr>
+            <tr>
+              <td>APRS-IS only (no radio)</td>
+              <td><code>is_only</code></td>
+              <td>Sent only to APRS-IS. No radio transmission and no radio channel required.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <h2>APRS-IS-only beaconing (no radio)</h2>
+
+    <p>
+      You don&rsquo;t need a radio to put your station on the APRS map.
+      Set a beacon&rsquo;s <strong>Send to</strong> to
+      <em>APRS-IS only (no radio)</em> and Graywolf sends it directly to
+      the APRS-IS network over the internet &mdash; ideal for a receive-only
+      site, a fixed home station with no transmitter, or anyone who just
+      wants to appear on <a href="https://aprs.fi" rel="noopener">aprs.fi</a>.
+    </p>
+
+    <p>Here&rsquo;s how the no-radio path works end to end:</p>
+
+    <ul>
+      <li>
+        <strong>No channel needed.</strong> When <em>Send to</em> is
+        <em>APRS-IS only</em>, the radio-channel picker disappears from the
+        beacon form &mdash; there is no RF leg to assign a channel to. You can
+        create one of these beacons even when <a href="channels.html">no
+        radio channels</a> exist at all.
+      </li>
+      <li>
+        <strong>The Beacons page tells you when you have no radio.</strong>
+        If no channels are configured, a banner at the top of the page
+        reminds you that you can beacon to APRS-IS only, and links to the
+        Channels page in case you do want to add RF later. New beacons
+        default to <em>APRS-IS only</em> in that situation.
+      </li>
+      <li>
+        <strong>The iGate is enabled automatically.</strong> An APRS-IS-only
+        beacon reaches the network through Graywolf&rsquo;s
+        <a href="igate.html">iGate</a> connection, so saving one turns the
+        iGate on for you if it wasn&rsquo;t already. You&rsquo;ll see a
+        confirmation when this happens.
+      </li>
+      <li>
+        <strong>Set your station callsign first.</strong> The iGate logs in
+        to APRS-IS using your <a href="callsign.html">station callsign</a>.
+        Without it the connection can&rsquo;t come up, so the beacon
+        won&rsquo;t reach the network until a callsign is set.
+      </li>
+    </ul>
+
     <div class="callout info">
       <span class="callout-icon">&#9432;</span>
       <div class="callout-body">
         <p>
-          <strong>APRS-IS only (no radio)?</strong> Set this beacon's
-          <em>Send to</em> to <em>APRS-IS only</em>. The beacon is gated
-          straight to APRS-IS and no radio channel is required &mdash; you
-          can add an APRS-IS-only beacon even with no channels configured.
-          Saving an APRS-IS-only beacon automatically enables the iGate so
-          an APRS-IS connection exists; make sure your station callsign is
-          set so the iGate can log in.
+          APRS-IS-only beacons are injected with a <code>TCPIP*</code> path
+          rather than an RF digipeater path (<code>WIDE1-1</code>, etc.).
+          This is the convention APRS-IS expects for self-originated
+          traffic &mdash; servers silently drop self-originated packets that
+          carry an RF path, so Graywolf sets the right path for you. The
+          <em>Path</em> field on the beacon only affects RF transmissions.
         </p>
       </div>
     </div>

--- a/docs/handbook/beacons.html
+++ b/docs/handbook/beacons.html
@@ -181,9 +181,10 @@
       <div class="callout-body">
         <p>
           <strong>APRS-IS only (no radio)?</strong> Set this beacon's
-          <em>Destination</em> to <em>APRS-IS only</em>. The beacon is gated
-          straight to APRS-IS and no radio channel is required. Enable the
-          iGate first so an APRS-IS connection exists.
+          <em>Send to</em> to <em>APRS-IS only</em>. The beacon is gated
+          straight to APRS-IS and no radio channel is required &mdash; you
+          can add an APRS-IS-only beacon even with no channels configured.
+          Enable the iGate first so an APRS-IS connection exists.
         </p>
       </div>
     </div>

--- a/docs/handbook/beacons.html
+++ b/docs/handbook/beacons.html
@@ -184,7 +184,9 @@
           <em>Send to</em> to <em>APRS-IS only</em>. The beacon is gated
           straight to APRS-IS and no radio channel is required &mdash; you
           can add an APRS-IS-only beacon even with no channels configured.
-          Enable the iGate first so an APRS-IS connection exists.
+          Saving an APRS-IS-only beacon automatically enables the iGate so
+          an APRS-IS connection exists; make sure your station callsign is
+          set so the iGate can log in.
         </p>
       </div>
     </div>

--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -121,7 +121,12 @@
     const n = parseInt(form.channel, 10);
     return lookupChannel(n);
   });
+  // APRS-IS-only beacons carry no RF leg, so the radio channel is
+  // irrelevant — the form hides the channel picker and skips the
+  // TX-capability gate entirely for them.
+  let needsChannel = $derived(form.send_path !== 'is_only');
   let txBlock = $derived.by(() => {
+    if (!needsChannel) return null;
     const c = selectedChannelObj;
     if (!c) return null;
     const cap = c.backing?.tx;
@@ -267,14 +272,18 @@
   });
 
   function openCreate() {
-    if (channels.length === 0) {
-      toasts.error('Create a channel first on the Channels page');
-      return;
-    }
     editing = null;
     form.type = 'position';
     form.object_name = '';
-    form.channel = String(channels[0].id);
+    // A radioless (APRS-IS-only) station has no channels at all. Rather
+    // than block beacon creation, default to an APRS-IS-only beacon so
+    // the operator can get on the network with no RF setup; the channel
+    // picker stays hidden until they pick an RF send path.
+    if (channels.length === 0) {
+      form.channel = '';
+    } else {
+      form.channel = String(channels[0].id);
+    }
     form.callsign = '';
     form.callsign_override = false;
     callsignError = '';
@@ -294,7 +303,7 @@
     form.comment = defaultComment;
     form.interval = '600';
     form.slot = '';
-    form.send_path = 'rf';
+    form.send_path = channels.length === 0 ? 'is_only' : 'rf';
     form.enabled = true;
     modalOpen = true;
   }
@@ -355,8 +364,10 @@
     callsignError = '';
     let channelId = parseInt(form.channel);
     if (form.send_path === 'is_only') {
-      // APRS-IS-only beacon: no RF channel needed.
-      if (!Number.isFinite(channelId) || channelId <= 0) channelId = 0;
+      // APRS-IS-only beacon: no RF channel needed. Store 0 unconditionally
+      // so the value is unambiguous even when switching from an RF beacon
+      // that had a channel selected.
+      channelId = 0;
     } else if (!Number.isFinite(channelId) || channelId <= 0) {
       toasts.error('Channel required');
       return;
@@ -502,8 +513,9 @@
 {:else}
   <div class="beacon-grid">
     {#each beacons as b}
+      {@const isOnly = b.send_path === 'is_only'}
       {@const refStatus = channelRefStatus(b.channel, channelsById)}
-      {@const broken = refStatus.status !== STATUS_OK}
+      {@const broken = !isOnly && refStatus.status !== STATUS_OK}
       {@const pillAriaLabel = broken
         ? (refStatus.status === STATUS_DELETED
             ? `Channel #${b.channel} deleted`
@@ -552,6 +564,10 @@
         </div>
 
         <div class="beacon-channel" class:broken>
+          {#if isOnly}
+            <span class="channel-label">Send to</span>
+            <span class="channel-value">APRS-IS only (no radio)</span>
+          {:else}
           <span
             class="channel-label"
             class:danger={broken}
@@ -568,6 +584,7 @@
           </span>
           {#if refStatus.status !== STATUS_DELETED}
             <span class="channel-value">{channelName(b.channel)}</span>
+          {/if}
           {/if}
         </div>
 
@@ -699,16 +716,36 @@
           <Input id="bcn-objname" bind:value={form.object_name} placeholder="e.g. FIELDDAY" maxlength="9" />
         </FormField>
       {/if}
-      <FormField label="Channel" id="bcn-channel"
-        hint="Radio channel this beacon transmits on. Defined on the Channels page.">
-        <ChannelListbox
-          id="bcn-channel"
-          bind:value={form.channel}
-          valueType="string"
-          channels={channels}
-          capabilityFilter={txPredicate}
-        />
+      <FormField label="Send to" id="bcn-send-path"
+        hint="Where this beacon is transmitted. APRS-IS only needs no radio channel — ideal for a station with no radio.">
+        <RadioGroup bind:value={form.send_path}>
+          <div class="pos-source-row">
+            <Radio value="rf" label="RF only" />
+            <Radio value="both" label="RF + APRS-IS" />
+            <Radio value="is_only" label="APRS-IS only (no radio)" />
+          </div>
+        </RadioGroup>
       </FormField>
+      {#if needsChannel}
+        {#if channels.length === 0}
+          <div class="no-channel-note" role="note">
+            No radio channels are configured. Add one on the
+            <a href="#/channels">Channels page</a>, or choose
+            <strong>APRS-IS only</strong> above to beacon without a radio.
+          </div>
+        {:else}
+          <FormField label="Channel" id="bcn-channel"
+            hint="Radio channel this beacon transmits on. Defined on the Channels page.">
+            <ChannelListbox
+              id="bcn-channel"
+              bind:value={form.channel}
+              valueType="string"
+              channels={channels}
+              capabilityFilter={txPredicate}
+            />
+          </FormField>
+        {/if}
+      {/if}
       <FormField
         label={form.type === 'object' ? 'Transmitting station (via)' : 'Callsign'}
         id="bcn-call"
@@ -842,16 +879,6 @@
       <FormField label="Slot (seconds past the hour)" id="bcn-slot"
         hint="Optional. Aligns each transmission to a fixed second past the top of the hour so multiple beacons stagger instead of flooding. E.g. 0 fires at :00/:30 with a 1800 s interval; 900 fires at :15/:45. Leave blank to fire on a plain interval.">
         <Input id="bcn-slot" bind:value={form.slot} type="number" min="0" max="3599" placeholder="e.g. 0" />
-      </FormField>
-      <FormField label="Destination" id="bcn-send-path"
-        hint="Where this beacon is transmitted. APRS-IS only needs no radio channel.">
-        <RadioGroup bind:value={form.send_path}>
-          <div class="pos-source-row">
-            <Radio value="rf" label="RF only" />
-            <Radio value="both" label="RF + APRS-IS" />
-            <Radio value="is_only" label="APRS-IS only (no radio)" />
-          </div>
-        </RadioGroup>
       </FormField>
     </div>
   </div>
@@ -1139,6 +1166,16 @@
     font-size: 12px;
     color: var(--color-text-muted, #888);
     line-height: 1.4;
+  }
+  .no-channel-note {
+    margin-bottom: 12px;
+    padding: 10px 12px;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--color-text-muted, #888);
+    background: var(--bg-secondary);
+    border: 1px dashed var(--border-color);
+    border-radius: var(--radius);
   }
   .symbol-swatch {
     flex: 0 0 auto;

--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -448,8 +448,27 @@
       modalOpen = false;
       beacons = await api.get('/beacons') || [];
       refreshChannels();
+      if (data.send_path === 'is_only') {
+        await ensureIgateEnabled();
+      }
     } catch (err) {
       toasts.error(err.message);
+    }
+  }
+
+  // An APRS-IS-only beacon only reaches the network when the iGate is
+  // connected to APRS-IS. Auto-enable the iGate on save so a radioless
+  // operator isn't left wondering why nothing shows up on aprs.fi.
+  // Best-effort: the beacon is already saved, so any failure here is
+  // surfaced as a toast rather than failing the whole operation.
+  async function ensureIgateEnabled() {
+    try {
+      const cfg = await api.get('/igate/config');
+      if (!cfg || cfg.enabled) return;
+      await api.put('/igate/config', { ...cfg, enabled: true });
+      toasts.success('iGate enabled so your APRS-IS-only beacon can reach the network');
+    } catch {
+      toasts.error('Beacon saved, but the iGate could not be enabled automatically. Enable it on the iGate page so APRS-IS-only beacons transmit.');
     }
   }
 
@@ -507,6 +526,17 @@
 <PageHeader title="Beacons" subtitle="APRS beacon configuration">
   <Button variant="primary" onclick={openCreate}>+ Add Beacon</Button>
 </PageHeader>
+
+{#if channelsStore.lastUpdated && channels.length === 0}
+  <div class="no-rf-banner" role="note">
+    <span class="no-rf-banner-icon" aria-hidden="true">&#9432;</span>
+    <div class="no-rf-banner-body">
+      <strong>No radio channels configured.</strong>
+      You can still beacon to APRS-IS only (no radio needed). To transmit
+      over RF, <a href="#/channels">create a channel</a> first.
+    </div>
+  </div>
+{/if}
 
 {#if beacons.length === 0}
   <div class="empty-state">No beacons configured. Add a beacon to start transmitting position reports.</div>
@@ -1176,6 +1206,28 @@
     background: var(--bg-secondary);
     border: 1px dashed var(--border-color);
     border-radius: var(--radius);
+  }
+  .no-rf-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    margin-bottom: 16px;
+    padding: 12px 14px;
+    font-size: 13px;
+    line-height: 1.45;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-left: 3px solid var(--color-info, #3b82f6);
+    border-radius: var(--radius);
+  }
+  .no-rf-banner-icon {
+    flex: 0 0 auto;
+    font-size: 16px;
+    color: var(--color-info, #3b82f6);
+    line-height: 1.4;
+  }
+  .no-rf-banner-body {
+    color: var(--text-secondary, var(--color-text-muted, #888));
   }
   .symbol-swatch {
     flex: 0 0 auto;

--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -259,11 +259,14 @@
     }
     // Deep-link entry from the map context menu's "Add fixed beacon
     // here" item: open the create modal with pos_source=fixed and the
-    // clicked coordinates prefilled. Done after the channels store has
-    // been kicked above so openCreate() finds a default channel.
+    // clicked coordinates prefilled. Await the channels store's first
+    // load so openCreate() defaults the send path off a populated list
+    // (no channels => APRS-IS only; otherwise RF) instead of racing an
+    // empty list and wrongly preselecting APRS-IS only on an RF station.
     const { lat, lon } = parseLatLonFromHash();
     if (lat != null && lon != null) {
       clearLatLonFromHash();
+      await refreshChannels();
       openCreate();
       form.pos_source = 'fixed';
       form.latitude = String(lat);
@@ -467,8 +470,13 @@
       if (!cfg || cfg.enabled) return;
       await api.put('/igate/config', { ...cfg, enabled: true });
       toasts.success('iGate enabled so your APRS-IS-only beacon can reach the network');
-    } catch {
-      toasts.error('Beacon saved, but the iGate could not be enabled automatically. Enable it on the iGate page so APRS-IS-only beacons transmit.');
+    } catch (err) {
+      // The most common failure here is a missing station callsign: the
+      // backend refuses to enable the iGate until one is set, which is
+      // exactly the state of a fresh radioless install. Surface the
+      // server's own actionable message rather than a generic "try the
+      // iGate page" that would fail for the same reason.
+      toasts.error(`Beacon saved, but the iGate could not be enabled automatically: ${err.message || 'enable it on the iGate page so APRS-IS-only beacons transmit.'}`);
     }
   }
 
@@ -527,6 +535,10 @@
   <Button variant="primary" onclick={openCreate}>+ Add Beacon</Button>
 </PageHeader>
 
+<!-- Gated on lastUpdated (set only after a successful fetch) so the
+     banner doesn't flash before the channels store's first load, and
+     stays hidden if that fetch errors — we don't claim "no channels"
+     when we don't actually know the channel set yet. -->
 {#if channelsStore.lastUpdated && channels.length === 0}
   <div class="no-rf-banner" role="note">
     <span class="no-rf-banner-icon" aria-hidden="true">&#9432;</span>


### PR DESCRIPTION
## Problem

We added APRS-IS-only beaconing (no RF) in #337, but the Beacons UI still made it impossible for a radioless station to actually create one:

- `openCreate()` hard-blocked with *"Create a channel first on the Channels page"* whenever no channels existed — so a station with no radio could never open the form.
- The channel picker was always shown and a channel was always required up front, even though an `is_only` beacon skips the RF leg entirely and ignores the channel.

Operators worked around this by trying to create channels without audio, which isn't the intended path for a pure APRS-IS station.

## Change (UI only)

- **No more hard block.** With zero channels, the create form opens and defaults the send path to **APRS-IS only**.
- **Send-path picker moved to the top** of the form and renamed **Send to** (it was a second field also labeled "Destination", colliding with the APRS tocall field). It now gates the channel picker below it.
- **Channel picker is hidden when send path is `is_only`** — the field is unused for these beacons. If an RF send path is chosen with no channels configured, a short note points to the Channels page.
- **`is_only` beacons store channel `0`** and render an **"APRS-IS only (no radio)"** pill in the list instead of the misleading "Channel deleted" status.
- Handbook callout updated to the new field label and the no-channel flow.

The backend already accepts channel `0` for `is_only` beacons and skips the RF sink, so no API changes were needed.

## Testing

- `npm run build` passes.
- `npm test` passes (the one failing test, `methodOptions` PTT ordering, fails on `main` too — unrelated).