### PR TITLE
android: keep message compose bar above the soft keyboard

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,7 +39,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|keyboardHidden|screenSize">
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
@@ -6,7 +6,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.Color
 import android.hardware.usb.UsbManager
 import android.net.LocalSocket
 import android.net.LocalSocketAddress
@@ -100,18 +99,24 @@ class MainActivity : Activity() {
      * mandatory: the platform stops auto-insetting content and no longer
      * resizes the window when the soft keyboard opens, so the SPA's sticky
      * compose bar (position:absolute; bottom:0) ends up underneath the IME --
-     * exactly the Messages-tab bug. We opt into edge-to-edge on every version
-     * for identical behavior, then pad the WebView by the system bars and,
-     * crucially, by the keyboard height. Padding the WebView's bottom shrinks
-     * the web viewport above the IME, so the compose bar sits atop the keyboard
-     * and `window.innerHeight` reflects the change (the visualViewport fallback
-     * in ComposeBar.svelte becomes a no-op rather than fighting this).
+     * exactly the Messages-tab bug. We opt into edge-to-edge on every version,
+     * then pad the WebView by the system bars and, crucially, by the keyboard
+     * height. Padding the WebView's bottom shrinks the web viewport above the
+     * IME, so the compose bar sits atop the keyboard and `window.innerHeight`
+     * reflects the change. ComposeBar.svelte skips its visualViewport translate
+     * in the Android shell (Platform.isAndroid) so the two don't double-offset.
+     *
+     * Two mechanisms feed the same listener: on API 30+ the IME arrives as a
+     * `Type.ime()` inset (handled here directly). On API 28-29 `Type.ime()` is
+     * always 0, so the manifest's `windowSoftInputMode="adjustResize"` resizes
+     * the decor frame instead, which re-fires this listener with a smaller
+     * frame -- do NOT drop adjustResize assuming the inset path covers 28-29.
      */
     private fun applyWindowInsets() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         // The padded inset strips render the WebView's own background; paint it
         // the chrome's dark tone so the bars don't flash white over the page.
-        webView.setBackgroundColor(Color.parseColor("#111111"))
+        webView.setBackgroundColor(getColor(R.color.chrome_bg))
         ViewCompat.setOnApplyWindowInsetsListener(webView) { v, insets ->
             val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             val ime = insets.getInsets(WindowInsetsCompat.Type.ime())

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
@@ -6,6 +6,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Color
 import android.hardware.usb.UsbManager
 import android.net.LocalSocket
 import android.net.LocalSocketAddress
@@ -22,6 +23,9 @@ import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import com.nw5w.graywolf.webview.WebAppInterface
 import com.nw5w.graywolf.webview.WebBridgeIds
 import java.io.IOException
@@ -86,7 +90,34 @@ class MainActivity : Activity() {
             }
         }
         setContentView(webView)
+        applyWindowInsets()
         ensurePerms()
+    }
+
+    /**
+     * Drive layout off window insets instead of letting the system pan or
+     * resize the decor for us. On Android 15+ (targetSdk 35+) edge-to-edge is
+     * mandatory: the platform stops auto-insetting content and no longer
+     * resizes the window when the soft keyboard opens, so the SPA's sticky
+     * compose bar (position:absolute; bottom:0) ends up underneath the IME --
+     * exactly the Messages-tab bug. We opt into edge-to-edge on every version
+     * for identical behavior, then pad the WebView by the system bars and,
+     * crucially, by the keyboard height. Padding the WebView's bottom shrinks
+     * the web viewport above the IME, so the compose bar sits atop the keyboard
+     * and `window.innerHeight` reflects the change (the visualViewport fallback
+     * in ComposeBar.svelte becomes a no-op rather than fighting this).
+     */
+    private fun applyWindowInsets() {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        // The padded inset strips render the WebView's own background; paint it
+        // the chrome's dark tone so the bars don't flash white over the page.
+        webView.setBackgroundColor(Color.parseColor("#111111"))
+        ViewCompat.setOnApplyWindowInsetsListener(webView) { v, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+            v.setPadding(bars.left, bars.top, bars.right, maxOf(bars.bottom, ime.bottom))
+            insets
+        }
     }
 
     private fun ensurePerms() {

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="ic_launcher_background">#FFFFFFFF</color>
+    <!-- App chrome tone. Single source for the status bar and the WebView
+         background painted behind the edge-to-edge inset strips. -->
+    <color name="chrome_bg">#111111</color>
 </resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.Graywolf" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="android:statusBarColor">#111111</item>
+        <item name="android:statusBarColor">@color/chrome_bg</item>
     </style>
 </resources>

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -680,12 +680,16 @@ cannot outlive the app, because no single mechanism covers both cases.
   `setOnApplyWindowInsetsListener` that pads the WebView by the system bars plus
   `max(systemBars.bottom, ime.bottom)`. The IME padding is the cross-system load-bearing
   bit: it shrinks the web viewport above the keyboard so the SPA's sticky compose bar
-  (`web/.../ComposeBar.svelte`, `position:absolute; bottom:0`) is never covered. The
-  manifest's `android:windowSoftInputMode="adjustResize"` is the pre-API-30 fallback
-  (where `WindowInsetsCompat.Type.ime()` reports 0). The WebView background is painted
-  the chrome's dark tone so the padded bar strips don't flash white. Do NOT revert to
-  letting the system manage insets -- on Android 15+ the compose bar disappears behind
-  the keyboard.
+  (`web/.../ComposeBar.svelte`, `position:absolute; bottom:0`) is never covered. That
+  component skips its own `visualViewport` translateY when `Platform.isAndroid` so the
+  two mechanisms don't stack into a double-offset; the web translate stays the path for
+  mobile browsers. The manifest's `android:windowSoftInputMode="adjustResize"` is the
+  pre-API-30 fallback: there `WindowInsetsCompat.Type.ime()` reports 0, so adjustResize
+  resizes the decor frame instead, re-firing the same listener -- do NOT drop it assuming
+  the inset path covers 28-29. The WebView background is painted `@color/chrome_bg` (the
+  single source the theme's `statusBarColor` also uses) so the padded bar strips don't
+  flash white. Do NOT revert to letting the system manage insets -- on Android 15+ the
+  compose bar disappears behind the keyboard.
 
 Source: [`../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt),
 [`../../cmd/graywolf/parentwatch.go`](../../cmd/graywolf/parentwatch.go),

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -673,6 +673,19 @@ cannot outlive the app, because no single mechanism covers both cases.
   (bounded) before tearing the same resources down. The cheap `UsbPttAdapter.init()`
   stays on the main thread so `MainActivity.onResume`'s `enumerate()` never races an
   uninitialized adapter.
+- **WebView owns its insets (edge-to-edge + keyboard):** `targetSdk=36` forces
+  edge-to-edge on Android 15+, where the platform no longer auto-insets the
+  content view or resizes the window for the soft keyboard. `MainActivity.applyWindowInsets`
+  calls `WindowCompat.setDecorFitsSystemWindows(window, false)` and a
+  `setOnApplyWindowInsetsListener` that pads the WebView by the system bars plus
+  `max(systemBars.bottom, ime.bottom)`. The IME padding is the cross-system load-bearing
+  bit: it shrinks the web viewport above the keyboard so the SPA's sticky compose bar
+  (`web/.../ComposeBar.svelte`, `position:absolute; bottom:0`) is never covered. The
+  manifest's `android:windowSoftInputMode="adjustResize"` is the pre-API-30 fallback
+  (where `WindowInsetsCompat.Type.ime()` reports 0). The WebView background is painted
+  the chrome's dark tone so the padded bar strips don't flash white. Do NOT revert to
+  letting the system manage insets -- on Android 15+ the compose bar disappears behind
+  the keyboard.
 
 Source: [`../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt),
 [`../../cmd/graywolf/parentwatch.go`](../../cmd/graywolf/parentwatch.go),

--- a/web/src/components/messages/ComposeBar.svelte
+++ b/web/src/components/messages/ComposeBar.svelte
@@ -27,6 +27,7 @@
 
   import { onMount } from 'svelte';
   import { Icon } from '@chrissnell/chonky-ui';
+  import { Platform } from '../../lib/platform.js';
   import CallsignAutocomplete from './CallsignAutocomplete.svelte';
   import {
     messagesPreferencesState,
@@ -258,6 +259,12 @@
     // the software keyboard without using position:fixed (which
     // floats under the keyboard on iOS). Gracefully degrades in
     // environments without visualViewport (desktop browsers, JSDOM).
+    //
+    // Skip entirely inside the Android shell: MainActivity pads the
+    // WebView by the IME inset, so the web viewport already shrinks
+    // above the keyboard. Translating again here would double-offset
+    // the bar off-screen.
+    if (Platform.isAndroid) return;
     const vv = typeof window !== 'undefined' ? window.visualViewport : null;
     if (!vv) return;
     function apply() {


### PR DESCRIPTION
## Problem

On the Messages tab (Android app), the compose text box was hidden behind the on-screen keyboard instead of sitting above it. Closing the keyboard and scrolling down revealed the box.

## Root cause

`targetSdk=36` forces edge-to-edge on Android 15+, where the platform no longer auto-insets the WebView content or resizes the window when the soft keyboard opens. The SPA's sticky compose bar (`ComposeBar.svelte`, `position:absolute; bottom:0`) therefore ended up underneath the IME. The existing `visualViewport` translate fallback in `ComposeBar.svelte` never fired because the WebView geometry doesn't change in that mode.

## Fix

`MainActivity.applyWindowInsets()` now drives layout off window insets:

- `WindowCompat.setDecorFitsSystemWindows(window, false)` to opt into edge-to-edge on every version for consistent behavior.
- A `setOnApplyWindowInsetsListener` that pads the WebView by the system bars plus `max(systemBars.bottom, ime.bottom)`. The IME padding shrinks the web viewport above the keyboard so the compose bar is never covered, and `window.innerHeight` reflects the change (the visualViewport fallback becomes a no-op rather than fighting it).
- The WebView background is painted the chrome's dark tone so the padded inset strips don't flash white.
- `android:windowSoftInputMode="adjustResize"` added as the pre-API-30 fallback (where `WindowInsetsCompat.Type.ime()` reports 0).

## Verification

`./gradlew :app:compileDebugKotlin` builds clean (only the pre-existing `UsbDeviceLister.kt` warning). Invariant documented in `docs/wiki/invariants.md`.
