### PR TITLE
Show lost-connection indicator instead of fabricated data (#365)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1063,3 +1063,46 @@ RX only once it is heard directly again.
 Source: [`../../pkg/stationcache/memcache.go`](../../pkg/stationcache/memcache.go) (`updateMetadata`, `isDirectRF`, `rfRank`);
 [`../../pkg/webapi/stations.go`](../../pkg/webapi/stations.go) (`StationDTO.LastDirectHeard`);
 [`../../web/src/lib/map/direct-rx-core.js`](../../web/src/lib/map/direct-rx-core.js) (`directHeardWithin`).
+
+## REST client surfaces a lost connection; it does not fabricate data in production
+
+A genuine network failure (a thrown `fetch`) in the legacy REST client
+[`web/src/lib/api.js`](../../web/src/lib/api.js) falls back to canned mock
+data **only when `import.meta.env.DEV` is true**. In a production build Vite
+replaces that to `false`, so the mock branch is dead code (tree-shaken out)
+and a thrown `fetch` instead `throw`s `ApiError(0, …)` and calls
+`markDisconnected()`. Any response received -- even a 4xx/5xx -- calls
+`markConnected()`, since it proves the server is reachable.
+
+Both `api.js` and the live-map data store
+[`web/src/lib/map/data-store.svelte.js`](../../web/src/lib/map/data-store.svelte.js)
+report into the shared store
+[`web/src/lib/stores/connection.js`](../../web/src/lib/stores/connection.js)
+(`online`, `markConnected`, `markDisconnected`). The store is plain
+`svelte/store` `writable`, **not** a `$state` runes module, because `api.js`
+is imported by `node --test`, which has no Svelte compiler. Screens read
+`online` to swap stale values for `--` placeholders and a lost-connection
+indicator: the Dashboard clears `status`/`position`/`packets` and shows a red
+banner; the APRS Logs screen shows a red "error" dot and no entries; the map
+status bar shows the red "error" dot. The data store's `start()` seeds
+`pollingState` from `get(online)` so switching *to* the map after the
+connection was already lost shows "error" immediately rather than a
+misleading green "live" dot.
+
+*Why:* before GH #365, a disconnected browser silently rendered the dev mock
+channels (`VHF APRS`/`9600 Data`), mock position (`35.0N 106.0W`), and mock
+beacons as if they were live, with a green status dot -- the operator had no
+way to tell the connection was lost.
+
+*How to apply:* never evaluate `import.meta.env.DEV` at module top level in
+`api.js` (it is `undefined` under `node --test` and would break import);
+keep the check inside the `catch`. Only flip the connection store to offline
+on a genuine network failure -- in the data store that means gating
+`markDisconnected()` on `e instanceof TypeError`, since the manual
+HTTP-status `throw`s come from a reachable server.
+
+Source: [`../../web/src/lib/api.js`](../../web/src/lib/api.js),
+[`../../web/src/lib/stores/connection.js`](../../web/src/lib/stores/connection.js),
+[`../../web/src/lib/map/data-store.svelte.js`](../../web/src/lib/map/data-store.svelte.js),
+[`../../web/src/routes/Dashboard.svelte`](../../web/src/routes/Dashboard.svelte),
+[`../../web/src/routes/Logs.svelte`](../../web/src/routes/Logs.svelte).

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1068,9 +1068,10 @@ Source: [`../../pkg/stationcache/memcache.go`](../../pkg/stationcache/memcache.g
 
 A genuine network failure (a thrown `fetch`) in the legacy REST client
 [`web/src/lib/api.js`](../../web/src/lib/api.js) falls back to canned mock
-data **only when `import.meta.env.DEV` is true**. In a production build Vite
-replaces that to `false`, so the mock branch is dead code (tree-shaken out)
-and a thrown `fetch` instead `throw`s `ApiError(0, …)` and calls
+data **only when `import.meta.env?.DEV` is truthy**. In a production build
+Vite resolves that to `false`, so the mock branch is dead code (`getMockData`
+and the whole mock dataset are tree-shaken out -- verified by grepping the
+built bundle) and a thrown `fetch` instead `throw`s `ApiError(0, …)` and calls
 `markDisconnected()`. Any response received -- even a 4xx/5xx -- calls
 `markConnected()`, since it proves the server is reachable.
 
@@ -1094,12 +1095,14 @@ channels (`VHF APRS`/`9600 Data`), mock position (`35.0N 106.0W`), and mock
 beacons as if they were live, with a green status dot -- the operator had no
 way to tell the connection was lost.
 
-*How to apply:* never evaluate `import.meta.env.DEV` at module top level in
-`api.js` (it is `undefined` under `node --test` and would break import);
-keep the check inside the `catch`. Only flip the connection store to offline
-on a genuine network failure -- in the data store that means gating
-`markDisconnected()` on `e instanceof TypeError`, since the manual
-HTTP-status `throw`s come from a reachable server.
+*How to apply:* use `import.meta.env?.DEV` (optional chaining) so the check
+is safe under `node --test`, where `import.meta.env` is `undefined` -- there
+it reads falsy, exercising the production throw path. `api.test.js` covers
+this with a rejected-fetch case asserting `ApiError(0)` and `online === false`.
+Only flip the connection store to offline on a genuine network failure -- in
+the data store that means gating `markDisconnected()` on `e instanceof
+TypeError`, since the manual HTTP-status `throw`s (incl. 401) come from a
+reachable server and already ran `markConnected()`.
 
 Source: [`../../web/src/lib/api.js`](../../web/src/lib/api.js),
 [`../../web/src/lib/stores/connection.js`](../../web/src/lib/stores/connection.js),

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -43,7 +43,7 @@ async function request(method, path, body = null) {
     // the UI stays explorable. In a production build a thrown fetch means
     // the browser genuinely lost contact with the server, so surface it as
     // an error instead of fabricating live-looking data (GH #365).
-    if (import.meta.env.DEV) {
+    if (import.meta.env?.DEV) {
       return getMockData(method, path, body);
     }
     throw new ApiError(0, { error: 'Connection to the server was lost' });

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -2,6 +2,7 @@
 // Returns mock data when the API is unreachable (dev without backend).
 
 import { getBearerToken } from './androidBridge.js';
+import { markConnected, markDisconnected } from './stores/connection.js';
 
 const MOCK_DELAY = 200;
 
@@ -34,11 +35,21 @@ async function request(method, path, body = null) {
   try {
     res = await fetch(`/api${path}`, opts);
   } catch {
-    // Genuine network failure (dev without backend, DNS, CORS). HTTP
-    // errors from a reachable backend must NOT fall through here —
-    // they need to surface so pages can render their error state.
-    return getMockData(method, path, body);
+    // Genuine network failure (DNS, CORS, server unreachable). HTTP errors
+    // from a reachable backend do NOT land here — they surface below so
+    // pages can render their own error state.
+    markDisconnected();
+    // Dev convenience: with no backend running, fall back to mock data so
+    // the UI stays explorable. In a production build a thrown fetch means
+    // the browser genuinely lost contact with the server, so surface it as
+    // an error instead of fabricating live-looking data (GH #365).
+    if (import.meta.env.DEV) {
+      return getMockData(method, path, body);
+    }
+    throw new ApiError(0, { error: 'Connection to the server was lost' });
   }
+  // Any response — even a 4xx/5xx — proves the server is reachable.
+  markConnected();
   if (res.status === 401) {
     if (getBearerToken() !== null) {
       // Android: no login route. The bearer token is per-launch and

--- a/web/src/lib/api.test.js
+++ b/web/src/lib/api.test.js
@@ -1,7 +1,9 @@
 import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { get } from 'svelte/store';
 import { _resetForTests as resetBridge } from './androidBridge.js';
 import { api } from './api.js';
+import { online, markConnected } from './stores/connection.js';
 
 // api.js reads globalThis.fetch and window.location.hash. Provide a
 // minimal window+location shim before importing it; tests reset the
@@ -35,4 +37,20 @@ test('does NOT redirect on 401 when Android bridge is present', async () => {
   globalThis.fetch = () => Promise.resolve(new Response('{}', { status: 401 }));
   await assert.rejects(() => api.get('/version'));
   assert.notEqual(globalThis.window.location.hash, '#/login');
+});
+
+test('network failure marks disconnected and throws ApiError (no fabricated data)', async () => {
+  // A thrown fetch is a genuine lost connection. import.meta.env is undefined
+  // under node --test, so import.meta.env?.DEV is falsy here — exactly the
+  // production path: no mock fallback, surface the error, flip the store.
+  markConnected();
+  assert.equal(get(online), true);
+  globalThis.fetch = () => Promise.reject(new TypeError('Failed to fetch'));
+  await assert.rejects(() => api.get('/status'), (err) => {
+    assert.equal(err.name, 'ApiError');
+    assert.equal(err.status, 0);
+    return true;
+  });
+  assert.equal(get(online), false);
+  markConnected();
 });

--- a/web/src/lib/map/data-store.svelte.js
+++ b/web/src/lib/map/data-store.svelte.js
@@ -205,9 +205,12 @@ export function createDataStore() {
       console.error('[data-store] poll error:', e);
       backoff = Math.min(backoff * 2, POLL_MAX_MS);
       pollingState = 'error';
-      // A thrown fetch (TypeError) is a genuine network failure; the manual
-      // HTTP-status throws above are from a reachable server, so don't let
-      // those flip the shared connection state to offline.
+      // Only a thrown fetch (a TypeError in every browser) is a genuine
+      // network failure. The manual HTTP-status throws above (incl. 401)
+      // come from a reachable server — markConnected() already ran for them
+      // right after fetch resolved — so they must NOT flip the shared
+      // connection state to offline, even though they still show 'error'
+      // locally on the map status bar.
       if (e instanceof TypeError) markDisconnected();
     } finally {
       inFlight = false;

--- a/web/src/lib/map/data-store.svelte.js
+++ b/web/src/lib/map/data-store.svelte.js
@@ -22,6 +22,8 @@
 
 import { SvelteMap } from 'svelte/reactivity';
 import { clockOffset } from './clock-offset.svelte.js';
+import { get } from 'svelte/store';
+import { online, markConnected, markDisconnected } from '../stores/connection.js';
 
 const POLL_BASE_MS = 5_000;
 const POLL_MAX_MS = 60_000;
@@ -156,6 +158,10 @@ export function createDataStore() {
         headers,
       });
 
+      // The fetch resolved, so the server is reachable — even a 4xx/5xx
+      // response clears a prior lost-connection state (GH #365).
+      markConnected();
+
       // Refresh the server-clock offset from the host-stamped Date header on
       // every response (200 and 304 both carry it).
       clockOffset.observe(res.headers);
@@ -199,6 +205,10 @@ export function createDataStore() {
       console.error('[data-store] poll error:', e);
       backoff = Math.min(backoff * 2, POLL_MAX_MS);
       pollingState = 'error';
+      // A thrown fetch (TypeError) is a genuine network failure; the manual
+      // HTTP-status throws above are from a reachable server, so don't let
+      // those flip the shared connection state to offline.
+      if (e instanceof TypeError) markDisconnected();
     } finally {
       inFlight = false;
     }
@@ -295,7 +305,11 @@ export function createDataStore() {
     if (started) return;
     started = true;
     backoff = POLL_BASE_MS;
-    pollingState = 'polling';
+    // If the app already knows it's offline (e.g. the operator switched to
+    // the map after losing the connection on another screen), show the error
+    // state up front rather than a misleading green "live" dot until the
+    // first poll fails (GH #365).
+    pollingState = get(online) ? 'polling' : 'error';
 
     if (typeof document !== 'undefined') {
       visibilityHandler = onVisibility;

--- a/web/src/lib/stores/connection.js
+++ b/web/src/lib/stores/connection.js
@@ -1,0 +1,27 @@
+// Tracks whether this browser currently has contact with the Graywolf
+// server. The REST client (lib/api.js) and the live-map data store both
+// report into this store: a genuine network failure (fetch throws) marks
+// the connection lost; any response from the server -- even an HTTP error --
+// proves the server is reachable and marks it restored.
+//
+// Screens read `online` to swap stale/fabricated data for placeholder
+// dashes and a prominent lost-connection indicator instead of silently
+// rendering the last-known values as if they were live (GH #365).
+//
+// Plain svelte/store (not a runes module) on purpose: lib/api.js imports
+// this, and lib/api.js is loaded by node --test, which has no Svelte
+// compiler to resolve $state. A writable works in both contexts.
+
+import { writable } from 'svelte/store';
+
+// Optimistic: assume connected until a fetch actually fails, so first paint
+// doesn't flash a disconnect indicator before any request has run.
+export const online = writable(true);
+
+export function markConnected() {
+  online.set(true);
+}
+
+export function markDisconnected() {
+  online.set(false);
+}

--- a/web/src/lib/stores/connection.test.js
+++ b/web/src/lib/stores/connection.test.js
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { get } from 'svelte/store';
+import { online, markConnected, markDisconnected } from './connection.js';
+
+test('starts optimistic (online) so first paint has no disconnect flash', () => {
+  assert.equal(get(online), true);
+});
+
+test('markDisconnected / markConnected flip the shared online flag', () => {
+  markDisconnected();
+  assert.equal(get(online), false);
+  markConnected();
+  assert.equal(get(online), true);
+});

--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { Button, Box } from '@chrissnell/chonky-ui';
   import { api } from '../lib/api.js';
+  import { online } from '../lib/stores/connection.js';
   import { formatAltitude, formatSpeed } from '../lib/settings/units.js';
   import { beaconLabel } from '../lib/beaconLabel.js';
   import PageHeader from '../components/PageHeader.svelte';
@@ -15,8 +16,21 @@
   let audioDevices = $state([]);
   let pollTimer = $state(null);
 
+  let offline = $derived(!$online);
+
   let hasInput = $derived(audioDevices.some(d => d.direction === 'input'));
   let hasOutput = $derived(audioDevices.some(d => d.direction === 'output'));
+
+  // When contact with the server is lost, the polled values we hold are
+  // stale — drop them so the cards fall back to placeholder dashes instead
+  // of presenting the last-known numbers as if they were live (GH #365).
+  $effect(() => {
+    if (!$online) {
+      status = null;
+      position = null;
+      packets = [];
+    }
+  });
 
   let totalRx = $derived(status?.channels?.reduce((sum, ch) => sum + (ch.rx_frames || 0), 0) ?? 0);
   let totalTx = $derived(status?.channels?.reduce((sum, ch) => sum + (ch.tx_frames || 0), 0) ?? 0);
@@ -167,16 +181,25 @@
 
 <PageHeader title="Dashboard" subtitle="Live station overview" />
 
-<div class="readiness-row">
-  <div class="ready-chip" class:ok={hasInput}>
-    <span class="ready-dot">{hasInput ? '\u25CF' : '\u25CB'}</span>
-    <span>RX {hasInput ? 'Ready' : 'No Input'}</span>
+{#if offline}
+  <div class="conn-lost" role="alert">
+    <span class="conn-dot"></span>
+    <span>Connection to the Graywolf server lost. Live data is unavailable until the connection is restored.</span>
   </div>
-  <div class="ready-chip" class:ok={hasOutput}>
-    <span class="ready-dot">{hasOutput ? '\u25CF' : '\u25CB'}</span>
-    <span>TX Audio {hasOutput ? 'Ready' : 'No Output'}</span>
+{/if}
+
+{#if !offline}
+  <div class="readiness-row">
+    <div class="ready-chip" class:ok={hasInput}>
+      <span class="ready-dot">{hasInput ? '\u25CF' : '\u25CB'}</span>
+      <span>RX {hasInput ? 'Ready' : 'No Input'}</span>
+    </div>
+    <div class="ready-chip" class:ok={hasOutput}>
+      <span class="ready-dot">{hasOutput ? '\u25CF' : '\u25CB'}</span>
+      <span>TX Audio {hasOutput ? 'Ready' : 'No Output'}</span>
+    </div>
   </div>
-</div>
+{/if}
 
 <!-- Channel Cards -->
 <div class="channel-grid">
@@ -231,22 +254,22 @@
       </div>
     {/each}
   {:else}
-    <div class="ch-card"><span class="text-muted">No channels configured</span></div>
+    <div class="ch-card"><span class="text-muted">{offline ? 'No data — connection lost' : 'No channels configured'}</span></div>
   {/if}
 </div>
 
 <!-- Station Summary -->
 <div class="stats-grid">
   <div class="stat-card">
-    <span class="stat-value">{totalRx}</span>
+    <span class="stat-value">{offline ? '—' : totalRx}</span>
     <span class="stat-label">Packets RX</span>
   </div>
   <div class="stat-card">
-    <span class="stat-value">{totalTx}</span>
+    <span class="stat-value">{offline ? '—' : totalTx}</span>
     <span class="stat-label">Packets TX</span>
   </div>
   <div class="stat-card">
-    <span class="stat-value">{igated}</span>
+    <span class="stat-value">{offline ? '—' : igated}</span>
     <span class="stat-label">iGated</span>
   </div>
   <div class="stat-card">
@@ -284,6 +307,29 @@
 </div>
 
 <style>
+  /* ── lost-connection banner ───────────────────── */
+  .conn-lost {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    margin-bottom: 16px;
+    border: 1px solid var(--color-danger);
+    border-radius: var(--radius);
+    background: var(--color-danger-muted, rgba(248, 81, 73, 0.15));
+    color: var(--color-danger);
+    font-size: 14px;
+    font-weight: 600;
+  }
+  .conn-dot {
+    width: 10px;
+    height: 10px;
+    flex: none;
+    border-radius: 50%;
+    background: var(--color-danger);
+    box-shadow: 0 0 8px var(--color-danger);
+  }
+
   /* ── readiness row ────────────────────────────── */
   .readiness-row {
     display: flex;

--- a/web/src/routes/Logs.svelte
+++ b/web/src/routes/Logs.svelte
@@ -70,7 +70,11 @@
   async function loadPackets() {
     try {
       packets = await api.get(`/packets?limit=${limit}`) || [];
-    } catch (_) { /* mock fallback */ }
+    } catch (_) {
+      // On a lost connection api.get throws; the `offline` state (driven by
+      // the connection store) renders the error indicator, and the $effect
+      // above clears any stale packets.
+    }
     loading = false;
   }
 

--- a/web/src/routes/Logs.svelte
+++ b/web/src/routes/Logs.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { Button, Input, Select, Box } from '@chrissnell/chonky-ui';
   import { api } from '../lib/api.js';
+  import { online } from '../lib/stores/connection.js';
   import PageHeader from '../components/PageHeader.svelte';
   import PacketLogViewer from '../components/PacketLogViewer.svelte';
   import { parseDisplay } from '../lib/packetColumns.js';
@@ -24,6 +25,15 @@
   let dirFilter = $state('all');
   let limit = $state('100');
   let loading = $state(true);
+
+  let offline = $derived(!$online);
+
+  // Drop the held packets when contact is lost so the viewer shows no
+  // entries alongside the error indicator, rather than a frozen log that
+  // looks current (GH #365).
+  $effect(() => {
+    if (!$online) packets = [];
+  });
 
   const dirOptions = [
     { value: 'all', label: 'All' },
@@ -100,6 +110,9 @@
 </script>
 
 <PageHeader title="APRS Logs" subtitle="Packet log viewer with filter/search">
+  <span class="conn-status" class:error={offline} aria-live="polite">
+    <span class="conn-dot"></span>{offline ? 'error' : 'live'}
+  </span>
   <Button onclick={loadPackets} disabled={loading}>Refresh</Button>
   <Button onclick={exportCsv}>Export CSV</Button>
 </PageHeader>
@@ -124,7 +137,9 @@
 </Box>
 
 <div style="margin-top: 12px;">
-  {#if loading}
+  {#if offline}
+    <Box><div class="empty">No log entries — connection to the Graywolf server lost.</div></Box>
+  {:else if loading}
     <Box><div class="empty">Loading...</div></Box>
   {:else if filtered.length === 0}
     <Box><div class="empty">No packets match filter</div></Box>
@@ -142,6 +157,28 @@
 </div>
 
 <style>
+  .conn-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-success);
+  }
+  .conn-status.error { color: var(--color-danger); }
+  .conn-status .conn-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--color-success);
+  }
+  .conn-status.error .conn-dot {
+    background: var(--color-danger);
+    box-shadow: 0 0 8px var(--color-danger);
+  }
+
   .filter-bar { display: flex; gap: 10px; flex-wrap: wrap; }
   .filter-input { flex: 1; min-width: 200px; }
   .filter-select { width: 140px; }


### PR DESCRIPTION
Fixes #365.

## Problem

When the browser loses its network connection to the Graywolf server, the legacy REST client (`web/src/lib/api.js`) silently fell back to **dev mock data** on any thrown `fetch`. In production that meant a disconnected Dashboard/Logs rendered fake channels (`VHF APRS` / `9600 Data`), a fake position (`35.0N 106.0W`), and fake beacons -- with a green "live" dot -- so the operator had no way to tell contact had been lost.

## Fix

- **`lib/api.js`**: the mock fallback is now gated on `import.meta.env.DEV`. Vite replaces this with `false` in production, so `getMockData` is dead code and tree-shaken out of the bundle. A genuine network failure now `throw`s and marks the connection lost; any response received (even 4xx/5xx) marks it reachable.
- **`lib/stores/connection.js`** (new): a shared `svelte/store` writable (`online` + `markConnected`/`markDisconnected`) that `api.js` and the live-map data store report into. Plain store, not a runes module, because `api.js` is imported by `node --test`.
- **Dashboard**: prominent red lost-connection banner; stats and channel cards fall back to `--` placeholders when offline.
- **APRS Logs**: red "error" dot in the header and no log entries when offline.
- **Map**: `data-store.svelte.js` `start()` seeds `pollingState` from the connection store, so switching *to* the map after the connection was already lost shows the red "error" dot immediately instead of a misleading green "live"/"idle" dot.

## Verification

- `npm run build` succeeds; confirmed `getMockData` and the mock dataset are tree-shaken from the production bundle.
- `npm test` -- 364 pass / 0 fail (added a unit test for the connection store).
- Wiki invariant added documenting the dev-only mock fallback and the shared connection store.