### PR TITLE
Keep callsign trail visible when newest fix leaves the viewport (#413)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1280,12 +1280,19 @@ as stale breadcrumbs.
 the server (head always counts; older points count only when newer than the
 trail cutoff, matching `stationToDTO`) so membership reflects what actually
 ships. Keep the client predicate any-position so it self-cleans: a track is
-retained while partly visible and pruned once fully off-screen.
+retained while partly visible and pruned once fully off-screen. The two
+checks are symmetric in shape (any-position, inclusive bounds) but not
+bit-exact: the client trail is length-capped (`MAX_TRAIL_LEN`), not
+time-trimmed, so `trailIntersectsBBox` may scan slightly older breadcrumbs
+than the server's cutoff-trimmed set. `pruneStale` still drops whole stations
+by `last_heard`, so the looseness is bounded.
 
 Source:
 [`../../pkg/stationcache/memcache.go`](../../pkg/stationcache/memcache.go)
 (`QueryBBox`, `stationInBBox`),
 [`../../pkg/stationcache/memcache_test.go`](../../pkg/stationcache/memcache_test.go)
 (`TestMemCache_QueryBBoxKeepsTrailWhenHeadLeaves`),
+[`../../web/src/lib/map/viewport-membership-core.js`](../../web/src/lib/map/viewport-membership-core.js)
+(`trailIntersectsBBox`, `viewport-membership-core.test.js`),
 [`../../web/src/lib/map/data-store.svelte.js`](../../web/src/lib/map/data-store.svelte.js)
 (`pruneOutOfBounds`).

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1256,3 +1256,36 @@ Source: [`../../web/src/lib/map/rf-only-core.js`](../../web/src/lib/map/rf-only-
 (filter `$effect`, `rfOnlyStationCount`),
 [`../../web/src/lib/map/popup-helpers.js`](../../web/src/lib/map/popup-helpers.js)
 (`viaText`).
+
+### 53. Map-viewport membership is any-trail-position, not head-only
+
+A station belongs to the current map view when **any** position in its
+visible trail falls inside the bbox -- not only its newest fix
+(`positions[0]`). Both ends of the live-map pipeline must agree on this:
+
+- Server: `MemCache.QueryBBox` (`stationInBBox`) returns a station if the
+  head or any non-trimmed trail point is inside the bbox.
+- Client: the data store's `pruneOutOfBounds` keeps a station while any of
+  its accumulated positions is inside the bbox, and drops it only once the
+  whole track has scrolled off-screen.
+
+*Why:* a head-only test on either side made a moving station's entire
+still-visible trail vanish the moment its newest position left the viewport
+(graywolf GH #413) -- the server stopped returning it and the client pruned
+it. The two checks must stay symmetric: if the server is looser than the
+client (or vice versa), tracks either flicker on bounds changes or pile up
+as stale breadcrumbs.
+
+*How to apply:* mirror the trail-cutoff trimming when scanning positions on
+the server (head always counts; older points count only when newer than the
+trail cutoff, matching `stationToDTO`) so membership reflects what actually
+ships. Keep the client predicate any-position so it self-cleans: a track is
+retained while partly visible and pruned once fully off-screen.
+
+Source:
+[`../../pkg/stationcache/memcache.go`](../../pkg/stationcache/memcache.go)
+(`QueryBBox`, `stationInBBox`),
+[`../../pkg/stationcache/memcache_test.go`](../../pkg/stationcache/memcache_test.go)
+(`TestMemCache_QueryBBoxKeepsTrailWhenHeadLeaves`),
+[`../../web/src/lib/map/data-store.svelte.js`](../../web/src/lib/map/data-store.svelte.js)
+(`pruneOutOfBounds`).

--- a/pkg/stationcache/memcache.go
+++ b/pkg/stationcache/memcache.go
@@ -148,14 +148,36 @@ func (c *MemCache) QueryBBox(bbox BBox, maxAge time.Duration) []Station {
 		if len(s.Positions) == 0 {
 			continue
 		}
-		p := s.Positions[0]
-		if p.Lat < bbox.SwLat || p.Lat > bbox.NeLat ||
-			p.Lon < bbox.SwLon || p.Lon > bbox.NeLon {
+		// Include the station when ANY position that will be shipped to
+		// the client falls inside the bbox, not just the latest fix. A
+		// head-only test made a moving station's entire still-visible
+		// trail vanish the moment its newest position left the viewport
+		// (GH #413). positions[0] is always shipped; positions[1:] ship
+		// only when newer than the trail cutoff, so mirror that trimming
+		// here to avoid keeping a station for a breadcrumb that won't
+		// actually render.
+		if !stationInBBox(s, bbox, cutoff) {
 			continue
 		}
 		out = append(out, snapshotStation(s))
 	}
 	return out
+}
+
+// stationInBBox reports whether any of the station's visible positions lie
+// within bbox. The head (positions[0]) always counts; older positions count
+// only when newer than cutoff, matching stationToDTO's trail trimming.
+func stationInBBox(s *Station, bbox BBox, cutoff time.Time) bool {
+	for i, p := range s.Positions {
+		if i > 0 && p.Timestamp.Before(cutoff) {
+			continue
+		}
+		if p.Lat >= bbox.SwLat && p.Lat <= bbox.NeLat &&
+			p.Lon >= bbox.SwLon && p.Lon <= bbox.NeLon {
+			return true
+		}
+	}
+	return false
 }
 
 // Lookup returns positions for the given callsigns regardless of bbox.

--- a/pkg/stationcache/memcache_test.go
+++ b/pkg/stationcache/memcache_test.go
@@ -130,6 +130,34 @@ func TestMemCache_MovingStationTrail(t *testing.T) {
 	assertFloat(t, "oldest lat", results[0].Positions[4].Lat, 40.0)
 }
 
+func TestMemCache_QueryBBoxKeepsTrailWhenHeadLeaves(t *testing.T) {
+	c := newTestCache(t)
+
+	// Station walks east out of the bbox: the first 3 fixes are inside,
+	// the last 2 (the newest, including the head) are outside.
+	bbox := BBox{SwLat: 39, SwLon: -106, NeLat: 41, NeLon: -104}
+	lons := []float64{-105.0, -104.5, -104.2, -103.5, -103.0}
+	for _, lon := range lons {
+		c.Update([]CacheEntry{stationEntry("stn:ROVER", "ROVER", 40.0, lon)})
+	}
+
+	// Head is now outside the bbox, but earlier breadcrumbs remain inside,
+	// so the station (and its whole trail) must still be returned -- GH #413.
+	results := c.QueryBBox(bbox, 1*time.Hour)
+	if len(results) != 1 {
+		t.Fatalf("expected station retained while trail intersects bbox, got %d", len(results))
+	}
+	if len(results[0].Positions) != len(lons) {
+		t.Fatalf("expected full %d-point trail, got %d", len(lons), len(results[0].Positions))
+	}
+
+	// Once the entire track has left the viewport, the station drops out.
+	eastBox := BBox{SwLat: 39, SwLon: -90, NeLat: 41, NeLon: -88}
+	if got := c.QueryBBox(eastBox, 1*time.Hour); len(got) != 0 {
+		t.Fatalf("expected station dropped when whole trail is off-screen, got %d", len(got))
+	}
+}
+
 func TestMemCache_TrailCap(t *testing.T) {
 	c := newTestCache(t)
 

--- a/web/src/lib/map/data-store.svelte.js
+++ b/web/src/lib/map/data-store.svelte.js
@@ -24,6 +24,7 @@ import { SvelteMap } from 'svelte/reactivity';
 import { clockOffset } from './clock-offset.svelte.js';
 import { get } from 'svelte/store';
 import { online, markConnected, markDisconnected } from '../stores/connection.js';
+import { trailIntersectsBBox } from './viewport-membership-core.js';
 
 const POLL_BASE_MS = 5_000;
 const POLL_MAX_MS = 60_000;
@@ -270,17 +271,10 @@ export function createDataStore() {
   function pruneOutOfBounds(b) {
     if (!b) return;
     for (const [callsign, s] of stations) {
-      const pts = s.positions;
-      if (!pts || pts.length === 0) continue;
-      const visible = pts.some(
-        (p) => p.lat >= b.swLat && p.lat <= b.neLat &&
-               p.lon >= b.swLon && p.lon <= b.neLon,
-      );
-      if (!visible) {
-        stations.delete(callsign);
-        trails.delete(callsign);
-        weather.delete(callsign);
-      }
+      if (trailIntersectsBBox(s.positions, b)) continue;
+      stations.delete(callsign);
+      trails.delete(callsign);
+      weather.delete(callsign);
     }
   }
 

--- a/web/src/lib/map/data-store.svelte.js
+++ b/web/src/lib/map/data-store.svelte.js
@@ -256,19 +256,27 @@ export function createDataStore() {
 
   // --- Imperative API ---
 
-  // pruneOutOfBounds drops stations whose primary position is outside
-  // the supplied bbox. Called from setBounds so a pan or zoom-in
-  // doesn't leave stale markers from the prior viewport floating around
-  // after the next /api/stations fetch (the server only returns
-  // stations inside the new bbox, so without this they'd never be
+  // pruneOutOfBounds drops stations whose ENTIRE trail is outside the
+  // supplied bbox. Called from setBounds so a pan or zoom-in doesn't
+  // leave stale markers from the prior viewport floating around after
+  // the next /api/stations fetch (the server only returns stations whose
+  // trail intersects the new bbox, so without this they'd never be
   // removed from the SvelteMap).
+  //
+  // Membership is any-position, not head-only: a moving station whose
+  // newest fix has left the viewport keeps its trail drawn as long as
+  // some earlier fix is still in view, and is dropped only once the
+  // whole track has scrolled off-screen (GH #413).
   function pruneOutOfBounds(b) {
     if (!b) return;
     for (const [callsign, s] of stations) {
-      const p = s.positions && s.positions[0];
-      if (!p) continue;
-      if (p.lat < b.swLat || p.lat > b.neLat ||
-          p.lon < b.swLon || p.lon > b.neLon) {
+      const pts = s.positions;
+      if (!pts || pts.length === 0) continue;
+      const visible = pts.some(
+        (p) => p.lat >= b.swLat && p.lat <= b.neLat &&
+               p.lon >= b.swLon && p.lon <= b.neLon,
+      );
+      if (!visible) {
         stations.delete(callsign);
         trails.delete(callsign);
         weather.delete(callsign);

--- a/web/src/lib/map/viewport-membership-core.js
+++ b/web/src/lib/map/viewport-membership-core.js
@@ -1,0 +1,22 @@
+// Pure predicate behind the live map's viewport pruning. A station belongs to
+// the current map view when ANY position in its accumulated trail falls inside
+// the bbox -- not only its newest fix (positions[0]).
+//
+// A head-only test made a moving station's entire still-visible trail vanish
+// the moment its newest position left the viewport: the server stopped
+// returning it and the client pruned it (graywolf #413). Keeping membership
+// any-position lets a track stay drawn while partly visible and drops it only
+// once the whole track has scrolled off-screen, so pruning stays self-cleaning.
+//
+// This mirrors the server's stationcache.stationInBBox (inclusive bounds, any
+// position) so the two layers agree -- see invariant #53. The one intentional
+// difference: the client trail is length-capped (MAX_TRAIL_LEN), not
+// time-trimmed, so it may scan slightly older breadcrumbs than the server's
+// cutoff-trimmed set. pruneStale still removes whole stations by last_heard.
+export function trailIntersectsBBox(positions, b) {
+  if (!positions || positions.length === 0 || !b) return false;
+  return positions.some(
+    (p) => p.lat >= b.swLat && p.lat <= b.neLat &&
+           p.lon >= b.swLon && p.lon <= b.neLon,
+  );
+}

--- a/web/src/lib/map/viewport-membership-core.test.js
+++ b/web/src/lib/map/viewport-membership-core.test.js
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { trailIntersectsBBox } from './viewport-membership-core.js';
+
+// bbox covering roughly the Front Range; lon is negative (west).
+const BBOX = { swLat: 39, swLon: -106, neLat: 41, neLon: -104 };
+
+test('station whose head is inside the bbox is a member', () => {
+  const positions = [{ lat: 40, lon: -105 }];
+  assert.equal(trailIntersectsBBox(positions, BBOX), true);
+});
+
+test('moving station keeps membership while an older breadcrumb is still in view', () => {
+  // Newest fix (positions[0]) has walked east out of the bbox, but earlier
+  // breadcrumbs remain inside -- the #413 regression case.
+  const positions = [
+    { lat: 40, lon: -103.0 }, // head, outside
+    { lat: 40, lon: -103.5 }, // outside
+    { lat: 40, lon: -104.2 }, // inside
+    { lat: 40, lon: -105.0 }, // inside
+  ];
+  assert.equal(trailIntersectsBBox(positions, BBOX), true);
+});
+
+test('station drops out only once the whole track has left view', () => {
+  const positions = [
+    { lat: 40, lon: -88 },
+    { lat: 40, lon: -89 },
+  ];
+  assert.equal(trailIntersectsBBox(positions, BBOX), false);
+});
+
+test('bbox edges are inclusive on both layers', () => {
+  assert.equal(trailIntersectsBBox([{ lat: 39, lon: -106 }], BBOX), true);
+  assert.equal(trailIntersectsBBox([{ lat: 41, lon: -104 }], BBOX), true);
+});
+
+test('empty or missing inputs are non-members, not errors', () => {
+  assert.equal(trailIntersectsBBox([], BBOX), false);
+  assert.equal(trailIntersectsBBox(null, BBOX), false);
+  assert.equal(trailIntersectsBBox([{ lat: 40, lon: -105 }], null), false);
+});


### PR DESCRIPTION
Fixes #413.

## Problem

When a moving station's most recent position moved outside the visible map area (by panning or zooming), the entire callsign track disappeared -- even though earlier breadcrumbs were still on screen.

## Root cause

Map-viewport membership was decided on the head position (`positions[0]`) alone, on **both** ends of the live-map pipeline:

- `MemCache.QueryBBox` only returned a station whose latest fix was inside the bbox, so the server stopped shipping it.
- The data store's `pruneOutOfBounds` deleted any station whose `positions[0]` was outside the new bbox, so the client dropped it (and its trail) on the next bounds change.

The combination wiped the whole track the instant the head left view.

## Fix

Membership is now **any-trail-position**, not head-only -- the reporter's suggested option (2):

- `QueryBBox` (`stationInBBox`) returns a station when the head or any non-trimmed trail point is inside the bbox. The position scan mirrors `stationToDTO`'s trail-cutoff trimming so it only counts positions that actually ship.
- `pruneOutOfBounds` keeps a station while any accumulated position is inside the bbox and drops it only once the whole track has scrolled off-screen, so it stays self-cleaning (no stale breadcrumbs piling up as you pan).

The two checks are kept symmetric and that rule is documented as invariant #53.

## Tests

- New `TestMemCache_QueryBBoxKeepsTrailWhenHeadLeaves`: a rover walks out of the bbox; the station is retained with its full trail while breadcrumbs remain in view, and is dropped once the whole track is off-screen.
- `go test ./pkg/stationcache/ ./pkg/webapi/` passes. Web test failures present on this run are pre-existing and unrelated (network/env tests, identical on a clean tree).