### PR TITLE
Explain how to test keying for VOX / Digirig tone PTT

### DIFF
--- a/web/src/routes/ptt/PttCard.svelte
+++ b/web/src/routes/ptt/PttCard.svelte
@@ -15,6 +15,12 @@
 
   let testing = $state(false);
 
+  // none/vox/digirig_tone have no PTT wire to pulse, so manual "Test PTT"
+  // (key/unkey) does nothing for them. vox and digirig_tone instead key off
+  // the transmit audio — they get a Test TX hint; none gets neither control.
+  let isToneKeyed = $derived(item.method === 'vox' || item.method === 'digirig_tone');
+  let canTestPttWire = $derived(item.method !== 'none' && !isToneKeyed);
+
   async function testPtt() {
     if (!item.channel_id || testing) return;
     testing = true;
@@ -75,7 +81,7 @@
   <div class="device-actions">
     <Button variant="primary" onclick={() => onChangeMethod(item)}>Change Method</Button>
     <Button variant="primary" onclick={() => onChangeDevice(item)}>Change Device</Button>
-    {#if item.method !== 'none' && item.method !== 'vox' && item.method !== 'digirig_tone'}
+    {#if canTestPttWire}
       <Button disabled={testing} onclick={testPtt}>
         {testing ? 'Keying…' : 'Test PTT (1s)'}
       </Button>
@@ -87,7 +93,7 @@
        manual key/unkey) does nothing for them. Rather than show a dead,
        greyed button, point the operator at Test TX, which transmits a tone
        through the audio path and keys the radio the way these methods do. -->
-  {#if item.method === 'vox' || item.method === 'digirig_tone'}
+  {#if isToneKeyed}
     <p class="test-hint">
       No PTT wire to pulse — this method keys the radio from the transmit audio.
       To verify keying, use <strong>Test TX</strong> on the Channels page.

--- a/web/src/routes/ptt/PttCard.svelte
+++ b/web/src/routes/ptt/PttCard.svelte
@@ -75,11 +75,24 @@
   <div class="device-actions">
     <Button variant="primary" onclick={() => onChangeMethod(item)}>Change Method</Button>
     <Button variant="primary" onclick={() => onChangeDevice(item)}>Change Device</Button>
-    <Button disabled={testing || item.method === 'none' || item.method === 'vox' || item.method === 'digirig_tone'} onclick={testPtt}>
-      {testing ? 'Keying…' : 'Test PTT (1s)'}
-    </Button>
+    {#if item.method !== 'none' && item.method !== 'vox' && item.method !== 'digirig_tone'}
+      <Button disabled={testing} onclick={testPtt}>
+        {testing ? 'Keying…' : 'Test PTT (1s)'}
+      </Button>
+    {/if}
     <Button variant="danger" onclick={() => onDelete(item)}>Delete</Button>
   </div>
+
+  <!-- VOX and Digirig tone PTT have no wire to pulse, so "Test PTT" (a
+       manual key/unkey) does nothing for them. Rather than show a dead,
+       greyed button, point the operator at Test TX, which transmits a tone
+       through the audio path and keys the radio the way these methods do. -->
+  {#if item.method === 'vox' || item.method === 'digirig_tone'}
+    <p class="test-hint">
+      No PTT wire to pulse — this method keys the radio from the transmit audio.
+      To verify keying, use <strong>Test TX</strong> on the Channels page.
+    </p>
+  {/if}
 </div>
 
 <style>
@@ -150,5 +163,12 @@
   .device-actions :global(.btn) {
     width: 100%;
     justify-content: center;
+  }
+
+  .test-hint {
+    margin: 10px 0 0;
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.4;
   }
 </style>


### PR DESCRIPTION
## The actual GRA-184 report

The operator's "greyed out" complaint was the **Test PTT (1s)** button on their Digirig tone PTT card — not the method picker (#380) or the recommended-device card (#382).

"Test PTT" manually pulses the PTT *wire*. VOX and Digirig tone PTT have no wire — their modem PTT driver is a no-op (`PttMethod::None | Vox | DigirigTone => NonePtt`), so a manual key/unkey does nothing. The button was therefore hard-disabled for those methods and rendered permanently greyed, which reads as a broken control.

## Fix

For VOX and Digirig tone PTT, drop the inert Test PTT button and show a short hint instead:

> No PTT wire to pulse — this method keys the radio from the transmit audio. To verify keying, use **Test TX** on the Channels page.

That points operators at the control that actually works for these methods: **Test TX** (`POST /channels/{id}/test-tx`) transmits a tone through the full TX path, so the Digirig keys the radio via its companion-channel tone exactly as it does on a real packet. Wire-keyed methods (serial RTS/DTR, GPIO, CM108, rigctld) keep the Test PTT button unchanged.

Template/style-only change in `PttCard.svelte`. All 365 web tests pass; component compiles clean.

## Context

This is the on-target fix for the operator's report. The two earlier PRs address adjacent, real-but-separate confusions surfaced while tracing this down: #380 (Android tone-PTT flow dead-end) and #382 (greyed "recommended" device card when all channels are configured).