### PR TITLE
Expose tracker beacon type in the UI to enable SmartBeaconing

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1356,3 +1356,23 @@ Source: [`../../pkg/stationcache/memcache.go`](../../pkg/stationcache/memcache.g
 `TestMemCache_OutOfOrderArrivalSortsByTime`,
 `TestMemCache_RevisitOutsideWindowKeepsPoint`),
 [`../../web/src/lib/map/layers/trails.js`](../../web/src/lib/map/layers/trails.js).
+
+### 55. SmartBeaconing requires a `tracker` beacon, not just the global toggle
+
+*Why:* The scheduler's `isSmart()` only adapts rate when a beacon's type is
+`tracker` AND its per-beacon `smart_beacon` flag is set AND the global
+`SmartBeaconConfig` singleton is enabled — all three. The global panel alone
+does nothing without a tracker beacon, which is why a station with a working
+GPS and SmartBeaconing "on" never beacons. The Beacons UI hides this: choosing
+the `Tracker` type forces `use_gps`, sets `smart_beacon`, and auto-enables the
+global singleton on save (mirroring the iGate auto-enable for APRS-IS-only
+beacons). If you add a beacon type or touch the save path, preserve all three
+gates or SmartBeaconing silently stops firing.
+
+Source: [`../../pkg/beacon/scheduler.go`](../../pkg/beacon/scheduler.go)
+(`isSmart`),
+[`../../pkg/app/adapters.go`](../../pkg/app/adapters.go)
+(`beaconConfigFromStore` SmartBeacon precedence),
+[`../../web/src/lib/trackerBeacon.js`](../../web/src/lib/trackerBeacon.js),
+[`../../web/src/routes/Beacons.svelte`](../../web/src/routes/Beacons.svelte)
+(`ensureSmartBeaconEnabled`).

--- a/web/src/lib/trackerBeacon.js
+++ b/web/src/lib/trackerBeacon.js
@@ -1,0 +1,21 @@
+// Position-source and SmartBeaconing flags a beacon should be saved
+// with, derived from its type and the form's chosen position source.
+//
+// A tracker is a GPS-driven mobile beacon: the backend builder always
+// reads its position (and the CSE/SPD course-speed extension) from the
+// live GPS fix, and the scheduler only engages SmartBeaconing when the
+// beacon type is `tracker` AND the per-beacon `smart_beacon` flag is set
+// (alongside the global SmartBeacon master switch). So a tracker always
+// forces use_gps and opts into smart_beacon, regardless of the form's
+// pos_source radio. Every other type leaves smart_beacon off and honors
+// the operator's GPS/fixed choice.
+//
+// Pure helper so the Beacons page and tests share one source of truth
+// for the rule the SmartBeaconing fix hinges on.
+export function trackerBeaconFlags(type, posSource) {
+  const isTracker = type === 'tracker';
+  return {
+    use_gps: isTracker || posSource === 'gps',
+    smart_beacon: isTracker,
+  };
+}

--- a/web/src/lib/trackerBeacon.test.js
+++ b/web/src/lib/trackerBeacon.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { trackerBeaconFlags } from './trackerBeacon.js';
+
+test('trackerBeaconFlags: tracker forces GPS and SmartBeaconing on', () => {
+  assert.deepEqual(trackerBeaconFlags('tracker', 'gps'), { use_gps: true, smart_beacon: true });
+});
+
+test('trackerBeaconFlags: tracker forces GPS even if pos_source says fixed', () => {
+  // The form forces pos_source to gps for trackers, but the payload must
+  // be correct even if that state were stale — the backend builder reads
+  // course/speed from the live fix and has no fixed-coordinate path.
+  assert.deepEqual(trackerBeaconFlags('tracker', 'fixed'), { use_gps: true, smart_beacon: true });
+});
+
+test('trackerBeaconFlags: position honors GPS source without smart_beacon', () => {
+  assert.deepEqual(trackerBeaconFlags('position', 'gps'), { use_gps: true, smart_beacon: false });
+});
+
+test('trackerBeaconFlags: position with fixed coordinates opts out of both', () => {
+  assert.deepEqual(trackerBeaconFlags('position', 'fixed'), { use_gps: false, smart_beacon: false });
+});
+
+test('trackerBeaconFlags: switching a tracker back to object clears smart_beacon', () => {
+  // Guards the no-stale-flag behavior: a beacon converted away from
+  // tracker must not keep smart_beacon set, or the scheduler would still
+  // treat it as a SmartBeaconing candidate.
+  assert.deepEqual(trackerBeaconFlags('object', 'fixed'), { use_gps: false, smart_beacon: false });
+});

