### PR TITLE
Detect Windows audio enhancements and warn in Audio Devices tab

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -30,6 +30,7 @@ Crate name: `graywolf-demod`. Binary: `graywolf-modem`. Source:
 | CPAL live audio I/O | `audio/soundcard.rs` |
 | ALSA card canonicalize + capture probe | `audio/soundcard.rs` (`parse_proc_asound_cards`, `group_alsa_cards`, `probe_capture`), `modem/mod.rs` (`collect_input_devices_linux`) |
 | Configured device name resolution (exact + ALSA shorthand alias) | `audio/soundcard.rs` (`find_device_by_id_or_alias`, `parse_alsa_hw_id`, `alsa_alias_matches`) |
+| Windows audio "enhancements"/APO detection (per-endpoint) -> UI warning | `modem/mod.rs` (`windows_enhancements_enabled`) reads the MMDevices registry hive `HKLM\…\MMDevices\Audio\{Render\|Capture}\{guid}\FxProperties` keyed off the cpal endpoint id; flows `AudioDeviceInfo.audio_enhancements_enabled` (proto) -> `modembridge.AvailableDevice.EnhancementsEnabled` (`enhancements_enabled` JSON) -> `web/src/routes/AudioDevices.svelte` banner/badge/per-device warning. Windows-only; always false elsewhere |
 | FLAC test vector playback | `audio/flac.rs` |
 | Stdin raw i16 PCM | `audio/stdin_raw.rs` |
 | SDR UDP audio bridge | `sdr/mod.rs` |

--- a/graywolf-modem/Cargo.toml
+++ b/graywolf-modem/Cargo.toml
@@ -76,6 +76,9 @@ windows = { version = "0.59", features = [
     "Win32_Security",
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
+    # Read per-endpoint audio "enhancements" state from the MMDevices
+    # registry hive (see windows_enhancements_enabled in modem/mod.rs).
+    "Win32_System_Registry",
 ] }
 
 [build-dependencies]

--- a/graywolf-modem/src/ipc/proto.rs
+++ b/graywolf-modem/src/ipc/proto.rs
@@ -120,6 +120,7 @@ mod tests {
                 is_default: true,
                 description: "Built-in Microphone".into(),
                 recommended: false,
+                audio_enhancements_enabled: false,
             }],
         });
         let mut buf = Vec::new();

--- a/graywolf-modem/src/modem/mod.rs
+++ b/graywolf-modem/src/modem/mod.rs
@@ -1613,6 +1613,92 @@ fn windows_device_id(dev: &cpal::Device) -> Option<String> {
     dev.id().ok().map(|id| id.1)
 }
 
