### PR TITLE
Fix DESKTOP_METHODS test: expect seven PTT methods (add vox)

### DIFF
--- a/web/src/routes/ptt/devices/methodOptions.test.js
+++ b/web/src/routes/ptt/devices/methodOptions.test.js
@@ -1,11 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-test('DESKTOP_METHODS includes all six PTT methods in display order', async () => {
+test('DESKTOP_METHODS includes all seven PTT methods in display order', async () => {
   const { DESKTOP_METHODS } = await import('./methodOptions.desktop.js');
   assert.deepEqual(
     DESKTOP_METHODS.map(m => m.wire.method),
-    ['none', 'serial_rts', 'serial_dtr', 'gpio', 'cm108', 'rigctld'],
+    ['none', 'vox', 'serial_rts', 'serial_dtr', 'gpio', 'cm108', 'rigctld'],
   );
 });
 


### PR DESCRIPTION
`methodOptions.desktop.js` gained a `vox` method inserted after `none`, making `DESKTOP_METHODS` seven entries. The test still asserted the old six-entry array, so it failed.

Updates the expected array to include `'vox'` after `'none'` and renames the test from "six" to "seven". This was pre-existing on main.

All four tests in the file pass.