### PR TITLE
Improve button contrast in default theme

### DIFF
--- a/web/themes/graywolf.css
+++ b/web/themes/graywolf.css
@@ -25,10 +25,17 @@
   --color-text-dim: #999999;
   --color-text-inverse: #ffffff;
   --color-accent: #215e21;
-  --color-primary: #ffaa00;
-  --color-primary-hover: #ffbb33;
-  --color-primary-muted: rgba(255, 170, 0, 0.12);
-  --color-primary-fg: #000000;
+  /* Deep orange rather than the bright #ffaa00. --color-primary doubles as a
+     foreground color (links, chonky-ui's outlined btn-primary at rest, message
+     leads/status icons) where bright orange on a light surface fell far below
+     readable contrast (~1.7:1 on the grey button background). #a85500 keeps the
+     orange brand identity while clearing WCAG AA as text on every light surface
+     here (>=4.6:1) and under white fill text (5.3:1) -- matching how the other
+     light themes (grayscale, high-contrast) use a dark primary with white fg. */
+  --color-primary: #a85500;
+  --color-primary-hover: #8a4500;
+  --color-primary-muted: rgba(168, 85, 0, 0.12);
+  --color-primary-fg: #ffffff;
   --color-danger: #c41010;
   --color-danger-hover: #d42020;
   --color-danger-muted: rgba(214, 2, 2, 0.12);


### PR DESCRIPTION
## Problem

In the default **Graywolf** light theme, primary buttons rendered yellow-orange (`#ffaa00`) text on a grey button surface — only **~1.7:1** contrast, hard to read (GRA-186).

The root cause is broader than buttons: `--color-primary` doubles as a foreground color across the app (links via `a { color: var(--color-primary) }`, chonky-ui's outlined `btn-primary` at rest, message leads, status icons). A bright orange works as a *fill* but fails as *text* on light surfaces. Notably, Graywolf was the only light theme using a light primary — `grayscale` (`#333`) and `high-contrast` (`#0b4fb3`) both already use a dark primary with white foreground for exactly this reason.

## Fix

Bring Graywolf in line with its sibling light themes:

| token | before | after |
|---|---|---|
| `--color-primary` | `#ffaa00` | `#a85500` |
| `--color-primary-hover` | `#ffbb33` | `#8a4500` |
| `--color-primary-muted` | `rgba(255,170,0,.12)` | `rgba(168,85,0,.12)` |
| `--color-primary-fg` | `#000000` | `#ffffff` |

Deep orange keeps the brand identity while clearing **WCAG AA** as text on every light surface here:

- `#a85500` on white: **5.30:1**, on surface `#f8f8f8`: **4.99:1**, on button grey `#f0f0f0`: **4.65:1**
- white fill text on `#a85500`: **5.30:1**; on hover `#8a4500`: **7.16:1**

This also fixes the same low-contrast issue everywhere `--color-primary` is used as text (links, conversation/tactical leads, outgoing message bubbles).

`graywolf-night` is untouched — bright orange on its near-black background is already high-contrast (~7:1).

Single-file change scoped to `web/themes/graywolf.css`.