### PR TITLE
Fix false 'clock not synchronized' warning on NTP-synced hosts

### DIFF
--- a/pkg/clocksync/clocksync_linux.go
+++ b/pkg/clocksync/clocksync_linux.go
@@ -4,30 +4,45 @@ package clocksync
 
 import "golang.org/x/sys/unix"
 
+// maxSyncedError mirrors the kernel's NTP_PHASE_LIMIT: 16 seconds, in
+// microseconds. The kernel grows the clock's maximum error by MAXFREQ
+// (500 us/sec) between time-source updates and re-asserts STA_UNSYNC once
+// maxerror crosses this limit (~8.9 h after the last update). systemd's
+// timedated derives "System clock synchronized" from the same threshold.
+const maxSyncedError = 16_000_000
+
 // Check queries the kernel NTP discipline state via adjtimex(2). A zero
 // Modes field makes this a read-only query that needs no privileges.
 //
-// The kernel initializes its NTP status word to STA_UNSYNC at boot and
-// clears that bit only once a time source (NTP, chrony, systemd-timesyncd)
-// has disciplined the clock -- the same signal `timedatectl`'s "System
-// clock synchronized" line is derived from. STA_UNSYNC alone is therefore
-// the precise "not disciplined" signal: it covers both the no-daemon case
-// (bit still set from boot) and the daemon-not-yet-converged case, while a
-// synced clock with a leap second pending (TIME_INS/TIME_DEL) keeps the
-// bit clear and is correctly reported as Synced.
+// We classify on the maxerror field, not the STA_UNSYNC status bit.
+// STA_UNSYNC is an unreliable "is the clock disciplined?" signal: chrony
+// leaves it set unless the `rtcsync` directive is configured, and
+// systemd-timesyncd lets the kernel re-assert it between polls -- both
+// produce false "unsynced" reports on hosts whose clocks are in fact
+// NTP-synced (the Raspberry Pi false positive this fixes). `timedatectl`'s
+// "System clock synchronized" line is computed by systemd-timedated's
+// ntp_synced(), which calls adjtimex and returns `maxerror < 16 s`,
+// explicitly ignoring STA_UNSYNC. Mirroring that threshold makes Graywolf
+// agree with timedatectl across daemons and configurations.
 func Check() Status {
 	var tmx unix.Timex
 	if _, err := unix.Adjtimex(&tmx); err != nil {
 		return Unknown
 	}
-	return classify(tmx.Status)
+	// Maxerror is int32 on 32-bit arches (e.g. arm) and int64 on 64-bit;
+	// widen to int64 so classify stays portable and unit-testable.
+	return classify(int64(tmx.Maxerror))
 }
 
