### PR TITLE
Persist map layers time range across navigation and reload

### DIFF
--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -237,7 +237,10 @@
     }
     return false;
   }
-  let timerangeSec = $state(Math.floor(dataStore.timerangeMs / 1000));
+  // Seed from the persisted per-browser preference so a non-default time
+  // range survives reload/navigation. The $effect below pushes it into the
+  // data store and writes any change back to mapState.
+  let timerangeSec = $state(mapState.timerange);
   let coordText = $state('');
   let zoomLevel = $state(null);
 
@@ -819,9 +822,11 @@
     windBarbsLayer?.setFilter(pred);
   });
 
-  // Push the timerange into the data store.
+  // Push the timerange into the data store and persist the selection so it
+  // is restored on the next load.
   $effect(() => {
     dataStore.setTimerange(timerangeSec * 1000);
+    mapState.timerange = timerangeSec;
   });
 
   // One-shot recenter on the station's "My Position" as soon as the data


### PR DESCRIPTION
Fixes #395.

## Problem

Selecting a map layers time range other than the default 1 hour was not retained when navigating away from the page or reloading -- it always reverted to 1 hour.

## Cause

The live map's time-range selector (`timerangeSec` in `LiveMapV2.svelte`) seeded its value from `dataStore.timerangeMs`, which always defaults to 3600s (1 hour), and pushed changes only into the data store -- never persisting them. The persistence infrastructure for this preference already existed (`mapState.timerange`, backed by the `map-timerange` localStorage key) but nothing read from or wrote to it, so it was effectively dead.

## Fix

- Seed `timerangeSec` from the persisted `mapState.timerange` preference instead of the data-store default.
- Write the selection back to `mapState.timerange` whenever it changes, alongside the existing push into the data store.

The selected range now survives navigation and reload. Frontend build and the full JS test suite (372 tests) pass.