### PR TITLE
Allow clearing the iGate TX channel to RX-only (#396)

### DIFF
--- a/web/src/lib/channelListboxOptions.js
+++ b/web/src/lib/channelListboxOptions.js
@@ -1,0 +1,37 @@
+// Pure option-model helpers for ChannelListbox. Extracted from the
+// component so the none-row / selection logic is unit-testable: the
+// web test runner is plain `node --test` with no Svelte render
+// harness, so anything worth asserting on lives here.
+
+// Build the listbox's unified option list: an opt-in leading "none"
+// row followed by one row per channel. Channel ids start at 1, so the
+// none row's sentinel (0) never collides with a real channel.
+export function buildOptions(channels, allowNone) {
+  const rows = (channels || []).map((c) => ({ none: false, channel: c }));
+  return allowNone ? [{ none: true }, ...rows] : rows;
+}
+
+// Value emitted when the none row is committed: the unset sentinel in
+// the parent's value space (0 for numeric pages like iGate, '' for
+// string pages).
+export function noneValueFor(valueType) {
+  return valueType === 'number' ? 0 : '';
+}
+
+// Coerce a listbox value (string or number) to a comparable number,
+// or null for the unset case ('' / null / undefined / non-finite).
+export function asChannelNumber(v) {
+  if (v === '' || v == null) return null;
+  const n = typeof v === 'string' ? parseInt(v, 10) : v;
+  return Number.isFinite(n) ? n : null;
+}
+
+// Index of the option matching `value` within `options`, or -1. The
+// none row matches the unset value (null / 0); channel rows match on
+// numeric id equality.
+export function resolveCurrentIdx(options, value) {
+  const num = asChannelNumber(value);
+  return options.findIndex((o) =>
+    o.none ? num == null || num === 0 : o.channel.id === num,
+  );
+}

--- a/web/src/lib/channelListboxOptions.test.js
+++ b/web/src/lib/channelListboxOptions.test.js
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildOptions,
+  noneValueFor,
+  asChannelNumber,
+  resolveCurrentIdx,
+} from './channelListboxOptions.js';
+
+const CH = [
+  { id: 1, name: 'VHF' },
+  { id: 2, name: 'UHF' },
+];
+
+test('buildOptions without allowNone is one row per channel', () => {
+  const opts = buildOptions(CH, false);
+  assert.equal(opts.length, 2);
+  assert.equal(opts[0].none, false);
+  assert.equal(opts[0].channel.id, 1);
+  assert.equal(opts[1].channel.id, 2);
+});
+
+test('buildOptions with allowNone prepends a none row', () => {
+  const opts = buildOptions(CH, true);
+  assert.equal(opts.length, 3);
+  assert.equal(opts[0].none, true);
+  assert.equal(opts[1].channel.id, 1);
+});
+
+test('buildOptions tolerates a null channel list', () => {
+  assert.deepEqual(buildOptions(null, false), []);
+  assert.equal(buildOptions(null, true).length, 1);
+  assert.equal(buildOptions(undefined, true)[0].none, true);
+});
+
+test('noneValueFor maps to the unset sentinel per value space', () => {
+  assert.equal(noneValueFor('number'), 0);
+  assert.equal(noneValueFor('string'), '');
+});
+
+test('asChannelNumber coerces strings and rejects the unset cases', () => {
+  assert.equal(asChannelNumber('2'), 2);
+  assert.equal(asChannelNumber(2), 2);
+  assert.equal(asChannelNumber(''), null);
+  assert.equal(asChannelNumber(null), null);
+  assert.equal(asChannelNumber(undefined), null);
+  assert.equal(asChannelNumber('not-a-number'), null);
+});
+
+test('resolveCurrentIdx finds a channel row by numeric id (string or number)', () => {
+  const opts = buildOptions(CH, false);
+  assert.equal(resolveCurrentIdx(opts, 2), 1);
+  assert.equal(resolveCurrentIdx(opts, '2'), 1);
+});
+
+test('resolveCurrentIdx maps value 0 to the none row when allowNone', () => {
+  const opts = buildOptions(CH, true);
+  // none row is index 0; value 0 / null / '' all select it.
+  assert.equal(resolveCurrentIdx(opts, 0), 0);
+  assert.equal(resolveCurrentIdx(opts, null), 0);
+  assert.equal(resolveCurrentIdx(opts, ''), 0);
+  // a real channel still resolves past the none row's offset.
+  assert.equal(resolveCurrentIdx(opts, 1), 1);
+  assert.equal(resolveCurrentIdx(opts, 2), 2);
+});
+
+test('resolveCurrentIdx returns -1 for value 0 without a none row (placeholder)', () => {
+  // The graywolf#396 regression guard: when the page does NOT offer a
+  // none row, an unset (0) value must fall through to the placeholder,
+  // not silently bind to a real channel.
+  const opts = buildOptions(CH, false);
+  assert.equal(resolveCurrentIdx(opts, 0), -1);
+  assert.equal(resolveCurrentIdx(opts, null), -1);
+});
+
+test('resolveCurrentIdx returns -1 for an unknown channel id', () => {
+  const opts = buildOptions(CH, true);
+  assert.equal(resolveCurrentIdx(opts, 99), -1);
+});

