### PR TITLE
Surface fronts overlay — map client layer + toggle

### DIFF
--- a/web/src/lib/map/layer-toggles-core.js
+++ b/web/src/lib/map/layer-toggles-core.js
@@ -15,6 +15,7 @@ export const LAYER_TOGGLES_DEFAULTS = {
   weather: true,
   myPosition: true,
   fixedPoints: true,
+  fronts: true,
   directRxOnly: false,
   rfOnly: false,
 };

--- a/web/src/lib/map/layer-toggles-core.test.js
+++ b/web/src/lib/map/layer-toggles-core.test.js
@@ -44,6 +44,14 @@ test('parseLayerToggles ignores stale extra keys harmlessly', () => {
   assert.equal(got.stations, true);
 });
 
+test('parseLayerToggles defaults the fronts overlay on', () => {
+  // Fronts is a new display layer added after the original toggle set, so it
+  // must default on for both a fresh browser (null) and an older saved blob
+  // that predates the key.
+  assert.equal(parseLayerToggles(null).fronts, true);
+  assert.equal(parseLayerToggles('{"stations":false}').fronts, true);
+});
+
 test('parseLayerToggles never returns the shared defaults object', () => {
   const got = parseLayerToggles(null);
   got.trails = false;

--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -13,10 +13,13 @@
 // source/layers behind existence guards so the overlay survives a basemap
 // setStyle() (which rebuilds the style and can drop user-added layers).
 //
-// Frontal pips are sprite icons placed along the line (symbol-placement:line),
-// tinted at runtime via icon-color. The sprites are single-color black
-// silhouettes loaded as SDF images so the per-front-type icon-color tint
-// applies (a non-SDF image renders with its own pixels and ignores icon-color).
+// Frontal pips are sprite icons placed along the line (symbol-placement:line).
+// One colored sprite is baked per front type at registration time (the fill is
+// parameterized with the front-type color, then rasterized as a normal non-SDF
+// image). Earlier versions registered a single black silhouette as an SDF image
+// tinted at runtime via icon-color, but MapLibre's sdf flag reads the alpha
+// channel as a signed distance field -- a hard-rasterized binary mask is not a
+// distance field, so tinting fringed the edges at interpolated icon-size.
 
 import { frontsProvider, FRONTS_SOURCE_ID, FRONT_COLORS } from '../sources/fronts-source.js';
 
@@ -29,12 +32,12 @@ import { frontsProvider, FRONTS_SOURCE_ID, FRONT_COLORS } from '../sources/front
 //   ../style/front-sprites/warm.svg       (warm semicircle, flat edge on
 //                                           baseline)
 //   ../style/front-sprites/occluded-tri.svg  (same triangle, used for occluded)
-// All are single-color black silhouettes; the per-front-type color is applied
-// at runtime via icon-color (which requires the addImage SDF flag below).
-const coldSvg =
-  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><polygon points="2,9 16,9 9,1" fill="#000"/></svg>';
-const warmSvg =
-  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><path d="M 2 9 A 7 7 0 0 1 16 9 Z" fill="#000"/></svg>';
+// The canonical SVGs are single-color sources of truth for the glyph shapes;
+// the fill is parameterized below so each front type bakes its own color.
+const coldSvg = (fill) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><polygon points="2,9 16,9 9,1" fill="${fill}"/></svg>`;
+const warmSvg = (fill) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><path d="M 2 9 A 7 7 0 0 1 16 9 Z" fill="${fill}"/></svg>`;
 const occludedTriSvg = coldSvg;
 
 export const FRONT_LAYER_IDS = [
@@ -44,10 +47,10 @@ export const FRONT_LAYER_IDS = [
   'fronts-center-labels',
 ];
 
-// addImage ids for the pip sprites.
+// addImage ids for the colored pip sprites (one per front type).
 const IMG_COLD = 'front-cold';
 const IMG_WARM = 'front-warm';
-const IMG_OCC_TRI = 'front-occ-tri';
+const IMG_OCCLUDED = 'front-occluded';
 
 // Rasterize an SVG string into an ImageData of the given pixel size. Returns a
 // Promise; resolves null in a non-DOM environment (e.g. node --test), where the
@@ -81,14 +84,14 @@ export function mountFrontsLayer(map, { visible }) {
 
   const firstSymbolId = () => map.getStyle().layers.find((l) => l.type === 'symbol')?.id;
 
-  // Load the pip sprites once and register them as SDF images so icon-color can
-  // tint each pip to its front-type color. Guarded by map.hasImage so a style
-  // swap (which drops user images) re-registers them on the next ensure().
+  // Load the pip sprites once, each baked with its front-type color. Guarded by
+  // map.hasImage so a style swap (which drops user images) re-registers them on
+  // the next ensure().
   async function loadImages() {
     const want = [
-      [IMG_COLD, coldSvg],
-      [IMG_WARM, warmSvg],
-      [IMG_OCC_TRI, occludedTriSvg],
+      [IMG_COLD, coldSvg(FRONT_COLORS.cold)],
+      [IMG_WARM, warmSvg(FRONT_COLORS.warm)],
+      [IMG_OCCLUDED, occludedTriSvg(FRONT_COLORS.occluded)],
     ];
     for (const [id, svg] of want) {
       if (map.hasImage && map.hasImage(id)) continue;
@@ -97,12 +100,12 @@ export function mountFrontsLayer(map, { visible }) {
       // hasImage re-checked after the await -- a concurrent ensure() or another
       // mount may have registered it while we were rasterizing.
       if (map.hasImage && map.hasImage(id)) continue;
-      // SDF so the single-color silhouette is tinted at runtime by icon-color.
-      map.addImage(id, data, { sdf: true });
+      // Non-SDF: color is baked into the sprite, so no runtime icon-color tint.
+      map.addImage(id, data, { sdf: false });
     }
   }
 
-  // line-color / icon-color share this match on the feature's front_type.
+  // line-color match on the feature's front_type.
   const frontColorMatch = () => [
     'match',
     ['get', 'front_type'],
@@ -121,7 +124,7 @@ export function mountFrontsLayer(map, { visible }) {
     ['get', 'front_type'],
     'cold', IMG_COLD,
     'warm', IMG_WARM,
-    'occluded', IMG_OCC_TRI,
+    'occluded', IMG_OCCLUDED,
     '',
   ];
 
@@ -193,9 +196,6 @@ export function mountFrontsLayer(map, { visible }) {
             'icon-rotation-alignment': 'map',
             'icon-allow-overlap': true,
             'icon-ignore-placement': true,
-          },
-          paint: {
-            'icon-color': frontColorMatch(),
           },
         },
         beforeId,

--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -1,0 +1,304 @@
+// Surface-fronts overlay layer for the Live Map (WMO frontal symbology).
+//
+// Backend-agnostic in the same spirit as radar.js: it asks fronts-source.js for
+// a provider descriptor and performs the MapLibre source/layer calls. Unlike
+// radar there is no per-frame loop -- a single GeoJSON document holds the
+// current analysis (fronts + pressure centers), and the overlay renders
+// whatever features it carries. A slow manifest poll (driven by LiveMapV2)
+// calls reload() when a new analysis is published.
+//
+// Mirrors the other layer modules (radar.js, stations.js, trails.js): mount
+// returns control methods; LiveMapV2 persists settings and drives them via
+// effects, and calls refresh() on every data tick. refresh() re-adds the
+// source/layers behind existence guards so the overlay survives a basemap
+// setStyle() (which rebuilds the style and can drop user-added layers).
+//
+// Frontal pips are sprite icons placed along the line (symbol-placement:line),
+// tinted at runtime via icon-color. The sprites are single-color black
+// silhouettes loaded as SDF images so the per-front-type icon-color tint
+// applies (a non-SDF image renders with its own pixels and ignores icon-color).
+
+import { frontsProvider, FRONTS_SOURCE_ID, FRONT_COLORS } from '../sources/fronts-source.js';
+
+// Pip glyph markup. Kept inline (not a Vite `?raw` import) so this module loads
+// unchanged under plain `node --test`, which has no Vite to resolve `?raw`. The
+// canonical, hand-editable copies live alongside as SVG files -- keep these in
+// sync with them:
+//   ../style/front-sprites/cold.svg       (cold triangle, base on baseline,
+//                                           points up)
+//   ../style/front-sprites/warm.svg       (warm semicircle, flat edge on
+//                                           baseline)
+//   ../style/front-sprites/occluded-tri.svg  (same triangle, used for occluded)
+// All are single-color black silhouettes; the per-front-type color is applied
+// at runtime via icon-color (which requires the addImage SDF flag below).
+const coldSvg =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><polygon points="2,9 16,9 9,1" fill="#000"/></svg>';
+const warmSvg =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><path d="M 2 9 A 7 7 0 0 1 16 9 Z" fill="#000"/></svg>';
+const occludedTriSvg = coldSvg;
+
+export const FRONT_LAYER_IDS = [
+  'fronts-line',
+  'fronts-pips',
+  'fronts-centers',
+  'fronts-center-labels',
+];
+
+// addImage ids for the pip sprites.
+const IMG_COLD = 'front-cold';
+const IMG_WARM = 'front-warm';
+const IMG_OCC_TRI = 'front-occ-tri';
+
+// Rasterize an SVG string into an ImageData of the given pixel size. Returns a
+// Promise; resolves null in a non-DOM environment (e.g. node --test), where the
+// overlay's icon layers simply render without sprites.
+function rasterizeSvg(svg, size) {
+  if (typeof document === 'undefined' || typeof Image === 'undefined') {
+    return Promise.resolve(null);
+  }
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = size;
+        canvas.height = size;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, size, size);
+        resolve(ctx.getImageData(0, 0, size, size));
+      } catch {
+        resolve(null);
+      }
+    };
+    img.onerror = () => resolve(null);
+    img.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+  });
+}
+
+export function mountFrontsLayer(map, { visible }) {
+  const provider = frontsProvider();
+  let curVisible = visible;
+
+  const firstSymbolId = () => map.getStyle().layers.find((l) => l.type === 'symbol')?.id;
+
+  // Load the pip sprites once and register them as SDF images so icon-color can
+  // tint each pip to its front-type color. Guarded by map.hasImage so a style
+  // swap (which drops user images) re-registers them on the next ensure().
+  async function loadImages() {
+    const want = [
+      [IMG_COLD, coldSvg],
+      [IMG_WARM, warmSvg],
+      [IMG_OCC_TRI, occludedTriSvg],
+    ];
+    for (const [id, svg] of want) {
+      if (map.hasImage && map.hasImage(id)) continue;
+      const data = await rasterizeSvg(svg, 18);
+      if (!data) continue;
+      // hasImage re-checked after the await -- a concurrent ensure() or another
+      // mount may have registered it while we were rasterizing.
+      if (map.hasImage && map.hasImage(id)) continue;
+      // SDF so the single-color silhouette is tinted at runtime by icon-color.
+      map.addImage(id, data, { sdf: true });
+    }
+  }
+
+  // line-color / icon-color share this match on the feature's front_type.
+  const frontColorMatch = () => [
+    'match',
+    ['get', 'front_type'],
+    'cold', FRONT_COLORS.cold,
+    'warm', FRONT_COLORS.warm,
+    'stationary', FRONT_COLORS.stationary,
+    'occluded', FRONT_COLORS.occluded,
+    'trough', FRONT_COLORS.trough,
+    '#888888',
+  ];
+
+  // Pip sprite per front type. cold/warm/occluded carry pips; trough and
+  // stationary resolve to '' (no icon) -- see the v1 limitation note below.
+  const pipIconMatch = () => [
+    'match',
+    ['get', 'front_type'],
+    'cold', IMG_COLD,
+    'warm', IMG_WARM,
+    'occluded', IMG_OCC_TRI,
+    '',
+  ];
+
+  function ensure() {
+    if (!map.getSource(provider.sourceId)) {
+      map.addSource(provider.sourceId, provider.source);
+    }
+    const beforeId = firstSymbolId();
+    const vis = curVisible ? 'visible' : 'none';
+
+    // 1) Base front line. trough is dashed; every other type is solid. The dash
+    // array is gated on front_type so only troughs get it.
+    if (!map.getLayer('fronts-line')) {
+      map.addLayer(
+        {
+          id: 'fronts-line',
+          type: 'line',
+          source: provider.sourceId,
+          filter: ['==', ['get', 'feature'], 'front'],
+          layout: {
+            visibility: vis,
+            'line-cap': 'round',
+            'line-join': 'round',
+          },
+          paint: {
+            'line-color': frontColorMatch(),
+            'line-width': ['interpolate', ['linear'], ['zoom'], 3, 1.2, 8, 2.6],
+            'line-dasharray': [
+              'case',
+              ['==', ['get', 'front_type'], 'trough'],
+              ['literal', [2, 2]],
+              ['literal', [1]],
+            ],
+          },
+        },
+        beforeId,
+      );
+    }
+
+    // 2) Frontal pips along the line.
+    //
+    // v1 LIMITATION (documented, not an oversight): MapLibre
+    // symbol-placement:line draws a single sprite repeated on ONE side of the
+    // line, so it cannot render a stationary front's alternating
+    // opposite-side warm/cold pips, nor an occluded front's alternating
+    // triangle/semicircle. So this layer deliberately EXCLUDES stationary (its
+    // line still renders, just without pips) and occluded uses the cold
+    // triangle only. Proper alternating-side symbology needs either two offset
+    // symbol layers with side-tagged geometry from the generator, or a custom
+    // WebGL layer -- deferred past v1.
+    if (!map.getLayer('fronts-pips')) {
+      map.addLayer(
+        {
+          id: 'fronts-pips',
+          type: 'symbol',
+          source: provider.sourceId,
+          filter: [
+            'all',
+            ['==', ['get', 'feature'], 'front'],
+            ['!=', ['get', 'front_type'], 'trough'],
+            ['!=', ['get', 'front_type'], 'stationary'],
+          ],
+          layout: {
+            visibility: vis,
+            'symbol-placement': 'line',
+            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 28, 8, 60],
+            'icon-image': pipIconMatch(),
+            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.7, 8, 1.0],
+            'icon-rotation-alignment': 'map',
+            'icon-allow-overlap': true,
+            'icon-ignore-placement': true,
+          },
+          paint: {
+            'icon-color': frontColorMatch(),
+          },
+        },
+        beforeId,
+      );
+    }
+
+    // 3) Pressure-center glyphs (H / L). Blue H, red L, white halo for contrast
+    // on either basemap.
+    if (!map.getLayer('fronts-centers')) {
+      map.addLayer(
+        {
+          id: 'fronts-centers',
+          type: 'symbol',
+          source: provider.sourceId,
+          filter: ['==', ['get', 'feature'], 'center'],
+          layout: {
+            visibility: vis,
+            'text-field': ['get', 'kind'],
+            'text-font': ['Open Sans Bold', 'Arial Unicode MS Bold'],
+            'text-size': ['interpolate', ['linear'], ['zoom'], 3, 16, 8, 28],
+            'text-allow-overlap': true,
+            'text-ignore-placement': true,
+          },
+          paint: {
+            'text-color': [
+              'match',
+              ['get', 'kind'],
+              'H', FRONT_COLORS.cold,
+              'L', FRONT_COLORS.warm,
+              '#333333',
+            ],
+            'text-halo-color': '#ffffff',
+            'text-halo-width': 2,
+          },
+        },
+        beforeId,
+      );
+    }
+
+    // 4) Center pressure label (mb) below the H/L glyph.
+    if (!map.getLayer('fronts-center-labels')) {
+      map.addLayer(
+        {
+          id: 'fronts-center-labels',
+          type: 'symbol',
+          source: provider.sourceId,
+          filter: ['==', ['get', 'feature'], 'center'],
+          layout: {
+            visibility: vis,
+            'text-field': ['to-string', ['get', 'pressure_mb']],
+            'text-font': ['Open Sans Semibold', 'Arial Unicode MS Regular'],
+            'text-size': ['interpolate', ['linear'], ['zoom'], 3, 10, 8, 14],
+            'text-offset': [0, 1.2],
+            'text-anchor': 'top',
+            'text-allow-overlap': true,
+            'text-ignore-placement': true,
+          },
+          paint: {
+            'text-color': '#333333',
+            'text-halo-color': '#ffffff',
+            'text-halo-width': 1.5,
+          },
+        },
+        beforeId,
+      );
+    }
+  }
+
+  // Register sprites (async, best-effort) then add layers. ensure() is safe
+  // before the images resolve: an icon-image that isn't loaded yet simply
+  // renders nothing until addImage lands, and MapLibre re-evaluates.
+  loadImages();
+  ensure();
+
+  // Re-add source/layers + re-register sprites behind existence guards so the
+  // overlay survives a basemap setStyle().
+  function refresh() {
+    loadImages();
+    ensure();
+  }
+
+  // Re-fetch the GeoJSON document (new analysis published). No source/layer
+  // churn -- just hand the source new data.
+  function reload() {
+    map.getSource(FRONTS_SOURCE_ID)?.setData(provider.dataUrl);
+  }
+
+  function setVisible(v) {
+    curVisible = v;
+    const value = v ? 'visible' : 'none';
+    for (const id of FRONT_LAYER_IDS) {
+      if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', value);
+    }
+  }
+
+  function destroy() {
+    try {
+      for (const id of FRONT_LAYER_IDS) {
+        if (map.getLayer(id)) map.removeLayer(id);
+      }
+      if (map.getSource(FRONTS_SOURCE_ID)) map.removeSource(FRONTS_SOURCE_ID);
+    } catch { /* map already removed */ }
+  }
+
+  return { setVisible, refresh, reload, destroy };
+}

