### PR TITLE
Surface non-printable bytes in the APRS packet log (GH #376)

### DIFF
--- a/web/src/components/PacketLogViewer.svelte
+++ b/web/src/components/PacketLogViewer.svelte
@@ -156,7 +156,7 @@
   <div class="pkt-foot">
     <code class="pkt-raw">{#each displaySegments(entry.display) as seg}{#if seg.ctrl}<span
           class="pkt-ctrl"
-          title={`non-printable byte 0x${seg.code.toString(16).padStart(2, '0')}`}
+          title={seg.title}
         >{seg.label}</span>{:else}{seg.text}{/if}{/each}</code>
     {#if inspectable && entry.raw}
       <button

--- a/web/src/components/PacketLogViewer.svelte
+++ b/web/src/components/PacketLogViewer.svelte
@@ -20,6 +20,7 @@
     formatTime,
     packetToEntry,
     audioLevel,
+    displaySegments,
   } from '../lib/packetColumns.js';
   import PacketInspector from './PacketInspector.svelte';
 
@@ -153,7 +154,10 @@
 
 {#snippet rawPacketFooter(entry)}
   <div class="pkt-foot">
-    <code class="pkt-raw">{entry.display || ''}</code>
+    <code class="pkt-raw">{#each displaySegments(entry.display) as seg}{#if seg.ctrl}<span
+          class="pkt-ctrl"
+          title={`non-printable byte 0x${seg.code.toString(16).padStart(2, '0')}`}
+        >{seg.label}</span>{:else}{seg.text}{/if}{/each}</code>
     {#if inspectable && entry.raw}
       <button
         type="button"
@@ -342,6 +346,18 @@
     white-space: normal;
     overflow-wrap: anywhere;
     word-break: break-all;
+  }
+
+  /* Non-printable byte token (e.g. <0x7f>): rendered inline in the raw line
+     with a distinct danger tint and chip so it can never be mistaken for
+     literal text that happens to read "<0x7f>". See GH #376. */
+  .pkt-ctrl {
+    color: var(--color-danger);
+    background: color-mix(in srgb, var(--color-danger) 14%, transparent);
+    border-radius: 2px;
+    padding: 0 2px;
+    font-weight: 700;
+    white-space: nowrap;
   }
 
   /* Subtle inspect affordance: dim by default, only brightens on

--- a/web/src/lib/packetColumns.js
+++ b/web/src/lib/packetColumns.js
@@ -115,11 +115,16 @@ export function directionToLevel(direction) {
  * from text that merely happens to read "<0x7f>".
  *
  * Returns an array of segments: `{ text }` for a printable run, or
- * `{ ctrl: true, code, label }` for one non-printable byte. A code point is
- * treated as non-printable when it is a C0 control (< 0x20), DEL (0x7F), a C1
- * control (0x80–0x9F), or U+FFFD (the replacement char marking a byte mangled
- * in transit). Ordinary higher Unicode — accented status text and the like —
- * is left in the printable run untouched.
+ * `{ ctrl: true, code, label, title }` for one non-printable byte. A code point
+ * is treated as non-printable when it is a C0 control (< 0x20), DEL (0x7F), a C1
+ * control (0x80–0x9F), or U+FFFD. In practice the two forms that reach the
+ * browser are DEL/C0 (valid single-byte UTF-8, passed through Go's json.Marshal
+ * untouched) and U+FFFD — the replacement char Go substitutes for any byte that
+ * is not valid UTF-8, which is how most corrupted high bytes actually arrive.
+ * The literal C1 range (0x80–0x9F) is only reachable if a payload carried those
+ * code points as valid 2-byte UTF-8; it is kept defensively rather than because
+ * the current backend emits it. Ordinary higher Unicode — accented status text
+ * and the like — is left in the printable run untouched.
  */
 export function displaySegments(str) {
   const out = [];
@@ -135,7 +140,11 @@ export function displaySegments(str) {
     const ctrl = cp < 0x20 || cp === 0x7f || (cp >= 0x80 && cp <= 0x9f) || cp === 0xfffd;
     if (ctrl) {
       flush();
-      out.push({ ctrl: true, code: cp, label: `<0x${cp.toString(16).padStart(2, '0')}>` });
+      const title =
+        cp === 0xfffd
+          ? 'invalid byte (replaced with U+FFFD in transit)'
+          : `non-printable byte 0x${cp.toString(16).padStart(2, '0')}`;
+      out.push({ ctrl: true, code: cp, label: `<0x${cp.toString(16).padStart(2, '0')}>`, title });
     } else {
       run += ch;
     }

--- a/web/src/lib/packetColumns.js
+++ b/web/src/lib/packetColumns.js
@@ -106,6 +106,45 @@ export function directionToLevel(direction) {
 }
 
 /**
+ * Split a packet display string into printable runs and individual
+ * non-printable bytes for the log line. APRS payloads should be plain
+ * printable ASCII, but a malformed packet can carry control bytes — most
+ * famously a 0x7F (DEL) wedged into a position report (GH #376) that renders
+ * invisibly yet silently breaks map plotting. We surface each one as a styled
+ * `<0x7f>` token (aprs.fi's convention) so the caller can colour it distinctly
+ * from text that merely happens to read "<0x7f>".
+ *
+ * Returns an array of segments: `{ text }` for a printable run, or
+ * `{ ctrl: true, code, label }` for one non-printable byte. A code point is
+ * treated as non-printable when it is a C0 control (< 0x20), DEL (0x7F), a C1
+ * control (0x80–0x9F), or U+FFFD (the replacement char marking a byte mangled
+ * in transit). Ordinary higher Unicode — accented status text and the like —
+ * is left in the printable run untouched.
+ */
+export function displaySegments(str) {
+  const out = [];
+  let run = '';
+  const flush = () => {
+    if (run) {
+      out.push({ text: run });
+      run = '';
+    }
+  };
+  for (const ch of str || '') {
+    const cp = ch.codePointAt(0);
+    const ctrl = cp < 0x20 || cp === 0x7f || (cp >= 0x80 && cp <= 0x9f) || cp === 0xfffd;
+    if (ctrl) {
+      flush();
+      out.push({ ctrl: true, code: cp, label: `<0x${cp.toString(16).padStart(2, '0')}>` });
+    } else {
+      run += ch;
+    }
+  }
+  flush();
+  return out;
+}
+
+/**
  * Project a raw packet into a Chonky LogEntry. Adds the `level` field
  * (so Chonky's level→class mapping picks up direction colour) without
  * mutating the original packet. The original direction is preserved on

--- a/web/src/lib/packetColumns.test.js
+++ b/web/src/lib/packetColumns.test.js
@@ -58,7 +58,7 @@ test('displaySegments: 0x7F (DEL) becomes a styled <0x7f> token', () => {
   const segs = displaySegments('K7XYZ>APRS:!47\x7f12.34N');
   assert.deepEqual(segs, [
     { text: 'K7XYZ>APRS:!47' },
-    { ctrl: true, code: 0x7f, label: '<0x7f>' },
+    { ctrl: true, code: 0x7f, label: '<0x7f>', title: 'non-printable byte 0x7f' },
     { text: '12.34N' },
   ]);
 });
@@ -66,29 +66,30 @@ test('displaySegments: 0x7F (DEL) becomes a styled <0x7f> token', () => {
 test('displaySegments: C0 control bytes are flagged with 2-digit hex', () => {
   assert.deepEqual(displaySegments('a\x00b\x1fc'), [
     { text: 'a' },
-    { ctrl: true, code: 0x00, label: '<0x00>' },
+    { ctrl: true, code: 0x00, label: '<0x00>', title: 'non-printable byte 0x00' },
     { text: 'b' },
-    { ctrl: true, code: 0x1f, label: '<0x1f>' },
+    { ctrl: true, code: 0x1f, label: '<0x1f>', title: 'non-printable byte 0x1f' },
     { text: 'c' },
   ]);
 });
 
 test('displaySegments: consecutive non-printables each get their own token', () => {
   assert.deepEqual(displaySegments('\x01\x02'), [
-    { ctrl: true, code: 0x01, label: '<0x01>' },
-    { ctrl: true, code: 0x02, label: '<0x02>' },
+    { ctrl: true, code: 0x01, label: '<0x01>', title: 'non-printable byte 0x01' },
+    { ctrl: true, code: 0x02, label: '<0x02>', title: 'non-printable byte 0x02' },
   ]);
 });
 
 test('displaySegments: C1 controls and U+FFFD are flagged, ordinary Unicode is not', () => {
   // Accented status text and emoji stay in the printable run...
   assert.deepEqual(displaySegments('café'), [{ text: 'café' }]);
-  // ...but C1 control (U+0085) and the replacement char are surfaced.
+  // ...but a C1 control (U+0085) and the replacement char are surfaced; U+FFFD
+  // marks a byte Go could not encode as valid UTF-8, so its tooltip says so.
   assert.deepEqual(displaySegments('xy�z'), [
     { text: 'x' },
-    { ctrl: true, code: 0x85, label: '<0x85>' },
+    { ctrl: true, code: 0x85, label: '<0x85>', title: 'non-printable byte 0x85' },
     { text: 'y' },
-    { ctrl: true, code: 0xfffd, label: '<0xfffd>' },
+    { ctrl: true, code: 0xfffd, label: '<0xfffd>', title: 'invalid byte (replaced with U+FFFD in transit)' },
     { text: 'z' },
   ]);
 });
@@ -96,7 +97,7 @@ test('displaySegments: C1 controls and U+FFFD are flagged, ordinary Unicode is n
 test('displaySegments: space and tab are treated correctly (space printable, tab not)', () => {
   assert.deepEqual(displaySegments('a b\tc'), [
     { text: 'a b' },
-    { ctrl: true, code: 0x09, label: '<0x09>' },
+    { ctrl: true, code: 0x09, label: '<0x09>', title: 'non-printable byte 0x09' },
     { text: 'c' },
   ]);
 });

--- a/web/src/lib/packetColumns.test.js
+++ b/web/src/lib/packetColumns.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { audioLevel } from './packetColumns.js';
+import { audioLevel, displaySegments } from './packetColumns.js';
 
 test('audioLevel: null when the packet carries no audio_level', () => {
   assert.equal(audioLevel({}), null);
@@ -41,4 +41,62 @@ test('audioLevel: mark/space fall back to level_dbfs when absent', () => {
   const r = audioLevel({ audio_level: { level_dbfs: -12 } });
   assert.equal(r.mark, -12);
   assert.equal(r.space, -12);
+});
+
+test('displaySegments: all-printable text is one run', () => {
+  assert.deepEqual(displaySegments('K7XYZ>APRS:!hello'), [{ text: 'K7XYZ>APRS:!hello' }]);
+});
+
+test('displaySegments: empty / null input yields no segments', () => {
+  assert.deepEqual(displaySegments(''), []);
+  assert.deepEqual(displaySegments(null), []);
+  assert.deepEqual(displaySegments(undefined), []);
+});
+
+// The motivating case from GH #376: a 0x7F (DEL) wedged into a beacon.
+test('displaySegments: 0x7F (DEL) becomes a styled <0x7f> token', () => {
+  const segs = displaySegments('K7XYZ>APRS:!47\x7f12.34N');
+  assert.deepEqual(segs, [
+    { text: 'K7XYZ>APRS:!47' },
+    { ctrl: true, code: 0x7f, label: '<0x7f>' },
+    { text: '12.34N' },
+  ]);
+});
+
+test('displaySegments: C0 control bytes are flagged with 2-digit hex', () => {
+  assert.deepEqual(displaySegments('a\x00b\x1fc'), [
+    { text: 'a' },
+    { ctrl: true, code: 0x00, label: '<0x00>' },
+    { text: 'b' },
+    { ctrl: true, code: 0x1f, label: '<0x1f>' },
+    { text: 'c' },
+  ]);
+});
+
+test('displaySegments: consecutive non-printables each get their own token', () => {
+  assert.deepEqual(displaySegments('\x01\x02'), [
+    { ctrl: true, code: 0x01, label: '<0x01>' },
+    { ctrl: true, code: 0x02, label: '<0x02>' },
+  ]);
+});
+
+test('displaySegments: C1 controls and U+FFFD are flagged, ordinary Unicode is not', () => {
+  // Accented status text and emoji stay in the printable run...
+  assert.deepEqual(displaySegments('café'), [{ text: 'café' }]);
+  // ...but C1 control (U+0085) and the replacement char are surfaced.
+  assert.deepEqual(displaySegments('xy�z'), [
+    { text: 'x' },
+    { ctrl: true, code: 0x85, label: '<0x85>' },
+    { text: 'y' },
+    { ctrl: true, code: 0xfffd, label: '<0xfffd>' },
+    { text: 'z' },
+  ]);
+});
+
+test('displaySegments: space and tab are treated correctly (space printable, tab not)', () => {
+  assert.deepEqual(displaySegments('a b\tc'), [
+    { text: 'a b' },
+    { ctrl: true, code: 0x09, label: '<0x09>' },
+    { text: 'c' },
+  ]);
 });


### PR DESCRIPTION
Closes #376.

## Problem
Non-printable bytes in a received APRS packet render invisibly in the log line. A real failure from the field: a `0x7F` (DEL) wedged into a position beacon prevented map plotting, with nothing on screen to explain why.

## Change
The raw packet line in the APRS log now surfaces each non-printable byte inline as a distinctly-styled `<0x7f>` token (aprs.fi's convention), so it can never be confused with literal text that happens to read `<0x7f>`. Legitimate text and ordinary higher Unicode (e.g. accented status text) are left untouched.

`displaySegments()` (in `web/src/lib/packetColumns.js`) splits the display string into printable runs and individual non-printable bytes — C0 controls (`< 0x20`), DEL (`0x7F`), C1 controls (`0x80`–`0x9F`), and the `U+FFFD` replacement char that marks a byte mangled in transit. The token carries a `title` tooltip with the exact hex value and is rendered with a danger-tinted chip in `PacketLogViewer.svelte`.

The Packet Inspector's hex/ASCII dump remains the faithful byte-level tool for deeper diagnosis; this change makes the problem visible at a glance in the log itself.

## Tests
Added unit coverage for `displaySegments` (13 cases incl. the 0x7F beacon case, consecutive control bytes, C1/U+FFFD, and that accented text and spaces stay printable). `node --test src/lib/packetColumns.test.js` passes.