### PR TITLE
Render model-derived global fronts overlay (beneath WPC, one toggle)

### DIFF
--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -253,12 +253,13 @@ export function mountFrontsLayer(map, { visible }) {
     if (!map.getSource(world.sourceId)) map.addSource(world.sourceId, world.source);
     if (!map.getSource(wpc.sourceId)) map.addSource(wpc.sourceId, wpc.source);
     const vis = curVisible ? 'visible' : 'none';
+    const firstSym = firstSymbolId();
 
     // WPC first, above the basemap symbol layers.
-    addLayers(layerSpecs(wpc.sourceId, 'fronts', vis), firstSymbolId());
+    addLayers(layerSpecs(wpc.sourceId, 'fronts', vis), firstSym);
     // World beneath WPC: insert before the WPC base line if present, else above
     // the basemap symbols. This keeps the analyst product on top over NA.
-    const worldBefore = map.getLayer('fronts-line') ? 'fronts-line' : firstSymbolId();
+    const worldBefore = map.getLayer('fronts-line') ? 'fronts-line' : firstSym;
     addLayers(layerSpecs(world.sourceId, 'fronts-world', vis), worldBefore);
   }
 

--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -1,17 +1,19 @@
 // Surface-fronts overlay layer for the Live Map (WMO frontal symbology).
 //
 // Backend-agnostic in the same spirit as radar.js: it asks fronts-source.js for
-// a provider descriptor and performs the MapLibre source/layer calls. Unlike
-// radar there is no per-frame loop -- a single GeoJSON document holds the
-// current analysis (fronts + pressure centers), and the overlay renders
+// provider descriptors and performs the MapLibre source/layer calls. Unlike
+// radar there is no per-frame loop -- a single GeoJSON document per source holds
+// the current analysis (fronts + pressure centers), and the overlay renders
 // whatever features it carries. A slow manifest poll (driven by LiveMapV2)
 // calls reload() when a new analysis is published.
 //
-// Mirrors the other layer modules (radar.js, stations.js, trails.js): mount
-// returns control methods; LiveMapV2 persists settings and drives them via
-// effects, and calls refresh() on every data tick. refresh() re-adds the
-// source/layers behind existence guards so the overlay survives a basemap
-// setStyle() (which rebuilds the style and can drop user-added layers).
+// TWO sources, one toggle:
+//   fronts       -- WPC coded surface bulletin (analysis, North America)
+//   fronts-world -- model-derived global fronts (GFS Thermal Front Parameter)
+// Both render with identical styling (same paint/layout, same pip sprites). The
+// world layers are inserted BENEATH the WPC layers so the analyst product wins
+// over North America and the model shows through everywhere else. setVisible /
+// refresh / reload / destroy fan out to both.
 //
 // Frontal pips are sprite icons placed along the line (symbol-placement:line).
 // One colored sprite is baked per front type at registration time (the fill is
@@ -21,7 +23,13 @@
 // channel as a signed distance field -- a hard-rasterized binary mask is not a
 // distance field, so tinting fringed the edges at interpolated icon-size.
 
-import { frontsProvider, FRONTS_SOURCE_ID, FRONT_COLORS } from '../sources/fronts-source.js';
+import {
+  frontsProvider,
+  frontsWorldProvider,
+  FRONTS_SOURCE_ID,
+  FRONTS_WORLD_SOURCE_ID,
+  FRONT_COLORS,
+} from '../sources/fronts-source.js';
 
 // Pip glyph markup. Kept inline (not a Vite `?raw` import) so this module loads
 // unchanged under plain `node --test`, which has no Vite to resolve `?raw`. The
@@ -32,22 +40,30 @@ import { frontsProvider, FRONTS_SOURCE_ID, FRONT_COLORS } from '../sources/front
 //   ../style/front-sprites/warm.svg       (warm semicircle, flat edge on
 //                                           baseline)
 //   ../style/front-sprites/occluded-tri.svg  (same triangle, used for occluded)
-// The canonical SVGs are single-color sources of truth for the glyph shapes;
-// the fill is parameterized below so each front type bakes its own color.
 const coldSvg = (fill) =>
   `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><polygon points="2,9 16,9 9,1" fill="${fill}"/></svg>`;
 const warmSvg = (fill) =>
   `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18"><path d="M 2 9 A 7 7 0 0 1 16 9 Z" fill="${fill}"/></svg>`;
 const occludedTriSvg = coldSvg;
 
