### PR TITLE
Move APRS log target/zoom icon to left of station name

### DIFF
--- a/web/src/components/PacketLogViewer.svelte
+++ b/web/src/components/PacketLogViewer.svelte
@@ -96,7 +96,6 @@
 {#snippet srcDstCell(_value, entry)}
   {@const calls = parseDisplay(entry)}
   <span class="pkt-srcdst">
-    <span class="pkt-src">{calls.src || '—'}</span>
     {#if entry.lat != null && entry.lon != null}
       <a
         class="pkt-locate"
@@ -114,6 +113,7 @@
         </svg>
       </a>
     {/if}
+    <span class="pkt-src">{calls.src || '—'}</span>
     <span class="pkt-arrow" aria-hidden="true">→</span>
     <span class="pkt-dst">{calls.dst || '—'}</span>
   </span>
@@ -210,7 +210,7 @@
     flex-shrink: 0;
   }
 
-  /* Scope-reticle locate button: sits right after the source callsign on any
+  /* Scope-reticle locate button: sits just before the source callsign on any
      packet that carries coordinates. Dim by default like the inspect loupe,
      brightening on hover/focus so it stays quiet until the operator wants it. */
   .pkt-locate {


### PR DESCRIPTION
Moves the scope-reticle locate icon in the APRS packet log so it sits to the left of the source callsign instead of the right. The icon still only renders for packets that carry coordinates and behaves identically; only its position in the source/destination cell changed.

Resolves GRA-176.