### PR TITLE
Fix Digirig Lite tone PTT greyed out on Android

### DIFF
--- a/web/src/routes/Ptt.svelte
+++ b/web/src/routes/Ptt.svelte
@@ -238,7 +238,10 @@
     if (w === 'vox') return false;
     if (w === 'digirig_tone') return false;
     if (w === 'rigctld') return false;
-    if (w === 'android' && method.wire.ptt_method === 4) return false;
+    // Android ptt_method 4 (VOX) and 5 (Digirig Lite tone) key via audio and
+    // need no serial/HID device — skip the device-selection step, same as
+    // desktop 'vox' and 'digirig_tone' above.
+    if (w === 'android' && (method.wire.ptt_method === 4 || method.wire.ptt_method === 5)) return false;
     return true;
   }
 


### PR DESCRIPTION
## Problem

On a fresh install, the new **Digirig Lite tone PTT** method can't be selected on Android — the operator gets stuck on a device-picker step with no devices and a permanently greyed-out **Save** button.

## Cause

Digirig Lite tone PTT keys the radio with an audio tone and needs no serial/HID device (the same as VOX, and the same as desktop's `digirig_tone`). But `needsDevice()` in `Ptt.svelte` only skipped the device-selection step for Android VOX (`ptt_method 4`), not tone PTT (`ptt_method 5`). Selecting it routed into `DialogChangeDevice`, whose Android device source returns an empty list for any method with no `deviceClass` — so `Save` (gated on a selected device) stayed disabled and the method could never be applied.

The Android methods table already documents that tone PTT carries no `deviceClass`; only the `needsDevice` gate was out of sync.

## Fix

Treat Android `ptt_method 5` like VOX: skip the device step and persist directly. One-line change mirroring the existing desktop `digirig_tone` handling.

All 365 web unit tests pass.