### PR TITLE
Add per-channel bad-FCS Prometheus metric

### DIFF
--- a/docs/handbook/monitoring.html
+++ b/docs/handbook/monitoring.html
@@ -108,6 +108,11 @@
               <td>Received packets (label: <code>channel</code>)</td>
             </tr>
             <tr>
+              <td><code>graywolf_rx_bad_fcs_total</code></td>
+              <td>counter</td>
+              <td>Packets received with a failed FCS (CRC) check and dropped (label: <code>channel</code>). Reported only for modem channels; a hardware KISS TNC validates the FCS itself, so its channels never report bad frames.</td>
+            </tr>
+            <tr>
               <td><code>graywolf_tx_frames_total</code></td>
               <td>counter</td>
               <td>Transmitted packets (label: <code>channel</code>)</td>

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,6 +21,7 @@ type Metrics struct {
 	Registry *prometheus.Registry
 
 	RxFrames       *prometheus.CounterVec
+	RxBadFcs       *prometheus.CounterVec
 	DcdTransitions *prometheus.CounterVec
 	DcdDropped     prometheus.Counter
 	ChildRestarts  prometheus.Counter
@@ -103,6 +104,12 @@ type Metrics struct {
 	// don't double-count them from StatusUpdate.)
 	lastDcdTransitions map[uint32]uint64
 
+	// Same delta translation for bad-FCS counts. Bad frames are dropped in
+	// the Rust modem and never arrive as ReceivedFrame, so unlike rx_frames
+	// there is no per-frame hook — the absolute counter rides in on the
+	// periodic StatusUpdate and is differenced here, exactly like DCD.
+	lastRxBadFcs map[uint32]uint64
+
 	// serialLabels caches the {name, device} pair last reported by
 	// ObserveKissSerialState so that ObserveKissSerialReconnect (which
 	// only receives ifaceID, mirroring the client reconnect contract) can
@@ -131,6 +138,10 @@ func New() *Metrics {
 		RxFrames: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "graywolf_rx_frames_total",
 			Help: "AX.25 frames successfully received, by channel.",
+		}, []string{"channel"}),
+		RxBadFcs: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "graywolf_rx_bad_fcs_total",
+			Help: "Frames received with a failed FCS (CRC) check and dropped, by channel. Only modem-backed channels report this; KISS-TNC channels stay absent because a hardware TNC validates the FCS itself and never forwards a bad frame over KISS (issue #132).",
 		}, []string{"channel"}),
 		DcdTransitions: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "graywolf_dcd_transitions_total",
@@ -298,10 +309,12 @@ func New() *Metrics {
 			Help: "Current backoff delay in seconds for the KISS serial supervisor while waiting to re-open. Zero when connected or not in backoff.",
 		}, []string{"interface_id", "name", "device"}),
 		lastDcdTransitions: make(map[uint32]uint64),
