### PR TITLE
Fix world map showing Download button after download (GH #364)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1063,3 +1063,34 @@ RX only once it is heard directly again.
 Source: [`../../pkg/stationcache/memcache.go`](../../pkg/stationcache/memcache.go) (`updateMetadata`, `isDirectRF`, `rfRank`);
 [`../../pkg/webapi/stations.go`](../../pkg/webapi/stations.go) (`StationDTO.LastDirectHeard`);
 [`../../web/src/lib/map/direct-rx-core.js`](../../web/src/lib/map/direct-rx-core.js) (`directHeardWithin`).
+
+### 49. `world` is a legitimate bare offline-map slug -- never namespace it
+
+The offline-map slug grammar (`pkg/mapsslug`) is namespaced -- `state/<x>`,
+`country/<iso2>`, `province/<iso2>/<x>` -- with exactly one bare exception: the
+single global archive `world`. The frontend region picker
+(`web/src/lib/maps/catalog-tree.js`, `buildWorldNode`) hardcodes this `world`
+slug, and the backend keys the DB row and the on-disk `world.pmtiles` by it.
+
+The two startup migrations that namespace **legacy** bare slugs predate the
+world archive (added in #277) and must explicitly skip `world`:
+
+- `Store.MigrateMapsDownloadSlugs` (`pkg/configstore/migrate_downloads.go`)
+  prepends `state/` to any DB slug lacking `/`.
+- `Manager.MigrateLegacyArchives` (`pkg/mapscache/manager.go`) moves any bare
+  `<x>.pmtiles` into `state/<x>.pmtiles`.
+
+*Why:* before the skip, every restart rewrote a downloaded `world` row+file to
+`state/world`. Offline rendering still worked (row and file moved together), but
+the picker's `statusOf('world')` lookup missed, so it showed a Download button
+for an already-downloaded world map (GH #364). Both migrations now also repair
+an existing `state/world` back to `world`.
+
+*How to apply:* any new top-level (non-regional) archive that uses a bare slug
+must be excluded from these bare-slug migrations the same way, or it will be
+mis-namespaced on the next startup.
+
+Source: [`../../pkg/configstore/migrate_downloads.go`](../../pkg/configstore/migrate_downloads.go);
+[`../../pkg/mapscache/manager.go`](../../pkg/mapscache/manager.go) (`MigrateLegacyArchives`, `repairWorldArchive`);
+[`../../pkg/mapsslug/slug.go`](../../pkg/mapsslug/slug.go);
+[`../../web/src/lib/maps/catalog-tree.js`](../../web/src/lib/maps/catalog-tree.js) (`buildWorldNode`).

--- a/pkg/configstore/migrate_downloads.go
+++ b/pkg/configstore/migrate_downloads.go
@@ -12,14 +12,21 @@ import (
 // row in maps_downloads. Idempotent: rows already containing "/" are
 // left alone. Run once at startup after AutoMigrate.
 //
-// Collision policy: if a row already exists at the namespaced target
-// (e.g. both "colorado" and "state/colorado" coexist after some prior
-// partial migration or hand edit), the legacy bare row is DELETED and
-// the namespaced row is kept. The unique-index on slug means a naive
-// UPDATE would error and abort startup, so this collision case is
-// handled explicitly. The whole pass runs in a single transaction so a
-// crash mid-migration leaves the table either fully migrated or fully
-// untouched.
+// The global "world" archive is a legitimate bare slug, not a legacy
+// state slug. This pass predates the world archive, so earlier releases
+// wrongly rewrote "world" to "state/world" on every startup, which made
+// the region picker (which looks up the fixed "world" slug) show a
+// Download button for an already-downloaded world map. A correct "world"
+// row is now left untouched and a mangled "state/world" row is repaired
+// back to "world".
+//
+// Collision policy: if a row already exists at the rename target (e.g.
+// both "colorado" and "state/colorado" coexist after some prior partial
+// migration or hand edit), the source row is DELETED and the target row
+// is kept. The unique-index on slug means a naive UPDATE would error and
+// abort startup, so this collision case is handled explicitly. The whole
+// pass runs in a single transaction so a crash mid-migration leaves the
+// table either fully migrated or fully untouched.
 func (s *Store) MigrateMapsDownloadSlugs(ctx context.Context) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var rows []MapsDownload
@@ -27,31 +34,40 @@ func (s *Store) MigrateMapsDownloadSlugs(ctx context.Context) error {
 			return err
 		}
 		for _, r := range rows {
-			if strings.Contains(r.Slug, "/") {
+			switch {
+			case r.Slug == "world":
+				// Legitimate global archive slug; never namespace it.
 				continue
-			}
-			target := "state/" + r.Slug
-
-			var existing MapsDownload
-			err := tx.Where("slug = ?", target).First(&existing).Error
-			if err == nil {
-				// Namespaced row already exists; drop the legacy
-				// duplicate to clear the way without clobbering the
-				// (presumably newer) namespaced row.
-				if err := tx.Delete(&MapsDownload{}, r.ID).Error; err != nil {
+			case r.Slug == "state/world":
+				// Undo the earlier mis-migration of the world archive.
+				if err := renameDownloadSlug(tx, r, "world"); err != nil {
 					return err
 				}
+			case strings.Contains(r.Slug, "/"):
 				continue
-			}
-			if !errors.Is(err, gorm.ErrRecordNotFound) {
-				return err
-			}
-			if err := tx.Model(&MapsDownload{}).
-				Where("id = ?", r.ID).
-				UpdateColumn("slug", target).Error; err != nil {
-				return err
+			default:
+				if err := renameDownloadSlug(tx, r, "state/"+r.Slug); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
 	})
+}
+
+// renameDownloadSlug changes r's slug to target within tx, honouring the
+// unique index on slug: if a row already holds target, the source row r
+// is dropped rather than clobbering the (presumably current) target row.
+func renameDownloadSlug(tx *gorm.DB, r MapsDownload, target string) error {
+	var existing MapsDownload
+	err := tx.Where("slug = ?", target).First(&existing).Error
+	if err == nil {
+		return tx.Delete(&MapsDownload{}, r.ID).Error
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	return tx.Model(&MapsDownload{}).
+		Where("id = ?", r.ID).
+		UpdateColumn("slug", target).Error
 }

--- a/pkg/mapscache/manager.go
+++ b/pkg/mapscache/manager.go
@@ -382,6 +382,12 @@ func (m *Manager) MigrateLegacyArchives(ctx context.Context) error {
 		return err
 	}
 	stateDir := filepath.Join(m.cacheDir, "state")
+	// Repair the world archive an earlier release's migration wrongly
+	// relocated into the state/ subdir. Keeps the file in step with the
+	// DB slug restored by MigrateMapsDownloadSlugs.
+	if err := m.repairWorldArchive(stateDir); err != nil {
+		return err
+	}
 	leafRE := mapsslug.LeafRegexp()
 	for _, e := range entries {
 		if e.IsDir() {
@@ -392,6 +398,11 @@ func (m *Manager) MigrateLegacyArchives(ctx context.Context) error {
 			continue
 		}
 		slug := strings.TrimSuffix(name, ".pmtiles")
+		if slug == "world" {
+			// The global world archive is a legitimate top-level slug,
+			// not a legacy bare state file -- leave it in place.
+			continue
+		}
 		if !leafRE.MatchString(slug) {
 			continue
 		}
@@ -413,6 +424,35 @@ func (m *Manager) MigrateLegacyArchives(ctx context.Context) error {
 		if err := os.Rename(oldPath, newPath); err != nil {
 			return fmt.Errorf("migrate %s: %w", name, err)
 		}
+	}
+	return nil
+}
+
+// repairWorldArchive moves a misplaced state/world.pmtiles back to the
+// top-level world.pmtiles. The world archive's legitimate slug is bare
+// "world"; an earlier release's legacy migration treated it as a state
+// slug and relocated the file under state/. Idempotent: a no-op when the
+// misplaced file is absent. If the canonical file already exists, the
+// misplaced copy is removed rather than clobbering it.
+func (m *Manager) repairWorldArchive(stateDir string) error {
+	misplaced := filepath.Join(stateDir, "world.pmtiles")
+	if _, err := os.Stat(misplaced); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("repair world archive: stat legacy: %w", err)
+	}
+	canonical := filepath.Join(m.cacheDir, "world.pmtiles")
+	if _, err := os.Stat(canonical); err == nil {
+		if err := os.Remove(misplaced); err != nil {
+			return fmt.Errorf("repair world archive: remove legacy: %w", err)
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("repair world archive: stat target: %w", err)
+	}
+	if err := os.Rename(misplaced, canonical); err != nil {
+		return fmt.Errorf("repair world archive: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #364.

## Root cause

The offline-map slug grammar (`pkg/mapsslug`) is namespaced -- `state/<x>`, `country/<iso2>`, `province/<iso2>/<x>` -- with one bare exception: the single global archive `world`. The region picker hardcodes that `world` slug.

Two startup migrations namespace **legacy** bare slugs, and both predate the world archive (added in #277):

- `Store.MigrateMapsDownloadSlugs` prepends `state/` to any DB slug lacking a `/`.
- `Manager.MigrateLegacyArchives` moves any bare `<x>.pmtiles` into `state/<x>.pmtiles`.

Neither excluded `world`, so on the first restart after downloading the world map, the `world` row and `world.pmtiles` were both rewritten to `state/world`. Offline rendering kept working (row and file moved together), but the picker's `statusOf('world')` lookup then missed -- so it showed a **Download** button for an already-downloaded world map. That also matches the report that the world map still works, still appears in the downloaded-maps list, and is still deletable there.

## Fix

- Skip the `world` slug in both migrations so a fresh download is never mis-namespaced.
- Repair already-affected installs: rename an existing `state/world` DB row and `state/world.pmtiles` file back to `world` (with the same collision handling the migrations already use).
- Tests for both the DB and file paths (untouched `world`, repaired `state/world`, idempotency).
- New invariant documented in `docs/wiki/invariants.md`.

Backend-only; the frontend was already correct.