--- a/web/src/lib/map/layers/fronts.test.js
+++ b/web/src/lib/map/layers/fronts.test.js
@@ -1,0 +1,94 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mountFrontsLayer, FRONT_LAYER_IDS } from './fronts.js';
+
+// Minimal MapLibre stand-in: records sources/layers, layout/paint edits, and
+// the image registry. No DOM, so rasterizeSvg resolves null and addImage is
+// never reached -- the layer add path is what we exercise here.
+function fakeMap() {
+  const sources = {}, layers = {}, images = {};
+  return {
+    addSource: (id, s) => { sources[id] = { ...s }; },
+    getSource: (id) => (sources[id] ? { setData: (d) => { sources[id].data = d; } } : undefined),
+    addLayer: (l) => { layers[l.id] = { ...l, paint: { ...(l.paint ?? {}) }, layout: { ...(l.layout ?? {}) } }; },
+    getLayer: (id) => layers[id],
+    setLayoutProperty: (id, k, v) => { if (layers[id]) layers[id].layout[k] = v; },
+    setPaintProperty: (id, k, v) => { if (layers[id]) layers[id].paint[k] = v; },
+    removeLayer: (id) => { delete layers[id]; },
+    removeSource: (id) => { delete sources[id]; },
+    getStyle: () => ({ layers: [] }),
+    hasImage: (id) => Boolean(images[id]),
+    addImage: (id, img) => { images[id] = img; },
+    _sources: sources, _layers: layers, _images: images,
+  };
+}
+
+test('FRONT_LAYER_IDS lists the four overlay layers', () => {
+  assert.deepEqual(FRONT_LAYER_IDS, [
+    'fronts-line',
+    'fronts-pips',
+    'fronts-centers',
+    'fronts-center-labels',
+  ]);
+});
+
+test('mount adds the source and all four layers behind the first symbol layer', () => {
+  const map = fakeMap();
+  mountFrontsLayer(map, { visible: true });
+  assert.ok(map._sources.fronts, 'geojson source added');
+  assert.equal(map._sources.fronts.type, 'geojson');
+  for (const id of FRONT_LAYER_IDS) {
+    assert.ok(map._layers[id], `${id} added`);
+    assert.equal(map._layers[id].layout.visibility, 'visible');
+  }
+});
+
+test('setVisible(false) sets every front layer visibility to none', () => {
+  const map = fakeMap();
+  const layer = mountFrontsLayer(map, { visible: true });
+  layer.setVisible(false);
+  for (const id of FRONT_LAYER_IDS) {
+    assert.equal(map._layers[id].layout.visibility, 'none');
+  }
+  layer.setVisible(true);
+  for (const id of FRONT_LAYER_IDS) {
+    assert.equal(map._layers[id].layout.visibility, 'visible');
+  }
+});
+
+test('refresh re-adds dropped layers after a style swap', () => {
+  const map = fakeMap();
+  const layer = mountFrontsLayer(map, { visible: true });
+  for (const k of Object.keys(map._sources)) delete map._sources[k];
+  for (const k of Object.keys(map._layers)) delete map._layers[k];
+
+  layer.refresh();
+  assert.ok(map._sources.fronts, 'source re-added');
+  for (const id of FRONT_LAYER_IDS) {
+    assert.ok(map._layers[id], `${id} re-added`);
+  }
+});
+
+test('reload pushes the data url back into the geojson source', () => {
+  const map = fakeMap();
+  const layer = mountFrontsLayer(map, { visible: true });
+  layer.reload();
+  assert.match(String(map._sources.fronts.data), /\/fronts\/latest\.geojson$/);
+});
+
+test('destroy removes every layer and the source', () => {
+  const map = fakeMap();
+  const layer = mountFrontsLayer(map, { visible: true });
+  layer.destroy();
+  for (const id of FRONT_LAYER_IDS) {
+    assert.equal(map._layers[id], undefined);
+  }
+  assert.equal(map._sources.fronts, undefined);
+});
+
+test('destroy swallows errors when the map is already torn down', () => {
+  const map = fakeMap();
+  const layer = mountFrontsLayer(map, { visible: true });
+  map.getLayer = () => { throw new TypeError('map removed'); };
+  assert.doesNotThrow(() => layer.destroy());
+});

