### PR TITLE
Fix RF Only map filter still showing APRS-IS stations (#394)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1198,3 +1198,38 @@ Source: [`../../pkg/aprs/mice.go`](../../pkg/aprs/mice.go)
 (`buildStationEntry`),
 [`../../pkg/aprs/mice_test.go`](../../pkg/aprs/mice_test.go)
 (`TestParseMicECommentSurfaced`).
+
+### 52. "RF Only" classifies on the current fix, not the whole trail
+
+The Live Map "RF Only" filter shows a station only when its **current fix**
+(`positions[0]`) arrived over the air (`direction === 'RX'`) and was not
+Internet-to-RF gated (`gated`). The predicate `isRfOnly`
+(`web/src/lib/map/rf-only-core.js`) inspects only `positions[0]` -- never the
+accumulated trail.
+
+*Why:* the data store accumulates a per-callsign trail by prepending each delta
+fix (`data-store.svelte.js` `mergeStation`). A mobile station heard on RF
+earlier and now arriving only via APRS-IS keeps a stale RF breadcrumb deep in
+that trail. The old predicate scanned every position and qualified the station
+on that stale breadcrumb, so it stayed visible under RF Only even though its
+marker and popup were labeled `APRS-IS` (`via === 'is'`) -- the bug in graywolf
+GitHub #394. The marker and the popup's `viaText` already describe the station
+by its newest reception (top-level `StationDTO.Via`/`Direction`/`Gated`, which
+track `positions[0]`), so the filter must classify off the same fix to stay
+consistent.
+
+*How to apply:* keep RF Only keyed on `positions[0]` only. Static stations are
+unaffected -- `stationcache`'s static-rebeacon merge folds the most RF-reachable
+copy of a fix into `positions[0]` via `rfRank` (invariant #48), so a fixed
+station once heard on RF and later re-beaconed via a gated/IS copy still
+qualifies. RF Only is the looser companion to Direct RX (#48): it keeps
+RF-digipeated stations (`hops > 0`) and drops only APRS-IS and Internet-to-RF
+gated current fixes.
+
+Source: [`../../web/src/lib/map/rf-only-core.js`](../../web/src/lib/map/rf-only-core.js)
+(`isRfOnly`),
+[`../../web/src/lib/map/rf-only-core.test.js`](../../web/src/lib/map/rf-only-core.test.js),
+[`../../web/src/routes/LiveMapV2.svelte`](../../web/src/routes/LiveMapV2.svelte)
+(filter `$effect`, `rfOnlyStationCount`),
+[`../../web/src/lib/map/popup-helpers.js`](../../web/src/lib/map/popup-helpers.js)
+(`viaText`).

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1212,14 +1212,26 @@ fix (`data-store.svelte.js` `mergeStation`). A mobile station heard on RF
 earlier and now arriving only via APRS-IS keeps a stale RF breadcrumb deep in
 that trail. The old predicate scanned every position and qualified the station
 on that stale breadcrumb, so it stayed visible under RF Only even though its
-marker and popup were labeled `APRS-IS` (`via === 'is'`) -- the bug in graywolf
-GitHub #394. The marker and the popup's `viaText` already describe the station
-by its newest reception (top-level `StationDTO.Via`/`Direction`/`Gated`, which
-track `positions[0]`), so the filter must classify off the same fix to stay
-consistent.
+marker (drawn at `positions[0]`) and popup badge labeled it `APRS-IS` -- the bug
+in graywolf GitHub #394. The marker is always `positions[0]`, so the filter must
+classify off that same fix.
+
+*Top-level fields vs. positions[0] -- they are NOT the same.*
+`stationcache.updateMetadata` overwrites the **station-level** `Direction`/
+`Via`/`Gated` (exposed as the top-level `StationDTO` fields, and what the popup
+badge reads via `popup.js` `s.direction` and `viaText`'s `s.via === 'is'`) with
+the **latest** packet on every update, unconditionally. `positions[0]`, by
+contrast, is rfRank-protected for static re-beacons. For the common case (a
+fresh or moving station) `positions[0]` *is* the latest fix and matches the
+badge; they diverge only for a static station heard on RF then re-beaconed via
+IS, where `positions[0]` stays `RX` (rfRank) while the top-level badge flips to
+`IS`. RF Only intentionally keys on the rfRank-protected `positions[0]`, so that
+static station stays visible (next paragraph) even though its popup badge may
+read APRS-IS. Do **not** "fix" that by classifying off the top-level fields --
+that would re-hide RF-reachable static stations.
 
 *How to apply:* keep RF Only keyed on `positions[0]` only. Static stations are
-unaffected -- `stationcache`'s static-rebeacon merge folds the most RF-reachable
+preserved -- `stationcache`'s static-rebeacon merge folds the most RF-reachable
 copy of a fix into `positions[0]` via `rfRank` (invariant #48), so a fixed
 station once heard on RF and later re-beaconed via a gated/IS copy still
 qualifies. RF Only is the looser companion to Direct RX (#48): it keeps

--- a/web/src/lib/map/rf-only-core.js
+++ b/web/src/lib/map/rf-only-core.js
@@ -1,0 +1,18 @@
+// Pure predicate behind the Live Map "RF Only" filter. A station qualifies
+// when its current fix arrived over the air (RX) and did not reach us as
+// Internet-to-RF gated traffic (the inner packet of an APRS third-party gate).
+// Unlike "Direct RX" this keeps RF-digipeated stations (hops > 0); it only
+// drops points whose latest reception was APRS-IS or Internet-to-RF gated.
+//
+// The check is against the current fix (positions[0]) only, never the whole
+// trail: the marker and popup label a station by its newest reception, so a
+// station now arriving via APRS-IS must not stay visible under RF Only just
+// because an older breadcrumb in its accumulated trail was once heard on RF
+// (graywolf #394). For static stations the server already folds the most
+// RF-reachable copy of a fix into positions[0] (see stationcache rfRank), so a
+// fixed station heard on RF and later re-beaconed via a gated/IS copy still
+// qualifies.
+export function isRfOnly(station) {
+  const p = station?.positions?.[0];
+  return !!p && p.direction === 'RX' && !p.gated;
+}

--- a/web/src/lib/map/rf-only-core.js
+++ b/web/src/lib/map/rf-only-core.js
@@ -5,13 +5,16 @@
 // drops points whose latest reception was APRS-IS or Internet-to-RF gated.
 //
 // The check is against the current fix (positions[0]) only, never the whole
-// trail: the marker and popup label a station by its newest reception, so a
-// station now arriving via APRS-IS must not stay visible under RF Only just
-// because an older breadcrumb in its accumulated trail was once heard on RF
-// (graywolf #394). For static stations the server already folds the most
-// RF-reachable copy of a fix into positions[0] (see stationcache rfRank), so a
-// fixed station heard on RF and later re-beaconed via a gated/IS copy still
-// qualifies.
+// trail: the marker is drawn at positions[0], so a station now arriving via
+// APRS-IS must not stay visible under RF Only just because an older breadcrumb
+// in its accumulated trail was once heard on RF (graywolf #394). For static
+// stations the server folds the most RF-reachable copy of a fix into
+// positions[0] (see stationcache rfRank), so a fixed station heard on RF and
+// later re-beaconed via a gated/IS copy still qualifies. Note positions[0] can
+// diverge from the popup's top-level direction/via badge in exactly that case
+// (the cache overwrites the station-level fields with the latest packet
+// unconditionally) -- positions[0] is the rfRank-protected copy and is the
+// correct basis for RF reachability.
 export function isRfOnly(station) {
   const p = station?.positions?.[0];
   return !!p && p.direction === 'RX' && !p.gated;

--- a/web/src/lib/map/rf-only-core.test.js
+++ b/web/src/lib/map/rf-only-core.test.js
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isRfOnly } from './rf-only-core.js';
+
+test('station whose current fix was heard directly on RF qualifies', () => {
+  const station = { positions: [{ direction: 'RX', hops: 0 }] };
+  assert.equal(isRfOnly(station), true);
+});
+
+test('station whose current fix was RF-digipeated qualifies', () => {
+  const station = { positions: [{ direction: 'RX', hops: 2 }] };
+  assert.equal(isRfOnly(station), true);
+});
+
+test('station whose current fix arrived via APRS-IS is excluded', () => {
+  const station = { positions: [{ direction: 'IS' }] };
+  assert.equal(isRfOnly(station), false);
+});
+
+test('station whose current fix was Internet-to-RF gated is excluded', () => {
+  const station = { positions: [{ direction: 'RX', gated: true }] };
+  assert.equal(isRfOnly(station), false);
+});
+
+test('current APRS-IS fix wins over a stale RF breadcrumb in the trail (#394)', () => {
+  // Moving station heard on RF earlier, now arriving only via APRS-IS. The
+  // marker/popup show the APRS-IS fix, so RF Only must hide it even though an
+  // older RF fix lingers in the accumulated trail.
+  const station = {
+    positions: [
+      { direction: 'IS' },
+      { direction: 'RX', hops: 0 },
+    ],
+  };
+  assert.equal(isRfOnly(station), false);
+});
+
+test('missing or empty positions are excluded', () => {
+  assert.equal(isRfOnly({ positions: [] }), false);
+  assert.equal(isRfOnly({}), false);
+  assert.equal(isRfOnly(null), false);
+});

--- a/web/src/lib/map/rf-only-core.test.js
+++ b/web/src/lib/map/rf-only-core.test.js
@@ -22,6 +22,20 @@ test('station whose current fix was Internet-to-RF gated is excluded', () => {
   assert.equal(isRfOnly(station), false);
 });
 
+test('gated wins over the RF-digipeated allowance', () => {
+  // A gated copy that also carries digi hops must still be dropped: gated is
+  // disqualifying regardless of hops, unlike a plain RF-digipeated fix.
+  const station = { positions: [{ direction: 'RX', hops: 2, gated: true }] };
+  assert.equal(isRfOnly(station), false);
+});
+
+test('our own transmission (TX) is excluded', () => {
+  // The filter qualifies on RX only, not merely "not IS"; our own TX beacon
+  // is not an RF reception of another station.
+  const station = { positions: [{ direction: 'TX', hops: 0 }] };
+  assert.equal(isRfOnly(station), false);
+});
+
 test('current APRS-IS fix wins over a stale RF breadcrumb in the trail (#394)', () => {
   // Moving station heard on RF earlier, now arriving only via APRS-IS. The
   // marker/popup show the APRS-IS fix, so RF Only must hide it even though an

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -39,6 +39,7 @@
   import { fmtLat, fmtLon, timeAgo } from '../lib/map/popup-helpers.js';
   import { clockOffset, formatOffsetMagnitude } from '../lib/map/clock-offset.svelte.js';
   import { directHeardWithin } from '../lib/map/direct-rx-core.js';
+  import { isRfOnly } from '../lib/map/rf-only-core.js';
   import { toasts } from '../lib/stores.js';
   import { online } from '../lib/stores/connection.js';
   import MapPinPlus from 'lucide-svelte/icons/map-pin-plus';
@@ -224,19 +225,11 @@
     return directHeardWithin(station, cutoffMs);
   }
 
-  // RF Only predicate: a station qualifies if at least one position was
-  // heard over the air (RX) and did not arrive via Internet-to-RF gating
-  // (the `gated` flag, set on the inner packet of a third-party gate).
-  // Unlike Direct RX this keeps RF-digipeated stations; it only drops
-  // points that are merely Internet traffic some iGate pushed onto RF.
-  function isRfOnly(station) {
-    const pts = station?.positions;
-    if (!Array.isArray(pts) || pts.length === 0) return false;
-    for (const p of pts) {
-      if (p.direction === 'RX' && !p.gated) return true;
-    }
-    return false;
-  }
+  // RF Only predicate lives in rf-only-core.js: a station qualifies when its
+  // current fix (positions[0]) arrived over the air (RX) and was not
+  // Internet-to-RF gated. Evaluating the current fix rather than the whole
+  // trail keeps the filter consistent with the marker/popup, which label a
+  // station by its newest reception (graywolf #394).
   // Seed from the persisted per-browser preference so a non-default time
   // range survives reload/navigation. The $effect below pushes it into the
   // data store and writes any change back to mapState.


### PR DESCRIPTION
## Problem

With the "RF Only" filter active on the Live Map, stations whose current packet arrived via APRS-IS still appeared (issue #394). The screenshots show a station whose popup is labeled **APRS-IS** (`via === 'is'`) yet remains visible under RF Only.

## Cause

`isRfOnly` scanned a station's **entire accumulated position trail** and kept it visible if *any* fix was ever heard on RF. The map data store builds that trail by prepending each delta fix, so a mobile station heard on RF earlier and now arriving only via APRS-IS keeps a stale RF breadcrumb deep in the trail. The filter qualified the station on that breadcrumb even though its marker and popup describe it by its newest reception.

## Fix

Classify on the **current fix** (`positions[0]`) only -- the same fix the marker and the popup's `via` label already use. The predicate is extracted into `web/src/lib/map/rf-only-core.js` with unit coverage, mirroring `direct-rx-core.js`.

Static stations are unaffected: the station cache folds the most RF-reachable copy of a fix into `positions[0]` via `rfRank`, so a fixed station once heard on RF still qualifies. RF Only remains the looser companion to Direct RX -- it keeps RF-digipeated stations and drops only APRS-IS / Internet-to-RF gated current fixes.

## Testing

- New `rf-only-core.test.js` (6 cases, all pass), including the #394 regression: an APRS-IS current fix with a stale RF breadcrumb behind it is correctly hidden.
- Full frontend suite shows no new failures (the 13 pre-existing failures are unrelated to the map).
- Wiki invariant added documenting the current-fix classification rule.

Closes #394
