### PR TITLE
Dashboard: 10-minute rolling average for packet RX/TX rates

### DIFF
--- a/web/src/lib/packetRate.js
+++ b/web/src/lib/packetRate.js
@@ -1,0 +1,38 @@
+// Trailing-window packet rate computation for the dashboard RX/TX cards.
+// Pure JS — no runes, no DOM — so the windowing and reset logic can be tested
+// independently of Dashboard.svelte.
+
+/**
+ * Append a cumulative-counter sample and compute the packets/hour rate over a
+ * trailing window.
+ *
+ * Samples hold absolute counter readings ({ t, rx, tx }); the rate is the
+ * delta between the newest and oldest in-window sample divided by their
+ * elapsed wall-clock time. Counters that move backwards (a station restart
+ * resets them) discard the stale window and start measuring fresh.
+ *
+ * @param {Array<{t:number,rx:number,tx:number}>} samples - prior samples, oldest first
+ * @param {{t:number,rx:number,tx:number}} sample - the new reading
+ * @param {number} windowMs - trailing window length in milliseconds
+ * @returns {{samples:Array, rxRate:(number|null), txRate:(number|null)}}
+ *   The pruned sample list and the rates in packets/hour, null until 2+ samples
+ *   span a non-zero interval.
+ */
+export function pushRateSample(samples, sample, windowMs) {
+  let next = samples;
+  const last = next[next.length - 1];
+  if (last && (sample.rx < last.rx || sample.tx < last.tx)) next = [];
+
+  next = next.concat(sample).filter((s) => s.t >= sample.t - windowMs);
+
+  const oldest = next[0];
+  const elapsedMs = sample.t - oldest.t;
+  if (next.length < 2 || elapsedMs <= 0) {
+    return { samples: next, rxRate: null, txRate: null };
+  }
+  return {
+    samples: next,
+    rxRate: ((sample.rx - oldest.rx) * 3600000) / elapsedMs,
+    txRate: ((sample.tx - oldest.tx) * 3600000) / elapsedMs,
+  };
+}

--- a/web/src/lib/packetRate.test.js
+++ b/web/src/lib/packetRate.test.js
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { pushRateSample } from './packetRate.js';
+
+const WINDOW = 10 * 60 * 1000; // 10 minutes
+
+test('pushRateSample: first sample has no rate yet', () => {
+  const r = pushRateSample([], { t: 0, rx: 100, tx: 5 }, WINDOW);
+  assert.equal(r.rxRate, null);
+  assert.equal(r.txRate, null);
+  assert.equal(r.samples.length, 1);
+});
+
+test('pushRateSample: rate is delta over elapsed, scaled to per-hour', () => {
+  // 60 RX / 6 TX over 60s => 3600 RX/hr, 360 TX/hr.
+  let s = [];
+  ({ samples: s } = pushRateSample(s, { t: 0, rx: 100, tx: 10 }, WINDOW));
+  const r = pushRateSample(s, { t: 60000, rx: 160, tx: 16 }, WINDOW);
+  assert.equal(r.rxRate, 3600);
+  assert.equal(r.txRate, 360);
+});
+
+test('pushRateSample: drops samples outside the trailing window', () => {
+  let s = [];
+  ({ samples: s } = pushRateSample(s, { t: 0, rx: 0, tx: 0 }, WINDOW));
+  ({ samples: s } = pushRateSample(s, { t: 5 * 60000, rx: 300, tx: 0 }, WINDOW));
+  // 11 minutes after the first sample: the t=0 reading falls out of the window.
+  const r = pushRateSample(s, { t: 11 * 60000, rx: 900, tx: 0 }, WINDOW);
+  assert.ok(!r.samples.some((x) => x.t === 0), 'oldest out-of-window sample pruned');
+  // Window now spans t=5min..11min: 600 packets over 360s => 6000/hr.
+  assert.equal(r.rxRate, 6000);
+});
+
+test('pushRateSample: counter reset (backwards) restarts the window', () => {
+  let s = [];
+  ({ samples: s } = pushRateSample(s, { t: 0, rx: 1000, tx: 50 }, WINDOW));
+  ({ samples: s } = pushRateSample(s, { t: 60000, rx: 1100, tx: 55 }, WINDOW));
+  // Station restarted: counters dropped. Window resets; no rate from one sample.
+  const r = pushRateSample(s, { t: 120000, rx: 5, tx: 0 }, WINDOW);
+  assert.deepEqual(r.samples, [{ t: 120000, rx: 5, tx: 0 }]);
+  assert.equal(r.rxRate, null);
+  assert.equal(r.txRate, null);
+});
+
+test('pushRateSample: zero traffic yields a real 0/hr, not null', () => {
+  let s = [];
+  ({ samples: s } = pushRateSample(s, { t: 0, rx: 42, tx: 7 }, WINDOW));
+  const r = pushRateSample(s, { t: 30000, rx: 42, tx: 7 }, WINDOW);
+  assert.equal(r.rxRate, 0);
+  assert.equal(r.txRate, 0);
+});
+
+test('pushRateSample: duplicate timestamp does not divide by zero', () => {
+  let s = [];
+  ({ samples: s } = pushRateSample(s, { t: 1000, rx: 0, tx: 0 }, WINDOW));
+  const r = pushRateSample(s, { t: 1000, rx: 10, tx: 1 }, WINDOW);
+  assert.equal(r.rxRate, null);
+  assert.equal(r.txRate, null);
+});

--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -5,6 +5,7 @@
   import { online } from '../lib/stores/connection.js';
   import { formatAltitude, formatSpeed } from '../lib/settings/units.js';
   import { beaconLabel } from '../lib/beaconLabel.js';
