### PR TITLE
Surface Mic-E mobile-beacon comments (GH #377)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1168,3 +1168,33 @@ Source: [`../../web/src/lib/api.js`](../../web/src/lib/api.js),
 [`../../web/src/lib/map/data-store.svelte.js`](../../web/src/lib/map/data-store.svelte.js),
 [`../../web/src/routes/Dashboard.svelte`](../../web/src/routes/Dashboard.svelte),
 [`../../web/src/routes/Logs.svelte`](../../web/src/routes/Logs.svelte).
+
+### 51. The stationcache reads `pkt.Comment`, so every parser must mirror its free-form text there
+
+*Why:* `pkg/stationcache/extract.go` (`buildStationEntry`) takes the
+displayed comment from `pkt.Comment` only -- it never reaches into the
+per-type sub-structs. Most parsers (position, object, item) already
+write their trailing text to `DecodedAPRSPacket.Comment` (or the
+sub-struct's `Comment`, which `ExtractEntry` forwards). Mic-E is the
+trap: `parseMicE` decodes the comment into `MicE.Status` and, before
+GH #377, stopped there -- so mobile-beacon comments like
+"KK4CUK Matt's Cozy" decoded correctly yet rendered blank in the UI
+while aprs.fi showed them. The fix copies `mic.Status` into
+`pkt.Comment` at the end of `parseMicE`. Any new packet type that
+carries human-readable trailing text must populate `pkt.Comment` (or a
+sub-struct `Comment` that `ExtractEntry` forwards); decoding it into a
+private field alone makes it invisible downstream.
+
+Mic-E corollary: the comment tail on real Byonics/McTracker mobile
+beacons is `<text>|<base91 telemetry>|!<DAO>!|3`. `stripMicEPipeTelemetry`
+removes each `|...|` block non-greedily (a greedy first-to-last sweep
+ate the DAO and left a stray "3"), then drops a lone unterminated `|`
+opener; `extractDAO` then consumes the `!DAO!`.
+
+Source: [`../../pkg/aprs/mice.go`](../../pkg/aprs/mice.go)
+(`parseMicE`, `stripMicEPipeTelemetry`),
+[`../../pkg/aprs/dao.go`](../../pkg/aprs/dao.go) (`extractDAO`),
+[`../../pkg/stationcache/extract.go`](../../pkg/stationcache/extract.go)
+(`buildStationEntry`),
+[`../../pkg/aprs/mice_test.go`](../../pkg/aprs/mice_test.go)
+(`TestParseMicECommentSurfaced`).

--- a/pkg/aprs/mice.go
+++ b/pkg/aprs/mice.go
@@ -171,6 +171,12 @@ func parseMicE(pkt *DecodedAPRSPacket, info []byte, frame *ax25.Frame) error {
 	mic.Status = extractDAO(&mic.Position, mic.Status)
 
 	pkt.MicE = &mic
+	// Surface the decoded free-form text as the packet-level comment.
+	// Mic-E carries its comment in MicE.Status, but the stationcache and
+	// every other downstream consumer read pkt.Comment — without this
+	// copy the comment on mobile beacons (e.g. "KK4CUK Matt's Cozy")
+	// silently vanished even though aprs.fi showed it (GH #377).
+	pkt.Comment = mic.Status
 	// Present MicE as a position packet for downstream consumers.
 	pkt.Position = &Position{
 		Latitude:  mic.Position.Latitude,
@@ -278,21 +284,34 @@ func decodeMicEDest(dest string) (lat float64, msgCode int, nsSign float64, lonO
 	return
 }
 
-// stripMicEPipeTelemetry removes an APRS base-91 telemetry block
-// ("|...|", APRS101 ch 13) from the middle or tail of a Mic-E comment
-// and returns the comment with any adjacent whitespace tidied up. We
-// don't currently decode the telemetry values themselves.
+// stripMicEPipeTelemetry removes APRS base-91 telemetry blocks
+// ("|...|", APRS101 ch 13) from a Mic-E comment and returns the comment
+// with any adjacent whitespace tidied up. We don't currently decode the
+// telemetry values themselves.
+//
+// Each "|...|" pair is matched non-greedily, left to right: a greedy
+// first-pipe-to-last-pipe sweep over a comment like
+// "text|tlm|!DAO!|3" swallows the DAO (so extractDAO never sees it) and
+// leaves the trailing "3" stranded as bogus comment text. Real
+// Byonics/McTracker mobile beacons emit exactly that shape, which is
+// what made GH #377's comments render as e.g. "KK4CUK Matt's Cozy3".
 func stripMicEPipeTelemetry(comment string) string {
-	first := strings.IndexByte(comment, '|')
-	if first < 0 {
-		return comment
+	for {
+		open := strings.IndexByte(comment, '|')
+		if open < 0 {
+			break
+		}
+		rel := strings.IndexByte(comment[open+1:], '|')
+		if rel < 0 {
+			// A lone, unterminated '|': a telemetry-block opener the
+			// radio truncated (the "|3" tail on the GH #377 beacons).
+			// No human comment follows it, so drop to end of string.
+			comment = comment[:open]
+			break
+		}
+		comment = comment[:open] + comment[open+1+rel+1:]
 	}
-	last := strings.LastIndexByte(comment, '|')
-	if last <= first {
-		return comment
-	}
-	out := comment[:first] + comment[last+1:]
-	return strings.TrimSpace(out)
+	return strings.TrimSpace(comment)
 }
 
 // isMicESymTable reports whether c is a valid APRS symbol table

--- a/pkg/aprs/mice.go
+++ b/pkg/aprs/mice.go
@@ -187,6 +187,7 @@ func parseMicE(pkt *DecodedAPRSPacket, info []byte, frame *ax25.Frame) error {
 		Altitude:  mic.Position.Altitude,
 		HasAlt:    mic.Position.HasAlt,
 		Symbol:    mic.Position.Symbol,
+		DAODatum:  mic.Position.DAODatum,
 	}
 	pkt.Type = PacketMicE
 	return nil
@@ -295,6 +296,11 @@ func decodeMicEDest(dest string) (lat float64, msgCode int, nsSign float64, lonO
 // leaves the trailing "3" stranded as bogus comment text. Real
 // Byonics/McTracker mobile beacons emit exactly that shape, which is
 // what made GH #377's comments render as e.g. "KK4CUK Matt's Cozy3".
+//
+// APRS101 ch 13 reserves '|' for telemetry framing, so by design a lone
+// unterminated '|' is treated as a truncated telemetry opener and the
+// rest of the string is dropped — a bare '|' is not expected in
+// human-readable Mic-E status text.
 func stripMicEPipeTelemetry(comment string) string {
 	for {
 		open := strings.IndexByte(comment, '|')

--- a/pkg/aprs/mice_test.go
+++ b/pkg/aprs/mice_test.go
@@ -458,6 +458,13 @@ func TestParseMicECommentSurfaced(t *testing.T) {
 			if pkt.MicE.Status != tc.want {
 				t.Errorf("MicE.Status = %q, want %q", pkt.MicE.Status, tc.want)
 			}
+			// All three beacons carry a base-91 DAO ("!w..!") wedged
+			// between the telemetry block and the trailing remnant. The
+			// strip rework exists precisely so extractDAO still consumes
+			// it — assert the precision was applied, not merely deleted.
+			if pkt.Position.DAODatum != 'W' {
+				t.Errorf("DAODatum = %q, want 'W' (DAO not applied)", pkt.Position.DAODatum)
+			}
 		})
 	}
 }

--- a/pkg/aprs/mice_test.go
+++ b/pkg/aprs/mice_test.go
@@ -417,3 +417,47 @@ func TestMicE_EndToEnd_Issue219(t *testing.T) {
 		t.Errorf("lon = %.4f, want ~-106.6752", pkt.Position.Longitude)
 	}
 }
+
+// TestParseMicECommentSurfaced covers GH #377: a mobile beacon's
+// free-form comment ("KK4CUK Matt's Cozy") was decoded into MicE.Status
+// but never copied to pkt.Comment, so the stationcache and the mobile
+// UI showed nothing even though aprs.fi displayed it. The trailing
+// "|...|!DAO!|3" telemetry/DAO/remnant tail these Byonics/McTracker
+// radios emit must be stripped cleanly — a greedy pipe sweep used to
+// leave a stray "3" on the end. The companion packets carrying only
+// telemetry (no human text) must surface an empty comment, not "3".
+func TestParseMicECommentSurfaced(t *testing.T) {
+	cases := []struct {
+		name string
+		dest string
+		info string
+		want string
+	}{
+		{"comment", "S7TP0U", "`qa4.RI'/'\"M)}KK4CUK Matt's Cozy|!>&@'j|!w<(!|3", "KK4CUK Matt's Cozy"},
+		{"telemetry_only_a", "S7RW2Q", "`q4o-fG'/'\"O#}|!;&A'm|!wi@!|3", ""},
+		{"telemetry_only_b", "S7TT4S", "`q[m.RF'/'\"Jp}|!?&D'j|!woI!|3", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src, _ := ax25.ParseAddress("N9825W")
+			dst, _ := ax25.ParseAddress(tc.dest)
+			f, err := ax25.NewUIFrame(src, dst, nil, []byte(tc.info))
+			if err != nil {
+				t.Fatal(err)
+			}
+			pkt, err := Parse(f)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pkt.MicE == nil {
+				t.Fatal("expected Mic-E packet")
+			}
+			if pkt.Comment != tc.want {
+				t.Errorf("pkt.Comment = %q, want %q", pkt.Comment, tc.want)
+			}
+			if pkt.MicE.Status != tc.want {
+				t.Errorf("MicE.Status = %q, want %q", pkt.MicE.Status, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Mobile beacons did not display their comment text in Graywolf, even though aprs.fi showed the same comment for the same beacon (GH #377). Example: callsign N9825W's beacons carry the comment "KK4CUK Matt's Cozy", visible on aprs.fi but blank in Graywolf.

## Root cause

These are Mic-E packets. `parseMicE` correctly decodes the free-form comment into `MicE.Status`, but never copies it to `DecodedAPRSPacket.Comment`. The stationcache (`buildStationEntry`) and everything downstream of it read `pkt.Comment` only -- so the decoded comment was silently dropped before it reached the UI.

A second, smaller bug: `stripMicEPipeTelemetry` used a greedy first-pipe-to-last-pipe sweep. On the real comment tail these Byonics/McTracker radios emit -- `<text>|<base91 telemetry>|!<DAO>!|3` -- that sweep ate the DAO and left a stray `3` glued to the comment (e.g. "KK4CUK Matt's Cozy3").

## Fix

- Copy `mic.Status` into `pkt.Comment` at the end of `parseMicE`.
- Rework `stripMicEPipeTelemetry` to remove each `|...|` telemetry block non-greedily and drop a trailing unterminated `|` opener, so `extractDAO` still sees the `!DAO!` and no remnant survives.

## Verification

Added `TestParseMicECommentSurfaced`, driven by the exact packets from issue #377:

| Destination | Decoded comment |
|---|---|
| S7TP0U | `KK4CUK Matt's Cozy` |
| S7RW2Q | (empty -- telemetry only) |
| S7TT4S | (empty -- telemetry only) |

Full `pkg/aprs`, `pkg/stationcache`, `pkg/webapi`, `pkg/beacon`, and `pkg/igate` suites pass; `go build ./...` clean.

Wiki invariant 51 added documenting the "parsers must mirror free-form text into `pkg.Comment`" contract that this bug violated.

Closes #377
