### PR TITLE
ci: stop Microsoft/Azure apt repos from flaking the example-scripts lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,17 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install shellcheck
-        run: sudo apt-get update -y && sudo apt-get install -y shellcheck
+        run: |
+          # The hosted-runner image ships Microsoft/Azure apt repos that
+          # intermittently return 403 ("no longer signed") and fail
+          # `apt-get update` -- even though shellcheck comes from Ubuntu's own
+          # mirror. Drop those third-party lists first so an unrelated outage
+          # can't fail this job. Ubuntu's own sources live in the deb822
+          # `ubuntu.sources` file and are untouched.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft*.list \
+                     /etc/apt/sources.list.d/*azure*.list || true
+          sudo apt-get update -y
+          sudo apt-get install -y shellcheck
 
       - name: shellcheck POSIX example scripts
         run: shellcheck examples/actions/posix/*.sh


### PR DESCRIPTION
The `Example Scripts Lint` job's `Install shellcheck` step runs `apt-get update`, which intermittently fails with `403 Forbidden` from the hosted runner's preinstalled **Microsoft/Azure** apt repos (`packages.microsoft.com` -- "no longer signed"). That fails the whole job even though shellcheck comes from Ubuntu's own mirror, and it took down an unrelated docs-only PR (#405).

Fix: remove the third-party `*microsoft*.list` / `*azure*.list` source files before `apt-get update`, so an outage in repos we don't use can't fail the job. Ubuntu's own sources (deb822 `ubuntu.sources`) are untouched, so shellcheck still installs.

No behavior change to what the job actually lints.
