### PR TITLE
fix(map): color pressure centers L=blue, H=red

### DIFF
--- a/web/src/lib/map/layers/fronts.js
+++ b/web/src/lib/map/layers/fronts.js
@@ -385,8 +385,8 @@ function layerSpecs(sourceId, idPrefix, vis) {
         'text-color': [
           'match',
           ['get', 'kind'],
-          'H', FRONT_COLORS.cold,
-          'L', FRONT_COLORS.warm,
+          'H', FRONT_COLORS.warm,
+          'L', FRONT_COLORS.cold,
           '#333333',
         ],
         'text-halo-color': '#ffffff',


### PR DESCRIPTION
Per request: swap the front pressure-center label colors so L is blue and H is red (was H=blue/L=red). One-line change in the centers paint expression; 15 fronts-layer tests + full web suite green.