+/// On Windows, report whether audio "enhancements" (system effects /
+/// APOs) are active for the endpoint identified by `endpoint_id` (the
+/// cpal `Device::id()` string, e.g. `{0.0.1.00000000}.{guid}`).
+///
+/// These DSP effects (Loudness Equalization, Bass Boost, noise
+/// suppression, etc.) sit between the radio and the modem and corrupt
+/// the AFSK/packet waveform, so we surface them and let the UI nudge the
+/// operator to turn them off for the device's channel.
+///
+/// Windows keeps per-endpoint effect state in the registry under
+/// `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\
+/// {Render|Capture}\{guid}\FxProperties`. That subkey only exists for
+/// endpoints that actually carry an enhancement/APO pipeline — the bare
+/// USB-audio interfaces most TNC setups use (DigiRig, AIOC, generic
+/// CM108) have none, so its absence reads as "no enhancements" and stays
+/// quiet. When the subkey is present, `PKEY_AudioEndpoint_Disable_SysFx`
+/// (`{1da5d803-d492-4edd-8c23-e0c0ffee7f0e},5`) is the master toggle the
+/// user sees as "Audio enhancements" in Settings / the Sound control
+/// panel: `1` = disabled (fine), `0` or absent = enabled. We therefore
+/// warn only when effects are present and not explicitly disabled.
+#[cfg(target_os = "windows")]
+fn windows_enhancements_enabled(endpoint_id: &str, is_input: bool) -> bool {
+    use windows::core::HSTRING;
+    use windows::Win32::Foundation::ERROR_SUCCESS;
+    use windows::Win32::System::Registry::{
+        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_LOCAL_MACHINE, KEY_READ,
+    };
+
+    // Endpoint id format: `{0.0.<flow>.00000000}.{endpoint-guid}`. The
+    // trailing `{endpoint-guid}` is the MMDevices registry subkey name.
+    let Some(pos) = endpoint_id.rfind("}.") else {
+        return false;
+    };
+    let guid = &endpoint_id[pos + 2..];
+    if guid.is_empty() {
+        return false;
+    }
+    let dir = if is_input { "Capture" } else { "Render" };
+    let path = format!(
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\MMDevices\\Audio\\{dir}\\{guid}\\FxProperties"
+    );
+    let wpath: HSTRING = path.as_str().into();
+
+    let mut hkey = HKEY::default();
+    // SAFETY: `wpath` is a valid NUL-terminated UTF-16 string that
+    // outlives the call; `hkey` is a valid out-param. Read-only access.
+    let rc = unsafe { RegOpenKeyExW(HKEY_LOCAL_MACHINE, &wpath, Some(0), KEY_READ, &mut hkey) };
+    if rc != ERROR_SUCCESS {
+        // No FxProperties subkey -> endpoint has no enhancement pipeline.
+        return false;
+    }
+
+    // PKEY_AudioEndpoint_Disable_SysFx, a REG_DWORD: 1 = enhancements
+    // disabled, 0 = enabled.
+    let value: HSTRING = "{1da5d803-d492-4edd-8c23-e0c0ffee7f0e},5".into();
+    let mut data: u32 = 0;
+    let mut data_len: u32 = std::mem::size_of::<u32>() as u32;
+    // SAFETY: `value` is a valid UTF-16 string; `data`/`data_len` point at
+    // a u32 buffer whose size is given in `data_len`; `hkey` came from a
+    // successful open above.
+    let q = unsafe {
+        RegQueryValueExW(
+            hkey,
+            &value,
+            None,
+            None,
+            Some(&mut data as *mut u32 as *mut u8),
+            Some(&mut data_len),
+        )
+    };
+    // SAFETY: `hkey` is a live key handle from the successful open.
+    unsafe {
+        let _ = RegCloseKey(hkey);
+    }
+
+    if q == ERROR_SUCCESS {
+        // Explicit value present: enhancements on unless the user has
+        // toggled them off (value == 1).
+        data != 1
+    } else {
+        // FxProperties exists but no explicit disable flag -> the effect
+        // pipeline runs by default.
+        true
+    }
+}
+
 /// dBFS floor representing silence — the theoretical dynamic range of
 /// 16-bit audio (~96 dB). Used as the "no signal" value in level scans.
 const NOISE_FLOOR_DBFS: f32 = -96.0;
@@ -1711,16 +1797,18 @@ where
         // string; `recommended` is always false on Windows (no plughw).
         // Issue #100.
         #[cfg(target_os = "windows")]
