### PR TITLE
Add manual coordinate entry to fixed point dialog

### DIFF
--- a/web/src/lib/map/coord-input.js
+++ b/web/src/lib/map/coord-input.js
@@ -1,0 +1,43 @@
+// Parsing for the manual lat/lon entry fields in the fixed-point dialog
+// (graywolf#417). Operators paste or type coordinates copied from other
+// tools, so we accept decimal degrees with an optional leading sign and an
+// optional hemisphere letter (N/S/E/W), e.g. "37.7749", "-122.4194",
+// "37.7749 N", "122.4194W". The hemisphere letter, when present, wins over a
+// sign and must match the axis (N/S for latitude, E/W for longitude).
+
+const RANGE = {
+  lat: { max: 90, neg: 'S', pos: 'N', label: 'Latitude' },
+  lon: { max: 180, neg: 'W', pos: 'E', label: 'Longitude' },
+};
+
+// parseCoordinate turns a user-entered string into a signed decimal-degree
+// number for the given axis ('lat' | 'lon'). Returns { value } on success or
+// { error } with a human-readable message suitable for inline display.
+export function parseCoordinate(text, axis) {
+  const spec = RANGE[axis];
+  const raw = String(text ?? '').trim();
+  if (!raw) return { error: `${spec.label} is required` };
+
+  // Pull an optional trailing/leading hemisphere letter off the number.
+  const m = raw.match(/^([nsew])?\s*([+-]?\d*\.?\d+)\s*([nsew])?$/i);
+  if (!m) return { error: `${spec.label} is not a valid number` };
+
+  const hemi = (m[1] || m[3] || '').toUpperCase();
+  let value = parseFloat(m[2]);
+  if (!Number.isFinite(value)) return { error: `${spec.label} is not a valid number` };
+
+  if (hemi) {
+    if (hemi !== spec.neg && hemi !== spec.pos) {
+      return { error: `Use ${spec.pos} or ${spec.neg} for ${spec.label.toLowerCase()}` };
+    }
+    // A sign and a contradicting hemisphere letter is ambiguous; reject it
+    // rather than silently picking one.
+    if (value < 0) return { error: `Don't combine a minus sign with ${hemi}` };
+    if (hemi === spec.neg) value = -value;
+  }
+
+  if (Math.abs(value) > spec.max) {
+    return { error: `${spec.label} must be between -${spec.max} and ${spec.max}` };
+  }
+  return { value };
+}

--- a/web/src/lib/map/coord-input.test.js
+++ b/web/src/lib/map/coord-input.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCoordinate } from './coord-input.js';
+
+test('parses plain decimal degrees', () => {
+  assert.deepEqual(parseCoordinate('37.7749', 'lat'), { value: 37.7749 });
+  assert.deepEqual(parseCoordinate('-122.4194', 'lon'), { value: -122.4194 });
+});
+
+test('honors hemisphere letters', () => {
+  assert.deepEqual(parseCoordinate('37.7749 N', 'lat'), { value: 37.7749 });
+  assert.deepEqual(parseCoordinate('37.7749S', 'lat'), { value: -37.7749 });
+  assert.deepEqual(parseCoordinate('W122.4194', 'lon'), { value: -122.4194 });
+});
+
+test('accepts integers and bare decimals', () => {
+  assert.deepEqual(parseCoordinate('0', 'lat'), { value: 0 });
+  assert.deepEqual(parseCoordinate('.5', 'lon'), { value: 0.5 });
+});
+
+test('rejects empty input', () => {
+  assert.match(parseCoordinate('   ', 'lat').error, /required/);
+});
+
+test('rejects out-of-range values', () => {
+  assert.match(parseCoordinate('91', 'lat').error, /between/);
+  assert.match(parseCoordinate('181', 'lon').error, /between/);
+  assert.equal(parseCoordinate('90', 'lat').value, 90);
+  assert.equal(parseCoordinate('-180', 'lon').value, -180);
+});
+
+test('rejects wrong-axis hemisphere letters', () => {
+  assert.match(parseCoordinate('37.0 E', 'lat').error, /N or S/);
+  assert.match(parseCoordinate('122.0 N', 'lon').error, /E or W/);
+});
+
+test('rejects a minus sign combined with a hemisphere letter', () => {
+  assert.match(parseCoordinate('-37.0 S', 'lat').error, /minus sign/);
+});
+
+test('rejects non-numeric junk', () => {
+  assert.match(parseCoordinate('abc', 'lat').error, /valid number/);
+  assert.match(parseCoordinate('12.3.4', 'lon').error, /valid number/);
+});

