### PR TITLE
Prompt a reload when the server is upgraded under an open tab

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -266,6 +266,23 @@ PMTiles infrastructure (manifest gen, R2 sync, Cloudflare Worker) is in
 [`../../pkg/updatescheck/checker.go`](../../pkg/updatescheck/checker.go)
 polls GitHub Releases once per day and serves the snapshot via webapi `/api/updates`.
 
+Distinct from that "a newer release exists upstream" check is the
+**"the server you're talking to changed underneath you"** check, which
+catches an operator upgrading/rebuilding graywolf while a tab is open.
+`GET /api/version` returns `{version, commit}` (commit added so a
+same-version rebuild is still detected; sourced from `Config.GitCommit`
+via [`pkg/app/wiring.go`](../../pkg/app/wiring.go) → `webapi.Config.Commit`).
+The web client captures that identity at load and re-checks it from
+[`web/src/lib/stores/server-version.svelte.js`](../../web/src/lib/stores/server-version.svelte.js)
+(pure latch/identity logic in
+[`server-version-core.js`](../../web/src/lib/server-version-core.js)); on a
+change it raises `ServerUpdatedBanner` app-wide with a Reload button. The
+re-check is **driven by the shared `online` connection store**: an upgrade
+restarts the process, which trips `online` false→true, and that reconnect
+edge triggers the version fetch (a slow interval poll is the fallback). So
+the version watch is coupled to the same disconnect/reconnect signal that
+[`web/src/lib/api.js`](../../web/src/lib/api.js) feeds.
+
 ## Android Kotlin platform service (`android/app/`)
 
 Kotlin code that backs the Android tablet build. The webview hosts the

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -1335,6 +1335,7 @@ func (a *App) wireHTTP(ctx context.Context) error {
 		Logger:             a.logger,
 		HistoryDBPath:      a.cfg.HistoryDBPath,
 		Version:            a.cfg.Version,
+		Commit:             a.cfg.GitCommit,
 		MapsCache:          mapsCache,
 		Catalog:            catalog,
 		Style:              styleCache,

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1421,7 +1421,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1469,7 +1468,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1526,7 +1524,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1567,7 +1564,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1760,7 +1756,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1802,7 +1797,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -7721,8 +7715,7 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer",
-                        "format": "int32"
+                        "type": "integer"
                     }
                 },
                 "source": {
@@ -7972,8 +7965,7 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -7988,8 +7980,7 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -7999,8 +7990,7 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -8008,8 +7998,7 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -8021,8 +8010,7 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -8037,12 +8025,10 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "table": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 }
             }
         },
@@ -8052,8 +8038,7 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number",
-                        "format": "float64"
+                        "type": "number"
                     }
                 },
                 "analogHas": {
@@ -8069,8 +8054,7 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -8086,8 +8070,7 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -8095,8 +8078,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -8171,21 +8153,17 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain24Hour": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rainSinceMid": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -8193,8 +8171,7 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -8202,8 +8179,7 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -8215,13 +8191,11 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 }
             }
         },
@@ -11185,11 +11159,6 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
-            "x-enum-descriptions": [
-                "heard on the air",
-                "transmitted by us",
-                "APRS-IS upload/download (iGate)"
-            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -11504,8 +11473,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -11598,8 +11566,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1421,6 +1421,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1468,6 +1469,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1524,6 +1526,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1564,6 +1567,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1756,6 +1760,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1797,6 +1802,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -7715,7 +7721,8 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "int32"
                     }
                 },
                 "source": {
@@ -7965,7 +7972,8 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -7980,7 +7988,8 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -7990,7 +7999,8 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -7998,7 +8008,8 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -8010,7 +8021,8 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -8025,10 +8037,12 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "table": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 }
             }
         },
@@ -8038,7 +8052,8 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number"
+                        "type": "number",
+                        "format": "float64"
                     }
                 },
                 "analogHas": {
@@ -8054,7 +8069,8 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -8070,7 +8086,8 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -8078,7 +8095,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -8153,17 +8171,21 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rain24Hour": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rainSinceMid": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -8171,7 +8193,8 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -8179,7 +8202,8 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -8191,11 +8215,13 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 }
             }
         },
