### PR TITLE
Fix Android top nav bar rendering behind system status bar (GH #390)

### DIFF
--- a/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
@@ -38,6 +38,9 @@ class MainActivity : Activity() {
     // request. Cleared in onRequestPermissionsResult after we post the
     // window.__btResult dispatch back to the WebView.
     private var pendingBtPermCallback: String? = null
+    // Last status-bar inset (CSS px) handed to the page as --android-inset-top.
+    // Re-applied after each navigation; see applyTopInsetToCss (GH #390).
+    private var lastTopInsetCssPx: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -86,6 +89,13 @@ class MainActivity : Activity() {
                         mainHandler.postDelayed({ view.reload() }, 1000)
                     }
                 }
+                override fun onPageFinished(view: WebView, url: String) {
+                    // loadUrl() swaps in a fresh document, dropping the inline
+                    // --android-inset-top we set on the previous one. Re-apply
+                    // the last known status-bar inset so the CSS-reserved top
+                    // strip survives navigation/reload (GH #390).
+                    applyTopInsetToCss()
+                }
             }
         }
         setContentView(webView)
@@ -107,14 +117,20 @@ class MainActivity : Activity() {
      * visualViewport translate in the Android shell (Platform.isAndroid) so the
      * two don't double-offset.
      *
-     * The TOP inset is deliberately NOT padded here. The SPA's top bar is
-     * `position:fixed; top:0`, and a fixed element is pinned to the visual
-     * viewport, which WebView top-padding does NOT shift -- padding the top
-     * would leave the bar stranded behind the status bar (GH #390). Instead the
-     * page opts into `viewport-fit=cover` (web/index.html) and the top bar
-     * reserves the status-bar strip itself via `env(safe-area-inset-top)`. So
-     * the top is owned by CSS, the bottom by native padding (the viewport must
-     * actually shrink for the keyboard, which env() cannot express).
+     * The TOP inset is deliberately NOT padded on the WebView here. The SPA's
+     * top bar is `position:fixed; top:0`, and a fixed element is pinned to the
+     * visual viewport, which WebView top-padding does NOT shift -- padding the
+     * top would leave the bar stranded behind the status bar (GH #390). The top
+     * bar reserves the status-bar strip itself in CSS. We cannot rely on
+     * `env(safe-area-inset-top)` for that value: Android WebView derives it from
+     * the display cutout, not the status bar, and returns 0 (or wrong values
+     * below WebView 140) on most devices -- which is why the first GH #390 fix
+     * regressed. Instead we feed the real status-bar inset to CSS as the
+     * `--android-inset-top` custom property (see `applyTopInsetToCss`); the SPA
+     * takes `max(env(safe-area-inset-top), var(--android-inset-top))` so both
+     * the Android shell and iOS / mobile browsers reserve the strip. So the top
+     * is owned by CSS (fed by us), the bottom by native padding (the viewport
+     * must actually shrink for the keyboard, which env() cannot express).
      *
      * Two mechanisms feed the same listener: on API 30+ the IME arrives as a
      * `Type.ime()` inset (handled here directly). On API 28-29 `Type.ime()` is
@@ -130,10 +146,37 @@ class MainActivity : Activity() {
         ViewCompat.setOnApplyWindowInsetsListener(webView) { v, insets ->
             val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
-            // Top stays 0: the fixed top bar reserves the status-bar strip in
-            // CSS via env(safe-area-inset-top) (GH #390). See the KDoc above.
+            // Top stays 0 on the WebView: the fixed top bar reserves the
+            // status-bar strip in CSS, using the inset we hand it below (GH #390).
             v.setPadding(bars.left, 0, bars.right, maxOf(bars.bottom, ime.bottom))
+            // Feed the real status-bar inset to CSS as --android-inset-top.
+            // Insets are physical px; CSS works in density-independent px.
+            val topCss = Math.round(bars.top / resources.displayMetrics.density)
+            if (topCss != lastTopInsetCssPx) {
+                lastTopInsetCssPx = topCss
+                applyTopInsetToCss()
+            }
             insets
+        }
+    }
+
+    /**
+     * Push the last-seen status-bar inset (in CSS px) into the page as the
+     * `--android-inset-top` custom property on the document root. The SPA's
+     * mobile top bar reserves the strip via
+     * `max(env(safe-area-inset-top), var(--android-inset-top))` (GH #390),
+     * working around Android WebView not reporting the status bar through
+     * env(safe-area-inset-top). Re-applied from onPageFinished because each
+     * navigation swaps in a fresh document that loses the inline property.
+     */
+    private fun applyTopInsetToCss() {
+        if (!::webView.isInitialized) return
+        val px = lastTopInsetCssPx
+        webView.post {
+            webView.evaluateJavascript(
+                "document.documentElement.style.setProperty('--android-inset-top', '${px}px')",
+                null,
+            )
         }
     }
 

--- a/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/nw5w/graywolf/MainActivity.kt
@@ -150,8 +150,10 @@ class MainActivity : Activity() {
             // status-bar strip in CSS, using the inset we hand it below (GH #390).
             v.setPadding(bars.left, 0, bars.right, maxOf(bars.bottom, ime.bottom))
             // Feed the real status-bar inset to CSS as --android-inset-top.
-            // Insets are physical px; CSS works in density-independent px.
-            val topCss = Math.round(bars.top / resources.displayMetrics.density)
+            // Insets are physical px; CSS works in density-independent px. Ceil
+            // (not round) so we never under-reserve the strip by a sub-pixel and
+            // let the bar creep back under the status bar.
+            val topCss = kotlin.math.ceil(bars.top / resources.displayMetrics.density).toInt()
             if (topCss != lastTopInsetCssPx) {
                 lastTopInsetCssPx = topCss
                 applyTopInsetToCss()

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -696,9 +696,13 @@ cannot outlive the app, because no single mechanism covers both cases.
     var(--android-inset-top, 0px))` so the Android shell (var set, env 0) and iOS / mobile
     browsers (env populated, var unset) both reserve the strip; all top-inset consumers
     (`App.svelte`, `Sidebar.svelte`, `RemoteActionsDrawer.svelte`) read `var(--safe-area-top)`.
-    Do NOT re-add `bars.top` to the WebView padding, do NOT make the top bar depend on
-    `env(safe-area-inset-top)` directly, and keep `viewport-fit=cover` in `web/index.html`
-    (it is still needed for the env() path on iOS / mobile browsers).
+    chonky-ui's `<Drawer>` (the mobile nav drawer, `web/.../Sidebar.svelte` `anchor="left"`)
+    bakes raw `env(safe-area-inset-top)` into its `.drawer` rule, so `app.css` overrides
+    `.drawer { padding-top: var(--safe-area-top) }` to feed it the native inset too -- the
+    proper fix belongs in chonky-ui itself; until then any new `.drawer`-based surface
+    inherits the override. Do NOT re-add `bars.top` to the WebView padding, do NOT make the
+    top bar depend on `env(safe-area-inset-top)` directly, and keep `viewport-fit=cover` in
+    `web/index.html` (it is still needed for the env() path on iOS / mobile browsers).
   - **Bottom is owned by native padding.** `env()` cannot express the keyboard, so the
     IME padding is the cross-system load-bearing bit: it shrinks the web viewport above
     the keyboard so the SPA's sticky compose bar (`web/.../ComposeBar.svelte`,

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -680,14 +680,25 @@ cannot outlive the app, because no single mechanism covers both cases.
   and a `setOnApplyWindowInsetsListener` that pads the WebView by the side bars and
   `max(systemBars.bottom, ime.bottom)` -- but **leaves the top inset at 0 on purpose**.
   The split is load-bearing and not interchangeable:
-  - **Top is owned by CSS.** The SPA's mobile top bar is `position:fixed; top:0`
-    (`web/.../Sidebar.svelte`), and a fixed element is pinned to the visual viewport,
-    which WebView top-padding does NOT shift -- padding the top leaves the bar stranded
-    behind the status bar (GH #390). Instead `web/index.html` sets `viewport-fit=cover`
-    so `env(safe-area-inset-top)` is populated, and the top bar reserves the status-bar
-    strip itself (`height: calc(56px + env(safe-area-inset-top))`, matching
-    `margin-top` on `.main-content`). Do NOT re-add `bars.top` to the WebView padding and
-    do NOT drop `viewport-fit=cover`.
+  - **Top is owned by CSS, fed the inset by native.** The SPA's mobile top bar is
+    `position:fixed; top:0` (`web/.../Sidebar.svelte`), and a fixed element is pinned to
+    the visual viewport, which WebView top-padding does NOT shift -- padding the top leaves
+    the bar stranded behind the status bar (GH #390). So the top bar reserves the
+    status-bar strip in CSS (`height: calc(56px + var(--safe-area-top))`, matching
+    `margin-top` on `.main-content`). The value is **not** taken from
+    `env(safe-area-inset-top)` alone: Android WebView derives that env var from the
+    display cutout, not the status bar, and returns 0 (or wrong values below WebView 140)
+    on most devices -- relying on it is what made the first GH #390 fix regress. Instead
+    `MainActivity.applyTopInsetToCss` injects the real status-bar inset (`systemBars.top`,
+    converted to CSS px) as the `--android-inset-top` custom property on the document root,
+    re-applied from `onPageFinished` because each `loadUrl` swaps in a fresh document.
+    `web/src/app.css` defines `--safe-area-top: max(env(safe-area-inset-top),
+    var(--android-inset-top, 0px))` so the Android shell (var set, env 0) and iOS / mobile
+    browsers (env populated, var unset) both reserve the strip; all top-inset consumers
+    (`App.svelte`, `Sidebar.svelte`, `RemoteActionsDrawer.svelte`) read `var(--safe-area-top)`.
+    Do NOT re-add `bars.top` to the WebView padding, do NOT make the top bar depend on
+    `env(safe-area-inset-top)` directly, and keep `viewport-fit=cover` in `web/index.html`
+    (it is still needed for the env() path on iOS / mobile browsers).
   - **Bottom is owned by native padding.** `env()` cannot express the keyboard, so the
     IME padding is the cross-system load-bearing bit: it shrinks the web viewport above
     the keyboard so the SPA's sticky compose bar (`web/.../ComposeBar.svelte`,

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -224,12 +224,12 @@
   @media (max-width: 768px) {
     .main-content {
       margin-left: 0;
-      margin-top: calc(56px + env(safe-area-inset-top));
+      margin-top: calc(56px + var(--safe-area-top));
       padding: 16px;
     }
     .main-content.full-bleed {
-      height: calc(100vh - 56px - env(safe-area-inset-top));
-      height: calc(100dvh - 56px - env(safe-area-inset-top));
+      height: calc(100vh - 56px - var(--safe-area-top));
+      height: calc(100dvh - 56px - var(--safe-area-top));
     }
   }
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -40,6 +40,17 @@
   --safe-area-top: max(env(safe-area-inset-top), var(--android-inset-top, 0px));
 }
 
+/* chonky-ui's <Drawer> reserves the top safe area with raw
+   env(safe-area-inset-top), which is 0 in the Android WebView (see
+   --safe-area-top above) -- so the mobile nav drawer's header would render
+   behind the status bar, the same GH #390 bug the top bar hits. Override it to
+   the native-fed inset. This rule follows chonky's @import so it wins on source
+   order at equal specificity. The proper home is chonky-ui itself; this
+   app-side override covers it until that lands. */
+.drawer {
+  padding-top: var(--safe-area-top);
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -29,6 +29,15 @@
      full width; mirrored by the matching CSS in Sidebar/App and the
      COMPACT_LAYOUT_QUERY breakpoint in lib/compactLayout.js. */
   --landscape-rail-width: 56px;
+  /* Effective top safe-area inset. Android WebView does NOT populate
+     env(safe-area-inset-top) from the status bar (only the display cutout, and
+     unreliably below WebView 140), so the CSS-reserved status-bar strip from
+     GH #390 collapsed to 0 and the mobile top bar slid back behind the status
+     bar. The native shell injects the real status-bar inset as
+     --android-inset-top (MainActivity.applyWindowInsets); take whichever is
+     larger so iOS / mobile browsers (env populated, var unset) and the Android
+     shell (var set, env 0) both reserve the strip. */
+  --safe-area-top: max(env(safe-area-inset-top), var(--android-inset-top, 0px));
 }
 
 * {

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -810,8 +810,8 @@
       top: 0;
       left: 0;
       right: 0;
-      height: calc(56px + env(safe-area-inset-top));
-      padding: env(safe-area-inset-top) 8px 0
+      height: calc(56px + var(--safe-area-top));
+      padding: var(--safe-area-top) 8px 0
         max(8px, env(safe-area-inset-right));
       padding-left: max(8px, env(safe-area-inset-left));
       background: var(--bg-secondary);

--- a/web/src/components/messages/remote_actions/RemoteActionsDrawer.svelte
+++ b/web/src/components/messages/remote_actions/RemoteActionsDrawer.svelte
@@ -245,10 +245,13 @@
     display: flex;
     flex-direction: column;
     /* Edge-to-edge: this drawer is pinned to the viewport edges, so it reserves
-       the status-bar / nav-bar safe areas itself (GH #390). On the Android shell
-       the bottom env() is 0 because the WebView is natively bottom-padded; it is
-       load-bearing for iOS / mobile-browser home indicators. */
-    padding: calc(16px + env(safe-area-inset-top)) 16px
+       the status-bar / nav-bar safe areas itself (GH #390). The top uses
+       --safe-area-top because Android WebView's env(safe-area-inset-top) is
+       unreliable; the native shell feeds the real status-bar inset there. On
+       the Android shell the bottom env() is 0 because the WebView is natively
+       bottom-padded; it is load-bearing for iOS / mobile-browser home
+       indicators. */
+    padding: calc(16px + var(--safe-area-top)) 16px
       calc(16px + env(safe-area-inset-bottom));
     overflow-y: auto;
     z-index: 50;


### PR DESCRIPTION
## Problem

On Android (v0.14.8+) the mobile top nav bar renders behind the system status bar, obscured and unusable. The previous GH #390 fix did not resolve it.

## Root cause

That fix had the `position:fixed; top:0` top bar reserve the status-bar strip via `env(safe-area-inset-top)`, populated by `viewport-fit=cover`. That mechanism works on iOS but **not in Android WebView**: Chromium derives `env(safe-area-inset-top)` from the *display cutout*, not the status bar, and returns `0` (or wrong values below WebView 140) on most devices. So the reserved strip collapsed to `0` and the bar slid right back behind the status bar.

This is a documented Android WebView limitation; the standard workaround is for the native shell to inject the real inset as a CSS variable.

## Fix

- **Native** (`MainActivity`): in the window-insets listener, convert `systemBars.top` to CSS px and inject it as the `--android-inset-top` custom property on the document root via `evaluateJavascript`. Re-applied from a new `onPageFinished` because each `loadUrl` swaps in a fresh document that loses the inline property.
- **CSS** (`app.css`): define `--safe-area-top: max(env(safe-area-inset-top), var(--android-inset-top, 0px))` so the Android shell (var set, env 0) and iOS / mobile browsers (env populated, var unset) both reserve the strip.
- All top-inset consumers (`App.svelte`, `Sidebar.svelte`, `RemoteActionsDrawer.svelte`) now read `var(--safe-area-top)`.

WebView top padding stays `0` -- the bar is `position:fixed` and would still strand behind the status bar if the WebView were top-padded (the original #390 trap). Bottom/IME handling is unchanged. `viewport-fit=cover` is kept for the iOS env() path.

## Verification

- `npm run build` (web) passes; compiled CSS contains `--safe-area-top: max(env(safe-area-inset-top), var(--android-inset-top, 0px))` and all consumers resolve to it.
- A full Android Gradle build could not run in this environment (requires JDK 17; sandbox has JDK 21, plus a cargo-ndk mismatch on the unrelated Rust NDK step). The Kotlin change is small and self-contained; please confirm on a device build.

Wiki invariant (`docs/wiki/invariants.md`, "Inset ownership is split") updated to document the native-fed inset mechanism.