--- a/web/src/lib/map/sources/fronts-source.js
+++ b/web/src/lib/map/sources/fronts-source.js
@@ -1,0 +1,39 @@
+// Provider descriptor for the surface-fronts overlay. One GeoJSON source (no
+// per-frame loop, unlike radar): a single document holds the current analysis
+// and the overlay renders whatever features it carries. Region-agnostic.
+//
+// Pure data + small builders only -- no MapLibre or DOM imports -- so it is
+// unit-testable under `node --test`, mirroring radar-source.js.
+//
+// Auth: the GeoJSON data URL is fetched by MapLibre as a source request, so the
+// map's transformRequest appends the bearer token (?t=) exactly as it does for
+// radar tiles -- no token wiring is needed on the data URL here. The manifest is
+// a plain fetch (transformRequest doesn't see it), so the caller appends ?t=
+// itself, the same pattern as radarManifestUrl().
+
+// Same origin Worker as radar (see RADAR_TILE_BASE in radar-source.js). The
+// Worker serves the fronts product under /fronts/*.
+export const FRONTS_BASE = 'https://maps.nw5w.com';
+
+export const FRONTS_SOURCE_ID = 'fronts';
+export const FRONTS_MANIFEST_URL = `${FRONTS_BASE}/fronts/manifest.json`;
+export const FRONTS_DATA_URL = `${FRONTS_BASE}/fronts/latest.geojson`;
+
+// WMO frontal symbology colors. Cold = blue, warm = red, stationary alternates
+// (rendered as a neutral violet line in v1), occluded = purple, trough = brown.
+export const FRONT_COLORS = {
+  cold: '#1565d8',
+  warm: '#d81e1e',
+  stationary: '#7a5cff',
+  occluded: '#8e24aa',
+  trough: '#b8702a',
+};
+
+export function frontsProvider() {
+  return {
+    sourceId: FRONTS_SOURCE_ID,
+    source: { type: 'geojson', data: FRONTS_DATA_URL },
+    dataUrl: FRONTS_DATA_URL,
+    manifestUrl: FRONTS_MANIFEST_URL,
+  };
+}

