### PR TITLE
Apply saved map layer toggles on remount (#363)

### DIFF
--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -532,6 +532,28 @@
       },
     });
 
+    // Apply the saved toggle state to the freshly-mounted layers. The
+    // setVisible/setFilter effects only depend on layerToggles.*, not on the
+    // layer references, so assigning a layer above does NOT re-run them. On a
+    // remount with a non-default config (e.g. Trails unchecked) the layers
+    // would otherwise be created visible/unfiltered and the saved preference
+    // never applied until the operator toggled a checkbox. (graywolf#363)
+    stationsLayer.setVisible(layerToggles.stations);
+    trailsLayer.setVisible(layerToggles.trails);
+    weatherLayer.setVisible(layerToggles.weather);
+    windBarbsLayer.setVisible(layerToggles.weather);
+    myPositionLayer.setVisible(layerToggles.myPosition);
+    fixedPointsLayer.setVisible(layerToggles.fixedPoints);
+    const initialPred = layerToggles.directRxOnly
+      ? isDirectRx
+      : layerToggles.rfOnly
+        ? isRfOnly
+        : null;
+    stationsLayer.setFilter(initialPred);
+    trailsLayer.setFilter(initialPred);
+    weatherLayer.setFilter(initialPred);
+    windBarbsLayer.setFilter(initialPred);
+
     function updateBounds() {
       const b = map.getBounds();
       dataStore.setBounds({


### PR DESCRIPTION
Fixes #363.

## Problem

Returning to the Live Map with a non-default layer configuration (e.g. Trails or Weather unchecked, or a Direct RX / RF Only filter active) rendered every station and overlay anyway. The pulldown and status indicators reflected the saved preferences, but the map ignored them until the operator manually toggled a layer off and back on.

## Cause

In `LiveMapV2.svelte` the `setVisible` / `setFilter` effects only track `layerToggles.*` — not the layer-module references. The layer modules are created later, asynchronously in `onMapReady` once the basemap style loads. Assigning a layer there does not re-run those effects (the toggle values did not change), so on a remount the modules were created fully visible and unfiltered (their internal default), and the saved preference was never pushed in. Toggling a checkbox mutated `layerToggles`, which re-fired the effect — hence the workaround.

## Fix

Push the current toggle visibility and RF filter into the freshly-mounted layers at the end of `onMapReady`, mirroring the radar layer's existing `visible:` seed and the `fixedPointsLayer.refresh()` call that exists for the same remount reason (#347).

## Verification

- `npm run build` succeeds.
- `npm test` unchanged (350 pass / 10 fail; the 10 failures are pre-existing and unrelated — federated-protocol and ignored-invites stores — confirmed present on a clean checkout).

A unit test for this path would require a DOM + maplibre harness that the current `node --test` setup lacks; the pure toggle-merge logic in `layer-toggles-core.js` remains covered.