-        let (stable_id, is_default, description, recommended) = {
+        let (stable_id, is_default, description, recommended, enhancements_enabled) = {
             let id = match windows_device_id(&dev) {
                 Some(id) => id,
                 None => continue,
             };
             let is_default = default_display_name == Some(id.as_str());
-            (id, is_default, windows_friendly_name(&dev), false)
+            let enhancements =
+                windows_enhancements_enabled(&id, kind == AudioDeviceKind::Input as i32);
+            (id, is_default, windows_friendly_name(&dev), false, enhancements)
         };
         #[cfg(not(target_os = "windows"))]
-        let (stable_id, is_default, description, recommended) = (
+        let (stable_id, is_default, description, recommended, enhancements_enabled) = (
             pcm_id.clone(),
             default_display_name == Some(display_name.as_str()),
             alsa_card_description(&pcm_id),
@@ -1728,6 +1816,8 @@ where
             // rather than a numeric index (CARD=0) which can change across
             // reboots if USB devices enumerate in a different order.
             crate::audio::soundcard::is_recommended_pcm_id(&pcm_id),
+            // Audio enhancements are a Windows-only concept.
+            false,
         );
 
         out.push(AudioDeviceInfo {
@@ -1740,6 +1830,7 @@ where
             is_default,
             description,
             recommended,
+            audio_enhancements_enabled: enhancements_enabled,
         });
     }
     out
@@ -1849,6 +1940,7 @@ fn collect_input_devices_linux(
                 is_default: false,
                 description: alsa_card_description(pcm),
                 recommended: true,
+                audio_enhancements_enabled: false,
             });
             continue;
         }
@@ -1911,6 +2003,7 @@ fn collect_input_devices_linux(
             is_default,
             description: alsa_card_description(&pcm),
             recommended,
+            audio_enhancements_enabled: false,
         });
     }
     out
@@ -2006,6 +2099,7 @@ fn collect_output_devices_linux(
                 is_default: false,
                 description: alsa_card_description(pcm),
                 recommended: is_recommended_pcm_id(pcm),
+                audio_enhancements_enabled: false,
             });
             continue;
         }
@@ -2038,6 +2132,7 @@ fn collect_output_devices_linux(
             is_default,
             description: alsa_card_description(&pcm),
             recommended: is_recommended_pcm_id(&pcm),
+            audio_enhancements_enabled: false,
         });
     }
     out

