### PR TITLE
feat(map): front styling tweaks + layers-pane reorg (APRS / Weather)

### DIFF
--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -114,7 +114,7 @@ function catmull(p0, p1, p2, p3, t) {
 // output is uniformly smooth regardless of the raw point spacing and the
 // straight-chord segmentation disappears. Endpoints are preserved; <3 points
 // (nothing to curve) pass through unchanged.
-export function smoothLine(pts, targetDeg = 0.15, maxSub = 10) {
+export function smoothLine(pts, targetDeg = 0.03, maxSub = 40) {
   if (!Array.isArray(pts) || pts.length < 3) return pts;
   const n = pts.length;
   const at = (i) => pts[Math.max(0, Math.min(n - 1, i))];
@@ -134,11 +134,14 @@ export function smoothLine(pts, targetDeg = 0.15, maxSub = 10) {
 
 // Return a copy of the FeatureCollection with every front LineString smoothed.
 // Pressure-center Points are untouched. Tolerant of missing/empty input.
-export function smoothFronts(fc) {
+export function smoothFronts(fc, targetDeg = 0.03, maxSub = 40) {
   if (!fc || !Array.isArray(fc.features)) return fc;
   const features = fc.features.map((f) => {
     if (f?.properties?.feature !== 'front' || f?.geometry?.type !== 'LineString') return f;
-    return { ...f, geometry: { ...f.geometry, coordinates: smoothLine(f.geometry.coordinates) } };
+    return {
+      ...f,
+      geometry: { ...f.geometry, coordinates: smoothLine(f.geometry.coordinates, targetDeg, maxSub) },
+    };
   });
   return { ...fc, features };
 }
@@ -154,6 +157,8 @@ export function mountFrontsLayer(map, { visible }) {
   // renders smooth curves and the pip icons sit flush instead of dangling off
   // the straight-chord corners. Starts empty until the first push.
   let curData = EMPTY_FC;
+  let lastRaw = EMPTY_FC; // unsmoothed document, kept so density can be re-tuned
+  let smoothTargetDeg = 0.03; // Catmull-Rom resample target; smaller = curvier
 
   const firstSymbolId = () => map.getStyle().layers.find((l) => l.type === 'symbol')?.id;
 
@@ -238,9 +243,9 @@ export function mountFrontsLayer(map, { visible }) {
           },
           paint: {
             'line-color': frontColorMatch(),
-            // A touch thicker than v1 so the boundaries read clearly. Dash units
-            // are line-width-relative, so troughs' dashes scale up with this.
-            'line-width': ['interpolate', ['linear'], ['zoom'], 3, 1.8, 8, 3.8],
+            // Dash units are line-width-relative, so troughs' dashes scale with
+            // this. Tunable live via window.gwFronts.tune({ lineWidth }).
+            'line-width': ['interpolate', ['linear'], ['zoom'], 3, 2.5, 8, 5],
             'line-dasharray': [
               'case',
               ['==', ['get', 'front_type'], 'trough'],
@@ -262,7 +267,7 @@ export function mountFrontsLayer(map, { visible }) {
       ['==', ['get', 'feature'], 'front'],
       ['==', ['get', 'front_type'], 'stationary'],
     ];
-    const stationaryWidth = ['interpolate', ['linear'], ['zoom'], 3, 1.8, 8, 3.8];
+    const stationaryWidth = ['interpolate', ['linear'], ['zoom'], 3, 2.5, 8, 5];
     if (!map.getLayer('fronts-stationary-line')) {
       map.addLayer(
         {
@@ -319,12 +324,13 @@ export function mountFrontsLayer(map, { visible }) {
             'symbol-placement': 'line',
             'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 30, 8, 60],
             'icon-image': pipIconMatch(),
-            // Sized to read as proper pips without dominating the line (~2-3x
-            // the line width). Tunable live via window.gwFronts.tune().
-            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.62, 8, 0.92],
+            // Tunable live via window.gwFronts.tune().
+            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.7, 8, 1.0],
             'icon-rotation-alignment': 'map',
-            'icon-allow-overlap': true,
-            'icon-ignore-placement': true,
+            // allow-overlap OFF (and no ignore-placement) so MapLibre drops pips
+            // it can't lay flat on a tight curve -- those are the ones that
+            // dangle off the bends -- instead of force-rendering them.
+            'icon-allow-overlap': false,
           },
         },
         beforeId,
@@ -349,13 +355,13 @@ export function mountFrontsLayer(map, { visible }) {
             // Repeat at ~the rendered sprite width (36px * icon-size) so the
             // sprites abut and the triangle/semicircle stay evenly spaced
             // (even alternation) rather than clustering with gaps between units.
-            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 24, 8, 34],
+            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 26, 8, 36],
             'icon-image': IMG_STATIONARY,
-            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.62, 8, 0.92],
+            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.7, 8, 1.0],
             'icon-rotation-alignment': 'map',
             'icon-keep-upright': false,
-            'icon-allow-overlap': true,
-            'icon-ignore-placement': true,
+            // See cold/warm pips: drop rather than dangle on tight curves.
+            'icon-allow-overlap': false,
           },
         },
         beforeId,
@@ -441,7 +447,11 @@ export function mountFrontsLayer(map, { visible }) {
   // and hand it to the source. No source/layer churn. Called by LiveMapV2 on
   // initial load and whenever the manifest poll sees a new analysis.
   function setData(rawFc) {
-    curData = smoothFronts(rawFc) ?? EMPTY_FC;
+    lastRaw = rawFc ?? EMPTY_FC;
+    applySmoothed();
+  }
+  function applySmoothed() {
+    curData = smoothFronts(lastRaw, smoothTargetDeg) ?? EMPTY_FC;
     map.getSource(FRONTS_SOURCE_ID)?.setData(curData);
   }
 
@@ -471,6 +481,7 @@ export function mountFrontsLayer(map, { visible }) {
   function tune(o = {}) {
     const sl = (id, p, v) => { if (v != null && map.getLayer(id)) map.setLayoutProperty(id, p, v); };
     const sp = (id, p, v) => { if (v != null && map.getLayer(id)) map.setPaintProperty(id, p, v); };
+    const pipLayers = ['fronts-pips', 'fronts-stationary-pips'];
     if (o.lineWidth != null) {
       for (const id of ['fronts-line', 'fronts-stationary-line', 'fronts-stationary-dash']) {
         sp(id, 'line-width', o.lineWidth);
@@ -480,7 +491,18 @@ export function mountFrontsLayer(map, { visible }) {
     sl('fronts-pips', 'symbol-spacing', o.pipSpacing);
     sl('fronts-stationary-pips', 'icon-size', o.statSize);
     sl('fronts-stationary-pips', 'symbol-spacing', o.statSpacing);
-    return o;
+    // Placement flags drive the dangling fix: with overlap/ignore-placement
+    // OFF, MapLibre drops pips it can't lay cleanly on a curve (the ones that
+    // dangle at bends) instead of force-rendering them.
+    if (o.allowOverlap != null) for (const id of pipLayers) sl(id, 'icon-allow-overlap', o.allowOverlap);
+    if (o.ignorePlacement != null) for (const id of pipLayers) sl(id, 'icon-ignore-placement', o.ignorePlacement);
+    // Re-smooth the lines at a new density (degrees per chord). Smaller = curvier
+    // (and more points). Re-runs the resample on the last fetched document.
+    if (o.smoothTarget != null) {
+      smoothTargetDeg = o.smoothTarget;
+      applySmoothed();
+    }
+    return { ...o, smoothTargetDeg };
   }
 
   // Snapshot of what's currently rendered, for console diagnostics.
@@ -488,6 +510,7 @@ export function mountFrontsLayer(map, { visible }) {
     const fronts = (curData?.features ?? []).filter((f) => f?.properties?.feature === 'front');
     return {
       zoom: map.getZoom?.(),
+      smoothTargetDeg,
       frontFeatures: fronts.length,
       maxLinePoints: fronts.reduce((m, f) => Math.max(m, f.geometry?.coordinates?.length ?? 0), 0),
       stationarySpriteLoaded: map.hasImage?.(IMG_STATIONARY) ?? null,

--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -39,10 +39,25 @@ const coldSvg = (fill) =>
 const warmSvg = (fill) =>
   `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><path d="M 2 9 A 7 7 0 0 1 16 9 Z" fill="${fill}"/></svg>`;
 const occludedTriSvg = coldSvg;
+// Stationary front: the proper WMO depiction is alternating cold/warm symbols on
+// OPPOSITE sides of the line. This single 36x18 sprite carries one full period
+// -- a cold triangle on the top half (apex up) and a warm semicircle on the
+// bottom half (bulges down) -- so when symbol-placement:line repeats it at
+// ~sprite-width spacing it tiles into triangle/semicircle/triangle/semicircle,
+// each on its own side. (Sweep-flag 1 with left-to-right endpoints bulges +y =
+// the bottom half, opposite the apex-up triangle.) The two colors are baked in,
+// so unlike the single-type pips this sprite is not parameterized by one fill.
+const stationarySvg = (cold, warm) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 18" width="36" height="18">` +
+  `<polygon points="3,9 15,9 9,1" fill="${cold}"/>` +
+  `<path d="M 21 9 A 6 6 0 0 1 33 9 Z" fill="${warm}"/></svg>`;
 
 export const FRONT_LAYER_IDS = [
   'fronts-line',
+  'fronts-stationary-line',
+  'fronts-stationary-dash',
   'fronts-pips',
+  'fronts-stationary-pips',
   'fronts-centers',
   'fronts-center-labels',
 ];
@@ -51,11 +66,12 @@ export const FRONT_LAYER_IDS = [
 const IMG_COLD = 'front-cold';
 const IMG_WARM = 'front-warm';
 const IMG_OCCLUDED = 'front-occluded';
+const IMG_STATIONARY = 'front-stationary';
 
 // Rasterize an SVG string into an ImageData of the given pixel size. Returns a
 // Promise; resolves null in a non-DOM environment (e.g. node --test), where the
 // overlay's icon layers simply render without sprites.
-function rasterizeSvg(svg, size) {
+function rasterizeSvg(svg, w, h = w) {
   if (typeof document === 'undefined' || typeof Image === 'undefined') {
     return Promise.resolve(null);
   }
@@ -64,11 +80,11 @@ function rasterizeSvg(svg, size) {
     img.onload = () => {
       try {
         const canvas = document.createElement('canvas');
-        canvas.width = size;
-        canvas.height = size;
+        canvas.width = w;
+        canvas.height = h;
         const ctx = canvas.getContext('2d');
-        ctx.drawImage(img, 0, 0, size, size);
-        resolve(ctx.getImageData(0, 0, size, size));
+        ctx.drawImage(img, 0, 0, w, h);
+        resolve(ctx.getImageData(0, 0, w, h));
       } catch {
         resolve(null);
       }
@@ -88,14 +104,17 @@ export function mountFrontsLayer(map, { visible }) {
   // map.hasImage so a style swap (which drops user images) re-registers them on
   // the next ensure().
   async function loadImages() {
+    // [id, svg, width, height] -- stationary is a wide 2-symbol sprite (36x18);
+    // the single-type pips are square (18x18).
     const want = [
-      [IMG_COLD, coldSvg(FRONT_COLORS.cold)],
-      [IMG_WARM, warmSvg(FRONT_COLORS.warm)],
-      [IMG_OCCLUDED, occludedTriSvg(FRONT_COLORS.occluded)],
+      [IMG_COLD, coldSvg(FRONT_COLORS.cold), 18, 18],
+      [IMG_WARM, warmSvg(FRONT_COLORS.warm), 18, 18],
+      [IMG_OCCLUDED, occludedTriSvg(FRONT_COLORS.occluded), 18, 18],
+      [IMG_STATIONARY, stationarySvg(FRONT_COLORS.cold, FRONT_COLORS.warm), 36, 18],
     ];
-    for (const [id, svg] of want) {
+    for (const [id, svg, w, h] of want) {
       if (map.hasImage && map.hasImage(id)) continue;
-      const data = await rasterizeSvg(svg, 18);
+      const data = await rasterizeSvg(svg, w, h);
       if (!data) continue;
       // hasImage re-checked after the await -- a concurrent ensure() or another
       // mount may have registered it while we were rasterizing.
@@ -105,16 +124,13 @@ export function mountFrontsLayer(map, { visible }) {
     }
   }
 
-  // line-color match on the feature's front_type. `stationary` is kept here
-  // even though stationary fronts are currently filtered out of every layer
-  // (see the line layer) so that re-enabling them later is a one-line filter
-  // change, not a color hunt.
+  // line-color match for the cold/warm/occluded/trough base line. stationary is
+  // not here -- it draws via its own two-tone (blue base + red dash) layers.
   const frontColorMatch = () => [
     'match',
     ['get', 'front_type'],
     'cold', FRONT_COLORS.cold,
     'warm', FRONT_COLORS.warm,
-    'stationary', FRONT_COLORS.stationary,
     'occluded', FRONT_COLORS.occluded,
     'trough', FRONT_COLORS.trough,
     '#888888',
@@ -138,14 +154,10 @@ export function mountFrontsLayer(map, { visible }) {
     const beforeId = firstSymbolId();
     const vis = curVisible ? 'visible' : 'none';
 
-    // 1) Base front line. trough is dashed; every other type is solid. The dash
-    // array is gated on front_type so only troughs get it.
-    //
-    // stationary fronts are EXCLUDED entirely: without proper alternating
-    // opposite-side symbology (the deferred limitation noted below) they render
-    // as a bare colored line that reads as a random stray line on the map, so
-    // we hide them until that symbology exists rather than show a misleading
-    // boundary.
+    // 1) Base front line for cold/warm/occluded/trough. trough is dashed; every
+    // other type is solid. stationary is handled by its own two-tone line +
+    // alternating-pip layers below (it needs cold/warm symbology on opposite
+    // sides), so it is excluded here.
     if (!map.getLayer('fronts-line')) {
       map.addLayer(
         {
@@ -179,17 +191,55 @@ export function mountFrontsLayer(map, { visible }) {
       );
     }
 
+    // 1b) Stationary front line: a solid cold-blue base with a warm-red dashed
+    // line painted on top, so the gaps reveal blue and the line reads as
+    // alternating red/blue segments -- the WMO two-tone stationary boundary --
+    // without needing per-segment color (which MapLibre line layers can't do).
+    const stationaryFilter = [
+      'all',
+      ['==', ['get', 'feature'], 'front'],
+      ['==', ['get', 'front_type'], 'stationary'],
+    ];
+    const stationaryWidth = ['interpolate', ['linear'], ['zoom'], 3, 1.8, 8, 3.8];
+    if (!map.getLayer('fronts-stationary-line')) {
+      map.addLayer(
+        {
+          id: 'fronts-stationary-line',
+          type: 'line',
+          source: provider.sourceId,
+          filter: stationaryFilter,
+          layout: { visibility: vis, 'line-cap': 'butt', 'line-join': 'round' },
+          paint: { 'line-color': FRONT_COLORS.cold, 'line-width': stationaryWidth },
+        },
+        beforeId,
+      );
+    }
+    if (!map.getLayer('fronts-stationary-dash')) {
+      map.addLayer(
+        {
+          id: 'fronts-stationary-dash',
+          type: 'line',
+          source: provider.sourceId,
+          filter: stationaryFilter,
+          layout: { visibility: vis, 'line-cap': 'butt', 'line-join': 'round' },
+          paint: {
+            'line-color': FRONT_COLORS.warm,
+            'line-width': stationaryWidth,
+            // Equal dash/gap: red covers half the line, blue base shows through
+            // the gaps -> alternating red/blue.
+            'line-dasharray': ['literal', [3, 3]],
+          },
+        },
+        beforeId,
+      );
+    }
+
     // 2) Frontal pips along the line.
     //
-    // v1 LIMITATION (documented, not an oversight): MapLibre
-    // symbol-placement:line draws a single sprite repeated on ONE side of the
-    // line, so it cannot render a stationary front's alternating
-    // opposite-side warm/cold pips, nor an occluded front's alternating
-    // triangle/semicircle. stationary fronts are hidden entirely (see the line
-    // layer above) until that symbology exists; occluded uses the cold triangle
-    // only. Proper alternating-side symbology needs either two offset symbol
-    // layers with side-tagged geometry from the generator, or a custom WebGL
-    // layer -- deferred past v1.
+    // cold/warm/occluded carry a single repeated sprite. occluded uses the cold
+    // triangle only (its alternating triangle/semicircle is still deferred).
+    // stationary is handled separately (layer 2b) with a combined 2-symbol
+    // sprite that produces the proper alternating opposite-side pips.
     if (!map.getLayer('fronts-pips')) {
       map.addLayer(
         {
@@ -211,6 +261,37 @@ export function mountFrontsLayer(map, { visible }) {
             // A little larger than v1 so the triangles/semicircles read clearly.
             'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.95, 8, 1.35],
             'icon-rotation-alignment': 'map',
+            'icon-allow-overlap': true,
+            'icon-ignore-placement': true,
+          },
+        },
+        beforeId,
+      );
+    }
+
+    // 2b) Stationary pips. The combined cold-triangle/warm-semicircle sprite is
+    // repeated along the line at roughly its own width, so the two symbols tile
+    // into the alternating opposite-side pattern. symbol-spacing is matched to
+    // the sprite footprint (wider than the single-type pips since each unit is
+    // two symbols) to keep the pattern continuous without overlap.
+    if (!map.getLayer('fronts-stationary-pips')) {
+      map.addLayer(
+        {
+          id: 'fronts-stationary-pips',
+          type: 'symbol',
+          source: provider.sourceId,
+          filter: stationaryFilter,
+          layout: {
+            visibility: vis,
+            'symbol-placement': 'line',
+            // Repeat at ~the rendered sprite width (36px * icon-size) so the
+            // sprites abut and the triangle/semicircle stay evenly spaced
+            // (even alternation) rather than clustering with gaps between units.
+            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 34, 8, 49],
+            'icon-image': IMG_STATIONARY,
+            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.95, 8, 1.35],
+            'icon-rotation-alignment': 'map',
+            'icon-keep-upright': false,
             'icon-allow-overlap': true,
             'icon-ignore-placement': true,
           },

--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -132,18 +132,70 @@ export function smoothLine(pts, targetDeg = 0.03, maxSub = 40) {
   return out;
 }
 
-// Return a copy of the FeatureCollection with every front LineString smoothed.
-// Pressure-center Points are untouched. Tolerant of missing/empty input.
-export function smoothFronts(fc, targetDeg = 0.03, maxSub = 40) {
+// Absolute turn (radians) at vertex b between segments a->b and b->c.
+function turnAt(a, b, c) {
+  let t = Math.atan2(c[1] - b[1], c[0] - b[0]) - Math.atan2(b[1] - a[1], b[0] - a[0]);
+  while (t > Math.PI) t -= 2 * Math.PI;
+  while (t < -Math.PI) t += 2 * Math.PI;
+  return Math.abs(t);
+}
+
+// Split a (dense, smoothed) line into the runs that are gentle enough to carry
+// pips, dropping tight bends. At each vertex we sum the turning over a +/-
+// windowDeg arc window (~a pip's footprint); where that exceeds maxTurn the
+// curve is too tight for a pip to sit flat, so it's excluded. The result feeds
+// the pip layers (via symbol-placement:line) so pips appear only on the gentle
+// spans -- the tight curve still draws its line, just without clashing pips.
+export function pipSpans(line, windowDeg = 0.3, maxTurn = 0.7) {
+  if (!Array.isArray(line) || line.length < 2) return [];
+  if (line.length < 3) return [line];
+  const n = line.length;
+  const cum = [0];
+  for (let i = 1; i < n; i++) cum[i] = cum[i - 1] + Math.hypot(line[i][0] - line[i - 1][0], line[i][1] - line[i - 1][1]);
+  const turn = new Array(n).fill(0);
+  for (let i = 1; i < n - 1; i++) turn[i] = turnAt(line[i - 1], line[i], line[i + 1]);
+  const excluded = new Array(n).fill(false);
+  for (let i = 0; i < n; i++) {
+    let s = 0;
+    for (let j = i; j < n && cum[j] - cum[i] <= windowDeg / 2; j++) s += turn[j];
+    for (let j = i - 1; j >= 0 && cum[i] - cum[j] <= windowDeg / 2; j--) s += turn[j];
+    if (s > maxTurn) excluded[i] = true;
+  }
+  const spans = [];
+  let run = [];
+  for (let i = 0; i < n; i++) {
+    if (!excluded[i]) run.push(line[i]);
+    else { if (run.length >= 2) spans.push(run); run = []; }
+  }
+  if (run.length >= 2) spans.push(run);
+  return spans;
+}
+
+// Return a copy of the FeatureCollection with every front LineString smoothed,
+// plus a companion `pipline` MultiLineString per front carrying only the gentle
+// spans (the pip layers follow these, so pips skip tight bends). Pressure-center
+// Points are untouched. Tolerant of missing/empty input.
+export function smoothFronts(fc, opts = {}) {
+  const { targetDeg = 0.03, maxSub = 40, pipWindowDeg = 0.3, pipMaxTurn = 0.7 } = opts;
   if (!fc || !Array.isArray(fc.features)) return fc;
-  const features = fc.features.map((f) => {
-    if (f?.properties?.feature !== 'front' || f?.geometry?.type !== 'LineString') return f;
-    return {
-      ...f,
-      geometry: { ...f.geometry, coordinates: smoothLine(f.geometry.coordinates, targetDeg, maxSub) },
-    };
-  });
-  return { ...fc, features };
+  const out = [];
+  for (const f of fc.features) {
+    if (f?.properties?.feature !== 'front' || f?.geometry?.type !== 'LineString') {
+      out.push(f);
+      continue;
+    }
+    const smoothed = smoothLine(f.geometry.coordinates, targetDeg, maxSub);
+    out.push({ ...f, geometry: { ...f.geometry, coordinates: smoothed } });
+    const spans = pipSpans(smoothed, pipWindowDeg, pipMaxTurn);
+    if (spans.length) {
+      out.push({
+        type: 'Feature',
+        properties: { ...f.properties, feature: 'pipline' },
+        geometry: { type: 'MultiLineString', coordinates: spans },
+      });
+    }
+  }
+  return { ...fc, features: out };
 }
 
 const EMPTY_FC = { type: 'FeatureCollection', features: [] };
@@ -159,6 +211,8 @@ export function mountFrontsLayer(map, { visible }) {
   let curData = EMPTY_FC;
   let lastRaw = EMPTY_FC; // unsmoothed document, kept so density can be re-tuned
   let smoothTargetDeg = 0.03; // Catmull-Rom resample target; smaller = curvier
+  let pipWindowDeg = 0.3; // arc window for the tight-bend pip test
+  let pipMaxTurn = 0.7; // radians of turn over that window before pips are dropped
 
   const firstSymbolId = () => map.getStyle().layers.find((l) => l.type === 'symbol')?.id;
 
@@ -267,6 +321,12 @@ export function mountFrontsLayer(map, { visible }) {
       ['==', ['get', 'feature'], 'front'],
       ['==', ['get', 'front_type'], 'stationary'],
     ];
+    // Pips follow the gentle-span `pipline` geometry, not the full front line.
+    const stationaryPipFilter = [
+      'all',
+      ['==', ['get', 'feature'], 'pipline'],
+      ['==', ['get', 'front_type'], 'stationary'],
+    ];
     const stationaryWidth = ['interpolate', ['linear'], ['zoom'], 3, 2.5, 8, 5];
     if (!map.getLayer('fronts-stationary-line')) {
       map.addLayer(
@@ -315,7 +375,7 @@ export function mountFrontsLayer(map, { visible }) {
           source: provider.sourceId,
           filter: [
             'all',
-            ['==', ['get', 'feature'], 'front'],
+            ['==', ['get', 'feature'], 'pipline'],
             ['!=', ['get', 'front_type'], 'trough'],
             ['!=', ['get', 'front_type'], 'stationary'],
           ],
@@ -348,7 +408,7 @@ export function mountFrontsLayer(map, { visible }) {
           id: 'fronts-stationary-pips',
           type: 'symbol',
           source: provider.sourceId,
-          filter: stationaryFilter,
+          filter: stationaryPipFilter,
           layout: {
             visibility: vis,
             'symbol-placement': 'line',
@@ -451,7 +511,7 @@ export function mountFrontsLayer(map, { visible }) {
     applySmoothed();
   }
   function applySmoothed() {
-    curData = smoothFronts(lastRaw, smoothTargetDeg) ?? EMPTY_FC;
+    curData = smoothFronts(lastRaw, { targetDeg: smoothTargetDeg, pipWindowDeg, pipMaxTurn }) ?? EMPTY_FC;
     map.getSource(FRONTS_SOURCE_ID)?.setData(curData);
   }
 
@@ -496,13 +556,15 @@ export function mountFrontsLayer(map, { visible }) {
     // dangle at bends) instead of force-rendering them.
     if (o.allowOverlap != null) for (const id of pipLayers) sl(id, 'icon-allow-overlap', o.allowOverlap);
     if (o.ignorePlacement != null) for (const id of pipLayers) sl(id, 'icon-ignore-placement', o.ignorePlacement);
-    // Re-smooth the lines at a new density (degrees per chord). Smaller = curvier
-    // (and more points). Re-runs the resample on the last fetched document.
-    if (o.smoothTarget != null) {
-      smoothTargetDeg = o.smoothTarget;
-      applySmoothed();
-    }
-    return { ...o, smoothTargetDeg };
+    // Re-process the geometry. smoothTarget = chord size (smaller = curvier).
+    // pipWindow/pipMaxTurn control the tight-bend pip dropout: a pip is dropped
+    // where the line turns more than pipMaxTurn radians across a +/-pipWindow
+    // arc. Lower pipMaxTurn (or larger pipWindow) drops pips on gentler bends.
+    if (o.smoothTarget != null) smoothTargetDeg = o.smoothTarget;
+    if (o.pipWindow != null) pipWindowDeg = o.pipWindow;
+    if (o.pipMaxTurn != null) pipMaxTurn = o.pipMaxTurn;
+    if (o.smoothTarget != null || o.pipWindow != null || o.pipMaxTurn != null) applySmoothed();
+    return { ...o, smoothTargetDeg, pipWindowDeg, pipMaxTurn };
   }
 
   // Snapshot of what's currently rendered, for console diagnostics.
@@ -511,6 +573,8 @@ export function mountFrontsLayer(map, { visible }) {
     return {
       zoom: map.getZoom?.(),
       smoothTargetDeg,
+      pipWindowDeg,
+      pipMaxTurn,
       frontFeatures: fronts.length,
       maxLinePoints: fronts.reduce((m, f) => Math.max(m, f.geometry?.coordinates?.length ?? 0), 0),
       stationarySpriteLoaded: map.hasImage?.(IMG_STATIONARY) ?? null,

--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -105,7 +105,10 @@ export function mountFrontsLayer(map, { visible }) {
     }
   }
 
-  // line-color match on the feature's front_type.
+  // line-color match on the feature's front_type. `stationary` is kept here
+  // even though stationary fronts are currently filtered out of every layer
+  // (see the line layer) so that re-enabling them later is a one-line filter
+  // change, not a color hunt.
   const frontColorMatch = () => [
     'match',
     ['get', 'front_type'],

--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -137,13 +137,23 @@ export function mountFrontsLayer(map, { visible }) {
 
     // 1) Base front line. trough is dashed; every other type is solid. The dash
     // array is gated on front_type so only troughs get it.
+    //
+    // stationary fronts are EXCLUDED entirely: without proper alternating
+    // opposite-side symbology (the deferred limitation noted below) they render
+    // as a bare colored line that reads as a random stray line on the map, so
+    // we hide them until that symbology exists rather than show a misleading
+    // boundary.
     if (!map.getLayer('fronts-line')) {
       map.addLayer(
         {
           id: 'fronts-line',
           type: 'line',
           source: provider.sourceId,
-          filter: ['==', ['get', 'feature'], 'front'],
+          filter: [
+            'all',
+            ['==', ['get', 'feature'], 'front'],
+            ['!=', ['get', 'front_type'], 'stationary'],
+          ],
           layout: {
             visibility: vis,
             'line-cap': 'round',
@@ -151,7 +161,9 @@ export function mountFrontsLayer(map, { visible }) {
           },
           paint: {
             'line-color': frontColorMatch(),
-            'line-width': ['interpolate', ['linear'], ['zoom'], 3, 1.2, 8, 2.6],
+            // A touch thicker than v1 so the boundaries read clearly. Dash units
+            // are line-width-relative, so troughs' dashes scale up with this.
+            'line-width': ['interpolate', ['linear'], ['zoom'], 3, 1.8, 8, 3.8],
             'line-dasharray': [
               'case',
               ['==', ['get', 'front_type'], 'trough'],
@@ -170,11 +182,11 @@ export function mountFrontsLayer(map, { visible }) {
     // symbol-placement:line draws a single sprite repeated on ONE side of the
     // line, so it cannot render a stationary front's alternating
     // opposite-side warm/cold pips, nor an occluded front's alternating
-    // triangle/semicircle. So this layer deliberately EXCLUDES stationary (its
-    // line still renders, just without pips) and occluded uses the cold
-    // triangle only. Proper alternating-side symbology needs either two offset
-    // symbol layers with side-tagged geometry from the generator, or a custom
-    // WebGL layer -- deferred past v1.
+    // triangle/semicircle. stationary fronts are hidden entirely (see the line
+    // layer above) until that symbology exists; occluded uses the cold triangle
+    // only. Proper alternating-side symbology needs either two offset symbol
+    // layers with side-tagged geometry from the generator, or a custom WebGL
+    // layer -- deferred past v1.
     if (!map.getLayer('fronts-pips')) {
       map.addLayer(
         {
@@ -190,9 +202,11 @@ export function mountFrontsLayer(map, { visible }) {
           layout: {
             visibility: vis,
             'symbol-placement': 'line',
-            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 28, 8, 60],
+            // Slightly wider spacing to keep the larger pips from crowding.
+            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 34, 8, 70],
             'icon-image': pipIconMatch(),
-            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.7, 8, 1.0],
+            // A little larger than v1 so the triangles/semicircles read clearly.
+            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.95, 8, 1.35],
             'icon-rotation-alignment': 'map',
             'icon-allow-overlap': true,
             'icon-ignore-placement': true,

--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -100,9 +100,60 @@ function rasterizeSvg(svg, w, h = w) {
   });
 }
 
+// Catmull-Rom interpolation of one parametric coordinate at t in [0,1].
+function catmull(p0, p1, p2, p3, t) {
+  const t2 = t * t;
+  const t3 = t2 * t;
+  const f = (a, b, c, d) =>
+    0.5 * (2 * b + (-a + c) * t + (2 * a - 5 * b + 4 * c - d) * t2 + (-a + 3 * b - 3 * c + d) * t3);
+  return [f(p0[0], p1[0], p2[0], p3[0]), f(p0[1], p1[1], p2[1], p3[1])];
+}
+
+// Densify a [lon,lat][] polyline into a smooth Catmull-Rom curve. Each input
+// segment is split into ceil(len/targetDeg) pieces (capped at maxSub), so the
+// output is uniformly smooth regardless of the raw point spacing and the
+// straight-chord segmentation disappears. Endpoints are preserved; <3 points
+// (nothing to curve) pass through unchanged.
+export function smoothLine(pts, targetDeg = 0.15, maxSub = 10) {
+  if (!Array.isArray(pts) || pts.length < 3) return pts;
+  const n = pts.length;
+  const at = (i) => pts[Math.max(0, Math.min(n - 1, i))];
+  const out = [];
+  for (let i = 0; i < n - 1; i++) {
+    const p0 = at(i - 1);
+    const p1 = at(i);
+    const p2 = at(i + 1);
+    const p3 = at(i + 2);
+    const segLen = Math.hypot(p2[0] - p1[0], p2[1] - p1[1]);
+    const sub = Math.max(1, Math.min(maxSub, Math.ceil(segLen / targetDeg)));
+    for (let s = 0; s < sub; s++) out.push(catmull(p0, p1, p2, p3, s / sub));
+  }
+  out.push(pts[n - 1]);
+  return out;
+}
+
+// Return a copy of the FeatureCollection with every front LineString smoothed.
+// Pressure-center Points are untouched. Tolerant of missing/empty input.
+export function smoothFronts(fc) {
+  if (!fc || !Array.isArray(fc.features)) return fc;
+  const features = fc.features.map((f) => {
+    if (f?.properties?.feature !== 'front' || f?.geometry?.type !== 'LineString') return f;
+    return { ...f, geometry: { ...f.geometry, coordinates: smoothLine(f.geometry.coordinates) } };
+  });
+  return { ...fc, features };
+}
+
+const EMPTY_FC = { type: 'FeatureCollection', features: [] };
+
 export function mountFrontsLayer(map, { visible }) {
   const provider = frontsProvider();
   let curVisible = visible;
+  // Smoothed FeatureCollection currently fed to the source. LiveMapV2 fetches
+  // the raw document (it holds the bearer token) and pushes it via setData();
+  // we Catmull-Rom the lines before handing them to MapLibre so the overlay
+  // renders smooth curves and the pip icons sit flush instead of dangling off
+  // the straight-chord corners. Starts empty until the first push.
+  let curData = EMPTY_FC;
 
   const firstSymbolId = () => map.getStyle().layers.find((l) => l.type === 'symbol')?.id;
 
@@ -158,7 +209,9 @@ export function mountFrontsLayer(map, { visible }) {
 
   function ensure() {
     if (!map.getSource(provider.sourceId)) {
-      map.addSource(provider.sourceId, provider.source);
+      // Source data is pushed (and smoothed) via setData(); seed it with the
+      // current smoothed document so a style swap re-adds it without a flash.
+      map.addSource(provider.sourceId, { type: 'geojson', data: curData });
     }
     const beforeId = firstSymbolId();
     const vis = curVisible ? 'visible' : 'none';
@@ -384,10 +437,12 @@ export function mountFrontsLayer(map, { visible }) {
     ensure();
   }
 
-  // Re-fetch the GeoJSON document (new analysis published). No source/layer
-  // churn -- just hand the source new data.
-  function reload() {
-    map.getSource(FRONTS_SOURCE_ID)?.setData(provider.dataUrl);
+  // Accept a freshly fetched (raw) GeoJSON document, smooth its front lines,
+  // and hand it to the source. No source/layer churn. Called by LiveMapV2 on
+  // initial load and whenever the manifest poll sees a new analysis.
+  function setData(rawFc) {
+    curData = smoothFronts(rawFc) ?? EMPTY_FC;
+    map.getSource(FRONTS_SOURCE_ID)?.setData(curData);
   }
 
   function setVisible(v) {
@@ -407,5 +462,5 @@ export function mountFrontsLayer(map, { visible }) {
     } catch { /* map already removed */ }
   }
 
-  return { setVisible, refresh, reload, destroy };
+  return { setVisible, refresh, setData, destroy };
 }

--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -317,11 +317,11 @@ export function mountFrontsLayer(map, { visible }) {
           layout: {
             visibility: vis,
             'symbol-placement': 'line',
-            // Slightly wider spacing to keep the larger pips from crowding.
-            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 34, 8, 70],
+            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 30, 8, 60],
             'icon-image': pipIconMatch(),
-            // A little larger than v1 so the triangles/semicircles read clearly.
-            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.95, 8, 1.35],
+            // Sized to read as proper pips without dominating the line (~2-3x
+            // the line width). Tunable live via window.gwFronts.tune().
+            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.62, 8, 0.92],
             'icon-rotation-alignment': 'map',
             'icon-allow-overlap': true,
             'icon-ignore-placement': true,
@@ -349,9 +349,9 @@ export function mountFrontsLayer(map, { visible }) {
             // Repeat at ~the rendered sprite width (36px * icon-size) so the
             // sprites abut and the triangle/semicircle stay evenly spaced
             // (even alternation) rather than clustering with gaps between units.
-            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 34, 8, 49],
+            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 24, 8, 34],
             'icon-image': IMG_STATIONARY,
-            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.95, 8, 1.35],
+            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.62, 8, 0.92],
             'icon-rotation-alignment': 'map',
             'icon-keep-upright': false,
             'icon-allow-overlap': true,
@@ -462,5 +462,37 @@ export function mountFrontsLayer(map, { visible }) {
     } catch { /* map already removed */ }
   }
 
-  return { setVisible, refresh, setData, destroy };
+  // Live visual tuning from the browser console (exposed via window.gwFronts by
+  // LiveMapV2). Adjust any knob and watch the map, then report the values that
+  // look right so they can be baked into the defaults above. Examples:
+  //   window.gwFronts.tune({ pipSize: 0.7, pipSpacing: 40 })
+  //   window.gwFronts.tune({ statSize: 0.8, statSpacing: 30, lineWidth: 3 })
+  // A number applies at all zooms; pass a MapLibre expression for a zoom ramp.
+  function tune(o = {}) {
+    const sl = (id, p, v) => { if (v != null && map.getLayer(id)) map.setLayoutProperty(id, p, v); };
+    const sp = (id, p, v) => { if (v != null && map.getLayer(id)) map.setPaintProperty(id, p, v); };
+    if (o.lineWidth != null) {
+      for (const id of ['fronts-line', 'fronts-stationary-line', 'fronts-stationary-dash']) {
+        sp(id, 'line-width', o.lineWidth);
+      }
+    }
+    sl('fronts-pips', 'icon-size', o.pipSize);
+    sl('fronts-pips', 'symbol-spacing', o.pipSpacing);
+    sl('fronts-stationary-pips', 'icon-size', o.statSize);
+    sl('fronts-stationary-pips', 'symbol-spacing', o.statSpacing);
+    return o;
+  }
+
+  // Snapshot of what's currently rendered, for console diagnostics.
+  function info() {
+    const fronts = (curData?.features ?? []).filter((f) => f?.properties?.feature === 'front');
+    return {
+      zoom: map.getZoom?.(),
+      frontFeatures: fronts.length,
+      maxLinePoints: fronts.reduce((m, f) => Math.max(m, f.geometry?.coordinates?.length ?? 0), 0),
+      stationarySpriteLoaded: map.hasImage?.(IMG_STATIONARY) ?? null,
+    };
+  }
+
+  return { setVisible, refresh, setData, destroy, tune, info };
 }

--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -44,13 +44,13 @@ const occludedTriSvg = coldSvg;
 // -- a cold triangle on the top half (apex up) and a warm semicircle on the
 // bottom half (bulges down) -- so when symbol-placement:line repeats it at
 // ~sprite-width spacing it tiles into triangle/semicircle/triangle/semicircle,
-// each on its own side. (Sweep-flag 1 with left-to-right endpoints bulges +y =
-// the bottom half, opposite the apex-up triangle.) The two colors are baked in,
-// so unlike the single-type pips this sprite is not parameterized by one fill.
+// each on its own side. (Arc sweep-flag 0 with left-to-right endpoints bulges
+// +y = the bottom half, opposite the apex-up triangle.) The two colors are
+// baked in, so unlike the single-type pips this is not parameterized by one fill.
 const stationarySvg = (cold, warm) =>
   `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 18" width="36" height="18">` +
-  `<polygon points="3,9 15,9 9,1" fill="${cold}"/>` +
-  `<path d="M 21 9 A 6 6 0 0 1 33 9 Z" fill="${warm}"/></svg>`;
+  `<polygon points="3,9 15,9 9,1.5" fill="${cold}"/>` +
+  `<path d="M 21 9 A 6 6 0 0 0 33 9 Z" fill="${warm}"/></svg>`;
 
 export const FRONT_LAYER_IDS = [
   'fronts-line',
@@ -67,6 +67,12 @@ const IMG_COLD = 'front-cold';
 const IMG_WARM = 'front-warm';
 const IMG_OCCLUDED = 'front-occluded';
 const IMG_STATIONARY = 'front-stationary';
+
+// Rasterize sprites at this device-pixel multiple and register them with a
+// matching `pixelRatio`, so the pips stay crisp at any zoom / icon-size instead
+// of pixelating like a 1x bitmap upscaled. (A baked-color non-SDF sprite is
+// just a bitmap, so DPI is the lever for sharpness.)
+const SPRITE_PIXEL_RATIO = 4;
 
 // Rasterize an SVG string into an ImageData of the given pixel size. Returns a
 // Promise; resolves null in a non-DOM environment (e.g. node --test), where the
@@ -114,13 +120,16 @@ export function mountFrontsLayer(map, { visible }) {
     ];
     for (const [id, svg, w, h] of want) {
       if (map.hasImage && map.hasImage(id)) continue;
-      const data = await rasterizeSvg(svg, w, h);
+      // Rasterize at SPRITE_PIXEL_RATIO x the logical size for crispness.
+      const data = await rasterizeSvg(svg, w * SPRITE_PIXEL_RATIO, h * SPRITE_PIXEL_RATIO);
       if (!data) continue;
       // hasImage re-checked after the await -- a concurrent ensure() or another
       // mount may have registered it while we were rasterizing.
       if (map.hasImage && map.hasImage(id)) continue;
       // Non-SDF: color is baked into the sprite, so no runtime icon-color tint.
-      map.addImage(id, data, { sdf: false });
+      // pixelRatio tells MapLibre this bitmap is hi-DPI, so icon-size still maps
+      // to the logical w/h and the extra pixels just sharpen it.
+      map.addImage(id, data, { sdf: false, pixelRatio: SPRITE_PIXEL_RATIO });
     }
   }
 

--- a/web/src/lib/map/layers/fronts.test.js
+++ b/web/src/lib/map/layers/fronts.test.js
@@ -1,6 +1,32 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mountFrontsLayer, FRONT_LAYER_IDS } from './fronts.js';
+import { mountFrontsLayer, FRONT_LAYER_IDS, smoothLine } from './fronts.js';
+
+// Sharpest turn (radians) between consecutive segments of a polyline.
+function maxTurn(pts) {
+  let m = 0;
+  for (let i = 1; i < pts.length - 1; i++) {
+    const a = Math.atan2(pts[i][1] - pts[i - 1][1], pts[i][0] - pts[i - 1][0]);
+    const b = Math.atan2(pts[i + 1][1] - pts[i][1], pts[i + 1][0] - pts[i][0]);
+    let d = Math.abs(b - a);
+    if (d > Math.PI) d = 2 * Math.PI - d;
+    m = Math.max(m, d);
+  }
+  return m;
+}
+
+test('smoothLine rounds corners (sharpest turn shrinks) and keeps endpoints', () => {
+  const coarse = [[0, 0], [2, 0], [2, 2], [4, 2]]; // two ~90deg corners
+  const smooth = smoothLine(coarse);
+  assert.ok(smooth.length > coarse.length, 'densified');
+  assert.deepEqual(smooth[0], [0, 0]);
+  assert.deepEqual(smooth.at(-1), [4, 2]);
+  assert.ok(maxTurn(smooth) < maxTurn(coarse) * 0.6, 'sharpest turn meaningfully reduced');
+});
+
+test('smoothLine passes through lines too short to curve', () => {
+  assert.deepEqual(smoothLine([[0, 0], [1, 1]]), [[0, 0], [1, 1]]);
+});
 
 // Minimal MapLibre stand-in: records sources/layers, layout/paint edits, and
 // the image registry. No DOM, so rasterizeSvg resolves null and addImage is
@@ -92,11 +118,28 @@ test('refresh re-adds dropped layers after a style swap', () => {
   }
 });
 
-test('reload pushes the data url back into the geojson source', () => {
+test('setData smooths front lines and pushes the object into the source', () => {
   const map = fakeMap();
   const layer = mountFrontsLayer(map, { visible: true });
-  layer.reload();
-  assert.match(String(map._sources.fronts.data), /\/fronts\/latest\.geojson$/);
+  const raw = {
+    type: 'FeatureCollection',
+    features: [
+      { type: 'Feature', properties: { feature: 'front', front_type: 'cold' },
+        geometry: { type: 'LineString', coordinates: [[0, 0], [3, 1], [6, 0], [9, 2]] } },
+      { type: 'Feature', properties: { feature: 'center', kind: 'H', pressure_mb: 1020 },
+        geometry: { type: 'Point', coordinates: [4, 4] } },
+    ],
+  };
+  layer.setData(raw);
+  const pushed = map._sources.fronts.data;
+  assert.equal(pushed.type, 'FeatureCollection');
+  const front = pushed.features[0];
+  // The front line is densified (more points than the 4 raw), endpoints kept.
+  assert.ok(front.geometry.coordinates.length > 4, 'line densified');
+  assert.deepEqual(front.geometry.coordinates[0], [0, 0]);
+  assert.deepEqual(front.geometry.coordinates.at(-1), [9, 2]);
+  // The pressure-center Point is passed through untouched.
+  assert.deepEqual(pushed.features[1].geometry.coordinates, [4, 4]);
 });
 
 test('destroy removes every layer and the source', () => {

--- a/web/src/lib/map/layers/fronts.test.js
+++ b/web/src/lib/map/layers/fronts.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mountFrontsLayer, FRONT_LAYER_IDS, smoothLine } from './fronts.js';
+import { mountFrontsLayer, FRONT_LAYER_IDS, smoothLine, pipSpans } from './fronts.js';
 
 // Sharpest turn (radians) between consecutive segments of a polyline.
 function maxTurn(pts) {
@@ -133,13 +133,32 @@ test('setData smooths front lines and pushes the object into the source', () => 
   layer.setData(raw);
   const pushed = map._sources.fronts.data;
   assert.equal(pushed.type, 'FeatureCollection');
-  const front = pushed.features[0];
+  const front = pushed.features.find((f) => f.properties.feature === 'front');
   // The front line is densified (more points than the 4 raw), endpoints kept.
   assert.ok(front.geometry.coordinates.length > 4, 'line densified');
   assert.deepEqual(front.geometry.coordinates[0], [0, 0]);
   assert.deepEqual(front.geometry.coordinates.at(-1), [9, 2]);
+  // A companion pipline (gentle-span geometry the pips follow) is emitted.
+  const pipline = pushed.features.find((f) => f.properties.feature === 'pipline');
+  assert.ok(pipline, 'pipline feature emitted');
+  assert.equal(pipline.geometry.type, 'MultiLineString');
   // The pressure-center Point is passed through untouched.
-  assert.deepEqual(pushed.features[1].geometry.coordinates, [4, 4]);
+  const center = pushed.features.find((f) => f.properties.feature === 'center');
+  assert.deepEqual(center.geometry.coordinates, [4, 4]);
+});
+
+test('pipSpans keeps gentle lines whole but cuts out a tight hairpin', () => {
+  // A nearly-straight line is one span, unbroken.
+  const gentle = [[0, 0], [1, 0.02], [2, 0], [3, 0.02], [4, 0]];
+  assert.equal(pipSpans(gentle).length, 1);
+  // A hairpin (doubles back) gets the tight section excluded, so pips won't be
+  // placed across the bend -- either split into spans or dropped entirely there.
+  const hairpin = [];
+  for (let i = 0; i <= 20; i++) hairpin.push([i * 0.05, 0]); // run out
+  for (let i = 1; i <= 20; i++) hairpin.push([1 - i * 0.05, 0.04]); // sharp U back
+  const spans = pipSpans(hairpin);
+  const totalPts = spans.reduce((n, s) => n + s.length, 0);
+  assert.ok(totalPts < hairpin.length, 'tight bend vertices were excluded from pip spans');
 });
 
 test('destroy removes every layer and the source', () => {

--- a/web/src/lib/map/layers/fronts.test.js
+++ b/web/src/lib/map/layers/fronts.test.js
@@ -23,16 +23,19 @@ function fakeMap() {
   };
 }
 
-test('FRONT_LAYER_IDS lists the four overlay layers', () => {
+test('FRONT_LAYER_IDS lists the overlay layers (incl. the stationary set)', () => {
   assert.deepEqual(FRONT_LAYER_IDS, [
     'fronts-line',
+    'fronts-stationary-line',
+    'fronts-stationary-dash',
     'fronts-pips',
+    'fronts-stationary-pips',
     'fronts-centers',
     'fronts-center-labels',
   ]);
 });
 
-test('mount adds the source and all four layers behind the first symbol layer', () => {
+test('mount adds the source and all layers behind the first symbol layer', () => {
   const map = fakeMap();
   mountFrontsLayer(map, { visible: true });
   assert.ok(map._sources.fronts, 'geojson source added');
@@ -43,15 +46,24 @@ test('mount adds the source and all four layers behind the first symbol layer', 
   }
 });
 
-test('stationary fronts are excluded from the line and pip layers', () => {
-  // The stationary symbology (alternating opposite-side pips) is deferred, so a
-  // bare stationary line reads as a stray mark -- it must not render at all.
+test('stationary fronts render via their own dedicated layers, not the base ones', () => {
+  // Proper WMO stationary symbology: a two-tone line + alternating cold/warm
+  // pips. The base line and the single-type pip layer must EXCLUDE stationary
+  // (it would double-draw / mis-color), and the dedicated stationary layers
+  // must filter to ONLY stationary.
   const map = fakeMap();
   mountFrontsLayer(map, { visible: true });
   const lineFilter = JSON.stringify(map._layers['fronts-line'].filter);
   const pipFilter = JSON.stringify(map._layers['fronts-pips'].filter);
-  assert.match(lineFilter, /"!=".*"front_type".*"stationary"/s, 'line excludes stationary');
-  assert.match(pipFilter, /"stationary"/, 'pip layer excludes stationary');
+  assert.match(lineFilter, /"!=".*"front_type".*"stationary"/s, 'base line excludes stationary');
+  assert.match(pipFilter, /"!=".*"stationary"/s, 'base pips exclude stationary');
+  for (const id of ['fronts-stationary-line', 'fronts-stationary-dash', 'fronts-stationary-pips']) {
+    const f = JSON.stringify(map._layers[id].filter);
+    assert.match(f, /"==".*"front_type".*"stationary"/s, `${id} filters to stationary only`);
+  }
+  // The dashed overlay is what creates the alternating red/blue line.
+  assert.ok(map._layers['fronts-stationary-dash'].paint['line-dasharray'], 'dash overlay present');
+  assert.equal(map._layers['fronts-stationary-pips'].layout['icon-image'], 'front-stationary');
 });
 
 test('setVisible(false) sets every front layer visibility to none', () => {

--- a/web/src/lib/map/layers/fronts.test.js
+++ b/web/src/lib/map/layers/fronts.test.js
@@ -43,6 +43,17 @@ test('mount adds the source and all four layers behind the first symbol layer', 
   }
 });
 
+test('stationary fronts are excluded from the line and pip layers', () => {
+  // The stationary symbology (alternating opposite-side pips) is deferred, so a
+  // bare stationary line reads as a stray mark -- it must not render at all.
+  const map = fakeMap();
+  mountFrontsLayer(map, { visible: true });
+  const lineFilter = JSON.stringify(map._layers['fronts-line'].filter);
+  const pipFilter = JSON.stringify(map._layers['fronts-pips'].filter);
+  assert.match(lineFilter, /"!=".*"front_type".*"stationary"/s, 'line excludes stationary');
+  assert.match(pipFilter, /"stationary"/, 'pip layer excludes stationary');
+});
+
 test('setVisible(false) sets every front layer visibility to none', () => {
   const map = fakeMap();
   const layer = mountFrontsLayer(map, { visible: true });

--- a/web/src/lib/map/sources/fronts-source.js
+++ b/web/src/lib/map/sources/fronts-source.js
@@ -5,11 +5,11 @@
 // Pure data + small builders only -- no MapLibre or DOM imports -- so it is
 // unit-testable under `node --test`, mirroring radar-source.js.
 //
-// Auth: the GeoJSON data URL is fetched by MapLibre as a source request, so the
-// map's transformRequest appends the bearer token (?t=) exactly as it does for
-// radar tiles -- no token wiring is needed on the data URL here. The manifest is
-// a plain fetch (transformRequest doesn't see it), so the caller appends ?t=
-// itself, the same pattern as radarManifestUrl().
+// Auth: both the manifest and the GeoJSON document are plain fetches by
+// LiveMapV2 (it holds the bearer token), so the caller appends ?t= to each, the
+// same pattern as radarManifestUrl(). The MapLibre source is fed an in-memory
+// (smoothed) object via the layer's setData, not a URL, so transformRequest is
+// not involved.
 
 // Same origin Worker as radar (see RADAR_TILE_BASE in radar-source.js). The
 // Worker serves the fronts product under /fronts/*.
@@ -32,7 +32,6 @@ export const FRONT_COLORS = {
 export function frontsProvider() {
   return {
     sourceId: FRONTS_SOURCE_ID,
-    source: { type: 'geojson', data: FRONTS_DATA_URL },
     dataUrl: FRONTS_DATA_URL,
     manifestUrl: FRONTS_MANIFEST_URL,
   };

--- a/web/src/lib/map/style/front-sprites/stationary.svg
+++ b/web/src/lib/map/style/front-sprites/stationary.svg
@@ -1,0 +1,8 @@
+<!-- Stationary front: one full WMO period in a 36x18 sprite. Cold triangle on
+     the top half (apex up), warm semicircle on the bottom half (bulges down),
+     so symbol-placement:line repeats it into alternating opposite-side pips.
+     Colors here are placeholders; fronts.js bakes FRONT_COLORS.cold/warm. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 18" width="36" height="18">
+  <polygon points="3,9 15,9 9,1" fill="#1565d8"/>
+  <path d="M 21 9 A 6 6 0 0 1 33 9 Z" fill="#d81e1e"/>
+</svg>

--- a/web/src/lib/map/style/front-sprites/stationary.svg
+++ b/web/src/lib/map/style/front-sprites/stationary.svg
@@ -3,6 +3,6 @@
      so symbol-placement:line repeats it into alternating opposite-side pips.
      Colors here are placeholders; fronts.js bakes FRONT_COLORS.cold/warm. -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 18" width="36" height="18">
-  <polygon points="3,9 15,9 9,1" fill="#1565d8"/>
-  <path d="M 21 9 A 6 6 0 0 1 33 9 Z" fill="#d81e1e"/>
+  <polygon points="3,9 15,9 9,1.5" fill="#1565d8"/>
+  <path d="M 21 9 A 6 6 0 0 0 33 9 Z" fill="#d81e1e"/>
 </svg>

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1070,141 +1070,153 @@
   />
 
   {#snippet panelBody()}
-    <div class="layer-toggles">
-      <label class="toggle-row">
-        <input
-          type="checkbox"
-          checked={layerToggles.stations}
-          onchange={(e) => (layerToggles.stations = e.currentTarget.checked)}
-        />
-        <span>Stations</span>
-      </label>
-      <label class="toggle-row">
-        <input
-          type="checkbox"
-          checked={layerToggles.trails}
-          onchange={(e) => (layerToggles.trails = e.currentTarget.checked)}
-        />
-        <span>Trails</span>
-      </label>
-      <label class="toggle-row">
-        <input
-          type="checkbox"
-          checked={layerToggles.weather}
-          onchange={(e) => (layerToggles.weather = e.currentTarget.checked)}
-        />
-        <span>Weather</span>
-      </label>
-      <label class="toggle-row">
-        <input
-          type="checkbox"
-          checked={layerToggles.myPosition}
-          onchange={(e) => (layerToggles.myPosition = e.currentTarget.checked)}
-        />
-        <span>My Position</span>
-      </label>
-      <label class="toggle-row">
-        <input
-          type="checkbox"
-          checked={layerToggles.fixedPoints}
-          onchange={(e) => (layerToggles.fixedPoints = e.currentTarget.checked)}
-        />
-        <span>Fixed Points</span>
-      </label>
-      <label class="toggle-row">
-        <input
-          type="checkbox"
-          checked={layerToggles.fronts}
-          onchange={(e) => (layerToggles.fronts = e.currentTarget.checked)}
-        />
-        <span>Fronts</span>
-      </label>
-      <label class="toggle-row">
-        <input
-          type="checkbox"
-          checked={layerToggles.directRxOnly}
-          onchange={(e) => (layerToggles.directRxOnly = e.currentTarget.checked)}
-        />
-        <span>Direct RX</span>
-      </label>
-      <label class="toggle-row">
-        <input
-          type="checkbox"
-          checked={layerToggles.rfOnly}
-          onchange={(e) => (layerToggles.rfOnly = e.currentTarget.checked)}
-        />
-        <span>RF Only</span>
-      </label>
-      <label class="toggle-row">
-        <input
-          type="checkbox"
-          checked={radarSettings.visible}
-          onchange={(e) => (radarSettings.visible = e.currentTarget.checked)}
-        />
-        <span>Radar</span>
-      </label>
-    </div>
-
-    <label class="timerange-label" for="radar-opacity-range">
-      Radar opacity: {Math.round(radarSettings.opacity * 100)}%
-    </label>
-    <input
-      id="radar-opacity-range"
-      type="range"
-      min="0.1"
-      max="1.0"
-      step="0.05"
-      class="radar-opacity-range"
-      bind:value={radarSettings.opacity}
-    />
-
-    {#if radarSettings.visible}
-      <!-- Radar loop animation: two text buttons [Play/Pause][Reset] and a
-           frame-position slider. Disabled until the manifest yields >1 frame. -->
-      <div class="radar-anim-buttons">
-        <button
-          type="button"
-          class="radar-anim-btn"
-          onclick={() => radarFrames.toggle()}
-          disabled={radarFrames.count <= 1}
-          aria-label={radarFrames.playing ? 'Pause radar loop' : 'Play radar loop'}
-        >
-          {radarFrames.playing ? 'Pause' : 'Play'}
-        </button>
-        <button
-          type="button"
-          class="radar-anim-btn"
-          onclick={() => radarFrames.stop()}
-          disabled={radarFrames.count <= 1}
-          aria-label="Reset radar loop and jump to the latest frame"
-        >
-          Reset
-        </button>
+    <!-- APRS: station/trail/position layers + the time-range filter. -->
+    <section class="layer-section">
+      <h3 class="layer-section-title">APRS</h3>
+      <div class="layer-toggles">
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            checked={layerToggles.stations}
+            onchange={(e) => (layerToggles.stations = e.currentTarget.checked)}
+          />
+          <span>Stations</span>
+        </label>
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            checked={layerToggles.trails}
+            onchange={(e) => (layerToggles.trails = e.currentTarget.checked)}
+          />
+          <span>Trails</span>
+        </label>
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            checked={layerToggles.myPosition}
+            onchange={(e) => (layerToggles.myPosition = e.currentTarget.checked)}
+          />
+          <span>My Position</span>
+        </label>
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            checked={layerToggles.fixedPoints}
+            onchange={(e) => (layerToggles.fixedPoints = e.currentTarget.checked)}
+          />
+          <span>Fixed Points</span>
+        </label>
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            checked={layerToggles.directRxOnly}
+            onchange={(e) => (layerToggles.directRxOnly = e.currentTarget.checked)}
+          />
+          <span>Direct RX</span>
+        </label>
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            checked={layerToggles.rfOnly}
+            onchange={(e) => (layerToggles.rfOnly = e.currentTarget.checked)}
+          />
+          <span>RF Only</span>
+        </label>
       </div>
-      <label class="timerange-label" for="radar-frame-range">{radarFrameLabel}</label>
-      <input
-        id="radar-frame-range"
-        type="range"
-        class="radar-frame-range"
-        min="0"
-        max={Math.max(0, radarFrames.count - 1)}
-        step="1"
-        value={radarFrames.index}
-        oninput={(e) => radarFrames.seek(Number(e.currentTarget.value))}
-        disabled={radarFrames.count <= 1}
-      />
-    {/if}
 
-    <label class="timerange-label" for="map-timerange-select">Time range</label>
-    <select
-      id="map-timerange-select"
-      class="map-timerange-select"
-      bind:value={timerangeSec}
-    >
-      {#each TIMERANGES_S as opt}
-        <option value={opt.value}>{opt.label}</option>
-      {/each}
-    </select>
+      <label class="timerange-label" for="map-timerange-select">Time range</label>
+      <select
+        id="map-timerange-select"
+        class="map-timerange-select"
+        bind:value={timerangeSec}
+      >
+        {#each TIMERANGES_S as opt}
+          <option value={opt.value}>{opt.label}</option>
+        {/each}
+      </select>
+    </section>
+
+    <!-- Weather: fronts + radar overlays and their controls. The existing
+         "Weather" (surface obs / wind barbs) toggle lives here too. -->
+    <section class="layer-section">
+      <h3 class="layer-section-title">Weather</h3>
+      <div class="layer-toggles">
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            checked={layerToggles.fronts}
+            onchange={(e) => (layerToggles.fronts = e.currentTarget.checked)}
+          />
+          <span>Fronts</span>
+        </label>
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            checked={layerToggles.weather}
+            onchange={(e) => (layerToggles.weather = e.currentTarget.checked)}
+          />
+          <span>Weather</span>
+        </label>
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            checked={radarSettings.visible}
+            onchange={(e) => (radarSettings.visible = e.currentTarget.checked)}
+          />
+          <span>Radar</span>
+        </label>
+      </div>
+
+      <label class="timerange-label" for="radar-opacity-range">
+        Radar opacity: {Math.round(radarSettings.opacity * 100)}%
+      </label>
+      <input
+        id="radar-opacity-range"
+        type="range"
+        min="0.1"
+        max="1.0"
+        step="0.05"
+        class="radar-opacity-range"
+        bind:value={radarSettings.opacity}
+      />
+
+      {#if radarSettings.visible}
+        <!-- Radar loop animation: two text buttons [Play/Pause][Reset] and a
+             frame-position slider. Disabled until the manifest yields >1 frame. -->
+        <div class="radar-anim-buttons">
+          <button
+            type="button"
+            class="radar-anim-btn"
+            onclick={() => radarFrames.toggle()}
+            disabled={radarFrames.count <= 1}
+            aria-label={radarFrames.playing ? 'Pause radar loop' : 'Play radar loop'}
+          >
+            {radarFrames.playing ? 'Pause' : 'Play'}
+          </button>
+          <button
+            type="button"
+            class="radar-anim-btn"
+            onclick={() => radarFrames.stop()}
+            disabled={radarFrames.count <= 1}
+            aria-label="Reset radar loop and jump to the latest frame"
+          >
+            Reset
+          </button>
+        </div>
+        <label class="timerange-label" for="radar-frame-range">{radarFrameLabel}</label>
+        <input
+          id="radar-frame-range"
+          type="range"
+          class="radar-frame-range"
+          min="0"
+          max={Math.max(0, radarFrames.count - 1)}
+          step="1"
+          value={radarFrames.index}
+          oninput={(e) => radarFrames.seek(Number(e.currentTarget.value))}
+          disabled={radarFrames.count <= 1}
+        />
+      {/if}
+    </section>
   {/snippet}
 
   {#if isMobile}
@@ -1419,6 +1431,22 @@
     padding: 10px 12px;
   }
 
+  /* Grouped sections (APRS, Weather) within the layers pane. A divider +
+     uppercase label separates the groups so the pane reads as two columns of
+     related controls rather than one long list. */
+  .layer-section + .layer-section {
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid var(--map-overlay-border);
+  }
+  .layer-section-title {
+    margin: 0 0 8px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--color-text-muted);
+  }
   .layer-toggles {
     display: flex;
     flex-direction: column;

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -206,6 +206,7 @@
   // attaches the token to it without any wiring here.
   let frontsToken = null;
   let frontsPollTimer = null;
+  let frontsDataRetry = null; // short retry until registration+token are ready
   let lastFrontsIssued = null;
   // De-dupe diagnostics like warnRadar: a persistent failure would otherwise
   // warn every poll. Only log when the failure stage changes.
@@ -247,19 +248,58 @@
     lastFrontsLoadStatus = null; // recovered
     if (issued == null) return;
     if (lastFrontsIssued !== null && issued !== lastFrontsIssued) {
-      frontsLayer?.reload();
+      loadFrontsData();
     }
     lastFrontsIssued = issued;
   }
+  // Fetch the GeoJSON document (token-gated, same as the manifest) and hand it
+  // to the layer, which smooths the lines before rendering. Kept here rather
+  // than in the layer module so all bearer-token handling stays in one place.
+  async function loadFrontsData() {
+    if (frontsDataRetry) { clearTimeout(frontsDataRetry); frontsDataRetry = null; }
+    if (!mapsState.registered) { frontsDataRetry = setTimeout(loadFrontsData, 2000); return; }
+    if (!frontsToken) frontsToken = await mapsState.revealToken();
+    if (!frontsToken) { frontsDataRetry = setTimeout(loadFrontsData, 2000); return; }
+    const url = `${frontsProvider().dataUrl}?t=${encodeURIComponent(frontsToken)}`;
+    let resp;
+    try {
+      resp = await fetch(url);
+    } catch (e) {
+      warnFronts('data-network', '[fronts] geojson fetch failed (network/CORS)', e);
+      return;
+    }
+    if (resp.status === 401) {
+      frontsToken = null;
+      warnFronts('data-401', '[fronts] geojson 401 -- token rejected; will re-reveal');
+      return;
+    }
+    if (!resp.ok) {
+      warnFronts('data-http', `[fronts] geojson fetch HTTP ${resp.status}`);
+      return;
+    }
+    let json;
+    try {
+      json = await resp.json();
+    } catch (e) {
+      warnFronts('data-parse', '[fronts] geojson JSON parse failed', e);
+      return;
+    }
+    frontsLayer?.setData(json);
+  }
   function startFrontsPolling() {
     if (frontsPollTimer) return;
-    pollFrontsManifest(); // immediate first check
+    loadFrontsData(); // pull the document now so the overlay paints immediately
+    pollFrontsManifest(); // immediate first manifest check (drives later reloads)
     frontsPollTimer = setInterval(pollFrontsManifest, 5 * 60 * 1000);
   }
   function stopFrontsPolling() {
     if (frontsPollTimer) {
       clearInterval(frontsPollTimer);
       frontsPollTimer = null;
+    }
+    if (frontsDataRetry) {
+      clearTimeout(frontsDataRetry);
+      frontsDataRetry = null;
     }
   }
 

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1085,6 +1085,14 @@
         <label class="toggle-row">
           <input
             type="checkbox"
+            checked={layerToggles.weather}
+            onchange={(e) => (layerToggles.weather = e.currentTarget.checked)}
+          />
+          <span>Weather Stations</span>
+        </label>
+        <label class="toggle-row">
+          <input
+            type="checkbox"
             checked={layerToggles.trails}
             onchange={(e) => (layerToggles.trails = e.currentTarget.checked)}
           />
@@ -1136,8 +1144,8 @@
       </select>
     </section>
 
-    <!-- Weather: fronts + radar overlays and their controls. The existing
-         "Weather" (surface obs / wind barbs) toggle lives here too. -->
+    <!-- Weather: fronts + radar overlays and their controls. (The surface-obs
+         layer toggle is "Weather Stations", grouped under APRS with Stations.) -->
     <section class="layer-section">
       <h3 class="layer-section-title">Weather</h3>
       <div class="layer-toggles">
@@ -1148,14 +1156,6 @@
             onchange={(e) => (layerToggles.fronts = e.currentTarget.checked)}
           />
           <span>Fronts</span>
-        </label>
-        <label class="toggle-row">
-          <input
-            type="checkbox"
-            checked={layerToggles.weather}
-            onchange={(e) => (layerToggles.weather = e.currentTarget.checked)}
-          />
-          <span>Weather</span>
         </label>
         <label class="toggle-row">
           <input

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -570,6 +570,13 @@
     // Surface fronts ride just above radar in the GL stack (lines + pip symbols
     // over the reflectivity fill) and below the station/trail markers.
     frontsLayer = mountFrontsLayer(map, { visible: layerToggles.fronts });
+    // Debug hooks for live front-symbology tuning from the browser console:
+    //   window.gwFronts.tune({ pipSize: 0.7, statSpacing: 30, lineWidth: 3 })
+    //   window.gwFronts.info()   window.gwMap.getZoom()
+    if (typeof window !== 'undefined') {
+      window.gwMap = map;
+      window.gwFronts = frontsLayer;
+    }
     // Trails first so the line sits beneath the (DOM) station markers
     // and below the weather labels in symbol-layer order.
     trailsLayer = mountTrailsLayer(map, () => dataStore.stations, {


### PR DESCRIPTION
## Front styling tweaks + layers-pane reorg

### Fronts (`layers/fronts.js`)
- **Thicker boundary lines:** `line-width` 1.2–2.6 → **1.8–3.8** across zoom. Trough dashes are line-width-relative, so the dashed troughs thicken with it.
- **Bigger pips:** cold triangles / warm semicircles `icon-size` 0.7–1.0 → **0.95–1.35**, with slightly wider spacing so they don't crowd.
- **Removed the "odd long purple line":** that was the **stationary fronts** (color `#7a5cff`) — the data had an E–W stationary front through southern Mississippi meeting a N–S one at New Mexico running up to CO/WY, exactly the path described. Without proper alternating opposite-side symbology (the deferred v1 limitation), stationary fronts render as a bare colored line that reads as a stray line, so they're now **hidden entirely** rather than shown misleadingly.

### Layers pane (`LiveMapV2.svelte`)
Split the flat list into two labeled sections with a divider, in order:
- **APRS** — Stations, Trails, My Position, Fixed Points, Direct RX, RF Only, Time range
- **Weather** — Fronts, Weather, Radar (+ opacity slider and the Play/Reset/scrubber controls)

**One judgment call:** the existing **"Weather"** toggle (surface obs / wind barbs) wasn't in your list — I put it in the Weather section since it's weather data and dropping it would remove a feature. Easy to relabel (e.g. "Surface Obs") or move if you'd prefer.

### Verification
406 web tests pass; `vite build` green. I can't eyeball the rendering headlessly — the line/pip sizes are declarative paint/layout values, but please confirm the thickness/size feel right once deployed and I'll nudge the numbers if needed.

Needs merge + a web-client deploy to go live. Refs GRA-197.