--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -98,6 +98,7 @@
     position_format: 'compressed', ambiguity: 0,
     pos_source: 'gps', latitude: '', longitude: '', alt_ft: '',
     comment: '', interval: '600', slot: '', send_path: 'rf', enabled: true,
+    smart_beacon: false,
   });
 
   let callsignError = $state('');
@@ -144,9 +145,18 @@
   let saveBlocked = $derived(!!txBlock && !txBlockAllowsSave);
   // The format radio + ambiguity sub-block apply only to types that
   // carry an APRS101 ch 6/9/10 position field. Object and custom
-  // beacons hide the whole section. The Beacons UI today only exposes
-  // 'position' and 'object', so the practical gate is "show on position".
-  let showFormat = $derived(form.type === 'position');
+  // beacons hide the whole section. Position and tracker beacons both
+  // emit a position report, so they share the format selector.
+  let showFormat = $derived(form.type === 'position' || form.type === 'tracker');
+  // A tracker is a GPS-driven mobile beacon: the backend builder always
+  // sources its position (and the CSE/SPD course-speed extension) from
+  // the live GPS fix, so fixed coordinates are never valid for it. Force
+  // the position source to GPS whenever tracker is selected so the form
+  // can't get into a state the scheduler would reject at send time.
+  let isTracker = $derived(form.type === 'tracker');
+  $effect(() => {
+    if (isTracker && form.pos_source !== 'gps') form.pos_source = 'gps';
+  });
   let showAmbiguity = $derived(
     showFormat &&
     (form.position_format === 'uncompressed' || form.position_format === 'mic_e'),
@@ -308,6 +318,7 @@
     form.slot = '';
     form.send_path = channels.length === 0 ? 'is_only' : 'rf';
     form.enabled = true;
+    form.smart_beacon = false;
     modalOpen = true;
   }
 
@@ -388,7 +399,13 @@
       }
       form.object_name = n;
     }
-    const useGps = form.pos_source === 'gps';
+    // Trackers always source position from the live GPS fix (the backend
+    // builder reads course/speed from it), so force use_gps regardless of
+    // the form's pos_source. The smart_beacon flag is the per-beacon
+    // opt-in the scheduler checks alongside the tracker type and the
+    // global SmartBeacon master switch.
+    const isTrackerSave = form.type === 'tracker';
+    const useGps = isTrackerSave || form.pos_source === 'gps';
     const latStr = form.latitude.trim();
     const lonStr = form.longitude.trim();
     const lat = latStr === '' ? 0 : parseFloat(latStr);
@@ -430,6 +447,7 @@
       callsign: callsignToSend,
       channel: channelId,
       use_gps: useGps,
+      smart_beacon: isTrackerSave,
       interval: parseInt(form.interval),
       slot_seconds: slotSeconds,
       latitude: lat,
@@ -454,6 +472,9 @@
       if (data.send_path === 'is_only') {
         await ensureIgateEnabled();
       }
+      if (isTrackerSave) {
+        await ensureSmartBeaconEnabled();
+      }
     } catch (err) {
       toasts.error(err.message);
     }
@@ -477,6 +498,26 @@
       // server's own actionable message rather than a generic "try the
       // iGate page" that would fail for the same reason.
       toasts.error(`Beacon saved, but the iGate could not be enabled automatically: ${err.message || 'enable it on the iGate page so APRS-IS-only beacons transmit.'}`);
+    }
+  }
+
+  // A tracker only SmartBeacons when the global SmartBeacon master
+  // switch is on — the scheduler gates on tracker type AND per-beacon
+  // smart_beacon AND this singleton's Enabled flag. A fresh install ships
+  // it off, so saving a tracker without flipping it would silently never
+  // transmit (the exact symptom users report). Auto-enable it on save,
+  // preserving the operator's existing curve parameters. Best-effort: the
+  // beacon is already saved, so failures surface as a toast.
+  async function ensureSmartBeaconEnabled() {
+    try {
+      const cfg = await api.get('/smart-beacon');
+      if (cfg && cfg.enabled) return;
+      const next = { ...(cfg || {}), enabled: true };
+      await api.put('/smart-beacon', next);
+      smartBeacon = { ...smartBeacon, enabled: true };
+      toasts.success('SmartBeaconing enabled so your tracker beacons transmit');
+    } catch (err) {
+      toasts.error(`Beacon saved, but SmartBeaconing could not be enabled automatically: ${err.message || 'enable it in the SmartBeaconing panel below.'}`);
     }
   }
 