--- a/pkg/ipcproto/graywolf.pb.go
+++ b/pkg/ipcproto/graywolf.pb.go
@@ -887,8 +887,12 @@ type AudioDeviceInfo struct {
 	IsDefault     bool                   `protobuf:"varint,7,opt,name=is_default,json=isDefault,proto3" json:"is_default,omitempty"`
 	Description   string                 `protobuf:"bytes,8,opt,name=description,proto3" json:"description,omitempty"`  // human-friendly name (e.g. USB product string)
 	Recommended   bool                   `protobuf:"varint,9,opt,name=recommended,proto3" json:"recommended,omitempty"` // true for plughw: devices (ALSA software conversion)
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Windows only: the endpoint has audio "enhancements" (system effects /
+	// APOs) active. Those DSP effects mangle AFSK/packet audio and degrade
+	// decoding, so the UI warns the operator. Always false on Linux/macOS.
+	AudioEnhancementsEnabled bool `protobuf:"varint,10,opt,name=audio_enhancements_enabled,json=audioEnhancementsEnabled,proto3" json:"audio_enhancements_enabled,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *AudioDeviceInfo) Reset() {
@@ -980,6 +984,13 @@ func (x *AudioDeviceInfo) GetDescription() string {
 func (x *AudioDeviceInfo) GetRecommended() bool {
 	if x != nil {
 		return x.Recommended
+	}
+	return false
+}
+
+func (x *AudioDeviceInfo) GetAudioEnhancementsEnabled() bool {
+	if x != nil {
+		return x.AudioEnhancementsEnabled
 	}
 	return false
 }
@@ -2301,7 +2312,7 @@ const file_graywolf_proto_rawDesc = "" +
 	"\x0fAudioDeviceList\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\rR\trequestId\x123\n" +
-	"\adevices\x18\x02 \x03(\v2\x19.graywolf.AudioDeviceInfoR\adevices\"\xb9\x02\n" +
+	"\adevices\x18\x02 \x03(\v2\x19.graywolf.AudioDeviceInfoR\adevices\"\xf7\x02\n" +
 	"\x0fAudioDeviceInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1b\n" +
 	"\tstable_id\x18\x02 \x01(\tR\bstableId\x12-\n" +
@@ -2312,7 +2323,9 @@ const file_graywolf_proto_rawDesc = "" +
 	"\n" +
 	"is_default\x18\a \x01(\bR\tisDefault\x12 \n" +
 	"\vdescription\x18\b \x01(\tR\vdescription\x12 \n" +
-	"\vrecommended\x18\t \x01(\bR\vrecommended\"\xd2\x01\n" +
+	"\vrecommended\x18\t \x01(\bR\vrecommended\x12<\n" +
+	"\x1aaudio_enhancements_enabled\x18\n" +
+	" \x01(\bR\x18audioEnhancementsEnabled\"\xd2\x01\n" +
 	"\rTransmitFrame\x12\x18\n" +
 	"\achannel\x18\x01 \x01(\rR\achannel\x12\x12\n" +
 	"\x04data\x18\x02 \x01(\fR\x04data\x12.\n" +

--- a/pkg/modembridge/requests.go
+++ b/pkg/modembridge/requests.go
@@ -164,15 +164,16 @@ func convertDeviceList(list *pb.AudioDeviceList) []AvailableDevice {
 			path = d.Name
 		}
 		out = append(out, AvailableDevice{
-			Name:        d.Name,
-			Description: d.Description,
-			Path:        path,
-			SampleRates: d.SampleRates,
-			Channels:    d.ChannelCounts,
-			HostAPI:     d.HostApi,
-			IsDefault:   d.IsDefault,
-			IsInput:     d.Kind == pb.AudioDeviceKind_AUDIO_DEVICE_KIND_INPUT,
-			Recommended: d.Recommended,
+			Name:                d.Name,
+			Description:         d.Description,
+			Path:                path,
+			SampleRates:         d.SampleRates,
+			Channels:            d.ChannelCounts,
+			HostAPI:             d.HostApi,
+			IsDefault:           d.IsDefault,
+			IsInput:             d.Kind == pb.AudioDeviceKind_AUDIO_DEVICE_KIND_INPUT,
+			Recommended:         d.Recommended,
+			EnhancementsEnabled: d.AudioEnhancementsEnabled,
 		})
 	}
 	return out

--- a/pkg/modembridge/types.go
+++ b/pkg/modembridge/types.go
@@ -33,6 +33,10 @@ type AvailableDevice struct {
 	IsDefault   bool     `json:"is_default"`
 	IsInput     bool     `json:"is_input"`
 	Recommended bool     `json:"recommended"` // true for plughw: devices (ALSA software conversion)
+	// EnhancementsEnabled is Windows-only: the endpoint has audio
+	// "enhancements" (system effects / APOs) active, which corrupt
+	// AFSK/packet audio. Always false on Linux/macOS.
+	EnhancementsEnabled bool `json:"enhancements_enabled"`
 }
 
 // InputLevel holds the level scan result for a single input device.

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -11024,6 +11024,10 @@
                     "description": "human-friendly name (e.g. USB product string)",
                     "type": "string"
                 },
+                "enhancements_enabled": {
+                    "description": "EnhancementsEnabled is Windows-only: the endpoint has audio\n\"enhancements\" (system effects / APOs) active, which corrupt\nAFSK/packet audio. Always false on Linux/macOS.",
+                    "type": "boolean"
+                },
                 "host_api": {
                     "type": "string"
                 },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -2429,6 +2429,12 @@ definitions:
       description:
         description: human-friendly name (e.g. USB product string)
         type: string
+      enhancements_enabled:
+        description: |-
+          EnhancementsEnabled is Windows-only: the endpoint has audio
+          "enhancements" (system effects / APOs) active, which corrupt
+          AFSK/packet audio. Always false on Linux/macOS.
+        type: boolean
       host_api:
         type: string
       is_default:

--- a/proto/graywolf.proto
+++ b/proto/graywolf.proto
@@ -109,6 +109,10 @@ message AudioDeviceInfo {
   bool is_default = 7;
   string description = 8;        // human-friendly name (e.g. USB product string)
   bool recommended = 9;          // true for plughw: devices (ALSA software conversion)
+  // Windows only: the endpoint has audio "enhancements" (system effects /
+  // APOs) active. Those DSP effects mangle AFSK/packet audio and degrade
+  // decoding, so the UI warns the operator. Always false on Linux/macOS.
+  bool audio_enhancements_enabled = 10;
 }
 
 enum AudioDeviceKind {

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -3360,6 +3360,12 @@ export interface components {
             channels?: number[];
             /** @description human-friendly name (e.g. USB product string) */
             description?: string;
+            /**
+             * @description EnhancementsEnabled is Windows-only: the endpoint has audio
+             *     "enhancements" (system effects / APOs) active, which corrupt
+             *     AFSK/packet audio. Always false on Linux/macOS.
+             */
+            enhancements_enabled?: boolean;
             host_api?: string;
             is_default?: boolean;
             is_input?: boolean;

--- a/web/src/routes/AudioDevices.svelte
+++ b/web/src/routes/AudioDevices.svelte
@@ -244,6 +244,14 @@
   let inputDevices = $derived(devices.filter(d => d.direction === 'input'));
   let outputDevices = $derived(devices.filter(d => d.direction === 'output'));
   let configuredPaths = $derived(new Set(devices.map(d => d.device_path)));
+  // Windows audio "enhancements" (system effects / APOs) corrupt the
+  // AFSK/packet waveform. The modem flags affected endpoints during a
+  // hardware scan; cross-reference by path so we can warn on both the
+  // detected-hardware cards and the configured devices actually in use.
+  let enhancedPaths = $derived(
+    new Set(available.filter(d => d.enhancements_enabled).map(d => d.path))
+  );
+  let hasEnhancedDevices = $derived(enhancedPaths.size > 0);
   // Level meters in the modem only fire for devices that a channel
   // actively binds to. If no channel has audio assigned, the meters
   // here will sit at -inf no matter what hardware is plugged in.
@@ -307,6 +315,20 @@
   </div>
 {/if}
 
+{#if hasEnhancedDevices}
+  <div class="enhancements-banner" role="alert">
+    <strong>Windows audio enhancements detected.</strong>
+    One or more audio devices below have Windows "enhancements" (system
+    effects such as Loudness Equalization, Bass Boost, or noise
+    suppression) turned on. These effects alter the audio before it
+    reaches the modem and will degrade or break AFSK/packet decoding.
+    Turn them off for each flagged device: open <em>Settings → System →
+    Sound</em>, click the device, and set <em>Audio enhancements</em> to
+    <em>Off</em> (on older Windows, use the Sound control panel's
+    "Enhancements" tab and check "Disable all enhancements").
+  </div>
+{/if}
+
 <!-- Station readiness -->
 <div class="readiness">
   <div class="readiness-item" class:ready={hasInput}>
@@ -364,6 +386,14 @@
             <span class="detail-value">Mono</span>
           </div>
         </div>
+        {#if enhancedPaths.has(dev.device_path)}
+          <div class="device-enhance-warn" role="alert">
+            <Badge variant="danger">Enhancements On</Badge>
+            <span>Windows audio enhancements are active on this device and
+            will distort packet audio. Disable them in Windows Sound
+            settings.</span>
+          </div>
+        {/if}
         <!-- Audio level meter -->
         <div class="level-section">
           <div class="level-row">
@@ -417,6 +447,9 @@
             {/if}
             {#if dev.recommended}
               <Badge variant="warning">Recommended</Badge>
+            {/if}
+            {#if dev.enhancements_enabled}
+              <Badge variant="danger">Enhancements On</Badge>
             {/if}
             <Badge variant={dev.is_input ? 'info' : 'success'}>
               {dev.is_input ? 'Input' : 'Output'}
@@ -565,6 +598,39 @@
     background: var(--bg-secondary, rgba(255, 255, 255, 0.06));
     padding: 1px 5px;
     border-radius: 3px;
+  }
+  .enhancements-banner {
+    margin: 0 0 16px;
+    padding: 10px 14px;
+    border: 1px solid var(--color-danger, #f85149);
+    border-left-width: 4px;
+    border-radius: var(--radius);
+    background: var(--color-danger-muted, rgba(248, 81, 73, 0.12));
+    color: var(--text-primary);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  .enhancements-banner strong {
+    display: block;
+    margin-bottom: 4px;
+  }
+  .enhancements-banner em {
+    font-style: normal;
+    background: var(--bg-secondary, rgba(255, 255, 255, 0.06));
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+  .device-enhance-warn {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 10px;
+    padding: 8px 10px;
+    border-radius: var(--radius);
+    background: var(--color-danger-muted, rgba(248, 81, 73, 0.12));
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--text-primary);
   }
 
   /* Station readiness */


### PR DESCRIPTION
## What

Windows "audio enhancements" (system effects / APOs -- Loudness Equalization, Bass Boost, noise suppression, etc.) apply DSP to the audio stream between the radio and the modem, which corrupts the AFSK/packet waveform and degrades or breaks decoding. Graywolf now detects, per endpoint, whether enhancements are active and warns the operator in the Audio Devices tab.

## How it's detected

cpal already gives us each Windows endpoint's IMMDevice id (`{0.0.1.00000000}.{guid}`). We read that endpoint's effect state from the registry:

```
HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\{Render|Capture}\{guid}\FxProperties
```

- The `FxProperties` subkey only exists for endpoints that actually carry an enhancement/APO pipeline. Bare USB-audio interfaces (DigiRig, AIOC, generic CM108 -- what most TNC setups use) have none, so the absence of the subkey reads as "no enhancements" and stays quiet -- this keeps false positives down.
- When the subkey is present, `PKEY_AudioEndpoint_Disable_SysFx` (`{1da5d803-d492-4edd-8c23-e0c0ffee7f0e},5`) is the master toggle the user sees as "Audio enhancements" in Settings / the Sound control panel: `1` = disabled (fine), `0` or absent = enabled. We warn only when effects are present and not explicitly disabled.

## Plumbing

New `audio_enhancements_enabled` flows: `AudioDeviceInfo` (proto) -> `AvailableDevice` (Go, `enhancements_enabled` JSON) -> `/audio-devices/available` -> UI. Always `false` on Linux/macOS.

The UI surfaces it three ways after a "Detect Devices" scan:
- a red banner above the device list with step-by-step instructions to disable enhancements,
- an "Enhancements On" badge on the detected-hardware card,
- a per-configured-device warning row (cross-referenced by device path) so the warning lands on the device the operator is actually using.

## Testing

- `cargo check` / `cargo clippy -D warnings` (Linux host) -- pass.
- The Windows-only registry code was type-checked against the `windows` 0.59 crate for the `x86_64-pc-windows-gnu` target in isolation (the full crate can't cross-compile here -- a transitive dep needs mingw). It compiles on `windows-latest` in the release workflow.
- `make docs-check`, `make docs-lint`, regenerated OpenAPI spec + TS client (`api-client-check` matches).
- `go test ./pkg/modembridge/... ./pkg/webapi/...` -- pass. `web` build -- pass.

**Needs validation on real Windows hardware** before merge: confirm that an endpoint with enhancements toggled on flags correctly, and that a typical USB ham interface does not produce a false positive. The detection semantics are documented inline at `windows_enhancements_enabled` in `graywolf-modem/src/modem/mod.rs` for easy verification against a machine's registry.

Closes GRA-203.