### PR TITLE
Fix map track doubling back on duplicate and out-of-order fixes (#421)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1256,3 +1256,51 @@ Source: [`../../web/src/lib/map/rf-only-core.js`](../../web/src/lib/map/rf-only-
 (filter `$effect`, `rfOnlyStationCount`),
 [`../../web/src/lib/map/popup-helpers.js`](../../web/src/lib/map/popup-helpers.js)
 (`viaText`).
+
+### 53. The stationcache trail is ordered newest-first by timestamp and deduplicates re-received fixes
+
+`MemCache.Update` (`pkg/stationcache/memcache.go`) keeps each station's
+`Positions` slice strictly **newest-first by `Timestamp`** and treats a
+single physical beacon heard more than once as one trail point, not several.
+Three paths enforce this for a position that differs from the head fix:
+
+- *Static re-beacon* (`!positionMoved(positions[0], new)`): fold into
+  `positions[0]`, advancing its timestamp/comment and rfRank-merging path
+  metadata (invariant #48).
+- *Late duplicate of an older fix* (`duplicateFix`): a digipeated, APRS-IS,
+  or second-channel copy of an earlier beacon that lands within `posEpsilon`
+  of an existing point **and** within `dupWindow` (2 min) of its timestamp.
+  Merge the reception metadata into that existing point; do **not** insert a
+  new point.
+- *Genuinely new fix*: insert in timestamp order via `insertPositionByTime`
+  (a plain prepend in the common in-order case), then cap at `MaxTrailLen`.
+
+*Why:* the Live Map trail layer (`web/src/lib/map/layers/trails.js`) draws
+one line segment between each consecutive pair of `positions`, so the array
+order **is** the rendered path. The earlier code prepended every moved fix in
+arrival order with no timestamp check and only deduplicated against
+`positions[0]`. On APRS-IS and digipeated feeds, duplicate and out-of-order
+copies are routine, so a delayed copy of an old fix was prepended as the new
+head -- the track doubled back on itself, drawing spurious lines between
+non-adjacent beacons (graywolf GitHub #421, reproduced "both with my own and
+others tracks"). Ordering by timestamp and collapsing same-fix copies makes
+the rendered line the chronological dot-to-dot path again.
+
+*How to apply:* never assume packet arrival order equals chronological order.
+Any new ingest path into the cache must go through `Update` so the ordering
+and dedup hold. `dupWindow` is a deliberate spatial+temporal guard: it is
+wide enough to absorb APRS-IS/store-and-forward delay but narrow enough that
+a genuine return to a prior location well outside the window stays a distinct
+fix. Delta mode (`since`) still emits only `positions[0]`, so an out-of-order
+*historical* fix inserted mid-slice surfaces on the next full reload rather
+than as a live delta -- acceptable, because the live head stays the true
+newest fix and no backward line is emitted.
+
+Source: [`../../pkg/stationcache/memcache.go`](../../pkg/stationcache/memcache.go)
+(`Update`, `duplicateFix`, `insertPositionByTime`, `mergeReception`,
+`positionMoved`),
+[`../../pkg/stationcache/memcache_test.go`](../../pkg/stationcache/memcache_test.go)
+(`TestMemCache_DuplicateOldFixDoesNotDoubleBack`,
+`TestMemCache_OutOfOrderArrivalSortsByTime`,
+`TestMemCache_RevisitOutsideWindowKeepsPoint`),
+[`../../web/src/lib/map/layers/trails.js`](../../web/src/lib/map/layers/trails.js).

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1296,6 +1296,18 @@ fix. Delta mode (`since`) still emits only `positions[0]`, so an out-of-order
 than as a live delta -- acceptable, because the live head stays the true
 newest fix and no backward line is emitted.
 
+The dedup scan **cannot** be short-circuited for fixes whose timestamp is
+newer than the head: a non-timestamped APRS packet is stamped with its
+*reception* time (`extract.go`, falling back to `time.Now()`), so a delayed
+copy of an earlier beacon -- the common real-world case -- carries the newest
+timestamp of all and is identifiable only by location within `dupWindow`,
+never by ordering. The scan is bounded, not full-trail: positions are
+newest-first, so `duplicateFix` stops once it drops below the window's lower
+edge. Note also that the history DB stores raw, un-deduplicated rows
+(`historydb.WriteEntries`), ordered `timestamp DESC` on `LoadRecent`; a
+hydrated trail therefore preserves correct ordering (no backward line) but
+may show a redundant point that the live cache would have merged.
+
 Source: [`../../pkg/stationcache/memcache.go`](../../pkg/stationcache/memcache.go)
 (`Update`, `duplicateFix`, `insertPositionByTime`, `mergeReception`,
 `positionMoved`),

--- a/pkg/stationcache/memcache.go
+++ b/pkg/stationcache/memcache.go
@@ -11,6 +11,14 @@ import (
 // identical (~1m at the equator). Used to deduplicate static re-beacons.
 const posEpsilon = 0.00001
 
+// dupWindow bounds how far apart in time two same-location fixes may be
+// and still be treated as the same physical beacon re-received over a
+// different path (a digipeated, APRS-IS, or second-channel copy that
+// arrived after the station has moved on). Copies of a single beacon
+// normally arrive within seconds of each other; this window leaves slack
+// for APRS-IS and store-and-forward digipeater delays. See issue #421.
+const dupWindow = 2 * time.Minute
+
 // MaxStations is the hard upper bound on resident MemCache entries.
 // The TTL-based prune (memMaxAge, default 24h) is the primary eviction
 // path for routine operation; this cap is a safety bound for the
@@ -101,34 +109,40 @@ func (c *MemCache) Update(entries []CacheEntry) {
 
 		if len(s.Positions) == 0 {
 			s.Positions = []Position{newPos}
-		} else if positionMoved(s.Positions[0], newPos) {
-			// Station moved — prepend new position, cap trail.
-			s.Positions = append(s.Positions, Position{}) // grow
-			copy(s.Positions[1:], s.Positions)
-			s.Positions[0] = newPos
-			if len(s.Positions) > MaxTrailLen {
-				s.Positions = s.Positions[:MaxTrailLen]
-			}
-		} else {
-			// Static re-beacon — advance the last-heard timestamp and the
-			// free-form comment from the latest packet. Reception-path
-			// metadata (via/path/hops/direction/channel/gated), however, is
-			// kept at the *most RF-reachable* copy seen for this fix (see
-			// rfRank). A station heard both directly and via a digipeater
-			// would otherwise have its direct copy clobbered by a later
-			// digipeated one, hiding it from the "Direct RX" filter (issue
-			// #130); likewise an RF-heard copy must not be clobbered by a
-			// later Internet-to-RF gated copy, which would hide it from the
+		} else if !positionMoved(s.Positions[0], newPos) {
+			// Static re-beacon at the current head — advance the last-heard
+			// timestamp and the free-form comment from the latest packet.
+			// Reception-path metadata (via/path/hops/direction/channel/gated),
+			// however, is kept at the *most RF-reachable* copy seen for this
+			// fix (see rfRank). A station heard both directly and via a
+			// digipeater would otherwise have its direct copy clobbered by a
+			// later digipeated one, hiding it from the "Direct RX" filter
+			// (issue #130); likewise an RF-heard copy must not be clobbered by
+			// a later Internet-to-RF gated copy, which would hide it from the
 			// "RF Only" filter. Ties refresh (latest wins).
+			mergeReception(&s.Positions[0], e)
 			s.Positions[0].Timestamp = e.Timestamp
 			s.Positions[0].Comment = e.Comment
-			if rfRank(e.Direction, e.Hops, e.Gated) >= rfRank(s.Positions[0].Direction, s.Positions[0].Hops, s.Positions[0].Gated) {
-				s.Positions[0].Via = e.Via
-				s.Positions[0].Path = e.Path
-				s.Positions[0].Hops = e.Hops
-				s.Positions[0].Direction = e.Direction
-				s.Positions[0].Gated = e.Gated
-				s.Positions[0].Channel = e.Channel
+		} else if i := duplicateFix(s.Positions, newPos); i >= 0 {
+			// Late duplicate of an earlier fix: a digipeated, APRS-IS, or
+			// second-channel copy of a beacon the station has since moved on
+			// from. Merge its reception metadata into the existing fix rather
+			// than inserting a new trail point. Inserting one would make the
+			// track double back on itself — a spurious line out to the stale
+			// position and back — instead of the chronological dot-to-dot
+			// path (issue #421). The existing fix keeps its original
+			// timestamp and comment; only path/RF metadata is reconciled.
+			mergeReception(&s.Positions[i], e)
+		} else {
+			// Genuinely new fix. Insert it in timestamp order (newest first)
+			// so an out-of-order arrival — common on APRS-IS and digipeated
+			// feeds — lands in its correct chronological slot rather than at
+			// the head, which would also draw a backward line (issue #421).
+			// In the common case the new fix is the newest and this is a
+			// plain prepend.
+			insertPositionByTime(&s.Positions, newPos)
+			if len(s.Positions) > MaxTrailLen {
+				s.Positions = s.Positions[:MaxTrailLen]
 			}
 		}
 	}
@@ -303,6 +317,57 @@ func rfRank(direction string, hops int, gated bool) int {
 func positionMoved(old, new Position) bool {
 	return math.Abs(old.Lat-new.Lat) > posEpsilon ||
 		math.Abs(old.Lon-new.Lon) > posEpsilon
+}
+
+// mergeReception folds a re-received copy of a fix into an existing trail
+// point, keeping the most RF-reachable reception metadata (see rfRank).
+// Ties refresh (latest wins). It does not touch the point's timestamp,
+// comment, or coordinates — callers decide whether those advance.
+func mergeReception(p *Position, e *CacheEntry) {
+	if rfRank(e.Direction, e.Hops, e.Gated) >= rfRank(p.Direction, p.Hops, p.Gated) {
+		p.Via = e.Via
+		p.Path = e.Path
+		p.Hops = e.Hops
+		p.Direction = e.Direction
+		p.Gated = e.Gated
+		p.Channel = e.Channel
+	}
+}
+
+// duplicateFix reports the index of an existing trail point that the
+// incoming fix is a re-reception of: the same location (within posEpsilon)
+// reported within dupWindow of an existing fix. The head (index 0) is
+// handled separately by the static-rebeacon path, so the search starts at
+// index 1. Returns -1 when the fix is genuinely new. See issue #421.
+func duplicateFix(positions []Position, p Position) int {
+	for i := 1; i < len(positions); i++ {
+		if positionMoved(positions[i], p) {
+			continue
+		}
+		dt := positions[i].Timestamp.Sub(p.Timestamp)
+		if dt < 0 {
+			dt = -dt
+		}
+		if dt <= dupWindow {
+			return i
+		}
+	}
+	return -1
+}
+
+// insertPositionByTime inserts p into a newest-first-by-timestamp slice,
+// preserving that ordering. Equal timestamps place p ahead of the existing
+// entry, so the common in-order arrival is a plain prepend.
+func insertPositionByTime(positions *[]Position, p Position) {
+	ps := *positions
+	idx := 0
+	for idx < len(ps) && ps[idx].Timestamp.After(p.Timestamp) {
+		idx++
+	}
+	ps = append(ps, Position{}) // grow
+	copy(ps[idx+1:], ps[idx:])
+	ps[idx] = p
+	*positions = ps
 }
 
 // snapshotStation returns a deep-enough copy of Station so the caller

--- a/pkg/stationcache/memcache.go
+++ b/pkg/stationcache/memcache.go
@@ -339,8 +339,20 @@ func mergeReception(p *Position, e *CacheEntry) {
 // reported within dupWindow of an existing fix. The head (index 0) is
 // handled separately by the static-rebeacon path, so the search starts at
 // index 1. Returns -1 when the fix is genuinely new. See issue #421.
+//
+// This scan cannot be skipped for fixes whose timestamp is newer than the
+// head: a non-timestamped APRS packet is stamped with its reception time,
+// so a delayed copy of an earlier beacon arrives with the newest timestamp
+// of all and is only identifiable by location + dupWindow, never by
+// ordering. The scan is bounded, not full-trail: positions are newest-first
+// by timestamp, so once an entry falls below the window's lower edge no
+// older entry can match and we stop.
 func duplicateFix(positions []Position, p Position) int {
+	lowerBound := p.Timestamp.Add(-dupWindow)
 	for i := 1; i < len(positions); i++ {
+		if positions[i].Timestamp.Before(lowerBound) {
+			break
+		}
 		if positionMoved(positions[i], p) {
 			continue
 		}

--- a/pkg/stationcache/memcache_test.go
+++ b/pkg/stationcache/memcache_test.go
@@ -552,3 +552,131 @@ func TestMemCache_LastDirectHeardNotAdvancedByDigi(t *testing.T) {
 		t.Fatalf("issue #130 regressed: fix no longer direct (Direction=%q Hops=%d)", p.Direction, p.Hops)
 	}
 }
+
+// movingEntry builds a position fix at an explicit time and location so a
+// test can reproduce out-of-order and duplicate arrivals deterministically.
+func movingEntry(key, callsign string, lat, lon float64, ts time.Time) CacheEntry {
+	e := stationEntry(key, callsign, lat, lon)
+	e.Timestamp = ts
+	return e
+}
+
+// trailLats returns the trail latitudes newest-first for assertions.
+func trailLats(t *testing.T, c *MemCache, key string) []float64 {
+	t.Helper()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	s := c.stations[key]
+	if s == nil {
+		t.Fatalf("station %q not in cache", key)
+	}
+	out := make([]float64, len(s.Positions))
+	for i, p := range s.Positions {
+		out[i] = p.Lat
+	}
+	return out
+}
+
+// TestMemCache_DuplicateOldFixDoesNotDoubleBack reproduces issue #421: a
+// late copy of an earlier beacon (relayed via a digipeater or APRS-IS)
+// arrives after the station has already moved on. It must merge into the
+// existing fix rather than appear as a fresh trail point, which would make
+// the rendered track double back on itself.
+func TestMemCache_DuplicateOldFixDoesNotDoubleBack(t *testing.T) {
+	c := newTestCache(t)
+	base := time.Now().Add(-10 * time.Minute)
+
+	// Chronological track: A (oldest) -> B -> C (newest).
+	c.Update([]CacheEntry{movingEntry("stn:CAR1", "CAR1", 40.00, -105.0, base)})
+	c.Update([]CacheEntry{movingEntry("stn:CAR1", "CAR1", 40.01, -105.0, base.Add(1*time.Minute))})
+	c.Update([]CacheEntry{movingEntry("stn:CAR1", "CAR1", 40.02, -105.0, base.Add(2*time.Minute))})
+
+	// A delayed digipeated copy of fix A arrives now, after the move.
+	dup := digiEntry("stn:CAR1", "CAR1", 40.00, -105.0, 2)
+	dup.Timestamp = base.Add(30 * time.Second) // close to original A in time
+	c.Update([]CacheEntry{dup})
+
+	lats := trailLats(t, c, "stn:CAR1")
+	want := []float64{40.02, 40.01, 40.00}
+	if len(lats) != len(want) {
+		t.Fatalf("duplicate old fix created a new trail point: got %v, want %v", lats, want)
+	}
+	for i := range want {
+		if lats[i] != want[i] {
+			t.Fatalf("trail order corrupted: got %v, want %v", lats, want)
+		}
+	}
+}
+
+// TestMemCache_OutOfOrderArrivalSortsByTime verifies that a genuinely-new
+// fix carrying an older (timestamped) report time is inserted in its
+// chronological slot rather than at the head, keeping the trail in
+// newest-first order so the rendered line stays a clean dot-to-dot path.
+func TestMemCache_OutOfOrderArrivalSortsByTime(t *testing.T) {
+	c := newTestCache(t)
+	base := time.Now().Add(-10 * time.Minute)
+
+	c.Update([]CacheEntry{movingEntry("stn:PLANE", "PLANE", 40.00, -105.0, base)})
+	c.Update([]CacheEntry{movingEntry("stn:PLANE", "PLANE", 40.02, -105.0, base.Add(2*time.Minute))})
+	// This fix is chronologically between the two above but arrives last.
+	c.Update([]CacheEntry{movingEntry("stn:PLANE", "PLANE", 40.01, -105.0, base.Add(1*time.Minute))})
+
+	lats := trailLats(t, c, "stn:PLANE")
+	want := []float64{40.02, 40.01, 40.00}
+	if len(lats) != len(want) {
+		t.Fatalf("expected %d positions, got %v", len(want), lats)
+	}
+	for i := range want {
+		if lats[i] != want[i] {
+			t.Fatalf("out-of-order arrival not sorted: got %v, want %v", lats, want)
+		}
+	}
+}
+
+// TestMemCache_RevisitOutsideWindowKeepsPoint ensures the duplicate guard
+// does not collapse a legitimate return to a prior location well outside
+// dupWindow — that is a real second visit and must stay a distinct fix.
+func TestMemCache_RevisitOutsideWindowKeepsPoint(t *testing.T) {
+	c := newTestCache(t)
+	base := time.Now().Add(-30 * time.Minute)
+
+	c.Update([]CacheEntry{movingEntry("stn:LOOP", "LOOP", 40.00, -105.0, base)})
+	c.Update([]CacheEntry{movingEntry("stn:LOOP", "LOOP", 40.05, -105.0, base.Add(5*time.Minute))})
+	// Returns to the start 10 minutes later — far outside dupWindow.
+	c.Update([]CacheEntry{movingEntry("stn:LOOP", "LOOP", 40.00, -105.0, base.Add(10*time.Minute))})
+
+	lats := trailLats(t, c, "stn:LOOP")
+	if len(lats) != 3 {
+		t.Fatalf("legitimate revisit should remain a distinct fix, got %v", lats)
+	}
+}
+
+// TestMemCache_DuplicateMergesRFMetadata confirms a deduplicated old-fix
+// copy still upgrades the stored reception metadata per rfRank (issue #130
+// generalized to non-head fixes), without adding a trail point.
+func TestMemCache_DuplicateMergesRFMetadata(t *testing.T) {
+	c := newTestCache(t)
+	base := time.Now().Add(-10 * time.Minute)
+
+	// Fix A first heard only via a digipeater, then the station moves.
+	a := digiEntry("stn:CAR2", "CAR2", 40.00, -105.0, 2)
+	a.Timestamp = base
+	c.Update([]CacheEntry{a})
+	c.Update([]CacheEntry{movingEntry("stn:CAR2", "CAR2", 40.02, -105.0, base.Add(2*time.Minute))})
+
+	// A delayed *direct* copy of fix A arrives — should upgrade A to direct.
+	direct := movingEntry("stn:CAR2", "CAR2", 40.00, -105.0, base.Add(20*time.Second))
+	c.Update([]CacheEntry{direct})
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	s := c.stations["stn:CAR2"]
+	if len(s.Positions) != 2 {
+		t.Fatalf("duplicate copy added a trail point: got %d positions", len(s.Positions))
+	}
+	// Positions[1] is fix A (older); it should now be classified direct.
+	if !isDirectRF(s.Positions[1].Direction, s.Positions[1].Hops) {
+		t.Fatalf("direct copy did not upgrade old fix: Direction=%q Hops=%d",
+			s.Positions[1].Direction, s.Positions[1].Hops)
+	}
+}

--- a/pkg/stationcache/memcache_test.go
+++ b/pkg/stationcache/memcache_test.go
@@ -680,3 +680,34 @@ func TestMemCache_DuplicateMergesRFMetadata(t *testing.T) {
 			s.Positions[1].Direction, s.Positions[1].Hops)
 	}
 }
+
+// TestMemCache_NonTimestampedDuplicateDedups locks in the dominant
+// real-world #421 case: a non-timestamped APRS beacon is stamped with its
+// reception time, so a delayed digipeated/IS copy of an earlier fix arrives
+// with the NEWEST timestamp of all. It must still merge into the original
+// fix by location + dupWindow, not get prepended as a new head. This guards
+// against "optimizing" duplicateFix away for newest-timestamp fixes.
+func TestMemCache_NonTimestampedDuplicateDedups(t *testing.T) {
+	c := newTestCache(t)
+	base := time.Now().Add(-90 * time.Second)
+
+	// A (oldest) then B (head); B is newer than A.
+	c.Update([]CacheEntry{movingEntry("stn:CAR3", "CAR3", 40.00, -105.0, base)})
+	c.Update([]CacheEntry{movingEntry("stn:CAR3", "CAR3", 40.02, -105.0, base.Add(30*time.Second))})
+
+	// Delayed copy of A, stamped at reception time — newer than the head B,
+	// but within dupWindow of A's timestamp.
+	dup := movingEntry("stn:CAR3", "CAR3", 40.00, -105.0, base.Add(90*time.Second))
+	c.Update([]CacheEntry{dup})
+
+	lats := trailLats(t, c, "stn:CAR3")
+	want := []float64{40.02, 40.00}
+	if len(lats) != len(want) {
+		t.Fatalf("newest-timestamp duplicate created a new trail point: got %v, want %v", lats, want)
+	}
+	for i := range want {
+		if lats[i] != want[i] {
+			t.Fatalf("trail order corrupted: got %v, want %v", lats, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #421 — the Live Map drew extra lines connecting non-adjacent beacons instead of a clean chronological dot-to-dot track.

## Root cause

The Live Map trail layer draws one line segment between each consecutive pair of entries in a station's `positions` array, so the array order **is** the rendered path. The station cache (`MemCache.Update`) built that array by prepending every moved fix in **arrival order**, with no timestamp check, and deduplicated only against the head fix (`positions[0]`).

On APRS-IS and digipeated feeds, duplicate and out-of-order copies of a beacon are routine (multiple igates, store-and-forward delay, second-channel reception). When a delayed copy of an *earlier* fix arrived after the station had already moved on, `positionMoved(positions[0], …)` was true, so it was prepended as the new head. The track then doubled back out to that stale position and forward again — the spurious lines the reporter saw "both with my own and others tracks."

## Fix

In `MemCache.Update`, keep `positions` strictly newest-first by timestamp and treat a single physical beacon heard more than once as one trail point:

- **Static re-beacon** at the head — unchanged (advance timestamp/comment, rfRank-merge path metadata).
- **Late duplicate of an older fix** — a copy landing within `posEpsilon` of an existing point and within a 2-minute window of its timestamp merges its reception metadata into that point instead of inserting a new one.
- **Genuinely new fix** — inserted in chronological slot (a plain prepend in the common in-order case) rather than blindly at the head.

The rfRank metadata-merge behavior (issues #130 / #268) is preserved and now also applies to deduplicated non-head fixes.

## Tests

New cases in `memcache_test.go` reproduce the bug (they fail without the fix) and cover the guardrails:

- `TestMemCache_DuplicateOldFixDoesNotDoubleBack`
- `TestMemCache_OutOfOrderArrivalSortsByTime`
- `TestMemCache_RevisitOutsideWindowKeepsPoint` (a legitimate revisit outside the window stays a distinct fix)
- `TestMemCache_DuplicateMergesRFMetadata`

All `pkg/stationcache` and `pkg/webapi` tests pass; `go vet` clean. Wiki invariant #53 documents the ordering/dedup contract.
