### PR TITLE
Fix ALSA capture flood on pre-t64 armv7l (#336)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 [[package]]
 name = "alsa"
 version = "0.11.0"
-source = "git+https://github.com/chrissnell/alsa-rs?rev=bd0668715753072e3ef74097a1bd65e96845fa7b#bd0668715753072e3ef74097a1bd65e96845fa7b"
+source = "git+https://github.com/chrissnell/alsa-rs?rev=56099e8915af95f322d6eeca3a24da5d7c7098e4#56099e8915af95f322d6eeca3a24da5d7c7098e4"
 dependencies = [
  "alsa-sys",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,13 @@ resolver = "2"
 # htstamp accessors into a 16-byte buffer so the C call cannot overflow --
 # without compiling for time64, so the armhf binary still links against the
 # (pre-t64) cross toolchain and keeps running on older 32-bit systems too.
+#
+# This rev also fixes the inverse regression (issue #336): the buffer decode
+# assumed the time64 layout unconditionally and returned garbage on pre-t64
+# (time32) libasound, flooding cpal with "get_htstamp was earlier than
+# get_trigger_htstamp" errors. The decode is now ABI-aware, so one time32
+# binary is correct on both pre-t64 and t64 userlands.
 # See docs/plans/2026-06-11-armhf-t64-alsa-htstamp-fix.md. Drop once the fix
 # is released upstream.
 [patch.crates-io]
-alsa = { git = "https://github.com/chrissnell/alsa-rs", rev = "bd0668715753072e3ef74097a1bd65e96845fa7b" }
+alsa = { git = "https://github.com/chrissnell/alsa-rs", rev = "56099e8915af95f322d6eeca3a24da5d7c7098e4" }

--- a/docs/plans/2026-06-11-armhf-t64-alsa-htstamp-fix.md
+++ b/docs/plans/2026-06-11-armhf-t64-alsa-htstamp-fix.md
@@ -296,3 +296,27 @@ The actual t64 overflow only manifests under Layer 2 (QEMU) / Layer 3 (hardware)
 - **`get_audio_htstamp` width.** Audio htstamp is also a `timespec` in alsa-rs;
   same 16-byte treatment. Confirm there is no other `Status` accessor returning a
   bare `timespec` that cpal touches (current alsa-rs: just the three).
+
+---
+
+## Postscript: the inverse regression (#336)
+
+The 16-byte buffer landed in fork rev `bd06687`, but its decode assumed the
+**time64 layout unconditionally** (`tv_sec` i64 @0, `tv_nsec` i32 @8). Section 5
+above bet that the decoded value was "wrong but unused" on time32 systems --
+that bet was wrong. cpal's ALSA backend *derives and validates* `htstamp -
+trigger_htstamp` internally before handing over the (ignored) `InputCallbackInfo`,
+so the garbage decode on a **pre-t64 / time32** `libasound` (Ubuntu 22.04 armv7l,
+glibc 2.35) produced a flood of `get_htstamp was earlier than
+get_trigger_htstamp` errors and endless stream rebuilds. Reported as #336.
+
+Fix (fork rev `56099e8`, pinned in `Cargo.toml`): decode per ABI. 64-bit targets
+read the native 16-byte layout; 32-bit targets recover `tv_sec` at offset 0 and
+take `tv_nsec` from the t64 slot (@8) when non-zero, else the time32 slot (@4).
+The buffer is zeroed before the C call, so the unwritten tail is deterministic
+and a single time32 binary is correct on **both** pre-t64 and t64 userlands.
+Unit tests cover both layouts (alsa-rs PR #1).
+
+Test-gap note: the original plan added only a t64 canary (Layer 2). A time32 /
+pre-t64 canary is still missing and is what would have caught this -- worth
+adding alongside the t64 one.


### PR DESCRIPTION
Fixes #336.

## Problem
The t64 ALSA fix (#231) shipped a forked `alsa-rs` that reads the htstamp into a 16-byte buffer to stop the time64 stack overflow, but it **decoded that buffer assuming the time64 layout unconditionally**. On a pre-t64 (time32) `libasound` -- Ubuntu 22.04 armv7l, glibc 2.35, e.g. Rockchip RV1106 -- the C call writes only 8 bytes, so the decode folded `nsec` into `tv_sec` and returned garbage. cpal's ALSA backend derives and validates `htstamp - trigger_htstamp` internally, so the garbage flooded the log with `get_htstamp was earlier than get_trigger_htstamp` and rebuilt the capture stream in a loop.

## Fix
Bumps the `alsa-rs` fork pin to rev `56099e8` (chrissnell/alsa-rs#1), whose decode is ABI-aware: 64-bit targets read the native 16-byte layout; 32-bit targets recover `tv_sec` at offset 0 and take `tv_nsec` from the t64 slot (@8) when non-zero, else the time32 slot (@4). The buffer is zeroed before the C call, so a single time32 binary is now correct on **both** pre-t64 and t64 userlands -- no separate artifacts, no toolchain change.

## Verification
- `cargo check` on the modem against the new rev: clean.
- alsa-rs compiles on both a 64-bit (x86_64) and a 32-bit (i686) target, exercising both decode branches.
- New unit tests in the fork cover the time32 and t64 layouts plus the zero-nsec edge.

## Compatibility
| target | time_t | before | after |
|---|---|---|---|
| 32-bit pre-t64 (Ubuntu 22.04 armv7l) | 32 | error flood + rebuild loop | correct |
| 32-bit t64 (current Pi OS) | 64 | works | works |
| arm64 / x86_64 | 64 | works | works |

## Follow-up
The original plan added only a t64 QEMU canary; a pre-t64 (time32) canary -- which would have caught this -- is still missing and worth adding alongside it.
