### PR TITLE
Recommend Serial RTS PTT for Digirig Mobile

### DIFF
--- a/web/src/routes/ptt/devices/methodOptions.desktop.js
+++ b/web/src/routes/ptt/devices/methodOptions.desktop.js
@@ -15,7 +15,7 @@ export const DESKTOP_METHODS = [
     meta: 'No PTT wire — the Digirig Lite keys the radio from a tone on the right channel while the packet audio plays on the left. Set this channel\'s output to the Left channel of a stereo Digirig Lite device.' },
   { wire: { method: 'serial_rts' },
     label: 'Serial RTS',
-    meta: 'USB-serial RTS line keys the radio. Use for FTDI / CP210x / CH340 cables.' },
+    meta: 'USB-serial RTS line keys the radio. The right choice for the Digirig Mobile, and works with FTDI / CP210x / CH340 cables.' },
   { wire: { method: 'serial_dtr' },
     label: 'Serial DTR',
     meta: 'USB-serial DTR line keys the radio. Less common than RTS.' },


### PR DESCRIPTION
Updates the Serial RTS PTT method description in the desktop PTT method selector to call out that it is the correct choice for the Digirig Mobile, while still noting it works with FTDI / CP210x / CH340 cables.