--- a/web/src/lib/map/coord-input.test.js
+++ b/web/src/lib/map/coord-input.test.js
@@ -38,6 +38,21 @@ test('rejects a minus sign combined with a hemisphere letter', () => {
   assert.match(parseCoordinate('-37.0 S', 'lat').error, /minus sign/);
 });
 
+test('round-trips the toFixed(6) seed used to pre-fill the dialog', () => {
+  // The dialog seeds its inputs with lat.toFixed(6) / lon.toFixed(6); the
+  // unedited path parses that string straight back, so it must recover the
+  // value losslessly at 6dp.
+  const lat = 37.774929;
+  const lon = -122.419418;
+  assert.deepEqual(parseCoordinate(lat.toFixed(6), 'lat'), { value: lat });
+  assert.deepEqual(parseCoordinate(lon.toFixed(6), 'lon'), { value: lon });
+});
+
+test('tolerates surrounding whitespace and a leading +', () => {
+  assert.deepEqual(parseCoordinate('  37.7749 N ', 'lat'), { value: 37.7749 });
+  assert.deepEqual(parseCoordinate('+37.7', 'lat'), { value: 37.7 });
+});
+
 test('rejects non-numeric junk', () => {
   assert.match(parseCoordinate('abc', 'lat').error, /valid number/);
   assert.match(parseCoordinate('12.3.4', 'lon').error, /valid number/);

--- a/web/src/lib/map/fixed-point-dialog.svelte
+++ b/web/src/lib/map/fixed-point-dialog.svelte
@@ -1,14 +1,16 @@
 <script>
   // Dialog for adding a user-defined fixed map point. Opened from the map's
-  // right-click context menu with the clicked lat/lon. Collects a name and
-  // an APRS symbol (reusing the SymbolPicker so the icon vocabulary matches
-  // station/beacon markers), then hands the result back via onConfirm.
+  // right-click context menu with the clicked lat/lon. Collects a name, an
+  // APRS symbol (reusing the SymbolPicker so the icon vocabulary matches
+  // station/beacon markers), and the coordinates -- pre-filled from the
+  // clicked location but editable so operators can type exact lat/lon
+  // (graywolf#417). Hands the result back via onConfirm.
 
   import { Button } from '@chrissnell/chonky-ui';
   import Modal from '../../components/Modal.svelte';
   import SymbolPicker from '../../components/SymbolPicker.svelte';
   import { createAprsIconElement } from './aprs-icon-element.js';
-  import { fmtLat, fmtLon } from './popup-helpers.js';
+  import { parseCoordinate } from './coord-input.js';
 
   let {
     open = $bindable(false),
@@ -21,17 +23,24 @@
   let table = $state('/');
   let symbol = $state('.');
   let overlay = $state('');
+  let latInput = $state('');
+  let lonInput = $state('');
+  let coordError = $state('');
   let pickerOpen = $state(false);
 
   // Reset the working fields each time the dialog opens so a prior entry
-  // doesn't bleed into the next point. Default '//' is the APRS "Red dot",
-  // a neutral, clearly-visible generic waypoint.
+  // doesn't bleed into the next point, and seed the coordinate fields from
+  // the clicked location. Default '/' table + '/' symbol is the APRS "Red
+  // dot", a neutral, clearly-visible generic waypoint.
   $effect(() => {
     if (open) {
       name = '';
       table = '/';
       symbol = '/';
       overlay = '';
+      latInput = lat.toFixed(5);
+      lonInput = lon.toFixed(5);
+      coordError = '';
     }
   });
 
@@ -55,7 +64,14 @@
     // Name is required server-side; guard here so Enter / the button can't
     // fire an empty-name request that would only come back as a 400 toast.
     if (!name.trim()) return;
-    onConfirm?.({ name: name.trim(), table, symbol, overlay });
+    const latRes = parseCoordinate(latInput, 'lat');
+    const lonRes = parseCoordinate(lonInput, 'lon');
+    if (latRes.error || lonRes.error) {
+      coordError = latRes.error || lonRes.error;
+      return;
+    }
+    coordError = '';
+    onConfirm?.({ name: name.trim(), table, symbol, overlay, lat: latRes.value, lon: lonRes.value });
     open = false;
   }
 
@@ -88,7 +104,34 @@
       </div>
     </div>
 
-    <div class="fp-coords">{fmtLat(lat)} {fmtLon(lon)}</div>
+    <div class="fp-coord-row">
+      <label class="fp-field">
+        <span class="fp-label">Latitude</span>
+        <input
+          class="fp-input"
+          type="text"
+          inputmode="decimal"
+          bind:value={latInput}
+          placeholder="37.77490"
+          onkeydown={(e) => e.key === 'Enter' && confirm()}
+        />
+      </label>
+      <label class="fp-field">
+        <span class="fp-label">Longitude</span>
+        <input
+          class="fp-input"
+          type="text"
+          inputmode="decimal"
+          bind:value={lonInput}
+          placeholder="-122.41940"
+          onkeydown={(e) => e.key === 'Enter' && confirm()}
+        />
+      </label>
+    </div>
+
+    {#if coordError}
+      <div class="fp-coord-error" role="alert">{coordError}</div>
+    {/if}
 
     <div class="fp-actions">
       <Button onclick={cancel}>Cancel</Button>
@@ -142,10 +185,17 @@
     height: 28px;
     flex: 0 0 auto;
   }
-  .fp-coords {
-    font-family: var(--font-mono);
+  .fp-coord-row {
+    display: flex;
+    gap: 12px;
+  }
+  .fp-coord-row .fp-field {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+  .fp-coord-error {
     font-size: 12px;
-    color: var(--color-text-muted);
+    color: var(--color-danger, #ff6b6b);
   }
   .fp-actions {
     display: flex;

--- a/web/src/lib/map/fixed-point-dialog.svelte
+++ b/web/src/lib/map/fixed-point-dialog.svelte
@@ -38,8 +38,8 @@
       table = '/';
       symbol = '/';
       overlay = '';
-      latInput = lat.toFixed(5);
-      lonInput = lon.toFixed(5);
+      latInput = lat.toFixed(6);
+      lonInput = lon.toFixed(6);
       coordError = '';
     }
   });
@@ -112,7 +112,9 @@
           type="text"
           inputmode="decimal"
           bind:value={latInput}
-          placeholder="37.77490"
+          placeholder="37.774900"
+          aria-invalid={!!coordError}
+          aria-describedby={coordError ? 'fp-coord-error' : undefined}
           onkeydown={(e) => e.key === 'Enter' && confirm()}
         />
       </label>
@@ -123,14 +125,16 @@
           type="text"
           inputmode="decimal"
           bind:value={lonInput}
-          placeholder="-122.41940"
+          placeholder="-122.419400"
+          aria-invalid={!!coordError}
+          aria-describedby={coordError ? 'fp-coord-error' : undefined}
           onkeydown={(e) => e.key === 'Enter' && confirm()}
         />
       </label>
     </div>
 
     {#if coordError}
-      <div class="fp-coord-error" role="alert">{coordError}</div>
+      <div id="fp-coord-error" class="fp-coord-error" role="alert">{coordError}</div>
     {/if}
 
     <div class="fp-actions">

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1388,15 +1388,15 @@
     bind:open={fpDialog.open}
     lat={fpDialog.lat}
     lon={fpDialog.lon}
-    onConfirm={async ({ name, table, symbol, overlay }) => {
+    onConfirm={async ({ name, table, symbol, overlay, lat, lon }) => {
       try {
         const p = await fixedPointsStore.add({
           name,
           table,
           symbol,
           overlay,
-          lat: fpDialog.lat,
-          lon: fpDialog.lon,
+          lat,
+          lon,
         });
         toasts.success(`Added "${p.name}"`);
       } catch (err) {


### PR DESCRIPTION
## Summary

Closes #417. The fixed point creation dialog now exposes editable **Latitude** and **Longitude** fields, pre-filled with the clicked map location. Operators can accept the clicked coordinates or type exact values directly -- useful for placing dozens of named landmarks along roads/trails missing from offline maps (the Pony Express Reride use case from the issue).

## Changes

- New `coord-input.js` helper: `parseCoordinate(text, axis)` accepts decimal degrees with an optional leading sign and optional `N/S/E/W` hemisphere letter (e.g. `37.7749`, `-122.4194`, `37.7749 N`, `W122.4194`), validates axis range, and returns a usable value or an inline error message.
- `fixed-point-dialog.svelte`: replaced the read-only coordinate display with two editable inputs seeded from the clicked location; validates on confirm and shows an inline error for bad input.
- `LiveMapV2.svelte`: persists the coordinates returned by the dialog rather than the original clicked coordinates.
- Name and icon selection are unchanged.

## Testing

- `coord-input.test.js` covers decimal parsing, hemisphere letters, range limits, wrong-axis letters, sign/letter conflicts, and junk input (8 cases, all passing).
- `npm run build` succeeds.