### PR TITLE
Tone down non-printable byte tokens in the packet log

### DIFF
--- a/web/src/components/PacketLogViewer.svelte
+++ b/web/src/components/PacketLogViewer.svelte
@@ -348,15 +348,16 @@
     word-break: break-all;
   }
 
-  /* Non-printable byte token (e.g. <0x7f>): rendered inline in the raw line
-     with a distinct danger tint and chip so it can never be mistaken for
-     literal text that happens to read "<0x7f>". See GH #376. */
-  .pkt-ctrl {
+  /* Non-printable byte token (e.g. <0x7f>): flagged with the danger colour so
+     it reads distinctly from text that merely happens to spell "<0x7f>", but
+     kept as plain inline text -- no background, no chip. Chonky ships
+     `.log-body span { display: block }`, which would otherwise stack each token
+     on its own full-width line; the parent-child selector outweighs it after
+     Svelte scoping so `display: inline` wins. See GH #376. */
+  .pkt-raw .pkt-ctrl {
+    display: inline;
     color: var(--color-danger);
-    background: color-mix(in srgb, var(--color-danger) 14%, transparent);
-    border-radius: 2px;
-    padding: 0 2px;
-    font-weight: 700;
+    font-weight: 600;
     white-space: nowrap;
   }
 


### PR DESCRIPTION
Follow-up to #384 based on UI feedback: the `<0x..>` tokens looked heavy — each one rendered on its own line with a full-bleed pink background.

## Cause
Chonky ships `.log-body span { display: block }`, so the token `<span>`s (bare spans in the log footer) became full-width block elements. That stacked each token on its own line and stretched the background tint across the whole row.

## Change
- Token is now plain inline text: danger colour + semibold for distinction, **no background, no chip, no padding**.
- Forced back inline via `.pkt-raw .pkt-ctrl { display: inline }` — the parent-child selector outweighs `.log-body span` after Svelte scoping.

Printable text and the inline flow are unchanged; the byte still reads distinctly from text that merely spells `<0x7f>`, per the original #376 request — just quietly.