### PR TITLE
Address mobile-browser map interface quirks (#348)

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -202,7 +202,12 @@
   .main-content.full-bleed {
     max-width: none;
     padding: 0;
+    /* dvh tracks the *visible* viewport as the mobile address bar
+       collapses/expands; 100vh (the largest viewport) would push the map's
+       bottom indicators behind the address bar (GH #348). vh first as a
+       fallback for browsers without dvh. */
     height: 100vh;
+    height: 100dvh;
     overflow: hidden;
     position: relative;
   }
@@ -218,6 +223,7 @@
     }
     .main-content.full-bleed {
       height: calc(100vh - 56px - env(safe-area-inset-top));
+      height: calc(100dvh - 56px - env(safe-area-inset-top));
     }
   }
 </style>

--- a/web/src/lib/map/maplibre-map.svelte
+++ b/web/src/lib/map/maplibre-map.svelte
@@ -186,6 +186,12 @@
       attributionControl: { compact: true },
       transformRequest,
     });
+    // Drop the rotate component of the two-finger touch gesture. On phones
+    // a pinch-to-zoom too easily nudges the bearing, leaving the map askew
+    // with no obvious way back (GH #348). Pinch-zoom is preserved; only the
+    // twist is ignored. Desktop right-drag rotate (dragRotate) and the
+    // compass reset are untouched, so this needs no settings switch.
+    map.touchZoomRotate.disableRotation();
     map.addControl(
       new maplibregl.NavigationControl({
         showCompass: true,

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -960,7 +960,7 @@
   {/snippet}
 
   {#if isMobile}
-    <!-- Mobile: FAB at top-right opens a bottom-sheet drawer. -->
+    <!-- Mobile: FAB at top-left opens a bottom-sheet drawer. -->
     <button
       type="button"
       class="map-fab"

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1086,14 +1086,15 @@
     overflow: hidden;
   }
 
-  /* FAB (mobile only). Sits to the LEFT of MapLibre's NavigationControl
-     (which is already top-right at the default 10px inset). NavigationControl
-     itself is hidden on touch widths via maplibre-map.svelte's media query,
-     so the FAB has the corner to itself. */
+  /* FAB (mobile only). Anchored top-LEFT so it clears MapLibre's
+     NavigationControl (compass) at top-right; in a narrow portrait window
+     the two used to overlap and the FAB hid the north-up reset (GH #348).
+     The desktop layer-card never renders on mobile, so the left corner is
+     free. */
   .map-fab {
     position: absolute;
     top: 12px;
-    right: 12px;
+    left: 12px;
     width: 44px;
     height: 44px;
     border-radius: 22px;
@@ -1328,11 +1329,17 @@
       text-overflow: ellipsis;
     }
   }
-  /* Pull the status bar up on mobile so it clears the bottom safe area
-     and the MapLibre attribution. */
+  /* Pull the status bar and coord/zoom readout up on mobile so they clear
+     the bottom safe area (home indicator / gesture bar) and the MapLibre
+     attribution. The dynamic-viewport height on .main-content.full-bleed
+     keeps the map's bottom edge inside the visible area as the address bar
+     collapses; these offsets keep the chrome off the safe-area inset. */
   @media (max-width: 768px) {
     .map-status-bar {
-      bottom: 14px;
+      bottom: calc(14px + env(safe-area-inset-bottom));
+    }
+    .map-coord-display {
+      bottom: calc(28px + env(safe-area-inset-bottom));
     }
   }
 


### PR DESCRIPTION
Addresses the three mobile-browser quirks from issue #348.

### 1. Map rotation sensitivity
Disabled the rotate component of the two-finger touch gesture via `map.touchZoomRotate.disableRotation()`. Pinch-to-zoom no longer nudges the bearing on phones. Pinch-zoom itself and desktop right-drag rotate are preserved, and the compass still resets bearing -- so this needs **no new settings switch**.

### 2. UI element overlap
Moved the mobile Map Layers FAB from top-right to top-left. It previously sat on top of MapLibre's compass / north-up reset in a narrow portrait window. The desktop layer-card never renders on mobile, so the left corner is free.

### 3. Hidden bottom indicators
The full-bleed map height used `100vh`, which on mobile is the *largest* viewport and pushed the scale / station-count / zoom indicators behind the collapsible address bar. Switched to `100dvh` (dynamic viewport height, with a `vh` fallback) so the map's bottom edge tracks the visible area as the address bar collapses/expands. Also added bottom safe-area insets to that chrome so it clears the home indicator / gesture bar.

Closes #348.

Frontend builds clean; map unit tests (85) pass.