+  import { pushRateSample } from '../lib/packetRate.js';
   import PageHeader from '../components/PageHeader.svelte';
   import PacketLogViewer from '../components/PacketLogViewer.svelte';
   import { logPrefsState } from '../lib/settings/log-prefs-store.svelte.js';
@@ -30,12 +31,26 @@
       status = null;
       position = null;
       packets = [];
+      // Drop the rolling-rate window so a reconnect starts measuring fresh
+      // rather than averaging across the offline gap.
+      rateSamples = [];
+      rxRate = null;
+      txRate = null;
     }
   });
 
   let totalRx = $derived(status?.channels?.reduce((sum, ch) => sum + (ch.rx_frames || 0), 0) ?? 0);
   let totalTx = $derived(status?.channels?.reduce((sum, ch) => sum + (ch.tx_frames || 0), 0) ?? 0);
   let igated = $derived(status?.igate?.rf_to_is_gated ?? 0);
+
+  // Rolling packets/hour rates over a trailing window. Each status poll
+  // samples the cumulative RX/TX counters; the rate is the delta divided by
+  // the elapsed wall-clock time, so it reflects recent activity rather than a
+  // lifetime average. Samples older than the window are dropped as it slides.
+  const RATE_WINDOW_MS = 10 * 60 * 1000;
+  let rateSamples = [];        // { t, rx, tx }, oldest first — not reactive
+  let rxRate = $state(null);   // packets/hour over the window, null until 2+ samples
+  let txRate = $state(null);
 
   // Activity tracking for RX/TX flash indicators
   let prevStats = {};
@@ -120,7 +135,19 @@
         }
       }
       status = st.value;
+      recordRateSample(st.value.channels);
     }
+  }
+
+  // Append a counter sample and recompute the trailing-window rates.
+  function recordRateSample(channels) {
+    const curRx = channels?.reduce((sum, ch) => sum + (ch.rx_frames || 0), 0) ?? 0;
+    const curTx = channels?.reduce((sum, ch) => sum + (ch.tx_frames || 0), 0) ?? 0;
+    const sample = { t: Date.now(), rx: curRx, tx: curTx };
+    const r = pushRateSample(rateSamples, sample, RATE_WINDOW_MS);
+    rateSamples = r.samples;
+    rxRate = r.rxRate;
+    txRate = r.txRate;
   }
 
   async function loadBeacons() {
@@ -179,11 +206,9 @@
     return `${h}h ${m}m`;
   }
 
-  // Average packets/hour over the station's uptime, derived from the same
-  // cumulative counters shown above. Returns an em-dash until uptime is known.
-  function formatRate(total, uptimeSeconds) {
-    if (!uptimeSeconds || uptimeSeconds <= 0) return '—';
-    const perHour = (total * 3600) / uptimeSeconds;
+  // Format a packets/hour rate; returns an em-dash until enough samples exist.
+  function formatRate(perHour) {
+    if (perHour == null) return '—';
     const rounded = perHour >= 100 ? Math.round(perHour) : Math.round(perHour * 10) / 10;
     return `${rounded.toLocaleString()}/hr`;
   }
@@ -301,12 +326,16 @@
   <div class="stat-card">
     <span class="stat-value">{offline ? '—' : totalRx}</span>
     <span class="stat-label">Packets RX</span>
-    <span class="stat-rate">{offline ? '—' : formatRate(totalRx, status?.uptime_seconds)}</span>
+    <span class="stat-rate" title="Packets per hour, averaged over the last 10 minutes">
+      {offline ? '—' : formatRate(rxRate)}{#if !offline && rxRate != null}<span class="stat-rate-qual">10m avg</span>{/if}
+    </span>
   </div>
   <div class="stat-card">
     <span class="stat-value">{offline ? '—' : totalTx}</span>
     <span class="stat-label">Packets TX</span>
-    <span class="stat-rate">{offline ? '—' : formatRate(totalTx, status?.uptime_seconds)}</span>
+    <span class="stat-rate" title="Packets per hour, averaged over the last 10 minutes">
+      {offline ? '—' : formatRate(txRate)}{#if !offline && txRate != null}<span class="stat-rate-qual">10m avg</span>{/if}
+    </span>
   </div>
   <div class="stat-card">
     <span class="stat-value">{offline ? '—' : igated}</span>
@@ -552,6 +581,12 @@
     color: var(--color-text-dim);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
+  }
+  .stat-rate-qual {
+    margin-left: 4px;
+    opacity: 0.65;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
   }
 
   /* ── packet feed wrapper ───────────────────────── */


### PR DESCRIPTION
Switches the dashboard's Packets RX / Packets TX rate figures from a lifetime average to a **10-minute rolling average**, per the request on GRA-205.

**How it works**
- Each status poll (every 5s) samples the cumulative RX/TX counters. The rate is the delta between the newest and oldest in-window sample divided by their elapsed wall-clock time, scaled to packets/hour.
- Samples older than 10 minutes are dropped as the window slides.
- A station restart (counters move backwards) or a dropped connection clears the window so it starts measuring fresh rather than averaging across the gap.
- Shows an em-dash until at least two samples span a non-zero interval.

**Telling the user what it is, without clutter**
- The rate line now reads e.g. `42/hr  10m avg`, with `10m avg` rendered as a small, dimmed qualifier.
- A tooltip on the figure spells it out: "Packets per hour, averaged over the last 10 minutes."

**Tests**
- The windowing/reset math is extracted to `web/src/lib/packetRate.js` (pure JS) and covered by `packetRate.test.js`: per-hour scaling, window pruning, counter-reset restart, zero-traffic 0/hr, and divide-by-zero guard. Full suite: 416 passing. `vite build` succeeds.