+		lastRxBadFcs:       make(map[uint32]uint64),
 		serialLabels:       make(map[uint32][2]string),
 	}
 	reg.MustRegister(
 		m.RxFrames,
+		m.RxBadFcs,
 		m.DcdTransitions,
 		m.DcdDropped,
 		m.ChildRestarts,
@@ -393,6 +406,13 @@ func (m *Metrics) UpdateFromStatus(s *pb.StatusUpdate) {
 	} else if s.DcdTransitions > prev {
 		m.DcdTransitions.WithLabelValues(label).Add(float64(s.DcdTransitions - prev))
 		m.lastDcdTransitions[s.Channel] = s.DcdTransitions
+	}
+
+	if prev, ok := m.lastRxBadFcs[s.Channel]; !ok || s.RxBadFcs < prev {
+		m.lastRxBadFcs[s.Channel] = s.RxBadFcs
+	} else if s.RxBadFcs > prev {
+		m.RxBadFcs.WithLabelValues(label).Add(float64(s.RxBadFcs - prev))
+		m.lastRxBadFcs[s.Channel] = s.RxBadFcs
 	}
 
 	m.AudioLevel.WithLabelValues(label).Set(float64(s.AudioLevelPeak))

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -53,13 +53,15 @@ func TestUpdateFromStatus(t *testing.T) {
 	m.UpdateFromStatus(&pb.StatusUpdate{
 		Channel:        0,
 		DcdTransitions: 5,
+		RxBadFcs:       10,
 		AudioLevelPeak: 0.4,
 		DcdState:       true,
 	})
-	// Second update: +3 DCD transitions.
+	// Second update: +3 DCD transitions, +4 bad-FCS.
 	m.UpdateFromStatus(&pb.StatusUpdate{
 		Channel:        0,
 		DcdTransitions: 8,
+		RxBadFcs:       14,
 		AudioLevelPeak: 0.2,
 		DcdState:       false,
 	})
@@ -67,6 +69,7 @@ func TestUpdateFromStatus(t *testing.T) {
 	body := scrape(t, m)
 	for _, want := range []string{
 		`graywolf_dcd_transitions_total{channel="0"} 3`,
+		`graywolf_rx_bad_fcs_total{channel="0"} 4`,
 		`graywolf_dcd_active{channel="0"} 0`,
 		`graywolf_audio_level{channel="0"} 0.2`,
 	} {
@@ -78,15 +81,19 @@ func TestUpdateFromStatus(t *testing.T) {
 
 func TestUpdateFromStatusHandlesRestart(t *testing.T) {
 	m := New()
-	m.UpdateFromStatus(&pb.StatusUpdate{Channel: 0, DcdTransitions: 100})
-	// Child restarted, counter reset to 2. Should rebaseline, not go negative.
-	m.UpdateFromStatus(&pb.StatusUpdate{Channel: 0, DcdTransitions: 2})
-	m.UpdateFromStatus(&pb.StatusUpdate{Channel: 0, DcdTransitions: 5})
+	m.UpdateFromStatus(&pb.StatusUpdate{Channel: 0, DcdTransitions: 100, RxBadFcs: 50})
+	// Child restarted, counters reset. Should rebaseline, not go negative.
+	m.UpdateFromStatus(&pb.StatusUpdate{Channel: 0, DcdTransitions: 2, RxBadFcs: 1})
+	m.UpdateFromStatus(&pb.StatusUpdate{Channel: 0, DcdTransitions: 5, RxBadFcs: 4})
 
 	body := scrape(t, m)
 	// 0 from first, rebaseline to 2, then +3 → total 3.
 	if !strings.Contains(body, `graywolf_dcd_transitions_total{channel="0"} 3`) {
 		t.Errorf("unexpected transitions counter after restart:\n%s", body)
+	}
+	// Same rebaseline math for bad-FCS: 0, rebaseline to 1, then +3 → total 3.
+	if !strings.Contains(body, `graywolf_rx_bad_fcs_total{channel="0"} 3`) {
+		t.Errorf("unexpected bad-fcs counter after restart:\n%s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Bad-FCS (failed CRC) frame counts are already computed per channel in the Rust modem and shipped over IPC in `StatusUpdate.rx_bad_fcs` — they feed the dashboard's per-channel "Bad FCS" tile — but `Metrics.UpdateFromStatus` ignored the field, so they never reached `/metrics`.

This adds **`graywolf_rx_bad_fcs_total{channel="…"}`**, fed by the same absolute-counter → monotonic-counter delta translation already used for `graywolf_dcd_transitions_total`, including the modem-restart rebaseline (counters going backwards rebaseline rather than emitting a negative delta).

## Notes

- **Modem channels only.** KISS-TNC channels stay absent by design: a hardware TNC validates the FCS itself and never forwards a bad frame over KISS (issue #132). This matches the existing REST/UI behavior where `RxBadFCS` stays 0 for those channels.
- **No per-frame hook.** Unlike `rx_frames` (incremented per `ReceivedFrame` via `ObserveReceivedFrame`), bad frames are dropped in the Rust modem and never arrive as frames, so the counter can only advance on the periodic `StatusUpdate` — exactly like `dcd_transitions`.
- No proto, Rust, or IPC changes needed — the value was already on the wire.
- No Grafana panel added: the bundled dashboard is KISS-TNC-specific, where this metric is always absent.

## Testing

- Extended `TestUpdateFromStatus` (delta) and `TestUpdateFromStatusHandlesRestart` (rebaseline) in `pkg/metrics/metrics_test.go`.
- `go vet`, `go test -race ./pkg/metrics/`, and `go build ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)