-// classify maps an adjtimex status word to a Status. Split out so the bit
-// logic is unit-testable without a live syscall.
-func classify(status int32) Status {
-	if status&unix.STA_UNSYNC != 0 {
-		return Unsynced
+// classify maps an adjtimex maxerror (microseconds) to a Status. A clock
+// being disciplined by a time source keeps maxerror well under the limit;
+// an undisciplined one sits at or above 16 s -- the kernel initializes
+// maxerror to NTP_PHASE_LIMIT at boot and lets it grow unbounded with no
+// daemon. Split out so the threshold logic is unit-testable without a live
+// syscall.
+func classify(maxerror int64) Status {
+	if maxerror < maxSyncedError {
+		return Synced
 	}
-	return Synced
+	return Unsynced
 }

--- a/pkg/clocksync/clocksync_linux_test.go
+++ b/pkg/clocksync/clocksync_linux_test.go
@@ -2,29 +2,26 @@
 
 package clocksync
 
-import (
-	"testing"
-
-	"golang.org/x/sys/unix"
-)
+import "testing"
 
 func TestClassify(t *testing.T) {
 	tests := []struct {
-		name   string
-		status int32
-		want   Status
+		name     string
+		maxerror int64
+		want     Status
 	}{
-		{"clean status", 0, Synced},
-		{"disciplined PLL, no unsync bit", unix.STA_PLL, Synced},
-		{"boot default / no daemon", unix.STA_UNSYNC, Unsynced},
-		{"daemon running but not converged", unix.STA_PLL | unix.STA_UNSYNC, Unsynced},
-		// A synced clock with a leap second queued sets STA_INS, not
-		// STA_UNSYNC -- it must not be reported as unsynced.
-		{"leap insert pending, still synced", unix.STA_INS, Synced},
+		{"freshly disciplined clock", 0, Synced},
+		{"small dispersion, well synced", 1_000, Synced},
+		{"converged daemon, mid-poll", maxSyncedError - 1, Synced},
+		// At exactly the 16 s limit the kernel re-asserts STA_UNSYNC, and
+		// timedatectl reports unsynced too (`maxerror < 16 s`).
+		{"at the 16s limit", maxSyncedError, Unsynced},
+		{"boot default / no daemon", 16_500_000, Unsynced},
+		{"long-undisciplined, grown unbounded", 900_000_000, Unsynced},
 	}
 	for _, tc := range tests {
-		if got := classify(tc.status); got != tc.want {
-			t.Errorf("%s: classify(%#x) = %d, want %d", tc.name, tc.status, got, tc.want)
+		if got := classify(tc.maxerror); got != tc.want {
+			t.Errorf("%s: classify(%d) = %d, want %d", tc.name, tc.maxerror, got, tc.want)
 		}
 	}
 }

--- a/pkg/clocksync/clocksync_linux_test.go
+++ b/pkg/clocksync/clocksync_linux_test.go
@@ -16,8 +16,8 @@ func TestClassify(t *testing.T) {
 		// At exactly the 16 s limit the kernel re-asserts STA_UNSYNC, and
 		// timedatectl reports unsynced too (`maxerror < 16 s`).
 		{"at the 16s limit", maxSyncedError, Unsynced},
-		{"boot default / no daemon", 16_500_000, Unsynced},
-		{"long-undisciplined, grown unbounded", 900_000_000, Unsynced},
+		{"boot default / no daemon", maxSyncedError + 500_000, Unsynced},
+		{"long-undisciplined, grown unbounded", maxSyncedError * 50, Unsynced},
 	}
 	for _, tc := range tests {
 		if got := classify(tc.maxerror); got != tc.want {


### PR DESCRIPTION
Some users see the startup warning

```
system clock is not synchronized to a time source; this skews packet ages and can hide stations from the map -- enable NTP (systemd-timesyncd, chrony, or ntpd)
```

even though `timedatectl status` reports `System clock synchronized: yes` with an active NTP service. Reported on a Raspberry Pi (no hardware RTC) running systemd-timesyncd.

## Root cause

`pkg/clocksync` classified on the adjtimex `STA_UNSYNC` status bit. That bit is not a reliable "is a time source disciplining the clock?" signal:

- **systemd-timesyncd:** the kernel re-asserts `STA_UNSYNC` once `time_maxerror` grows past `NTP_PHASE_LIMIT` (16 s; maxerror climbs 500 us/sec, so ~8.9 h after the last update) and timesyncd does not refresh it often enough to keep it clear.
- **chrony:** `set_sync_status()` forces the kernel `synchronised` flag off (leaving `STA_UNSYNC` set) unless the `rtcsync` directive is configured -- a permanent false positive in the common default config.

Crucially, `timedatectl`s "System clock synchronized" line does **not** come from `STA_UNSYNC`. systemd-timedated`s `ntp_synced()` calls `adjtimex` and returns `maxerror < 16 s`, with an explicit comment that it ignores `STA_UNSYNC`. That is why Graywolf and `timedatectl` disagreed.

## Fix

Classify on the `maxerror` field instead of `STA_UNSYNC`, mirroring timedateds 16 s threshold. This makes the startup banner agree with `timedatectl status` across daemons and configurations. It also aligns with `pkg/diagcollect`, which already reads `timedatectl show -p NTPSynchronized`.

- A truly undisciplined clock keeps `maxerror` at or above 16 s (the kernel initializes it to `NTP_PHASE_LIMIT` at boot and lets it grow unbounded with no daemon), so the genuine no-NTP case still warns.
- `maxerror` is `int32` on 32-bit arches (arm/Pi) and `int64` on 64-bit; widened to `int64` so `classify` stays portable. Cross-compiles verified for `arm` and `arm64`.

Unit tests updated to cover the maxerror threshold (boundary at exactly 16 s, sub-limit synced, grown-unbounded unsynced). `go vet` and `go test ./pkg/clocksync/` pass.