@@ -11159,6 +11185,11 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
+            "x-enum-descriptions": [
+                "heard on the air",
+                "transmitted by us",
+                "APRS-IS upload/download (iGate)"
+            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -11473,7 +11504,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -11566,7 +11598,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -11742,6 +11775,10 @@
         "webapi.VersionResponse": {
             "type": "object",
             "properties": {
+                "commit": {
+                    "description": "Commit is the build-time git commit of the running server. The web\nUI captures (version, commit) at load and re-checks this endpoint to\nnotice when the server binary changed underneath it (e.g. the\noperator upgraded graywolf) so it can prompt a reload. Including the\ncommit — not just the release version — means a same-version rebuild\nfrom source is still detected.",
+                    "type": "string"
+                },
                 "platform": {
                     "description": "Platform is runtime.GOOS of the server process — \"windows\", \"linux\",\n\"darwin\", etc. The UI uses it to surface platform-specific guidance\n(e.g. the Windows app-volume warning on the Audio Devices page).",
                     "type": "string"

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,7 +50,6 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
-          format: int32
           type: integer
         type: array
       source:
@@ -229,7 +228,6 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
-        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -241,7 +239,6 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
-        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -249,14 +246,12 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
-        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
-        format: float64
         type: number
       phg:
         allOf:
@@ -264,7 +259,6 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
-        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -275,17 +269,14 @@ definitions:
   aprs.Symbol:
     properties:
       code:
-        format: int32
         type: integer
       table:
-        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
-          format: float64
           type: number
         type: array
       analogHas:
@@ -298,7 +289,6 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
-        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -310,13 +300,11 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
-        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -369,31 +357,25 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
-        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
-        format: float64
         type: number
       rain24Hour:
-        format: float64
         type: number
       rainSinceMid:
-        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
-        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
-        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -403,11 +385,9 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
-        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
-        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -2545,10 +2525,6 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
-    x-enum-descriptions:
-      - heard on the air
-      - transmitted by us
-      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2770,7 +2746,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -2837,7 +2812,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -4007,7 +3981,6 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4028,7 +4001,6 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4059,7 +4031,6 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4101,7 +4072,6 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4222,7 +4192,6 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4243,7 +4212,6 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,6 +50,7 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
+          format: int32
           type: integer
         type: array
       source:
@@ -228,6 +229,7 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
+        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -239,6 +241,7 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
+        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -246,12 +249,14 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
+        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
+        format: float64
         type: number
       phg:
         allOf:
@@ -259,6 +264,7 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
+        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -269,14 +275,17 @@ definitions:
   aprs.Symbol:
     properties:
       code:
+        format: int32
         type: integer
       table:
+        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
+          format: float64
           type: number
         type: array
       analogHas:
@@ -289,6 +298,7 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
+        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -300,11 +310,13 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
+        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -357,25 +369,31 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
+        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
+        format: float64
         type: number
       rain24Hour:
+        format: float64
         type: number
       rainSinceMid:
+        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
+        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
+        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -385,9 +403,11 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
+        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
+        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -2525,6 +2545,10 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
+    x-enum-descriptions:
+      - heard on the air
+      - transmitted by us
+      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2746,6 +2770,7 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -2812,6 +2837,7 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -2934,6 +2960,15 @@ definitions:
     type: object
   webapi.VersionResponse:
     properties:
+      commit:
+        description: |-
+          Commit is the build-time git commit of the running server. The web
+          UI captures (version, commit) at load and re-checks this endpoint to
+          notice when the server binary changed underneath it (e.g. the
+          operator upgraded graywolf) so it can prompt a reload. Including the
+          commit — not just the release version — means a same-version rebuild
+          from source is still detected.
+        type: string
       platform:
         description: |-
           Platform is runtime.GOOS of the server process — "windows", "linux",
@@ -3972,6 +4007,7 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -3992,6 +4028,7 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4022,6 +4059,7 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4063,6 +4101,7 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4183,6 +4222,7 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4203,6 +4243,7 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
+          format: int32
           in: path
           name: id
           required: true

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -62,6 +62,7 @@ type Server struct {
 	startedAt          time.Time
 	historyDBPath      string // read-only; set by -history-db flag
 	version            string // build-time version string returned by GET /api/version
+	commit             string // build-time git commit returned by GET /api/version
 	igateStatusFn      func() *igate.Status
 	gpsReload          chan struct{} // signalled when GPS config changes
 	beaconReload       chan struct{} // signalled when beacon config changes
@@ -193,6 +194,7 @@ type Config struct {
 	Logger             *slog.Logger
 	HistoryDBPath      string // path to history database, from -history-db flag
 	Version            string // build-time version string reported by GET /api/version
+	Commit             string // build-time git commit reported by GET /api/version
 	// MapsAuth is the registration client used by
 	// POST /api/preferences/maps/register. Optional; NewServer
 	// defaults to a client pointed at mapsauth.DefaultBaseURL when
@@ -246,6 +248,7 @@ func NewServer(cfg Config) (*Server, error) {
 		startedAt:          time.Now(),
 		historyDBPath:      cfg.HistoryDBPath,
 		version:            cfg.Version,
+		commit:             cfg.Commit,
 		updatesReloadCh:    make(chan struct{}, 1),
 		mapsAuth:           mapsClient,
 		mapsCache:          cfg.MapsCache,

--- a/pkg/webapi/version.go
+++ b/pkg/webapi/version.go
@@ -8,6 +8,13 @@ import (
 // VersionResponse is the JSON shape returned by GET /api/version.
 type VersionResponse struct {
 	Version string `json:"version"`
+	// Commit is the build-time git commit of the running server. The web
+	// UI captures (version, commit) at load and re-checks this endpoint to
+	// notice when the server binary changed underneath it (e.g. the
+	// operator upgraded graywolf) so it can prompt a reload. Including the
+	// commit — not just the release version — means a same-version rebuild
+	// from source is still detected.
+	Commit string `json:"commit"`
 	// Platform is runtime.GOOS of the server process — "windows", "linux",
 	// "darwin", etc. The UI uses it to surface platform-specific guidance
 	// (e.g. the Windows app-volume warning on the Audio Devices page).
@@ -32,7 +39,7 @@ func RegisterVersion(srv *Server, mux *http.ServeMux) {
 	if srv == nil || mux == nil {
 		return
 	}
-	mux.HandleFunc("GET /api/version", getVersion(srv.version))
+	mux.HandleFunc("GET /api/version", getVersion(srv.version, srv.commit))
 }
 
 // getVersion returns the build-time version string captured by
@@ -44,10 +51,11 @@ func RegisterVersion(srv *Server, mux *http.ServeMux) {
 // @Produce  json
 // @Success  200 {object} webapi.VersionResponse
 // @Router   /version [get]
-func getVersion(version string) http.HandlerFunc {
+func getVersion(version, commit string) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, VersionResponse{
 			Version:  version,
+			Commit:   commit,
 			Platform: runtime.GOOS,
 		})
 	}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -5,6 +5,8 @@
   import { Platform } from './lib/platform.js';
   import Sidebar from './components/Sidebar.svelte';
   import NewsPopup from './components/NewsPopup.svelte';
+  import ServerUpdatedBanner from './components/ServerUpdatedBanner.svelte';
+  import { serverVersion } from './lib/stores/server-version.svelte.js';
   import { start as startMessagesTransport } from './lib/messagesTransport.js';
   import { releaseNotes } from './lib/releaseNotesStore.svelte.js';
   import { unitsState } from './lib/settings/units-store.svelte.js';
@@ -138,6 +140,9 @@
     if (authChecked && !isLoginPage && !messagesTransportStarted) {
       messagesTransportStarted = true;
       startMessagesTransport();
+      // Watch for the server build changing underneath this tab (operator
+      // upgraded graywolf) and surface a reload banner. Idempotent.
+      serverVersion.start();
       // Pull release notes the user hasn't acknowledged yet. App.svelte
       // mounts <NewsPopup> only when unseen.length > 0, so an empty
       // response is a silent no-op.
@@ -155,6 +160,7 @@
 {#if isLoginPage}
   <Router {routes} />
 {:else if authChecked}
+  <ServerUpdatedBanner />
   <div class="app-layout">
     <Sidebar />
     <main class="main-content" class:full-bleed={currentPath === '/map' || currentPath === '/messages' || currentPath.startsWith('/messages/')}>

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2041,50 +2041,33 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /**
-             * Format: float64
-             * @description meters (0 if none reported)
-             */
+            /** @description meters (0 if none reported) */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /**
-             * Format: int32
-             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
-             */
+            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive north
-             */
+            /** @description decimal degrees, positive north */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive east
-             */
+            /** @description decimal degrees, positive east */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /**
-             * Format: float64
-             * @description knots
-             */
+            /** @description knots */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
-            /** Format: int32 */
             code?: number;
-            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2093,20 +2076,14 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /**
-             * Format: int32
-             * @description bits 0..7 (only lower 8)
-             */
+            /** @description bits 0..7 (only lower 8) */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /**
-             * Format: int32
-             * @description BITS. sense-bits bitmap (active-high per bit)
-             */
+            /** @description BITS. sense-bits bitmap (active-high per bit) */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2134,47 +2111,27 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /**
-             * Format: float64
-             * @description tenths of millibar (e.g. 10132 = 1013.2)
-             */
+            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
             pressure?: number;
-            /**
-             * Format: float64
-             * @description hundredths of an inch
-             */
+            /** @description hundredths of an inch */
             rain1Hour?: number;
-            /** Format: float64 */
             rain24Hour?: number;
-            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /**
-             * Format: float64
-             * @description inches (via 's' after 'g')
-             */
+            /** @description inches (via 's' after 'g') */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /**
-             * Format: float64
-             * @description degrees F
-             */
+            /** @description degrees F */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /**
-             * Format: float64
-             * @description mph (5-minute peak)
-             */
+            /** @description mph (5-minute peak) */
             windGust?: number;
-            /**
-             * Format: float64
-             * @description mph (1-minute sustained)
-             */
+            /** @description mph (1-minute sustained) */
             windSpeed?: number;
         };
         "configstore.Referrer": {

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2041,33 +2041,50 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /** @description meters (0 if none reported) */
+            /**
+             * Format: float64
+             * @description meters (0 if none reported)
+             */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
+            /**
+             * Format: int32
+             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
+             */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /** @description decimal degrees, positive north */
+            /**
+             * Format: float64
+             * @description decimal degrees, positive north
+             */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /** @description decimal degrees, positive east */
+            /**
+             * Format: float64
+             * @description decimal degrees, positive east
+             */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /** @description knots */
+            /**
+             * Format: float64
+             * @description knots
+             */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
+            /** Format: int32 */
             code?: number;
+            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2076,14 +2093,20 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /** @description bits 0..7 (only lower 8) */
+            /**
+             * Format: int32
+             * @description bits 0..7 (only lower 8)
+             */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /** @description BITS. sense-bits bitmap (active-high per bit) */
+            /**
+             * Format: int32
+             * @description BITS. sense-bits bitmap (active-high per bit)
+             */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2111,27 +2134,47 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
+            /**
+             * Format: float64
+             * @description tenths of millibar (e.g. 10132 = 1013.2)
+             */
             pressure?: number;
-            /** @description hundredths of an inch */
+            /**
+             * Format: float64
+             * @description hundredths of an inch
+             */
             rain1Hour?: number;
+            /** Format: float64 */
             rain24Hour?: number;
+            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /** @description inches (via 's' after 'g') */
+            /**
+             * Format: float64
+             * @description inches (via 's' after 'g')
+             */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /** @description degrees F */
+            /**
+             * Format: float64
+             * @description degrees F
+             */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /** @description mph (5-minute peak) */
+            /**
+             * Format: float64
+             * @description mph (5-minute peak)
+             */
             windGust?: number;
-            /** @description mph (1-minute sustained) */
+            /**
+             * Format: float64
+             * @description mph (1-minute sustained)
+             */
             windSpeed?: number;
         };
         "configstore.Referrer": {
@@ -3653,6 +3696,15 @@ export interface components {
             logs?: components["schemas"]["webapi.SystemLogEntry"][];
         };
         "webapi.VersionResponse": {
+            /**
+             * @description Commit is the build-time git commit of the running server. The web
+             *     UI captures (version, commit) at load and re-checks this endpoint to
+             *     notice when the server binary changed underneath it (e.g. the
+             *     operator upgraded graywolf) so it can prompt a reload. Including the
+             *     commit — not just the release version — means a same-version rebuild
+             *     from source is still detected.
+             */
+            commit?: string;
             /**
              * @description Platform is runtime.GOOS of the server process — "windows", "linux",
              *     "darwin", etc. The UI uses it to surface platform-specific guidance

--- a/web/src/components/ServerUpdatedBanner.svelte
+++ b/web/src/components/ServerUpdatedBanner.svelte
@@ -108,7 +108,8 @@
     border-radius: var(--radius, 4px);
     border: 1px solid var(--accent);
     background: var(--accent);
-    color: var(--accent-fg, #fff);
+    color: var(--color-bg, #0d1117);
+    transition: filter 0.15s;
   }
   .banner-reload:hover,
   .banner-reload:focus-visible {

--- a/web/src/components/ServerUpdatedBanner.svelte
+++ b/web/src/components/ServerUpdatedBanner.svelte
@@ -1,0 +1,164 @@
+<script>
+  import { Icon } from '@chrissnell/chonky-ui';
+  import { serverVersion } from '../lib/stores/server-version.svelte.js';
+
+  // The server build changed underneath this tab. We prompt rather than
+  // auto-reload so the operator doesn't lose in-flight work (a half-typed
+  // message, an open AX.25 terminal session, map pan/zoom). Dismiss is
+  // session-local: the watcher's latch stays set, but the operator has
+  // acknowledged it and we stop nagging until the next full load.
+  let dismissed = $state(false);
+
+  function reload() {
+    window.location.reload();
+  }
+
+  function onKeydown(e) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      dismissed = true;
+    }
+  }
+</script>
+
+{#if serverVersion.updateAvailable && !dismissed}
+  <!--
+    svelte-ignore a11y_no_noninteractive_element_interactions
+    The aside captures Escape so keyboard users can dismiss without reaching
+    for the mouse; the explicit buttons remain the canonical affordances.
+  -->
+  <aside
+    class="server-updated-banner"
+    role="alert"
+    aria-labelledby="server-updated-title"
+    tabindex="-1"
+    onkeydown={onKeydown}
+  >
+    <span class="banner-icon" aria-hidden="true">
+      <Icon name="refresh-cw" size="sm" />
+    </span>
+    <div class="banner-body">
+      <p class="banner-text" id="server-updated-title">
+        <strong>Graywolf was updated on the server.</strong>
+        Reload to get the latest version.
+      </p>
+    </div>
+    <button type="button" class="banner-reload" onclick={reload}>
+      Reload
+    </button>
+    <button
+      type="button"
+      class="banner-dismiss"
+      aria-label="Dismiss server update notice"
+      onclick={() => (dismissed = true)}
+    >
+      <Icon name="x" size="lg" />
+    </button>
+  </aside>
+{/if}
+
+<style>
+  /* App-wide sticky bar: this should follow the operator across pages and
+     stay visible while scrolling, unlike the in-page UpdateAvailableBanner.
+     Accent tokens (informational), matching the update-available banner. */
+  .server-updated-banner {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--accent);
+    background: var(--accent-bg);
+    color: var(--text-primary, inherit);
+    line-height: 1.45;
+    outline: none;
+  }
+  .server-updated-banner:focus-visible {
+    box-shadow: inset 0 0 0 2px var(--accent);
+  }
+  .banner-icon {
+    flex: 0 0 auto;
+    color: var(--accent);
+    display: inline-flex;
+    align-items: center;
+    line-height: 1;
+  }
+  .banner-body {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .banner-text {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.45;
+  }
+  .banner-text strong {
+    margin-right: 4px;
+  }
+  .banner-reload {
+    flex: 0 0 auto;
+    appearance: none;
+    cursor: pointer;
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 6px 14px;
+    border-radius: var(--radius, 4px);
+    border: 1px solid var(--accent);
+    background: var(--accent);
+    color: var(--accent-fg, #fff);
+  }
+  .banner-reload:hover,
+  .banner-reload:focus-visible {
+    filter: brightness(1.08);
+    outline: none;
+  }
+  .banner-dismiss {
+    flex: 0 0 auto;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    width: 32px;
+    height: 32px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    border-radius: var(--radius, 4px);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font: inherit;
+  }
+  .banner-dismiss:hover,
+  .banner-dismiss:focus-visible {
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--text-primary) 8%, transparent);
+    outline: none;
+  }
+
+  /* Forced-colors (Windows High Contrast / macOS Increase Contrast). */
+  @media (forced-colors: active) {
+    .server-updated-banner {
+      border-bottom: 1px solid CanvasText;
+      background: Canvas;
+      color: CanvasText;
+    }
+    .banner-reload {
+      border: 1px solid ButtonText;
+      background: ButtonFace;
+      color: ButtonText;
+    }
+    .banner-icon,
+    .banner-dismiss {
+      color: CanvasText;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .banner-reload {
+      transition: none !important;
+    }
+  }
+</style>

--- a/web/src/lib/server-version-core.js
+++ b/web/src/lib/server-version-core.js
@@ -1,0 +1,55 @@
+// Pure logic for detecting that the graywolf server changed underneath an
+// open browser tab (the operator upgraded/rebuilt graywolf). Kept free of
+// Svelte runes, fetch, and timers so it runs under `node --test`; the
+// reactive glue (fetch + interval + connection store) lives in
+// stores/server-version.svelte.js.
+
+// Separator joining version + commit into one identity token. A pipe can't
+// appear in a semver-ish version string or a git hash, so two different
+// (version, commit) pairs can never alias to the same token.
+const SEP = '|';
+
+// serverIdentity reduces a GET /api/version response to a single token that
+// uniquely names the running build: the (version, commit) pair. Comparing
+// the commit too — not just the release version — means a same-version
+// rebuild from source is still detected. Returns '' for a missing/blank
+// response so a transient failure is treated as "no information," never as
+// a change.
+export function serverIdentity(data) {
+  if (!data || typeof data !== 'object') return '';
+  const version = typeof data.version === 'string' ? data.version : '';
+  const commit = typeof data.commit === 'string' ? data.commit : '';
+  if (version === '' && commit === '') return '';
+  return version + SEP + commit;
+}
+
+// createIdentityWatcher is a one-way latch. It records the first non-empty
+// identity it sees (the build the page was loaded against) and reports a
+// change once it later observes a *different* non-empty identity. Empty
+// observations are ignored, so neither a failed fetch nor a server that
+// reports no version can establish or move the baseline, or false-trigger.
+// Once changed it stays changed — the operator should reload regardless of
+// any later flapping.
+export function createIdentityWatcher() {
+  let boot = '';
+  let changed = false;
+  return {
+    get boot() { return boot; },
+    get changed() { return changed; },
+    // observe folds one identity into the latch and returns true only on
+    // the observation that flips changed false -> true (so a caller can
+    // act exactly once).
+    observe(identity) {
+      if (!identity) return false;
+      if (boot === '') {
+        boot = identity;
+        return false;
+      }
+      if (!changed && identity !== boot) {
+        changed = true;
+        return true;
+      }
+      return false;
+    },
+  };
+}

--- a/web/src/lib/server-version-core.test.js
+++ b/web/src/lib/server-version-core.test.js
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { serverIdentity, createIdentityWatcher } from './server-version-core.js';
+
+// serverIdentity joins (version, commit) with a pipe separator.
+const J = (v, c) => v + '|' + c;
+
+test('serverIdentity combines version and commit', () => {
+  assert.equal(serverIdentity({ version: '0.14.9', commit: 'abc123' }), J('0.14.9', 'abc123'));
+});
+
+test('serverIdentity tolerates missing fields', () => {
+  assert.equal(serverIdentity({ version: '0.14.9' }), J('0.14.9', ''));
+  assert.equal(serverIdentity({ commit: 'abc123' }), J('', 'abc123'));
+});
+
+test('serverIdentity returns empty for blank/missing input', () => {
+  assert.equal(serverIdentity(null), '');
+  assert.equal(serverIdentity(undefined), '');
+  assert.equal(serverIdentity({}), '');
+  assert.equal(serverIdentity('nope'), '');
+  assert.equal(serverIdentity({ version: '', commit: '' }), '');
+});
+
+test('serverIdentity distinguishes same version, different commit', () => {
+  assert.notEqual(
+    serverIdentity({ version: '0.14.9', commit: 'aaa' }),
+    serverIdentity({ version: '0.14.9', commit: 'bbb' }),
+  );
+});
+
+test('watcher records boot identity without reporting a change', () => {
+  const w = createIdentityWatcher();
+  assert.equal(w.observe(J('0.14.9', 'abc')), false);
+  assert.equal(w.boot, J('0.14.9', 'abc'));
+  assert.equal(w.changed, false);
+});
+
+test('watcher reports change exactly once on a different identity', () => {
+  const w = createIdentityWatcher();
+  w.observe(J('0.14.9', 'abc'));
+  assert.equal(w.observe(J('0.14.9', 'abc')), false, 'same identity is not a change');
+  assert.equal(w.observe(J('0.15.0', 'def')), true, 'first differing identity flips the latch');
+  assert.equal(w.observe(J('0.15.0', 'def')), false, 'does not re-fire for the same new identity');
+  assert.equal(w.observe(J('0.16.0', 'ghi')), false, 'stays latched, no second fire');
+  assert.equal(w.changed, true);
+});
+
+test('watcher ignores empty observations (transient failures)', () => {
+  const w = createIdentityWatcher();
+  assert.equal(w.observe(''), false, 'empty before boot does not establish baseline');
+  assert.equal(w.boot, '');
+  w.observe(J('0.14.9', 'abc'));
+  assert.equal(w.observe(''), false, 'empty after boot is not a change');
+  assert.equal(w.changed, false);
+  assert.equal(w.observe(J('0.15.0', 'def')), true);
+});
+
+test('watcher detects a same-version rebuild via commit', () => {
+  const w = createIdentityWatcher();
+  w.observe(serverIdentity({ version: '0.14.9', commit: 'aaa' }));
+  assert.equal(w.observe(serverIdentity({ version: '0.14.9', commit: 'bbb' })), true);
+});

--- a/web/src/lib/stores/server-version.svelte.js
+++ b/web/src/lib/stores/server-version.svelte.js
@@ -1,0 +1,74 @@
+// Watches the running server's build identity and flips `updateAvailable`
+// when it changes underneath the open tab — i.e. the operator upgraded or
+// rebuilt graywolf on the server. App.svelte renders a reload banner off
+// this so a stale SPA stops silently running old code against a new server.
+//
+// Trigger strategy (see the design note on GH): a server upgrade always
+// restarts the process, which trips the shared `online` connection store
+// false -> true; we re-check /api/version on that reconnect edge. A slow
+// fallback poll covers a restart fast enough that no in-flight request
+// registered the disconnect. The pure latch/identity logic lives in
+// ../server-version-core.js (unit-tested under node --test).
+
+import { online } from './connection.js';
+import { serverIdentity, createIdentityWatcher } from '../server-version-core.js';
+
+const DEFAULT_INTERVAL_MS = 60_000;
+
+export const serverVersion = (() => {
+  let updated = $state(false);
+  const watcher = createIdentityWatcher();
+  let started = false;
+  let timer = null;
+  let unsubOnline = null;
+
+  async function check() {
+    try {
+      const res = await fetch('/api/version', { credentials: 'same-origin' });
+      if (!res.ok) return;
+      const data = await res.json();
+      if (watcher.observe(serverIdentity(data))) {
+        updated = true;
+      }
+    } catch {
+      // A failed fetch during the upgrade restart is expected and means
+      // nothing on its own; the reconnect edge will re-trigger a check
+      // once the new server answers.
+    }
+  }
+
+  // start is idempotent. intervalMs is injectable for tests.
+  function start(intervalMs = DEFAULT_INTERVAL_MS) {
+    if (started || typeof window === 'undefined') return;
+    started = true;
+
+    // Establish the boot baseline right away.
+    check();
+
+    // Re-check on every disconnect -> reconnect transition. online.subscribe
+    // fires synchronously with the current value first; seeding prevOnline
+    // to that value means the initial callback is never mistaken for a
+    // reconnect.
+    let prevOnline = true;
+    unsubOnline = online.subscribe((isOnline) => {
+      if (isOnline && !prevOnline) check();
+      prevOnline = isOnline;
+    });
+
+    timer = setInterval(check, intervalMs);
+  }
+
+  // stop is here for symmetry/tests; the app never tears the watcher down
+  // because it should live for the whole session.
+  function stop() {
+    if (timer) { clearInterval(timer); timer = null; }
+    if (unsubOnline) { unsubOnline(); unsubOnline = null; }
+    started = false;
+  }
+
+  return {
+    get updateAvailable() { return updated; },
+    start,
+    stop,
+  };
+})();


### PR DESCRIPTION
## The problem

If you have a browser tab open to graywolf and then upgrade graywolf on the server underneath it, **the tab has no idea anything changed.** It keeps running the old embedded SPA against the new server indefinitely — only a manual reload picks up the new version.

Why nothing currently catches it:
- The client reads `/api/version` exactly **once**, at page load, and never re-checks.
- The route bundle is **static** (no lazy-loaded chunks), so a stale client doesn't even hard-fail with 404s on navigation — it just silently runs old code.

So the staleness is invisible until the operator happens to reload.

## The fix

Detect the change and prompt a reload.

- **`/api/version` now also returns the build git `commit`** (in addition to `version`), so even a same-version rebuild from source is detected. It's sourced from `Config.GitCommit`, which is already linker-injected — no new build plumbing.
- **The client captures `(version, commit)` at load and re-checks it.** The re-check is driven by the shared `online` connection store: a server upgrade always restarts the process, which trips `online` false→true, and that reconnect edge triggers a version fetch. A slow (60s) interval poll is the fallback for a restart fast enough that no in-flight request registered the disconnect.
- **On a change, an app-wide `ServerUpdatedBanner` appears with a Reload button.** It prompts rather than auto-reloading, so in-flight work — a half-composed message, an open AX.25 terminal session, map pan/zoom — isn't discarded. The operator reloads when convenient.

## Design notes

- This is distinct from the existing GitHub "a newer release exists upstream" check (`/api/updates`). This one is about the *running* server's build changing underneath the tab.
- Pure latch/identity logic lives in `server-version-core.js` (no Svelte/fetch/timers, unit-tested under `node --test`); the fetch/interval/connection glue is isolated in the `.svelte.js` store.
- The identity separator is a literal `|` (a version string and git hash never contain one).

## Testing

- 8 new unit tests for the identity/latch logic; full JS suite passes (442/442).
- Go `webapi`/`app` vet + tests pass; regenerated OpenAPI spec + TS client (`make docs-check` / `api-client-check` confirm sync).
- End-to-end browser test against the real component + store (mocked `/api/version`): hidden at boot, appears on reconnect after a version change with a working Reload button, dismiss works, and the fallback interval poll also detects a change with no reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)