--- a/web/src/lib/components/ChannelListbox.svelte
+++ b/web/src/lib/components/ChannelListbox.svelte
@@ -32,11 +32,24 @@
   //     needs to see their previous choice and why it's invalid — but
   //     can't be selected, are skipped in keyboard nav, and are
   //     excluded from typeahead. Default: always-ok.
+  //   - allowNone / noneLabel: opt-in synthetic leading row that maps
+  //     to the unset sentinel (numeric 0 / empty string). iGate uses
+  //     this so an RX-only setup can clear its TX channel — the column
+  //     is genuinely optional there. The none row is always selectable
+  //     regardless of capabilityFilter, so a previously-selected
+  //     channel that has since gone non-TX-capable can still be
+  //     escaped. Default: off (Beacons/Digipeater/Kiss require a
+  //     channel, so they never expose it).
   //
   // The listbox is controlled: parent owns `value`, we call bindable.
 
   import ChannelOption from './ChannelOption.svelte';
   import { ariaLabel as rowAriaLabel } from '../channelBacking.js';
+  import {
+    buildOptions,
+    noneValueFor,
+    resolveCurrentIdx,
+  } from '../channelListboxOptions.js';
 
   let {
     value = $bindable(),
@@ -49,19 +62,23 @@
     placeholder = 'Select a channel',
     onChange = undefined,
     capabilityFilter = () => ({ ok: true, reason: '' }),
+    allowNone = false,
+    noneLabel = 'None',
   } = $props();
-
-  // Coerce value for comparison. Native handling: accept both string
-  // and number, match on numeric equality.
-  function asNumber(v) {
-    if (v === '' || v == null) return null;
-    const n = typeof v === 'string' ? parseInt(v, 10) : v;
-    return Number.isFinite(n) ? n : null;
-  }
 
   function emitValue(n) {
     if (n == null) return null;
     return valueType === 'number' ? n : String(n);
+  }
+
+  // Unified option model (see channelListboxOptions.js): an opt-in
+  // leading none row followed by one row per channel. Every
+  // index-based path below (capability, nav, typeahead, commit, aria,
+  // render) iterates this list so the none row participates uniformly.
+  let options = $derived(buildOptions(channels, allowNone));
+
+  function optionName(o) {
+    return o.none ? noneLabel : o.channel.name || '';
   }
 
   let open = $state(false);
@@ -71,10 +88,13 @@
 
   // Precompute the capability verdict per option so every consumer
   // (render, nav, typeahead, commit, aria) reads the same verdict —