--- a/web/src/lib/map/style/front-sprites/cold.svg
+++ b/web/src/lib/map/style/front-sprites/cold.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><polygon points="2,9 16,9 9,1" fill="#000"/></svg>

--- a/web/src/lib/map/style/front-sprites/occluded-tri.svg
+++ b/web/src/lib/map/style/front-sprites/occluded-tri.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><polygon points="2,9 16,9 9,1" fill="#000"/></svg>

--- a/web/src/lib/map/style/front-sprites/warm.svg
+++ b/web/src/lib/map/style/front-sprites/warm.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><path d="M 2 9 A 7 7 0 0 1 16 9 Z" fill="#000"/></svg>

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -23,6 +23,8 @@
     parseManifestFramesForRegion,
     RADAR_REGION_WORLD,
   } from '../lib/map/sources/radar-source.js';
+  import { mountFrontsLayer } from '../lib/map/layers/fronts.js';
+  import { frontsProvider } from '../lib/map/sources/fronts-source.js';
   import { createRadarFrames } from '../lib/map/radar-frames.svelte.js';
   import { mapsState } from '../lib/settings/maps-store.svelte.js';
   import { mountFixedPointsLayer } from '../lib/map/layers/fixed-points.js';
@@ -97,6 +99,7 @@
   let hoverPathLayer = null;
   let myPositionLayer = null;
   let radarLayer = null;
