### PR TITLE
Fix object beacons sending a fixed 111111z timestamp (#412)

### DIFF
--- a/pkg/beacon/builder.go
+++ b/pkg/beacon/builder.go
@@ -136,7 +136,12 @@ func (s *Scheduler) buildInfo(ctx context.Context, b Config) (string, error) {
 		} else if lat == 0 && lon == 0 {
 			return "", fmt.Errorf("object beacon: fixed coordinates are 0/0 (configure lat/lon or enable use_gps)")
 		}
-		return ObjectInfo(b.ObjectName, true, "", lat, lon, altM, b.SymbolTable, b.SymbolCode, phg, comment), nil
+		// Object reports carry a real DDHHMMz UTC timestamp (APRS101
+		// ch 11). Without one the encoder falls back to a fixed
+		// "111111z", which APRS-IS and APRS.fi reject as out-of-order
+		// once wall-clock time drifts away from it (issue #412).
+		ts := DHMZulu(s.clock.Now().UTC())
+		return ObjectInfo(b.ObjectName, true, ts, lat, lon, altM, b.SymbolTable, b.SymbolCode, phg, comment), nil
 
 	case TypeCustom:
 		if b.CustomInfo == "" {

--- a/pkg/beacon/encoder.go
+++ b/pkg/beacon/encoder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/chrissnell/graywolf/pkg/aprs"
 )
@@ -221,6 +222,14 @@ func ObjectInfo(objectName string, live bool, timestampDHM string, lat, lon, alt
 	}
 	sb.WriteString(comment)
 	return sb.String()
+}
+
+// DHMZulu formats t as the 7-char "DDHHMMz" UTC timestamp used in APRS
+// object reports (APRS101 ch 11) — day-of-month, hour, minute, then the
+// 'z' zulu indicator. The caller is responsible for passing a UTC time;
+// the 'z' suffix asserts UTC and the day/hour/minute are taken verbatim.
+func DHMZulu(t time.Time) string {
+	return fmt.Sprintf("%02d%02d%02dz", t.Day(), t.Hour(), t.Minute())
 }
 
 // StatusInfo builds an APRS status report: ">comment".

--- a/pkg/beacon/object_timestamp_test.go
+++ b/pkg/beacon/object_timestamp_test.go
@@ -1,0 +1,78 @@
+package beacon
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/aprs"
+)
+
+// TestDHMZulu pins the DDHHMMz formatting, including zero-padding of
+// single-digit day/hour/minute.
+func TestDHMZulu(t *testing.T) {
+	cases := []struct {
+		t    time.Time
+		want string
+	}{
+		{time.Date(2026, 6, 28, 14, 5, 0, 0, time.UTC), "281405z"},
+		{time.Date(2026, 1, 2, 3, 4, 0, 0, time.UTC), "020304z"},
+		{time.Date(2026, 12, 31, 23, 59, 0, 0, time.UTC), "312359z"},
+	}
+	for _, c := range cases {
+		if got := DHMZulu(c.t); got != c.want {
+			t.Errorf("DHMZulu(%s) = %q, want %q", c.t, got, c.want)
+		}
+	}
+}
+
+// TestBuildObjectInfoUsesClockTimestamp is the regression guard for
+// issue #412: object beacons must carry a real DDHHMMz timestamp derived
+// from the current (UTC) time, not the fixed "111111z" placeholder that
+// APRS-IS / APRS.fi reject as out-of-order. It also confirms the clock's
+// local time is converted to UTC before formatting.
+func TestBuildObjectInfoUsesClockTimestamp(t *testing.T) {
+	// 09:05 in UTC-5 is 14:05 UTC on the 28th -> "281405z".
+	est := time.FixedZone("EST", -5*3600)
+	clk := newFakeClock(time.Date(2026, 6, 28, 9, 5, 0, 0, est))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	s, err := New(Options{Sink: newMockSink(1), Clock: clk, Logger: logger})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	info, err := s.buildInfo(context.Background(), Config{
+		Type:       TypeObject,
+		ObjectName: "FIELD DAY",
+		Lat:        43.353,
+		Lon:        -87.975,
+	})
+	if err != nil {
+		t.Fatalf("buildInfo: %v", err)
+	}
+
+	if strings.Contains(info, "111111z") {
+		t.Errorf("object info still uses the fixed 111111z placeholder: %q", info)
+	}
+	if !strings.Contains(info, "281405z") {
+		t.Errorf("object info missing expected UTC timestamp 281405z: %q", info)
+	}
+	// The 9-char name (with its internal space) must survive intact —
+	// the other half of issue #412 was a non-bug, so guard against a
+	// regression that would truncate it.
+	if !strings.HasPrefix(info, ";FIELD DAY*281405z") {
+		t.Errorf("unexpected object header: %q", info)
+	}
+	// And it must still be a parseable object report.
+	pkt, err := aprs.ParseInfo([]byte(info))
+	if err != nil {
+		t.Fatalf("parse: %v (%q)", err, info)
+	}
+	if pkt.Object == nil {
+		t.Fatalf("not decoded as an object: %q", info)
+	}
+}


### PR DESCRIPTION
Fixes the timestamp half of #412.

## The problem

Object beacons always shipped the timestamp `111111z`. That's not a wildcard — it's a fixed value meaning "the 11th at 11:11 UTC." As soon as real time drifts away from it, APRS-IS and APRS.fi reject the object as a delayed/out-of-order packet, so it never shows up on the map. @digitalmisery's capture in the issue shows it exactly:

```
;FIELD DAY*111111z4321.19N\08758.50W;/A=000817Ozaukee Radio Club Field Day 2026  [Delayed or out-of-order packet (timestamp)]
```

## Root cause

`buildInfo` built every object beacon with an empty timestamp argument:

```go
ObjectInfo(b.ObjectName, true, "", lat, lon, ...)
```

and `ObjectInfo` substitutes the literal `"111111z"` when the timestamp is empty. So every object beacon, on RF and APRS-IS alike, carried the placeholder.

## The fix

Generate a real `DDHHMMz` UTC timestamp from the scheduler's existing injectable `Clock` and pass it through:

- New pure helper `DHMZulu(t time.Time)` in `encoder.go` (APRS101 ch 11 formatting).
- `builder.go`'s object case now passes `DHMZulu(s.clock.Now().UTC())`.

`ObjectInfo`'s empty-string fallback is left intact for back-compat (its existing tests pass `""`); the builder now always supplies a real value, so the placeholder is no longer reachable in production.

## On the other half of #412 (object name length)

The OP also reported only being able to use ~7 of the 9 object-name characters. I could **not** reproduce that — the input `maxlength` is 9, save-time validation allows 9, the encoder pads/truncates to exactly 9, and the APRS-IS path preserves trailing spaces. @digitalmisery's own 9-char name "FIELD DAY" transmits intact. What the OP saw was almost certainly this same timestamp bug causing the object to be rejected by APRS.fi, which reads as "it didn't work." This PR should resolve what they observed.

## Testing

- `TestDHMZulu` — pins `DDHHMMz` formatting incl. zero-padding.
- `TestBuildObjectInfoUsesClockTimestamp` — builds an object beacon through a fake clock at a fixed time; asserts the real UTC timestamp is present (verifying local→UTC conversion), no `111111z` remains, the full 9-char "FIELD DAY" name survives, and the result still parses as an object.
- Full `go build ./...`, `go vet`, and the beacon suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)