### PR TITLE
Add a Hex bytes toggle for non-printable bytes in the packet log

### DIFF
--- a/docs/handbook/logs.html
+++ b/docs/handbook/logs.html
@@ -100,7 +100,8 @@
       <li>The <strong>type filter</strong> at the top narrows the table to a single packet kind (mic-e, position, weather, telemetry, object, status, third-party, message, &hellip;).</li>
       <li><strong>Auto-refresh</strong> &mdash; on by default, the page polls for new packets every couple of seconds. Turn it off to freeze the list so the rows you&rsquo;re reading stop changing while you study a packet path; the Refresh button still pulls the latest on demand.</li>
       <li><strong>Auto-scroll</strong> &mdash; on by default, the view follows new packets to the bottom. Turn it off to keep your scroll position put as packets arrive, then use the Jump to bottom control when you want to catch up.</li>
-      <li>The entry count under the controls shows how many rows you&rsquo;re looking at. Both toggles are remembered per device, so a phone can stay frozen while a desktop keeps tailing.</li>
+      <li><strong>Hex bytes</strong> &mdash; off by default. Turn it on to surface non-printable bytes in the raw packet line as styled <code>&lt;0x7f&gt;</code> hex tokens, handy when a stray control character (for example a <code>0x7F</code> wedged into a position report) is breaking map plotting. Left off, the line reads as ordinary text.</li>
+      <li>The entry count under the controls shows how many rows you&rsquo;re looking at. The toggles are remembered per device, so a phone can stay frozen while a desktop keeps tailing.</li>
     </ul>
 
     <p>

--- a/docs/handbook/logs.html
+++ b/docs/handbook/logs.html
@@ -100,7 +100,7 @@
       <li>The <strong>type filter</strong> at the top narrows the table to a single packet kind (mic-e, position, weather, telemetry, object, status, third-party, message, &hellip;).</li>
       <li><strong>Auto-refresh</strong> &mdash; on by default, the page polls for new packets every couple of seconds. Turn it off to freeze the list so the rows you&rsquo;re reading stop changing while you study a packet path; the Refresh button still pulls the latest on demand.</li>
       <li><strong>Auto-scroll</strong> &mdash; on by default, the view follows new packets to the bottom. Turn it off to keep your scroll position put as packets arrive, then use the Jump to bottom control when you want to catch up.</li>
-      <li><strong>Hex bytes</strong> &mdash; off by default. Turn it on to surface non-printable bytes in the raw packet line as styled <code>&lt;0x7f&gt;</code> hex tokens, handy when a stray control character (for example a <code>0x7F</code> wedged into a position report) is breaking map plotting. Left off, the line reads as ordinary text.</li>
+      <li><strong>Non-ASCII data</strong> &mdash; off by default. Turn it on to surface non-printable bytes in the raw packet line as styled <code>&lt;0x7f&gt;</code> hex tokens, handy when a stray control character (for example a <code>0x7F</code> wedged into a position report) is breaking map plotting. Left off, the line reads as ordinary text.</li>
       <li>The entry count under the controls shows how many rows you&rsquo;re looking at. The toggles are remembered per device, so a phone can stay frozen while a desktop keeps tailing.</li>
     </ul>
 

--- a/web/src/components/PacketLogViewer.svelte
+++ b/web/src/components/PacketLogViewer.svelte
@@ -363,15 +363,16 @@
     word-break: break-all;
   }
 