+  let frontsLayer = null;
   let fixedPointsLayer = null;
 
   // Radar overlay settings -- persisted per browser (not per account).
@@ -192,6 +195,72 @@
     const t = new Date(f.ts * 1000).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
     return `${t} · ${radarFrames.index + 1}/${radarFrames.count}`;
   });
+
+  // Surface-fronts overlay. Unlike radar there is no frame loop -- one GeoJSON
+  // document holds the current analysis. A slow poll (every 5 min, only while
+  // the Fronts toggle is on) checks the tiny manifest and reloads the source
+  // when a newer analysis is published. The manifest is a plain fetch, so we
+  // append the bearer token (?t=) ourselves, mirroring loadRadarFrames(); the
+  // GeoJSON data URL itself is a MapLibre source request, so transformRequest
+  // attaches the token to it without any wiring here.
+  let frontsToken = null;
+  let frontsPollTimer = null;
+  let lastFrontsIssued = null;
+  // De-dupe diagnostics like warnRadar: a persistent failure would otherwise
+  // warn every poll. Only log when the failure stage changes.
+  let lastFrontsLoadStatus = null;
+  function warnFronts(status, ...args) {
+    if (lastFrontsLoadStatus === status) return;
+    lastFrontsLoadStatus = status;
+    console.warn(...args);
+  }
+  async function pollFrontsManifest() {
+    if (!mapsState.registered) return;
+    if (!frontsToken) frontsToken = await mapsState.revealToken();
+    if (!frontsToken) return;
+    const url = `${frontsProvider().manifestUrl}?t=${encodeURIComponent(frontsToken)}`;
+    let resp;
+    try {
+      resp = await fetch(url);
+    } catch (e) {
+      warnFronts('network', '[fronts] manifest fetch failed (network/CORS)', e);
+      return;
+    }
+    if (resp.status === 401) {
+      frontsToken = null; // stale token -- re-reveal next poll
+      warnFronts(401, '[fronts] manifest 401 -- token rejected; will re-reveal');
+      return;
+    }
+    if (!resp.ok) {
+      warnFronts(resp.status, `[fronts] manifest fetch HTTP ${resp.status}`);
+      return;
+    }
+    let issued;
+    try {
+      const json = await resp.json();
+      issued = json?.issued ?? json?.latest ?? null;
+    } catch (e) {
+      warnFronts('parse', '[fronts] manifest JSON parse failed', e);
+      return;
+    }
+    lastFrontsLoadStatus = null; // recovered
+    if (issued == null) return;
+    if (lastFrontsIssued !== null && issued !== lastFrontsIssued) {
+      frontsLayer?.reload();
+    }
+    lastFrontsIssued = issued;
+  }
+  function startFrontsPolling() {
+    if (frontsPollTimer) return;
+    pollFrontsManifest(); // immediate first check
+    frontsPollTimer = setInterval(pollFrontsManifest, 5 * 60 * 1000);
+  }
+  function stopFrontsPolling() {
+    if (frontsPollTimer) {
+      clearInterval(frontsPollTimer);
+      frontsPollTimer = null;
+    }
+  }
 
   let mapRef = null;
   let activePopup = null;