-  // no drift, no re-evaluating in each code path.
+  // no drift, no re-evaluating in each code path. The none row is
+  // always enabled — it's the escape hatch and capabilityFilter never
+  // applies to it.
   let capability = $derived(
-    channels.map((c) => {
-      const v = capabilityFilter(c) || { ok: true, reason: '' };
+    options.map((o) => {
+      if (o.none) return { ok: true, reason: '' };
+      const v = capabilityFilter(o.channel) || { ok: true, reason: '' };
       return { ok: !!v.ok, reason: v.reason || '' };
     }),
   );
@@ -88,9 +108,9 @@
   // unchanged if every option ahead is disabled (so the caret doesn't
   // wrap past the ends and doesn't jump into a dead cell).
   function stepIdx(fromIdx, dir) {
-    if (channels.length === 0) return fromIdx;
+    if (options.length === 0) return fromIdx;
     let i = fromIdx + dir;
-    while (i >= 0 && i < channels.length) {
+    while (i >= 0 && i < options.length) {
       if (isEnabled(i)) return i;
       i += dir;
     }
@@ -100,13 +120,13 @@
   // First / last enabled index for Home / End. Falls back to the
   // current activeIdx if every option is disabled.
   function firstEnabledIdx() {
-    for (let i = 0; i < channels.length; i += 1) {
+    for (let i = 0; i < options.length; i += 1) {
       if (isEnabled(i)) return i;
     }
     return activeIdx;
   }
   function lastEnabledIdx() {
-    for (let i = channels.length - 1; i >= 0; i -= 1) {
+    for (let i = options.length - 1; i >= 0; i -= 1) {
       if (isEnabled(i)) return i;
     }
     return activeIdx;
@@ -124,8 +144,8 @@
     // Find first enabled option whose name starts with the buffer.
     // Disabled options are excluded: typeahead should land the user
     // on something they can actually commit.
-    const idx = channels.findIndex(
-      (c, i) => isEnabled(i) && (c.name || '').toLowerCase().startsWith(typeBuf),
+    const idx = options.findIndex(
+      (o, i) => isEnabled(i) && optionName(o).toLowerCase().startsWith(typeBuf),
     );
     if (idx !== -1) {
       activeIdx = idx;
@@ -133,14 +153,12 @@
     }
   }
 
-  let currentIdx = $derived.by(() => {
-    const n = asNumber(value);
-    if (n == null) return -1;
-    return channels.findIndex((c) => c.id === n);
-  });
+  let currentIdx = $derived(resolveCurrentIdx(options, value));
+  let selectedOption = $derived(currentIdx >= 0 ? options[currentIdx] : null);
   let selectedChannel = $derived(
-    currentIdx >= 0 ? channels[currentIdx] : null,
+    selectedOption && !selectedOption.none ? selectedOption.channel : null,
   );
+  let selectedIsNone = $derived(!!selectedOption?.none);
 
   function openList() {
     if (disabled) return;
@@ -152,7 +170,7 @@
       activeIdx = currentIdx;
     } else {
       const f = firstEnabledIdx();
-      activeIdx = f >= 0 ? f : (channels.length > 0 ? 0 : -1);
+      activeIdx = f >= 0 ? f : (options.length > 0 ? 0 : -1);
     }
     // Scroll into view after the popup mounts.
     queueMicrotask(scrollActiveIntoView);
@@ -165,14 +183,19 @@
   }
 
   function commit(idx) {
-    const c = channels[idx];
-    if (!c) return;
+    const o = options[idx];
+    if (!o) return;
     // Disabled options cannot be committed. No state change, no
     // onchange fire — just bail. The trigger stays open so the user
     // can pick a different row.
     if (!isEnabled(idx)) return;
-    value = emitValue(c.id);
-    onChange?.(c);
+    if (o.none) {
+      value = noneValueFor(valueType);
+      onChange?.(null);
+    } else {
+      value = emitValue(o.channel.id);
+      onChange?.(o.channel);
+    }
     closeList({ focusTrigger: true });
   }
 
@@ -274,8 +297,9 @@
   // option is disabled so screen readers announce e.g. "Channel 3,
   // VHF, no output device configured, unavailable" via
   // aria-activedescendant during keyboard nav.
-  function optionAriaLabel(c, idx) {
-    const base = rowAriaLabel(c);
+  function optionAriaLabel(o, idx) {
+    if (o.none) return noneLabel;
+    const base = rowAriaLabel(o.channel);
     const cap = capability[idx];
     if (cap && !cap.ok) {
       const r = cap.reason ? cap.reason + ', ' : '';
@@ -305,6 +329,8 @@
   >
     {#if selectedChannel}
       <ChannelOption channel={selectedChannel} variant="trigger-compact" />
+    {:else if selectedIsNone}
+      <span class="none-trigger">{noneLabel}</span>
     {:else}
       <span class="placeholder">{placeholder}</span>
     {/if}
@@ -320,12 +346,12 @@
       tabindex="-1"
       onkeydown={onListKey}
     >
-      {#if channels.length === 0}
+      {#if options.length === 0}
         <li class="empty" role="option" aria-selected="false" aria-disabled="true">
           No channels configured
         </li>
       {:else}
-        {#each channels as c, idx (c.id)}
+        {#each options as o, idx (o.none ? 'none' : o.channel.id)}
           <!-- Keyboard handling for options is centralised on the
                <ul role="listbox"> above via onListKey — Enter commits
                the active option. The svelte-a11y lint doesn't see
@@ -342,7 +368,7 @@
             role="option"
             aria-selected={currentIdx === idx}
             aria-disabled={!capability[idx]?.ok ? 'true' : undefined}
-            aria-label={optionAriaLabel(c, idx)}
+            aria-label={optionAriaLabel(o, idx)}
             onmouseenter={() => {
               // Honour the skip-in-nav rule on mouse hover too, so
               // arrow-key position doesn't teleport to a disabled row
@@ -351,11 +377,15 @@
             }}
             onclick={() => commit(idx)}
           >
-            <ChannelOption
-              channel={c}
-              unavailable={!capability[idx]?.ok}
-              unavailableReason={capability[idx]?.reason ?? ''}
-            />
+            {#if o.none}
+              <span class="none-row">{noneLabel}</span>
+            {:else}
+              <ChannelOption
+                channel={o.channel}
+                unavailable={!capability[idx]?.ok}
+                unavailableReason={capability[idx]?.reason ?? ''}
+              />
+            {/if}
           </li>
         {/each}
       {/if}
@@ -394,6 +424,16 @@
   }
   .placeholder {
     color: var(--text-muted);
+  }
+  /* The synthetic none row reads as a normal, selectable choice (not a
+     muted placeholder) since picking it is a deliberate action. */
+  .none-trigger {
+    color: var(--text-primary);
+  }
+  .none-row {
+    display: block;
+    padding: 2px 0;
+    color: var(--text-primary);
   }
   .chev {
     color: var(--text-muted);

--- a/web/src/routes/Igate.svelte
+++ b/web/src/routes/Igate.svelte
@@ -245,11 +245,13 @@
     // for string/numeric fields (server, port, software_name, etc.) so
     // no UI-side || fallbacks are needed. Booleans still use ??
     // because the server can't distinguish "unset" from "explicit
-    // false", and tx_channel falls back to the first available channel
-    // since the default only makes sense relative to the live list.
+    // false". tx_channel is taken verbatim: 0 means "none (RX only)",
+    // a first-class, selectable choice now (see graywolf#396) — forcing
+    // it onto the first available channel here would silently re-arm TX
+    // and make "none" impossible to persist.
     startChannelsStore();
-    // Invalidate synchronously so the default-channel fallback below
-    // sees a fresh list; then the poller keeps it current.
+    // Invalidate synchronously so the channel list is fresh before the
+    // form seeds from it; then the poller keeps it current.
     await refreshChannels();
     // Load station callsign in parallel with the iGate config. A
     // failed load is treated as "missing" so the banner renders — we
@@ -268,14 +270,13 @@
       })(),
       (async () => {
         const data = await api.get('/igate/config');
-        const defaultCh = channels.length ? Math.min(...channels.map(c => c.id)) : 0;
         loadedServerFilter = data.server_filter ?? '';
         form = {
           enabled: data.enabled ?? false,
           server: data.server,
           port: String(data.port),
           server_filter: data.server_filter ?? '',
-          tx_channel: data.tx_channel || defaultCh,
+          tx_channel: data.tx_channel ?? 0,
           simulation_mode: data.simulation_mode ?? false,
           gate_rf_to_is: data.gate_rf_to_is ?? true,
           gate_is_to_rf: data.gate_is_to_rf ?? false,
@@ -621,6 +622,8 @@
               channels={channels}
               ariaLabelledBy={describedBy}
               capabilityFilter={txPredicate}
+              allowNone
+              noneLabel="None (RX only)"
             />
           {/snippet}
         </FormField>


### PR DESCRIPTION
## Problem

Reported in #396. After setting up an iGate TX channel for testing and then removing the output device, the operator could not revert the iGate to RX-only. The iGate **TX Channel** picker only ever listed channels (filtered by TX-capability), so there was no way to select "none" / "RX only". The persisted `tx_channel` kept pointing at a now-non-TX-capable channel, which blocked Save and produced `Cannot enable iGate: TX channel not TX-capable - no output device configured` on re-enable.

The backend already supports an RX-only iGate: both `ValidateChannelRef` and `requireTxCapableChannel` short-circuit on `tx_channel == 0`. The gap was purely in the UI never offering that value.

## Fix

- **`ChannelListbox`**: add an opt-in `allowNone` / `noneLabel` prop that renders a leading synthetic row mapping to the unset sentinel (`0` for numeric pages, `''` for string pages). The none row is always selectable regardless of `capabilityFilter`, so a previously-selected channel that has gone non-TX-capable can still be escaped. Off by default, so Beacons / Digipeater / Kiss (where a channel is required) are unaffected.
- **iGate page**: expose the row as **None (RX only)**, and stop forcing the loaded `tx_channel` onto the first available channel so a saved `0` round-trips as none instead of silently re-arming TX.
- Extracted the option-model / selection logic into `channelListboxOptions.js` with unit tests (the web runner is plain `node --test` with no Svelte render harness).

## Note on default behavior

A fresh install now defaults the iGate TX channel to **None (RX only)** rather than auto-selecting the first channel. This matches the iGate's RX-only-by-default posture (`gate_is_to_rf` defaults false) and is the safer default; operators who want IS->RF gating or outbound messages pick a TX channel explicitly.

## Testing

- `npm test` — 381 pass (9 new in `channelListboxOptions.test.js`)
- `npm run build` — green

Closes #396