-  /* Non-printable byte token (e.g. <0x7f>): rendered inline in the raw line
-     with a distinct danger tint and chip so it can never be mistaken for
-     literal text that happens to read "<0x7f>". See GH #376. */
-  .pkt-ctrl {
+  /* Non-printable byte token (e.g. <0x7f>): flagged with the danger colour so
+     it reads distinctly from text that merely happens to spell "<0x7f>", but
+     kept as plain inline text -- no background, no chip. Chonky ships
+     `.log-body span { display: block }`, which would otherwise stack each token
+     on its own full-width line; the parent-child selector outweighs it after
+     Svelte scoping so `display: inline` wins. See GH #376. */
+  .pkt-raw .pkt-ctrl {
+    display: inline;
     color: var(--color-danger);
-    background: color-mix(in srgb, var(--color-danger) 14%, transparent);
-    border-radius: 2px;
-    padding: 0 2px;
-    font-weight: 700;
+    font-weight: 600;
     white-space: nowrap;
   }
 

--- a/web/src/components/PacketLogViewer.svelte
+++ b/web/src/components/PacketLogViewer.svelte
@@ -36,6 +36,11 @@
     // the Logs route's auto-refresh / auto-scroll controls). Forwarded to
     // Chonky's LogViewer; see its LogToolbarToggle type.
     toolbarToggles = undefined,
+    // Surface non-printable bytes in the raw packet line as styled <0x7f>
+    // hex tokens (GH #376). Off by default so the line reads as clean text;
+    // the Logs/Dashboard toolbars bind this to an operator toggle for when
+    // a malformed packet needs diagnosing.
+    showNonPrintable = false,
     showHeader = true,
     mobileBreakpoint = '768px',
     // When set, each packet with a raw frame gets a subtle inspect affordance
@@ -162,10 +167,10 @@
 
 {#snippet rawPacketFooter(entry)}
   <div class="pkt-foot">
-    <code class="pkt-raw">{#each displaySegments(entry.display) as seg}{#if seg.ctrl}<span
+    <code class="pkt-raw">{#if showNonPrintable}{#each displaySegments(entry.display) as seg}{#if seg.ctrl}<span
           class="pkt-ctrl"
           title={seg.title}
-        >{seg.label}</span>{:else}{seg.text}{/if}{/each}</code>
+        >{seg.label}</span>{:else}{seg.text}{/if}{/each}{:else}{entry.display}{/if}</code>
     {#if inspectable && entry.raw}
       <button
         type="button"

--- a/web/src/lib/settings/log-prefs-store.svelte.js
+++ b/web/src/lib/settings/log-prefs-store.svelte.js
@@ -9,12 +9,17 @@
 //                 operator is reading stops changing.
 //   autoScroll  — follow new packets to the bottom of the viewer.
 //                 Off keeps the scroll position put as packets arrive.
+//   showNonPrintable — surface non-printable bytes in the raw packet line
+//                 as styled <0x7f> hex tokens (GH #376). Off by default:
+//                 ordinary operators see clean text, and only those
+//                 diagnosing a malformed packet opt into the noise.
 //
-// Both default on, preserving the prior always-live behavior for anyone
-// who never opens the toggles.
+// autoRefresh / autoScroll default on, preserving the prior always-live
+// behavior; showNonPrintable defaults off.
 
 const LS_AUTO_REFRESH = 'aprs-log-auto-refresh';
 const LS_AUTO_SCROLL = 'aprs-log-auto-scroll';
+const LS_SHOW_NONPRINTABLE = 'aprs-log-show-nonprintable';
 
 function readBool(key, dflt) {
   try {
@@ -32,10 +37,12 @@ function writeBool(key, v) {
 export const logPrefsState = (() => {
   let autoRefresh = $state(readBool(LS_AUTO_REFRESH, true));
   let autoScroll = $state(readBool(LS_AUTO_SCROLL, true));
+  let showNonPrintable = $state(readBool(LS_SHOW_NONPRINTABLE, false));
 
   return {
     get autoRefresh() { return autoRefresh; },
     get autoScroll() { return autoScroll; },
+    get showNonPrintable() { return showNonPrintable; },
     setAutoRefresh(v) {
       autoRefresh = !!v;
       writeBool(LS_AUTO_REFRESH, autoRefresh);
@@ -43,6 +50,10 @@ export const logPrefsState = (() => {
     setAutoScroll(v) {
       autoScroll = !!v;
       writeBool(LS_AUTO_SCROLL, autoScroll);
+    },
+    setShowNonPrintable(v) {
+      showNonPrintable = !!v;
+      writeBool(LS_SHOW_NONPRINTABLE, showNonPrintable);
     },
   };
 })();

--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -72,7 +72,7 @@
       title: 'Follow new packets to the bottom',
     },
     {
-      label: 'Hex bytes',
+      label: 'Non-ASCII data',
       checked: logPrefsState.showNonPrintable,
       onChange: (v) => logPrefsState.setShowNonPrintable(v),
       title: 'Show non-printable bytes as <0x7f> hex tokens',

--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -71,6 +71,12 @@
       onChange: (v) => logPrefsState.setAutoScroll(v),
       title: 'Follow new packets to the bottom',
     },
+    {
+      label: 'Hex bytes',
+      checked: logPrefsState.showNonPrintable,
+      onChange: (v) => logPrefsState.setShowNonPrintable(v),
+      title: 'Show non-printable bytes as <0x7f> hex tokens',
+    },
   ]);
 
   onMount(() => {
@@ -325,6 +331,7 @@
       live={logPrefsState.autoRefresh}
       autoscroll={logPrefsState.autoScroll}
       {toolbarToggles}
+      showNonPrintable={logPrefsState.showNonPrintable}
       showHeader
       mobileBreakpoint="768px"
     />

--- a/web/src/routes/Logs.svelte
+++ b/web/src/routes/Logs.svelte
@@ -101,6 +101,12 @@
       onChange: (v) => logPrefsState.setAutoScroll(v),
       title: 'Follow new packets to the bottom',
     },
+    {
+      label: 'Hex bytes',
+      checked: logPrefsState.showNonPrintable,
+      onChange: (v) => logPrefsState.setShowNonPrintable(v),
+      title: 'Show non-printable bytes as <0x7f> hex tokens',
+    },
   ]);
 
   let filtered = $derived.by(() => {
@@ -179,6 +185,7 @@
       live={logPrefsState.autoRefresh}
       autoscroll={logPrefsState.autoScroll}
       {toolbarToggles}
+      showNonPrintable={logPrefsState.showNonPrintable}
       showHeader
       mobileBreakpoint="768px"
       inspectable

--- a/web/src/routes/Logs.svelte
+++ b/web/src/routes/Logs.svelte
@@ -102,7 +102,7 @@
       title: 'Follow new packets to the bottom',
     },
     {
-      label: 'Hex bytes',
+      label: 'Non-ASCII data',
       checked: logPrefsState.showNonPrintable,
       onChange: (v) => logPrefsState.setShowNonPrintable(v),
       title: 'Show non-printable bytes as <0x7f> hex tokens',


### PR DESCRIPTION
Follow-up to the non-printable byte work (#384) based on UI feedback: surfacing every `<0x7f>` token is noise for everyday log reading and only matters when chasing a malformed packet. This gates the tokens behind an operator toggle, **off by default**, built on the toggle infrastructure from #386 (now merged).

## Change
- New device-local pref `showNonPrintable` in `log-prefs-store` (localStorage `aprs-log-show-nonprintable`), defaulting **off** — unlike auto-refresh/auto-scroll which default on.
- A compact **Hex bytes** toggle in the log viewer toolbar (Logs page and Dashboard feed), next to Auto-refresh / Auto-scroll. Short label so the toolbar stays tidy.
- `PacketLogViewer` takes a `showNonPrintable` prop: when on, the raw line renders the styled `<0x7f>` tokens (current behavior); when off, it renders the display string as plain text. State is shared, so the choice carries between Logs and Dashboard.

## Default behavior
With the toggle off (the default), the packet log reads as ordinary text — the pre-#384 look. Operators diagnosing a stray control byte (e.g. a `0x7F` wedged into a position report breaking map plotting, per #376) flip it on to reveal the bytes.

Rebased onto `main` after #386 merged. Build green, all 372 web tests pass.