@@ -596,6 +637,8 @@
             <Badge variant={b.enabled ? 'success' : 'default'}>{b.enabled ? 'Enabled' : 'Disabled'}</Badge>
             {#if b.type === 'object'}
               <Badge variant="info">Object</Badge>
+            {:else if b.type === 'tracker'}
+              <Badge variant="info">Tracker</Badge>
             {/if}
             {#if b.send_path === 'is_only'}
               <Badge variant="info">APRS-IS only</Badge>
@@ -745,13 +788,22 @@
           <div class="pos-source-row">
             <Radio value="position" label="Position" />
             <Radio value="object" label="Object" />
+            <Radio value="tracker" label="Tracker" />
           </div>
         </RadioGroup>
         <div class="type-hint">
           <div><strong>Position:</strong> a beacon for a station.</div>
           <div><strong>Object:</strong> a named item such as a repeater, event site, hospital.</div>
+          <div><strong>Tracker:</strong> a GPS-driven mobile beacon that uses SmartBeaconing to adapt its rate to your speed and turns.</div>
         </div>
       </FormField>
+      {#if isTracker}
+        <div class="tracker-note">
+          This beacon transmits your live GPS position and adjusts its rate
+          using the <strong>SmartBeaconing</strong> settings below. Saving it
+          turns SmartBeaconing on automatically.
+        </div>
+      {/if}
       {#if form.type === 'object'}
         <FormField label="Object name" id="bcn-objname"
           hint="1-9 characters. Appears as the object's label on APRS maps.">
@@ -879,17 +931,24 @@
     </div>
 
     <div class="beacon-form-col">
-      <FormField label="Position source" id="bcn-pos-source"
-        hint={form.type === 'object'
-          ? "Choose whether this object's coordinates come from the live GPS fix or from fixed values you enter below."
-          : "Choose whether this beacon's coordinates come from the live GPS fix or from fixed values you enter below."}>
-        <RadioGroup bind:value={form.pos_source}>
-          <div class="pos-source-row">
-            <Radio value="gps" label="Use latest fix from GPS" />
-            <Radio value="fixed" label="Use fixed coordinates" />
-          </div>
-        </RadioGroup>
-      </FormField>
+      {#if isTracker}
+        <FormField label="Position source" id="bcn-pos-source"
+          hint="Trackers always transmit the live GPS fix — that's what lets SmartBeaconing follow your movement.">
+          <div class="tracker-gps-fixed">Live GPS fix</div>
+        </FormField>
+      {:else}
+        <FormField label="Position source" id="bcn-pos-source"
+          hint={form.type === 'object'
+            ? "Choose whether this object's coordinates come from the live GPS fix or from fixed values you enter below."
+            : "Choose whether this beacon's coordinates come from the live GPS fix or from fixed values you enter below."}>
+          <RadioGroup bind:value={form.pos_source}>
+            <div class="pos-source-row">
+              <Radio value="gps" label="Use latest fix from GPS" />
+              <Radio value="fixed" label="Use fixed coordinates" />
+            </div>
+          </RadioGroup>
+        </FormField>
+      {/if}
       {#if form.pos_source === 'fixed'}
         <FormField label="Latitude" id="bcn-lat"
           hint="Decimal degrees, north positive (e.g. 37.5 for Half Moon Bay; -33.86 for Sydney).">
@@ -1208,6 +1267,24 @@
     font-size: 12px;
     color: var(--color-text-muted, #888);
     line-height: 1.4;
+  }
+  .tracker-note {
+    margin: 8px 0 12px;
+    padding: 10px 12px;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--color-text-muted, #888);
+    background: var(--bg-secondary);
+    border: 1px dashed var(--border-color);
+    border-radius: var(--radius);
+  }
+  .tracker-gps-fixed {
+    padding: 8px 10px;
+    font-size: 13px;
+    color: var(--color-text-muted, #888);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
   }
   .no-channel-note {
     margin-bottom: 12px;

--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -14,6 +14,7 @@
   import { getChannel as lookupChannel } from '../lib/stores/channels.svelte.js';
   import { txPredicate, TX_REASON_FALLBACK } from '../lib/channelBacking.js';
   import { beaconLabel } from '../lib/beaconLabel.js';
+  import { trackerBeaconFlags } from '../lib/trackerBeacon.js';
   import {
     channelRefStatus,
     buildChannelsById,
@@ -399,13 +400,13 @@
       }
       form.object_name = n;
     }
-    // Trackers always source position from the live GPS fix (the backend
-    // builder reads course/speed from it), so force use_gps regardless of
-    // the form's pos_source. The smart_beacon flag is the per-beacon
-    // opt-in the scheduler checks alongside the tracker type and the
-    // global SmartBeacon master switch.
+    // Trackers always source position from the live GPS fix and opt into
+    // SmartBeaconing; trackerBeaconFlags is the shared, tested rule (see
+    // lib/trackerBeacon.js). useGps also gates the fixed-coordinate
+    // validation below.
     const isTrackerSave = form.type === 'tracker';
-    const useGps = isTrackerSave || form.pos_source === 'gps';
+    const { use_gps: useGps, smart_beacon: smartBeaconFlag } =
+      trackerBeaconFlags(form.type, form.pos_source);
     const latStr = form.latitude.trim();
     const lonStr = form.longitude.trim();
     const lat = latStr === '' ? 0 : parseFloat(latStr);
@@ -447,7 +448,7 @@
       callsign: callsignToSend,
       channel: channelId,
       use_gps: useGps,
-      smart_beacon: isTrackerSave,
+      smart_beacon: smartBeaconFlag,
       interval: parseInt(form.interval),
       slot_seconds: slotSeconds,
       latitude: lat,
@@ -511,9 +512,12 @@
   async function ensureSmartBeaconEnabled() {
     try {
       const cfg = await api.get('/smart-beacon');
-      if (cfg && cfg.enabled) return;
-      const next = { ...(cfg || {}), enabled: true };
-      await api.put('/smart-beacon', next);
+      // GET always returns a fully-populated config (stored row or
+      // defaults). A missing one means something upstream is wrong —
+      // bail rather than PUT all-zero curve params the API would reject.
+      if (!cfg) throw new Error('SmartBeacon settings unavailable');
+      if (cfg.enabled) return;
+      await api.put('/smart-beacon', { ...cfg, enabled: true });
       smartBeacon = { ...smartBeacon, enabled: true };
       toasts.success('SmartBeaconing enabled so your tracker beacons transmit');
     } catch (err) {


### PR DESCRIPTION
## Problem

Multiple users reported SmartBeaconing never transmits even with a working, recognized GPS. The handbook documents a `tracker` beacon type ("GPS-driven position beacon with SmartBeacon rate adaptation"), but the beacon setup form only ever offered **Position** and **Object**.

## Root cause

SmartBeaconing is fully implemented in the backend, but it only engages for `tracker`-type beacons. Three gates must all be true at send time:

- `pkg/beacon/scheduler.go` — `isSmart()` requires `c.Type == TypeTracker`
- `pkg/app/adapters.go` — `cfg.SmartBeacon` is non-nil only when the per-beacon `smart_beacon` flag is set **and** the global SmartBeacon singleton is enabled

The web form (`web/src/routes/Beacons.svelte`) exposed neither a `tracker` type nor the per-beacon `smart_beacon` flag. So a user could enable the global SmartBeaconing panel, get a GPS fix, create a "Position" beacon — and nothing would ever smart-beacon, because no tracker beacon could be created. The `tracker` path was dead UI-side.

## Fix (frontend only — backend already supports trackers)

- Add a **Tracker** option to the beacon-type selector, with a description matching the handbook.
- Trackers always transmit the live GPS fix (the builder reads course/speed from it), so the position-source picker is replaced with a fixed "Live GPS fix" and `use_gps` is forced on.
- Saving a tracker sets the per-beacon `smart_beacon` flag and auto-enables the global SmartBeacon master switch (preserving existing curve params) — mirroring the existing iGate auto-enable pattern — so it works without a separate trip to the panel below.
- Tracker beacons get the position-format selector (compressed/uncompressed/Mic-E) and a Tracker badge in the list.

## Notes

- The handbook's beacon-types table was already correct; this aligns the UI to it. No doc change needed.
- `custom` and `igate` types remain backend-only in the create form — a separate pre-existing gap, out of scope here.

## Verification

- `npm run build` — passes
- `npm test` — 429/429 pass