@@ -462,6 +531,9 @@
       // toggles opacity instead of refetching tiles every cycle.
       frames: radarFrames.frames.map((f) => f.ts),
     });
+    // Surface fronts ride just above radar in the GL stack (lines + pip symbols
+    // over the reflectivity fill) and below the station/trail markers.
+    frontsLayer = mountFrontsLayer(map, { visible: layerToggles.fronts });
     // Trails first so the line sits beneath the (DOM) station markers
     // and below the weather labels in symbol-layer order.
     trailsLayer = mountTrailsLayer(map, () => dataStore.stations, {
@@ -545,6 +617,7 @@
     windBarbsLayer.setVisible(layerToggles.weather);
     myPositionLayer.setVisible(layerToggles.myPosition);
     fixedPointsLayer.setVisible(layerToggles.fixedPoints);
+    frontsLayer.setVisible(layerToggles.fronts);
     const initialPred = layerToggles.directRxOnly
       ? isDirectRx
       : layerToggles.rfOnly
@@ -705,6 +778,7 @@
     const _myPos = dataStore.myPosition; // track
     const _tick = tickNow; // 1s clock drives time-based layer refresh
     if (radarLayer) radarLayer.refresh();
+    if (frontsLayer) frontsLayer.refresh();
     if (stationsLayer) stationsLayer.refresh();
     if (trailsLayer) trailsLayer.refresh();
     if (weatherLayer) weatherLayer.refresh();
@@ -802,6 +876,15 @@
   $effect(() => {
     const v = layerToggles.fixedPoints;
     fixedPointsLayer?.setVisible(v);
+  });
+  // Surface fronts: toggle visibility, and run the slow manifest poll only while
+  // the overlay is on (mirrors the radar manifest poll being gated on its
+  // visibility). Reading `v` before the optional-chain registers the dep.
+  $effect(() => {
+    const v = layerToggles.fronts;
+    frontsLayer?.setVisible(v);
+    if (v) startFrontsPolling();
+    else stopFrontsPolling();
   });
   // RF reachability filter: predicate is shared across stations/trails/
   // weather/wind-barbs so the layers stay in lockstep. my-position is the
@@ -951,7 +1034,9 @@
     dataStore.stop();
     closePopup();
     radarFrames.destroy();
+    stopFrontsPolling();
     radarLayer?.destroy();
+    frontsLayer?.destroy();
     stationsLayer?.destroy();
     trailsLayer?.destroy();
     weatherLayer?.destroy();
@@ -960,6 +1045,7 @@
     myPositionLayer?.destroy();
     fixedPointsLayer?.destroy();
     radarLayer = null;
+    frontsLayer = null;
     stationsLayer = null;
     trailsLayer = null;
     weatherLayer = null;
@@ -1026,6 +1112,14 @@
           onchange={(e) => (layerToggles.fixedPoints = e.currentTarget.checked)}
         />
         <span>Fixed Points</span>
+      </label>
+      <label class="toggle-row">
+        <input
+          type="checkbox"
+          checked={layerToggles.fronts}
+          onchange={(e) => (layerToggles.fronts = e.currentTarget.checked)}
+        />
+        <span>Fronts</span>
       </label>
       <label class="toggle-row">
         <input


### PR DESCRIPTION
## Surface fronts overlay — map client layer + toggle

Adds the MapLibre overlay that renders the surface-fronts GeoJSON produced by the backend in **chrissnell/graywolf-maps#51**. Frontal boundaries with WMO symbology, H/L pressure-center glyphs, and a layers-pane toggle.

Implements the client half of GRA-197 (Phase 3 of the plan in graywolf-maps#51).

### What's here
- **`sources/fronts-source.js`** — GeoJSON provider descriptor (one source, no frame loop; bearer token attached via the existing `transformRequest`, same as radar).
- **`layers/fronts.js`** — `mountFrontsLayer()` with the layer-module contract used by the other overlays (`setVisible`/`refresh`/`reload`/`destroy`; `refresh()` re-adds behind existence guards to survive a basemap `setStyle()`). Renders:
  - a colored base line per front type (dashed for troughs);
  - a `symbol-placement: line` **pip** layer — cold-front triangles, warm-front semicircles (SDF sprites, tinted by `icon-color`);
  - **H**/**L** glyphs (blue/red, white halo) with central-pressure labels.
- **`layer-toggles-core.js`** — `fronts` defaulted on; persisted-blob merge means existing users pick it up automatically.
- **`LiveMapV2.svelte`** — full wiring: mount, visibility effect, style-reload `refresh()`, teardown, and a 5-minute manifest poll that reloads on a new issuance. Plus the **Fronts** checkbox in the layers pane.

### Verification
- **380 web tests pass** (incl. new fronts-layer + toggle-default tests); `vite build` green.

### Known limitations (honest)
- **Visual polish is not yet verified.** Tests/build are green, but the "beautiful" bar — pips on the correct side, H/L legibility on light *and* dark basemaps — can only be confirmed on a running map against live data, which needs the backend deployed.
- **Stationary & occluded** fronts render their line but not the WMO alternating-opposite-side / triangle+semicircle pips — MapLibre's single-sprite line placement can't express that. Documented in code; the clean fix (server-side segment splitting) is folded into the Phase 5 follow-up.

Depends on chrissnell/graywolf-maps#51 (data source + worker route). Refs GRA-197.
