### PR TITLE
Fix fixed-point persistence on remount and add touch long-press

### DIFF
--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -539,11 +539,12 @@
     }
 
     // Right-click background → open context menu. Bail when the click
-    // landed on a station marker (or any DOM child of one): markers own
-    // a left-click popup and we don't want to fight that surface.
+    // landed on a marker (or any DOM child of one): station markers own a
+    // left-click popup and fixed-point markers own a delete popup, so we
+    // don't want the background menu to fight either surface.
     map.on('contextmenu', (e) => {
       const target = e.originalEvent?.target;
-      if (target && target.closest && target.closest('.gw-station-marker')) {
+      if (target && target.closest && target.closest('.gw-station-marker, .gw-fixed-marker')) {
         return;
       }
       e.preventDefault?.();
@@ -562,7 +563,10 @@
     // contextmenu event fires (graywolf#347). A single finger held still for
     // LONGPRESS_MS opens the menu; any second touch (pinch), a drag past
     // LONGPRESS_SLOP px, or an early lift cancels it so normal pan/zoom is
-    // untouched.
+    // untouched. On browsers that DO synthesize a contextmenu on long-press,
+    // both paths call openCtxMenuAt with near-identical coords — the second
+    // open just overwrites the first single ctxMenu state, so it's a no-op,
+    // not a duplicate menu.
     const LONGPRESS_MS = 500;
     const LONGPRESS_SLOP = 10;
     let lpTimer = null;
@@ -581,7 +585,9 @@
         return;
       }
       const target = e.originalEvent?.target;
-      if (target && target.closest && target.closest('.gw-station-marker')) {
+      // Same guard as the right-click path: a press that lands on a marker
+      // belongs to that marker's own tap surface, not the background menu.
+      if (target && target.closest && target.closest('.gw-station-marker, .gw-fixed-marker')) {
         return;
       }
       const t = touches[0];

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -478,6 +478,12 @@
     fixedPointsLayer = mountFixedPointsLayer(map, () => fixedPointsStore.points, {
       onMarkerClick: (point) => openFixedPointPopup(map, point),
     });
+    // Render any points already in the store at mount time. The refresh
+    // $effect only fires on a points.length change, and on a remount (e.g.
+    // navigating back to the map) the layer is created here -- after that
+    // effect's first run -- so without this call pre-existing points stay
+    // invisible until the operator adds another one. (graywolf#347)
+    fixedPointsLayer.refresh();
     myPositionLayer = mountMyPositionLayer(map, () => dataStore.myPosition, {
       onMarkerEnter: () => {
         if (activePopup) return;
@@ -522,6 +528,16 @@
     map.on('mousemove', (e) => updateCoordText(e.lngLat));
     map.on('mouseout', () => (coordText = ''));
 
+    // Open the background context menu at viewport coords vx/vy anchored to
+    // the given lngLat. Shared by right-click (desktop) and long-press
+    // (touch) so both surfaces behave identically once triggered.
+    function openCtxMenuAt(vx, vy, lngLat) {
+      ctxMenu = { open: true, x: vx, y: vy, lat: lngLat.lat, lon: lngLat.lng };
+      // Suppress hover overlays while the menu is up.
+      closePopup();
+      hoverPathLayer?.clear();
+    }
+
     // Right-click background → open context menu. Bail when the click
     // landed on a station marker (or any DOM child of one): markers own
     // a left-click popup and we don't want to fight that surface.
@@ -539,17 +555,58 @@
       const oe = e.originalEvent;
       const vx = oe?.clientX ?? e.point.x;
       const vy = oe?.clientY ?? e.point.y;
-      ctxMenu = {
-        open: true,
-        x: vx,
-        y: vy,
-        lat: e.lngLat.lat,
-        lon: e.lngLat.lng,
-      };
-      // Suppress hover overlays while the menu is up.
-      closePopup();
-      hoverPathLayer?.clear();
+      openCtxMenuAt(vx, vy, e.lngLat);
     });
+
+    // Long-press background → same context menu, for touchscreens where no
+    // contextmenu event fires (graywolf#347). A single finger held still for
+    // LONGPRESS_MS opens the menu; any second touch (pinch), a drag past
+    // LONGPRESS_SLOP px, or an early lift cancels it so normal pan/zoom is
+    // untouched.
+    const LONGPRESS_MS = 500;
+    const LONGPRESS_SLOP = 10;
+    let lpTimer = null;
+    let lpStart = null;
+    function clearLongPress() {
+      if (lpTimer !== null) {
+        clearTimeout(lpTimer);
+        lpTimer = null;
+      }
+      lpStart = null;
+    }
+    map.on('touchstart', (e) => {
+      const touches = e.originalEvent?.touches;
+      if (!touches || touches.length !== 1) {
+        clearLongPress();
+        return;
+      }
+      const target = e.originalEvent?.target;
+      if (target && target.closest && target.closest('.gw-station-marker')) {
+        return;
+      }
+      const t = touches[0];
+      lpStart = { x: t.clientX, y: t.clientY };
+      const lngLat = e.lngLat;
+      lpTimer = setTimeout(() => {
+        lpTimer = null;
+        openCtxMenuAt(lpStart.x, lpStart.y, lngLat);
+        lpStart = null;
+      }, LONGPRESS_MS);
+    });
+    map.on('touchmove', (e) => {
+      if (!lpStart) return;
+      const t = e.originalEvent?.touches?.[0];
+      if (
+        !t ||
+        Math.abs(t.clientX - lpStart.x) > LONGPRESS_SLOP ||
+        Math.abs(t.clientY - lpStart.y) > LONGPRESS_SLOP
+      ) {
+        clearLongPress();
+      }
+    });
+    map.on('touchend', clearLongPress);
+    map.on('touchcancel', clearLongPress);
+
     // Any camera change closes the menu — its anchor lat/lon would drift.
     map.on('movestart', closeCtxMenu);
     map.on('zoomstart', closeCtxMenu);


### PR DESCRIPTION
Addresses #347 (user-added fixed map points).

### 1. Persistence across navigation (bug)
Fixed points created on the map disappeared after navigating away (Dashboard, APRS Logs) and returning, reappearing only after adding a new point.

**Root cause:** The fixed-points refresh `$effect` only tracks `fixedPointsStore.points.length`. On a remount, that effect runs once *before* the map's async `style.load` callback assigns `fixedPointsLayer`, so its `refresh()` is a no-op. Since `points.length` doesn't change afterward, the effect never re-fires and the markers are never created -- until the operator adds a point, which bumps the length and renders the whole set. (Other layers escape this because their refresh effect also tracks the 1s clock, which re-fires after mount.)

**Fix:** Call `fixedPointsLayer.refresh()` explicitly right after mounting the layer, so points already in the store render immediately on every (re)mount.

### 2. Touch long-press (feature)
The right-click context menu was the only way to add a point, which touchscreen browsers can't reach. Added a long-press handler that opens the same background menu: a single finger held still for 500ms triggers it; a second touch (pinch), a drag past a 10px slop threshold, or an early lift cancels it, so normal pan/zoom is unaffected.

### Not included: cross-device sync (#347 item 3)
Points are stored in `localStorage` only (`map-fixed-points`), so they're per-browser and lost on clearing browser data -- working as currently designed, not a bug. True cross-device sync needs a server-side store + REST endpoints + client wiring; that's a larger change best tracked separately.

### Verification
`npm run build` succeeds; `npm test` passes (355/355).