+// Layer id sets. WPC keeps its original ids (stable); world mirrors them with a
+// `fronts-world-` prefix. ALL_LAYER_IDS drives visibility/teardown over both.
 export const FRONT_LAYER_IDS = [
   'fronts-line',
   'fronts-pips',
   'fronts-centers',
   'fronts-center-labels',
 ];
+export const FRONT_WORLD_LAYER_IDS = [
+  'fronts-world-line',
+  'fronts-world-pips',
+  'fronts-world-centers',
+  'fronts-world-center-labels',
+];
+const ALL_LAYER_IDS = [...FRONT_WORLD_LAYER_IDS, ...FRONT_LAYER_IDS];
 
-// addImage ids for the colored pip sprites (one per front type).
+// addImage ids for the colored pip sprites (one per front type, shared by both
+// sources).
 const IMG_COLD = 'front-cold';
 const IMG_WARM = 'front-warm';
 const IMG_OCCLUDED = 'front-occluded';
@@ -78,15 +94,140 @@ function rasterizeSvg(svg, size) {
   });
 }
 
+// line-color match on the feature's front_type (source-independent).
+function frontColorMatch() {
+  return [
+    'match',
+    ['get', 'front_type'],
+    'cold', FRONT_COLORS.cold,
+    'warm', FRONT_COLORS.warm,
+    'stationary', FRONT_COLORS.stationary,
+    'occluded', FRONT_COLORS.occluded,
+    'trough', FRONT_COLORS.trough,
+    '#888888',
+  ];
+}
+
+// Pip sprite per front type. cold/warm/occluded carry pips; trough and
+// stationary resolve to '' (no icon) -- see the v1 limitation note below.
+function pipIconMatch() {
+  return [
+    'match',
+    ['get', 'front_type'],
+    'cold', IMG_COLD,
+    'warm', IMG_WARM,
+    'occluded', IMG_OCCLUDED,
+    '',
+  ];
+}
+
+// Build the four layer definitions for a source, with ids prefixed by idPrefix
+// ('fronts' or 'fronts-world'). Identical paint/layout for both sources.
+//
+// v1 LIMITATION (documented, not an oversight): MapLibre symbol-placement:line
+// draws a single sprite repeated on ONE side of the line, so it cannot render a
+// stationary front's alternating opposite-side pips, nor an occluded front's
+// alternating triangle/semicircle. So the pip layer EXCLUDES stationary (its
+// line still renders, just without pips) and occluded uses the cold triangle
+// only. Proper alternating-side symbology is deferred past v1.
+function layerSpecs(sourceId, idPrefix, vis) {
+  return [
+    {
+      id: `${idPrefix}-line`,
+      type: 'line',
+      source: sourceId,
+      filter: ['==', ['get', 'feature'], 'front'],
+      layout: { visibility: vis, 'line-cap': 'round', 'line-join': 'round' },
+      paint: {
+        'line-color': frontColorMatch(),
+        'line-width': ['interpolate', ['linear'], ['zoom'], 3, 1.2, 8, 2.6],
+        'line-dasharray': [
+          'case',
+          ['==', ['get', 'front_type'], 'trough'],
+          ['literal', [2, 2]],
+          ['literal', [1]],
+        ],
+      },
+    },
+    {
+      id: `${idPrefix}-pips`,
+      type: 'symbol',
+      source: sourceId,
+      filter: [
+        'all',
+        ['==', ['get', 'feature'], 'front'],
+        ['!=', ['get', 'front_type'], 'trough'],
+        ['!=', ['get', 'front_type'], 'stationary'],
+      ],
+      layout: {
+        visibility: vis,
+        'symbol-placement': 'line',
+        'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 28, 8, 60],
+        'icon-image': pipIconMatch(),
+        'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.7, 8, 1.0],
+        'icon-rotation-alignment': 'map',
+        'icon-allow-overlap': true,
+        'icon-ignore-placement': true,
+      },
+    },
+    {
+      id: `${idPrefix}-centers`,
+      type: 'symbol',
+      source: sourceId,
+      filter: ['==', ['get', 'feature'], 'center'],
+      layout: {
+        visibility: vis,
+        'text-field': ['get', 'kind'],
+        'text-font': ['Open Sans Bold', 'Arial Unicode MS Bold'],
+        'text-size': ['interpolate', ['linear'], ['zoom'], 3, 16, 8, 28],
+        'text-allow-overlap': true,
+        'text-ignore-placement': true,
+      },
+      paint: {
+        'text-color': [
+          'match',
+          ['get', 'kind'],
+          'H', FRONT_COLORS.cold,
+          'L', FRONT_COLORS.warm,
+          '#333333',
+        ],
+        'text-halo-color': '#ffffff',
+        'text-halo-width': 2,
+      },
+    },
+    {
+      id: `${idPrefix}-center-labels`,
+      type: 'symbol',
+      source: sourceId,
+      filter: ['==', ['get', 'feature'], 'center'],
+      layout: {
+        visibility: vis,
+        'text-field': ['to-string', ['get', 'pressure_mb']],
+        'text-font': ['Open Sans Semibold', 'Arial Unicode MS Regular'],
+        'text-size': ['interpolate', ['linear'], ['zoom'], 3, 10, 8, 14],
+        'text-offset': [0, 1.2],
+        'text-anchor': 'top',
+        'text-allow-overlap': true,
+        'text-ignore-placement': true,
+      },
+      paint: {
+        'text-color': '#333333',
+        'text-halo-color': '#ffffff',
+        'text-halo-width': 1.5,
+      },
+    },
+  ];
+}
+
 export function mountFrontsLayer(map, { visible }) {
-  const provider = frontsProvider();
+  const wpc = frontsProvider();
+  const world = frontsWorldProvider();
   let curVisible = visible;
 
   const firstSymbolId = () => map.getStyle().layers.find((l) => l.type === 'symbol')?.id;
 
   // Load the pip sprites once, each baked with its front-type color. Guarded by
-  // map.hasImage so a style swap (which drops user images) re-registers them on
-  // the next ensure().
+  // map.hasImage so a style swap (which drops user images) re-registers them.
   async function loadImages() {
     const want = [
       [IMG_COLD, coldSvg(FRONT_COLORS.cold)],
@@ -97,176 +238,31 @@ export function mountFrontsLayer(map, { visible }) {
       if (map.hasImage && map.hasImage(id)) continue;
       const data = await rasterizeSvg(svg, 18);
       if (!data) continue;
-      // hasImage re-checked after the await -- a concurrent ensure() or another
-      // mount may have registered it while we were rasterizing.
       if (map.hasImage && map.hasImage(id)) continue;
-      // Non-SDF: color is baked into the sprite, so no runtime icon-color tint.
       map.addImage(id, data, { sdf: false });
     }
   }
 
-  // line-color match on the feature's front_type.
-  const frontColorMatch = () => [
-    'match',
-    ['get', 'front_type'],
-    'cold', FRONT_COLORS.cold,
-    'warm', FRONT_COLORS.warm,
-    'stationary', FRONT_COLORS.stationary,
-    'occluded', FRONT_COLORS.occluded,
-    'trough', FRONT_COLORS.trough,
-    '#888888',
-  ];
-
-  // Pip sprite per front type. cold/warm/occluded carry pips; trough and
-  // stationary resolve to '' (no icon) -- see the v1 limitation note below.
-  const pipIconMatch = () => [
-    'match',
-    ['get', 'front_type'],
-    'cold', IMG_COLD,
-    'warm', IMG_WARM,
-    'occluded', IMG_OCCLUDED,
-    '',
-  ];
-
-  function ensure() {
-    if (!map.getSource(provider.sourceId)) {
-      map.addSource(provider.sourceId, provider.source);
-    }
-    const beforeId = firstSymbolId();
-    const vis = curVisible ? 'visible' : 'none';
-
-    // 1) Base front line. trough is dashed; every other type is solid. The dash
-    // array is gated on front_type so only troughs get it.
-    if (!map.getLayer('fronts-line')) {
-      map.addLayer(
-        {
-          id: 'fronts-line',
-          type: 'line',
-          source: provider.sourceId,
-          filter: ['==', ['get', 'feature'], 'front'],
-          layout: {
-            visibility: vis,
-            'line-cap': 'round',
-            'line-join': 'round',
-          },
-          paint: {
-            'line-color': frontColorMatch(),
-            'line-width': ['interpolate', ['linear'], ['zoom'], 3, 1.2, 8, 2.6],
-            'line-dasharray': [
-              'case',
-              ['==', ['get', 'front_type'], 'trough'],
-              ['literal', [2, 2]],
-              ['literal', [1]],
-            ],
-          },
-        },
-        beforeId,
-      );
-    }
-
-    // 2) Frontal pips along the line.
-    //
-    // v1 LIMITATION (documented, not an oversight): MapLibre
-    // symbol-placement:line draws a single sprite repeated on ONE side of the
-    // line, so it cannot render a stationary front's alternating
-    // opposite-side warm/cold pips, nor an occluded front's alternating
-    // triangle/semicircle. So this layer deliberately EXCLUDES stationary (its
-    // line still renders, just without pips) and occluded uses the cold
-    // triangle only. Proper alternating-side symbology needs either two offset
-    // symbol layers with side-tagged geometry from the generator, or a custom
-    // WebGL layer -- deferred past v1.
-    if (!map.getLayer('fronts-pips')) {
-      map.addLayer(
-        {
-          id: 'fronts-pips',
-          type: 'symbol',
-          source: provider.sourceId,
-          filter: [
-            'all',
-            ['==', ['get', 'feature'], 'front'],
-            ['!=', ['get', 'front_type'], 'trough'],
-            ['!=', ['get', 'front_type'], 'stationary'],
-          ],
-          layout: {
-            visibility: vis,
-            'symbol-placement': 'line',
-            'symbol-spacing': ['interpolate', ['linear'], ['zoom'], 3, 28, 8, 60],
-            'icon-image': pipIconMatch(),
-            'icon-size': ['interpolate', ['linear'], ['zoom'], 3, 0.7, 8, 1.0],
-            'icon-rotation-alignment': 'map',
-            'icon-allow-overlap': true,
-            'icon-ignore-placement': true,
-          },
-        },
-        beforeId,
-      );
-    }
-
-    // 3) Pressure-center glyphs (H / L). Blue H, red L, white halo for contrast
-    // on either basemap.
-    if (!map.getLayer('fronts-centers')) {
-      map.addLayer(
-        {
-          id: 'fronts-centers',
-          type: 'symbol',
-          source: provider.sourceId,
-          filter: ['==', ['get', 'feature'], 'center'],
-          layout: {
-            visibility: vis,
-            'text-field': ['get', 'kind'],
-            'text-font': ['Open Sans Bold', 'Arial Unicode MS Bold'],
-            'text-size': ['interpolate', ['linear'], ['zoom'], 3, 16, 8, 28],
-            'text-allow-overlap': true,
-            'text-ignore-placement': true,
-          },
-          paint: {
-            'text-color': [
-              'match',
-              ['get', 'kind'],
-              'H', FRONT_COLORS.cold,
-              'L', FRONT_COLORS.warm,
-              '#333333',
-            ],
-            'text-halo-color': '#ffffff',
-            'text-halo-width': 2,
-          },
-        },
-        beforeId,
-      );
-    }
-
-    // 4) Center pressure label (mb) below the H/L glyph.
-    if (!map.getLayer('fronts-center-labels')) {
-      map.addLayer(
-        {
-          id: 'fronts-center-labels',
-          type: 'symbol',
-          source: provider.sourceId,
-          filter: ['==', ['get', 'feature'], 'center'],
-          layout: {
-            visibility: vis,
-            'text-field': ['to-string', ['get', 'pressure_mb']],
-            'text-font': ['Open Sans Semibold', 'Arial Unicode MS Regular'],
-            'text-size': ['interpolate', ['linear'], ['zoom'], 3, 10, 8, 14],
-            'text-offset': [0, 1.2],
-            'text-anchor': 'top',
-            'text-allow-overlap': true,
-            'text-ignore-placement': true,
-          },
-          paint: {
-            'text-color': '#333333',
-            'text-halo-color': '#ffffff',
-            'text-halo-width': 1.5,
-          },
-        },
-        beforeId,
-      );
+  function addLayers(specs, beforeId) {
+    for (const spec of specs) {
+      if (!map.getLayer(spec.id)) map.addLayer(spec, beforeId);
     }
   }
 
-  // Register sprites (async, best-effort) then add layers. ensure() is safe
-  // before the images resolve: an icon-image that isn't loaded yet simply
-  // renders nothing until addImage lands, and MapLibre re-evaluates.
+  function ensure() {
+    if (!map.getSource(world.sourceId)) map.addSource(world.sourceId, world.source);
+    if (!map.getSource(wpc.sourceId)) map.addSource(wpc.sourceId, wpc.source);
+    const vis = curVisible ? 'visible' : 'none';
+
+    // WPC first, above the basemap symbol layers.
+    addLayers(layerSpecs(wpc.sourceId, 'fronts', vis), firstSymbolId());
+    // World beneath WPC: insert before the WPC base line if present, else above
+    // the basemap symbols. This keeps the analyst product on top over NA.
+    const worldBefore = map.getLayer('fronts-line') ? 'fronts-line' : firstSymbolId();
+    addLayers(layerSpecs(world.sourceId, 'fronts-world', vis), worldBefore);
+  }
+
+  // Register sprites (async, best-effort) then add layers.
   loadImages();
   ensure();
 
@@ -277,26 +273,27 @@ export function mountFrontsLayer(map, { visible }) {
     ensure();
   }
 
-  // Re-fetch the GeoJSON document (new analysis published). No source/layer
-  // churn -- just hand the source new data.
+  // Re-fetch both GeoJSON documents (new analysis/cycle published).
   function reload() {
-    map.getSource(FRONTS_SOURCE_ID)?.setData(provider.dataUrl);
+    map.getSource(FRONTS_SOURCE_ID)?.setData(wpc.dataUrl);
+    map.getSource(FRONTS_WORLD_SOURCE_ID)?.setData(world.dataUrl);
   }
 
   function setVisible(v) {
     curVisible = v;
     const value = v ? 'visible' : 'none';
-    for (const id of FRONT_LAYER_IDS) {
+    for (const id of ALL_LAYER_IDS) {
       if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', value);
     }
   }
 
   function destroy() {
     try {
-      for (const id of FRONT_LAYER_IDS) {
+      for (const id of ALL_LAYER_IDS) {
         if (map.getLayer(id)) map.removeLayer(id);
       }
       if (map.getSource(FRONTS_SOURCE_ID)) map.removeSource(FRONTS_SOURCE_ID);
+      if (map.getSource(FRONTS_WORLD_SOURCE_ID)) map.removeSource(FRONTS_WORLD_SOURCE_ID);
     } catch { /* map already removed */ }
   }
 

--- a/web/src/lib/map/layers/fronts.test.js
+++ b/web/src/lib/map/layers/fronts.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mountFrontsLayer, FRONT_LAYER_IDS } from './fronts.js';
+import { mountFrontsLayer, FRONT_LAYER_IDS, FRONT_WORLD_LAYER_IDS } from './fronts.js';
 
 // Minimal MapLibre stand-in: records sources/layers, layout/paint edits, and
 // the image registry. No DOM, so rasterizeSvg resolves null and addImage is
@@ -41,6 +41,36 @@ test('mount adds the source and all four layers behind the first symbol layer', 
     assert.ok(map._layers[id], `${id} added`);
     assert.equal(map._layers[id].layout.visibility, 'visible');
   }
+});
+
+test('world layer ids exist and are distinct from the WPC layer ids', () => {
+  assert.ok(FRONT_WORLD_LAYER_IDS.includes('fronts-world-line'));
+  assert.ok(FRONT_WORLD_LAYER_IDS.includes('fronts-world-pips'));
+  for (const id of FRONT_WORLD_LAYER_IDS) {
+    assert.ok(!FRONT_LAYER_IDS.includes(id), `${id} must not collide with a WPC id`);
+  }
+});
+
+test('mount adds the world source + layers alongside WPC, under one toggle', () => {
+  const map = fakeMap();
+  const layer = mountFrontsLayer(map, { visible: true });
+  assert.ok(map._sources['fronts-world'], 'world geojson source added');
+  for (const id of FRONT_WORLD_LAYER_IDS) {
+    assert.ok(map._layers[id], `${id} added`);
+  }
+  // The single toggle hides both layer sets.
+  layer.setVisible(false);
+  for (const id of [...FRONT_LAYER_IDS, ...FRONT_WORLD_LAYER_IDS]) {
+    assert.equal(map._layers[id].layout.visibility, 'none');
+  }
+});
+
+test('reload pushes data urls into both geojson sources', () => {
+  const map = fakeMap();
+  const layer = mountFrontsLayer(map, { visible: true });
+  layer.reload();
+  assert.match(String(map._sources.fronts.data), /\/fronts\/latest\.geojson$/);
+  assert.match(String(map._sources['fronts-world'].data), /\/fronts\/world\/latest\.geojson$/);
 });
 
 test('setVisible(false) sets every front layer visibility to none', () => {

--- a/web/src/lib/map/layers/fronts.test.js
+++ b/web/src/lib/map/layers/fronts.test.js
@@ -7,19 +7,26 @@ import { mountFrontsLayer, FRONT_LAYER_IDS, FRONT_WORLD_LAYER_IDS } from './fron
 // never reached -- the layer add path is what we exercise here.
 function fakeMap() {
   const sources = {}, layers = {}, images = {};
+  // `order` mirrors MapLibre's layer array (later = rendered on top) so tests
+  // can assert beforeId placement / z-order.
+  const order = [];
   return {
     addSource: (id, s) => { sources[id] = { ...s }; },
     getSource: (id) => (sources[id] ? { setData: (d) => { sources[id].data = d; } } : undefined),
-    addLayer: (l) => { layers[l.id] = { ...l, paint: { ...(l.paint ?? {}) }, layout: { ...(l.layout ?? {}) } }; },
+    addLayer: (l, beforeId) => {
+      layers[l.id] = { ...l, paint: { ...(l.paint ?? {}) }, layout: { ...(l.layout ?? {}) } };
+      const at = beforeId ? order.indexOf(beforeId) : -1;
+      if (at >= 0) order.splice(at, 0, l.id); else order.push(l.id);
+    },
     getLayer: (id) => layers[id],
     setLayoutProperty: (id, k, v) => { if (layers[id]) layers[id].layout[k] = v; },
     setPaintProperty: (id, k, v) => { if (layers[id]) layers[id].paint[k] = v; },
-    removeLayer: (id) => { delete layers[id]; },
+    removeLayer: (id) => { delete layers[id]; const i = order.indexOf(id); if (i >= 0) order.splice(i, 1); },
     removeSource: (id) => { delete sources[id]; },
     getStyle: () => ({ layers: [] }),
     hasImage: (id) => Boolean(images[id]),
     addImage: (id, img) => { images[id] = img; },
-    _sources: sources, _layers: layers, _images: images,
+    _sources: sources, _layers: layers, _images: images, _order: order,
   };
 }
 
@@ -65,6 +72,18 @@ test('mount adds the world source + layers alongside WPC, under one toggle', () 
   }
 });
 
+test('world layers are inserted beneath all WPC layers (z-order)', () => {
+  const map = fakeMap();
+  mountFrontsLayer(map, { visible: true });
+  const idx = (id) => map._order.indexOf(id);
+  const worldMax = Math.max(...FRONT_WORLD_LAYER_IDS.map(idx));
+  const wpcMin = Math.min(...FRONT_LAYER_IDS.map(idx));
+  for (const id of [...FRONT_LAYER_IDS, ...FRONT_WORLD_LAYER_IDS]) {
+    assert.ok(idx(id) >= 0, `${id} present in layer order`);
+  }
+  assert.ok(worldMax < wpcMin, 'every world layer renders beneath every WPC layer');
+});
+
 test('reload pushes data urls into both geojson sources', () => {
   const map = fakeMap();
   const layer = mountFrontsLayer(map, { visible: true });
@@ -94,7 +113,8 @@ test('refresh re-adds dropped layers after a style swap', () => {
 
   layer.refresh();
   assert.ok(map._sources.fronts, 'source re-added');
-  for (const id of FRONT_LAYER_IDS) {
+  assert.ok(map._sources['fronts-world'], 'world source re-added');
+  for (const id of [...FRONT_LAYER_IDS, ...FRONT_WORLD_LAYER_IDS]) {
     assert.ok(map._layers[id], `${id} re-added`);
   }
 });

--- a/web/src/lib/map/sources/fronts-source.js
+++ b/web/src/lib/map/sources/fronts-source.js
@@ -37,3 +37,20 @@ export function frontsProvider() {
     manifestUrl: FRONTS_MANIFEST_URL,
   };
 }
+
+// Model-derived GLOBAL fronts (GFS Thermal Front Parameter). Same schema and
+// styling as the WPC source, served under /fronts/world/* and tagged
+// region:"world". Rendered BENEATH the WPC layers so the analyst product wins
+// over North America and the model shows through everywhere else.
+export const FRONTS_WORLD_SOURCE_ID = 'fronts-world';
+export const FRONTS_WORLD_MANIFEST_URL = `${FRONTS_BASE}/fronts/world/manifest.json`;
+export const FRONTS_WORLD_DATA_URL = `${FRONTS_BASE}/fronts/world/latest.geojson`;
+
+export function frontsWorldProvider() {
+  return {
+    sourceId: FRONTS_WORLD_SOURCE_ID,
+    source: { type: 'geojson', data: FRONTS_WORLD_DATA_URL },
+    dataUrl: FRONTS_WORLD_DATA_URL,
+    manifestUrl: FRONTS_WORLD_MANIFEST_URL,
+  };
+}

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -212,12 +212,18 @@
   let lastFrontsIssued = null;
   let lastFrontsWorldIssued = null;
   // De-dupe diagnostics like warnRadar: a persistent failure would otherwise
-  // warn every poll. Only log when the failure stage changes.
-  let lastFrontsLoadStatus = null;
+  // warn every poll. The de-dupe is keyed by status string and tracked PER
+  // SOURCE: a healthy `na` must not clear a persistently-failing `world`'s
+  // warning (the normal state while the world source is rolling out). A source
+  // clears only its own statuses on success.
+  const frontsWarned = new Set();
   function warnFronts(status, ...args) {
-    if (lastFrontsLoadStatus === status) return;
-    lastFrontsLoadStatus = status;
+    if (frontsWarned.has(status)) return;
+    frontsWarned.add(status);
     console.warn(...args);
+  }
+  function clearFrontsWarn(label) {
+    for (const s of [...frontsWarned]) if (s.startsWith(`${label}-`)) frontsWarned.delete(s);
   }
   // Fetch one fronts manifest and return its issuance marker, or undefined on
   // any failure (network/401/HTTP/parse). A 401 clears the token to re-reveal.
@@ -241,7 +247,9 @@
     }
     try {
       const json = await resp.json();
-      return json?.issued ?? json?.latest ?? null;
+      const issued = json?.issued ?? json?.latest ?? null;
+      clearFrontsWarn(label); // this source recovered
+      return issued;
     } catch (e) {
       warnFronts(`${label}-parse`, `[fronts] ${label} manifest JSON parse failed`, e);
       return undefined;
@@ -252,8 +260,10 @@
     if (!frontsToken) frontsToken = await mapsState.revealToken();
     if (!frontsToken) return;
     const na = await fetchFrontsIssued(frontsProvider().manifestUrl, 'na');
+    // If `na` got a 401 it cleared the token; don't fire a guaranteed second
+    // 401 at the world manifest -- re-reveal on the next poll instead.
+    if (!frontsToken) return;
     const world = await fetchFrontsIssued(frontsWorldProvider().manifestUrl, 'world');
-    if (na !== undefined || world !== undefined) lastFrontsLoadStatus = null; // recovered
     let changed = false;
     if (na !== undefined && na != null) {
       if (lastFrontsIssued !== null && na !== lastFrontsIssued) changed = true;

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -24,7 +24,7 @@
     RADAR_REGION_WORLD,
   } from '../lib/map/sources/radar-source.js';
   import { mountFrontsLayer } from '../lib/map/layers/fronts.js';
-  import { frontsProvider } from '../lib/map/sources/fronts-source.js';
+  import { frontsProvider, frontsWorldProvider } from '../lib/map/sources/fronts-source.js';
   import { createRadarFrames } from '../lib/map/radar-frames.svelte.js';
   import { mapsState } from '../lib/settings/maps-store.svelte.js';
   import { mountFixedPointsLayer } from '../lib/map/layers/fixed-points.js';
@@ -206,7 +206,11 @@
   // attaches the token to it without any wiring here.
   let frontsToken = null;
   let frontsPollTimer = null;
+  // One issuance marker per source (WPC analysis + model-derived world). Either
+  // changing triggers a reload of both GeoJSON sources (the layer's reload()
+  // refreshes both -- cheap, and they share the toggle).
   let lastFrontsIssued = null;
+  let lastFrontsWorldIssued = null;
   // De-dupe diagnostics like warnRadar: a persistent failure would otherwise
   // warn every poll. Only log when the failure stage changes.
   let lastFrontsLoadStatus = null;
@@ -215,41 +219,51 @@
     lastFrontsLoadStatus = status;
     console.warn(...args);
   }
-  async function pollFrontsManifest() {
-    if (!mapsState.registered) return;
-    if (!frontsToken) frontsToken = await mapsState.revealToken();
-    if (!frontsToken) return;
-    const url = `${frontsProvider().manifestUrl}?t=${encodeURIComponent(frontsToken)}`;
+  // Fetch one fronts manifest and return its issuance marker, or undefined on
+  // any failure (network/401/HTTP/parse). A 401 clears the token to re-reveal.
+  async function fetchFrontsIssued(manifestUrl, label) {
+    const url = `${manifestUrl}?t=${encodeURIComponent(frontsToken)}`;
     let resp;
     try {
       resp = await fetch(url);
     } catch (e) {
-      warnFronts('network', '[fronts] manifest fetch failed (network/CORS)', e);
-      return;
+      warnFronts(`${label}-network`, `[fronts] ${label} manifest fetch failed (network/CORS)`, e);
+      return undefined;
     }
     if (resp.status === 401) {
       frontsToken = null; // stale token -- re-reveal next poll
-      warnFronts(401, '[fronts] manifest 401 -- token rejected; will re-reveal');
-      return;
+      warnFronts(`${label}-401`, `[fronts] ${label} manifest 401 -- token rejected; will re-reveal`);
+      return undefined;
     }
     if (!resp.ok) {
-      warnFronts(resp.status, `[fronts] manifest fetch HTTP ${resp.status}`);
-      return;
+      warnFronts(`${label}-${resp.status}`, `[fronts] ${label} manifest fetch HTTP ${resp.status}`);
+      return undefined;
     }
-    let issued;
     try {
       const json = await resp.json();
-      issued = json?.issued ?? json?.latest ?? null;
+      return json?.issued ?? json?.latest ?? null;
     } catch (e) {
-      warnFronts('parse', '[fronts] manifest JSON parse failed', e);
-      return;
+      warnFronts(`${label}-parse`, `[fronts] ${label} manifest JSON parse failed`, e);
+      return undefined;
     }
-    lastFrontsLoadStatus = null; // recovered
-    if (issued == null) return;
-    if (lastFrontsIssued !== null && issued !== lastFrontsIssued) {
-      frontsLayer?.reload();
+  }
+  async function pollFrontsManifest() {
+    if (!mapsState.registered) return;
+    if (!frontsToken) frontsToken = await mapsState.revealToken();
+    if (!frontsToken) return;
+    const na = await fetchFrontsIssued(frontsProvider().manifestUrl, 'na');
+    const world = await fetchFrontsIssued(frontsWorldProvider().manifestUrl, 'world');
+    if (na !== undefined || world !== undefined) lastFrontsLoadStatus = null; // recovered
+    let changed = false;
+    if (na !== undefined && na != null) {
+      if (lastFrontsIssued !== null && na !== lastFrontsIssued) changed = true;
+      lastFrontsIssued = na;
     }
-    lastFrontsIssued = issued;
+    if (world !== undefined && world != null) {
+      if (lastFrontsWorldIssued !== null && world !== lastFrontsWorldIssued) changed = true;
+      lastFrontsWorldIssued = world;
+    }
+    if (changed) frontsLayer?.reload();
   }
   function startFrontsPolling() {
     if (frontsPollTimer) return;


### PR DESCRIPTION
## Render the model-derived global fronts overlay

Client side of the global fronts feature. Adds a second GeoJSON source for the model-derived global fronts (`/fronts/world/latest.geojson`) under the **existing single "Fronts" toggle**, drawn beneath the WPC layers. Reuses the exact same WMO symbology, sprites, and paint/layout as the WPC overlay — region-agnostic, so it renders whatever features arrive.

- `fronts-source.js` — `frontsWorldProvider()` + world URLs.
- `fronts.js` — world line/pip/center layers (ids `fronts-world-*`), inserted below the WPC base line; `setVisible`/`refresh`/`reload`/`destroy` fan out to both sources.
- `LiveMapV2.svelte` — the slow manifest poll now watches both the WPC and world manifests and reloads on either cycle change; one checkbox controls both.

Backend that produces the data: `chrissnell/graywolf-maps` PR #55. With that PR's server-side North-America clip, the world document carries no fronts over NA, so the WPC analyst analysis owns that region and the model fills everywhere else; the WPC-on-top z-order here is now belt-and-suspenders.

### Verification
Full web suite green (409 tests) + `vite build`. New unit tests cover the world layer ids, that both sources mount under one toggle, and that `reload()` refreshes both. Visual quality (pip placement, curve smoothness, the NA seam) can only be confirmed on a running map against the deployed `/fronts/world/*` route — that check is deploy-gated, as with the original WPC overlay.
