### PR TITLE
android: keep top bar below the status bar on edge-to-edge (GH #390)

### DIFF
--- a/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
@@ -100,11 +100,21 @@ class MainActivity : Activity() {
      * resizes the window when the soft keyboard opens, so the SPA's sticky
      * compose bar (position:absolute; bottom:0) ends up underneath the IME --
      * exactly the Messages-tab bug. We opt into edge-to-edge on every version,
-     * then pad the WebView by the system bars and, crucially, by the keyboard
-     * height. Padding the WebView's bottom shrinks the web viewport above the
-     * IME, so the compose bar sits atop the keyboard and `window.innerHeight`
-     * reflects the change. ComposeBar.svelte skips its visualViewport translate
-     * in the Android shell (Platform.isAndroid) so the two don't double-offset.
+     * then pad the WebView by the side/bottom system bars and, crucially, by the
+     * keyboard height. Padding the WebView's bottom shrinks the web viewport
+     * above the IME, so the compose bar sits atop the keyboard and
+     * `window.innerHeight` reflects the change. ComposeBar.svelte skips its
+     * visualViewport translate in the Android shell (Platform.isAndroid) so the
+     * two don't double-offset.
+     *
+     * The TOP inset is deliberately NOT padded here. The SPA's top bar is
+     * `position:fixed; top:0`, and a fixed element is pinned to the visual
+     * viewport, which WebView top-padding does NOT shift -- padding the top
+     * would leave the bar stranded behind the status bar (GH #390). Instead the
+     * page opts into `viewport-fit=cover` (web/index.html) and the top bar
+     * reserves the status-bar strip itself via `env(safe-area-inset-top)`. So
+     * the top is owned by CSS, the bottom by native padding (the viewport must
+     * actually shrink for the keyboard, which env() cannot express).
      *
      * Two mechanisms feed the same listener: on API 30+ the IME arrives as a
      * `Type.ime()` inset (handled here directly). On API 28-29 `Type.ime()` is
@@ -120,7 +130,9 @@ class MainActivity : Activity() {
         ViewCompat.setOnApplyWindowInsetsListener(webView) { v, insets ->
             val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
-            v.setPadding(bars.left, bars.top, bars.right, maxOf(bars.bottom, ime.bottom))
+            // Top stays 0: the fixed top bar reserves the status-bar strip in
+            // CSS via env(safe-area-inset-top) (GH #390). See the KDoc above.
+            v.setPadding(bars.left, 0, bars.right, maxOf(bars.bottom, ime.bottom))
             insets
         }
     }

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -673,23 +673,34 @@ cannot outlive the app, because no single mechanism covers both cases.
   (bounded) before tearing the same resources down. The cheap `UsbPttAdapter.init()`
   stays on the main thread so `MainActivity.onResume`'s `enumerate()` never races an
   uninitialized adapter.
-- **WebView owns its insets (edge-to-edge + keyboard):** `targetSdk=36` forces
-  edge-to-edge on Android 15+, where the platform no longer auto-insets the
-  content view or resizes the window for the soft keyboard. `MainActivity.applyWindowInsets`
-  calls `WindowCompat.setDecorFitsSystemWindows(window, false)` and a
-  `setOnApplyWindowInsetsListener` that pads the WebView by the system bars plus
-  `max(systemBars.bottom, ime.bottom)`. The IME padding is the cross-system load-bearing
-  bit: it shrinks the web viewport above the keyboard so the SPA's sticky compose bar
-  (`web/.../ComposeBar.svelte`, `position:absolute; bottom:0`) is never covered. That
-  component skips its own `visualViewport` translateY when `Platform.isAndroid` so the
-  two mechanisms don't stack into a double-offset; the web translate stays the path for
-  mobile browsers. The manifest's `android:windowSoftInputMode="adjustResize"` is the
-  pre-API-30 fallback: there `WindowInsetsCompat.Type.ime()` reports 0, so adjustResize
-  resizes the decor frame instead, re-firing the same listener -- do NOT drop it assuming
-  the inset path covers 28-29. The WebView background is painted `@color/chrome_bg` (the
-  single source the theme's `statusBarColor` also uses) so the padded bar strips don't
-  flash white. Do NOT revert to letting the system manage insets -- on Android 15+ the
-  compose bar disappears behind the keyboard.
+- **Inset ownership is split: top in CSS, bottom in native padding (edge-to-edge + keyboard):**
+  `targetSdk=36` forces edge-to-edge on Android 15+, where the platform no longer
+  auto-insets the content view or resizes the window for the soft keyboard.
+  `MainActivity.applyWindowInsets` calls `WindowCompat.setDecorFitsSystemWindows(window, false)`
+  and a `setOnApplyWindowInsetsListener` that pads the WebView by the side bars and
+  `max(systemBars.bottom, ime.bottom)` -- but **leaves the top inset at 0 on purpose**.
+  The split is load-bearing and not interchangeable:
+  - **Top is owned by CSS.** The SPA's mobile top bar is `position:fixed; top:0`
+    (`web/.../Sidebar.svelte`), and a fixed element is pinned to the visual viewport,
+    which WebView top-padding does NOT shift -- padding the top leaves the bar stranded
+    behind the status bar (GH #390). Instead `web/index.html` sets `viewport-fit=cover`
+    so `env(safe-area-inset-top)` is populated, and the top bar reserves the status-bar
+    strip itself (`height: calc(56px + env(safe-area-inset-top))`, matching
+    `margin-top` on `.main-content`). Do NOT re-add `bars.top` to the WebView padding and
+    do NOT drop `viewport-fit=cover`.
+  - **Bottom is owned by native padding.** `env()` cannot express the keyboard, so the
+    IME padding is the cross-system load-bearing bit: it shrinks the web viewport above
+    the keyboard so the SPA's sticky compose bar (`web/.../ComposeBar.svelte`,
+    `position:absolute; bottom:0`) is never covered. That component skips its own
+    `visualViewport` translateY when `Platform.isAndroid` so the two mechanisms don't
+    stack into a double-offset; the web translate stays the path for mobile browsers.
+  The manifest's `android:windowSoftInputMode="adjustResize"` is the pre-API-30 fallback:
+  there `WindowInsetsCompat.Type.ime()` reports 0, so adjustResize resizes the decor
+  frame instead, re-firing the same listener -- do NOT drop it assuming the inset path
+  covers 28-29. The WebView background is painted `@color/chrome_bg` (the single source
+  the theme's `statusBarColor` also uses) so the padded bar strips don't flash white.
+  Do NOT revert to letting the system manage insets -- on Android 15+ the compose bar
+  disappears behind the keyboard.
 
 Source: [`../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt`](../../android/app/src/main/kotlin/com/nw5w/graywolf/GraywolfService.kt),
 [`../../cmd/graywolf/parentwatch.go`](../../cmd/graywolf/parentwatch.go),

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />

--- a/web/src/components/messages/remote_actions/RemoteActionsDrawer.svelte
+++ b/web/src/components/messages/remote_actions/RemoteActionsDrawer.svelte
@@ -244,7 +244,12 @@
     box-shadow: -2px 0 12px rgba(0,0,0,0.15);
     display: flex;
     flex-direction: column;
-    padding: 16px;
+    /* Edge-to-edge: this drawer is pinned to the viewport edges, so it reserves
+       the status-bar / nav-bar safe areas itself (GH #390). On the Android shell
+       the bottom env() is 0 because the WebView is natively bottom-padded; it is
+       load-bearing for iOS / mobile-browser home indicators. */
+    padding: calc(16px + env(safe-area-inset-top)) 16px
+      calc(16px + env(safe-area-inset-bottom));
     overflow-y: auto;
     z-index: 50;
   }


### PR DESCRIPTION
## Problem

On Android v0.14.8 the app's top navigation bar renders behind the system status bar (clock/battery), clipping the graywolf wordmark and nav icons so they can't be tapped. Reported in GH #390.

## Root cause

The v0.14.8 edge-to-edge change (#379) pads the WebView by the top system-bar inset. But the SPA's mobile top bar is `position: fixed; top: 0`, and a fixed element is pinned to the *visual viewport* — which WebView top-padding does **not** shift. So the bar stayed stranded behind the status bar.

The web CSS was already written for the correct model — `Sidebar.svelte`'s `.top-bar` reserves the status-bar strip via `env(safe-area-inset-top)` — but `env()` evaluates to 0 unless the page opts into `viewport-fit=cover`, which was missing.

## Fix

- Add `viewport-fit=cover` to the viewport meta so `env(safe-area-inset-top)` is populated.
- Stop padding the WebView's top inset; let the existing CSS own it.

The bottom IME padding is unchanged — it remains load-bearing for keeping the message compose bar above the soft keyboard. The result is a clean ownership split (documented in `docs/wiki/invariants.md`): **top inset → CSS `env()`, bottom inset → native WebView padding** (the viewport must actually shrink for the keyboard, which `env()` can't express).
