### PR TITLE
Fix coordinate display overlapping map status text on narrow displays

### DIFF
--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1706,6 +1706,9 @@
     .map-status-bar {
       bottom: calc(14px + env(safe-area-inset-bottom));
     }
+    /* The coord readout is lifted clear of this status bar in the
+       max-width: 900px block below -- the two offsets are coupled; keep
+       them in sync if you change either. */
   }
 
   /* On narrow viewports the centered status bar grows wide enough to reach

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1706,8 +1706,16 @@
     .map-status-bar {
       bottom: calc(14px + env(safe-area-inset-bottom));
     }
+  }
+
+  /* On narrow viewports the centered status bar grows wide enough to reach
+     the bottom-right coord/zoom readout and hide it (graywolf #418). Lift
+     the readout clear of the status bar so the two stack instead of
+     overlapping. The offset also keeps it above the bottom safe-area inset
+     and MapLibre attribution on mobile. */
+  @media (max-width: 900px) {
     .map-coord-display {
-      bottom: calc(28px + env(safe-area-inset-bottom));
+      bottom: calc(52px + env(safe-area-inset-bottom));
     }
   }
 


### PR DESCRIPTION
## Problem

On narrow viewports (reported in Firefox, graywolf #418), the bottom-right coordinate/zoom readout on the live map can be partially hidden behind the centered map status bar (station count, time interval, etc.).

The status bar is centered (`left: 50%`) with `white-space: nowrap`, so as the viewport narrows it grows wide enough to reach into the bottom-right corner where the coordinate readout sits.

## Fix

Below 900px, lift the coordinate/zoom readout above the status bar so the two stack vertically instead of overlapping. The offset also keeps the readout above the bottom safe-area inset and MapLibre attribution on mobile.

CSS-only change scoped to the existing media-query block in `LiveMapV2.svelte`.

Closes #418