### PR TITLE
Map status bar: show error indicator when offline at mount (#374)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1106,9 +1106,12 @@ built bundle) and a thrown `fetch` instead `throw`s `ApiError(0, …)` and calls
 `markDisconnected()`. Any response received -- even a 4xx/5xx -- calls
 `markConnected()`, since it proves the server is reachable.
 
-Both `api.js` and the live-map data store
-[`web/src/lib/map/data-store.svelte.js`](../../web/src/lib/map/data-store.svelte.js)
-report into the shared store
+`api.js`, the live-map data store
+[`web/src/lib/map/data-store.svelte.js`](../../web/src/lib/map/data-store.svelte.js),
+and the basemap component
+[`web/src/lib/map/maplibre-map.svelte`](../../web/src/lib/map/maplibre-map.svelte)
+(its `fetchUpstreamStyle`, which uses a raw `fetch`, not `api.js`) all report
+into the shared store
 [`web/src/lib/stores/connection.js`](../../web/src/lib/stores/connection.js)
 (`online`, `markConnected`, `markDisconnected`). The store is plain
 `svelte/store` `writable`, **not** a `$state` runes module, because `api.js`
@@ -1116,10 +1119,18 @@ is imported by `node --test`, which has no Svelte compiler. Screens read
 `online` to swap stale values for `--` placeholders and a lost-connection
 indicator: the Dashboard clears `status`/`position`/`packets` and shows a red
 banner; the APRS Logs screen shows a red "error" dot and no entries; the map
-status bar shows the red "error" dot. The data store's `start()` seeds
-`pollingState` from `get(online)` so switching *to* the map after the
-connection was already lost shows "error" immediately rather than a
-misleading green "live" dot.
+status bar shows the red "error" dot.
+
+The map status bar (`LiveMapV2.svelte`) derives its dot/label from **both**
+`$online` and `dataStore.pollingState` -- `!$online` forces "error" on its
+own. This is load-bearing, not belt-and-suspenders: when the operator opens
+the map while *already* offline, the basemap style fetch fails, so
+`maplibre-map.svelte` never fires `oncreate`, `dataStore.start()` never runs,
+and `pollingState` stays stuck at its initial `'idle'`. Seeding `pollingState`
+from `get(online)` inside `start()` is therefore *insufficient* on its own
+(it's dead code on that path); the status bar must read `$online` directly so
+it shows "error" rather than a misleading green "idle" dot (GH #374). The
+`start()` seed is still kept for the connected-then-disconnected first paint.
 
 *Why:* before GH #365, a disconnected browser silently rendered the dev mock
 channels (`VHF APRS`/`9600 Data`), mock position (`35.0N 106.0W`), and mock

--- a/web/src/lib/map/maplibre-map.svelte
+++ b/web/src/lib/map/maplibre-map.svelte
@@ -17,6 +17,7 @@
   import { localBoundsStore } from '../maps/local-bounds-store.svelte.js';
   import { createFederatedProtocol } from './sources/gw-federated-protocol.js';
   import { absolutizeStyleUrls } from './style-urls.js';
+  import { markConnected, markDisconnected } from '../stores/connection.js';
 
   let { initialCenter = [-98, 39], initialZoom = 4, oncreate = null } = $props();
 
@@ -85,7 +86,19 @@
   let cachedUpstreamStyle = null;
 
   async function fetchUpstreamStyle() {
-    const res = await fetch(STYLE_URL);
+    let res;
+    try {
+      res = await fetch(STYLE_URL);
+    } catch (e) {
+      // A thrown fetch is a genuine network failure. Surface it to the shared
+      // connection state so the map status bar shows "error" instead of a
+      // stale green dot when the operator opens the map while already offline
+      // and the basemap style can't be loaded (GH #365, #374).
+      if (e instanceof TypeError) markDisconnected();
+      throw e;
+    }
+    // Any response — even a 4xx/5xx — proves the server is reachable.
+    markConnected();
     if (!res.ok) throw new Error(`fetch style: ${res.status}`);
     return await res.json();
   }

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -40,6 +40,7 @@
   import { clockOffset, formatOffsetMagnitude } from '../lib/map/clock-offset.svelte.js';
   import { directHeardWithin } from '../lib/map/direct-rx-core.js';
   import { toasts } from '../lib/stores.js';
+  import { online } from '../lib/stores/connection.js';
   import MapPinPlus from 'lucide-svelte/icons/map-pin-plus';
   import MapPinned from 'lucide-svelte/icons/map-pinned';
   import Copy from 'lucide-svelte/icons/copy';
@@ -913,15 +914,21 @@
     // clock — not the host-corrected serverNow().
     return timeAgo(t.toISOString(), Date.now());
   });
+  // A lost connection forces the error state regardless of pollingState. When
+  // the operator opens the map while already offline, the basemap style fetch
+  // fails, so MaplibreMap never fires `oncreate`, dataStore.start() never runs,
+  // and pollingState is stuck at its initial 'idle' — which would otherwise
+  // render a misleading green dot + "idle". Reading $online directly makes the
+  // status bar honest no matter how the map mounted (GH #365, #374).
   let pollDotClass = $derived(
-    dataStore.pollingState === 'error'
+    !$online || dataStore.pollingState === 'error'
       ? 'error'
       : dataStore.pollingState === 'polling'
         ? 'polling'
         : '',
   );
   let pollLabel = $derived(
-    dataStore.pollingState === 'error'
+    !$online || dataStore.pollingState === 'error'
       ? 'error'
       : dataStore.pollingState === 'polling'
         ? 'live'


### PR DESCRIPTION
Fixes #374. Follow-up to #369.

## Problem

After #369, the Dashboard and APRS Logs screens correctly indicate a lost connection, but switching **to** the live map after the connection was already lost still showed a green dot and "idle".

## Root cause

The map status bar was driven solely by `dataStore.pollingState`. That state only leaves its initial `'idle'` once `dataStore.start()` runs -- and `start()` is only called from `MaplibreMap`'s `oncreate` callback. When the operator opens the map while already offline, the basemap style fetch (`fetchUpstreamStyle`) throws, so `oncreate` never fires, `start()` never runs, and `pollingState` is stuck at `'idle'` (green + "idle"). #369's `start()` seed of `pollingState` from `get(online)` is therefore dead code on that path.

## Fix

- `LiveMapV2.svelte`: derive the status dot/label from `$online` as well -- `!$online` forces the "error" state regardless of the data-store lifecycle, so a lost connection always shows the red dot + "error".
- `maplibre-map.svelte`: the style fetch uses a raw `fetch` (not `api.js`), so on its own it never reported into the connection store. It now calls `markDisconnected()` on a genuine network failure (and `markConnected()` on any response), so the offline state is detected even when the map is the first screen to touch the network.

## Verification

`npm run build` and `npm test` (365 tests) both pass. Wiki invariant #50 updated to document why the status bar must read `$online` directly.
