### PR TITLE
docs(handbook): document the Bad FCS dashboard metric

### DIFF
--- a/docs/handbook/monitoring.html
+++ b/docs/handbook/monitoring.html
@@ -226,6 +226,139 @@
       </div>
     </div>
 
+    <h2>Understanding "Bad FCS"</h2>
+
+    <p>
+      Every AX.25 frame ends with a two-byte <em>Frame Check Sequence</em>
+      (FCS) &mdash; a CRC&#8209;16/CCITT checksum the sender computes over the
+      packet. The receiver recomputes it and compares. The dashboard's
+      <strong>Bad FCS</strong> counter (and the
+      <code>graywolf_rx_bad_fcs_total</code> metric) counts frame-shaped
+      signals that the modem demodulated all the way to a closing HDLC flag
+      but whose checksum did not match &mdash; so the frame was rejected and
+      dropped rather than passed on.
+    </p>
+
+    <p>
+      Only <em>plausible</em> candidates are counted: the demodulator must
+      have found an opening and closing flag with at least a minimum-length
+      packet of bits between them, and the frame must have failed both the
+      direct check and every configured bit-fix retry. Pure noise, runts, and
+      aborts are not counted. In other words, Bad FCS represents real
+      HDLC-shaped energy on the channel that <em>almost</em> decoded but
+      didn't.
+    </p>
+
+    <div class="callout info">
+      <span class="callout-icon">&#9432;</span>
+      <div class="callout-body">
+        <p>
+          <strong>It is a trend, not a precise packet count.</strong> Graywolf
+          runs several bit-slicers per channel in parallel to maximize good
+          decodes. A single burst of noise can look like a broken frame to
+          many slicers at once, so the modem deliberately reports the bad-FCS
+          tally from one representative slicer instead of summing all of them.
+          Treat the number as a signal-quality indicator that you watch over
+          time, not as an exact tally of lost packets.
+        </p>
+      </div>
+    </div>
+
+    <h3>What counts as a "high" value?</h3>
+
+    <p>
+      There is no fixed threshold, because a healthy value depends entirely on
+      what your receiver hears. The two things that matter are the
+      <strong>ratio</strong> of bad to good frames and the
+      <strong>trend</strong> over time &mdash; not the raw number.
+    </p>
+
+    <div class="box">
+      <div class="box-header">Reading the ratio</div>
+      <div class="box-body">
+        <table>
+          <thead>
+            <tr><th>Pattern</th><th>Most likely meaning</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Many bad FCS <em>and</em> a healthy, growing good-frame
+                  count</td>
+              <td>Usually benign. A sensitive, wide-coverage receiver on a
+                  busy uncoordinated channel (such as 144.390 MHz APRS) hears
+                  constant collisions and distant stations right at the edge of
+                  decodability. A bad:good ratio of several&#8209;to&#8209;one
+                  is common and is not by itself a fault.</td>
+            </tr>
+            <tr>
+              <td>Many bad FCS but <em>few</em> good frames</td>
+              <td>Points at a local problem rather than the band: receive audio
+                  too hot (clipping) or too weak, a twist / de-emphasis
+                  mismatch, or RF interference &mdash; classic offenders include
+                  USB / switching-supply EMI near the radio or sound device.</td>
+            </tr>
+            <tr>
+              <td>A previously low count that climbs steadily</td>
+              <td>Something changed: a new noise source, an antenna or
+                  connector problem, or a drifted audio level. Investigate the
+                  change, not the absolute number.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <p>
+      So a station seeing, for example, ~4,500 bad versus ~1,000 good frames is
+      not automatically in trouble &mdash; on a busy APRS receiver that ratio
+      is plausibly just collisions and weak DX. The question to answer is
+      whether the <em>good</em> count is healthy for your location and whether
+      the audio is clean. Use the steps below to decide.
+    </p>
+
+    <h3>Diagnosing poor FCS performance</h3>
+
+    <ol>
+      <li><strong>Check the good-frame rate alongside it.</strong> If RX is
+        still climbing at a normal pace for your area, you are mostly hearing
+        collisions and marginal traffic &mdash; benign. If good frames have
+        stalled while Bad FCS keeps rising, treat it as a local fault.</li>
+      <li><strong>Look at the channel's audio level.</strong> On the dashboard,
+        the per-channel level bar should peak comfortably without pinning at
+        the top (clipping) or barely moving (too weak). Both extremes wreck the
+        FCS rate.</li>
+      <li><strong>Record a clip and decode it offline.</strong> Capture a short
+        <code>.wav</code> of live traffic and run it back through the real
+        demodulator:
+        <pre><code>graywolf-modem --decode rx.wav</code></pre>
+        Watch <code>rx_bad_fcs</code> versus <code>rx_frames</code>, and check
+        <code>level_dbfs_med</code> (near 0&nbsp;dBFS means clipping; very low
+        means too weak) and <code>twist_db_med</code> (a large twist points at
+        a de-emphasis / audio-response problem rather than overall level). See
+        <a href="audio.html">Audio Devices</a> for the full field list.</li>
+      <li><strong>Tune against the same clip.</strong> Because
+        <code>--decode</code> is deterministic on a fixed file, decode the same
+        recording repeatedly while adjusting receive gain; the setting that
+        yields the most <code>rx_frames</code> with the fewest
+        <code>rx_bad_fcs</code> and no clipping wins.</li>
+      <li><strong>Hunt for interference.</strong> If the audio is clean but Bad
+        FCS stays high with few decodes, suspect EMI &mdash; move USB cables,
+        sound interfaces, and switching supplies away from the radio and
+        antenna feed.</li>
+    </ol>
+
+    <div class="callout tip">
+      <span class="callout-icon">&#10003;</span>
+      <div class="callout-body">
+        <p>
+          A hardware KISS TNC validates the FCS itself and never forwards a bad
+          frame, so its channels always show <strong>Bad FCS: 0</strong>. The
+          metric is only meaningful for software-modem (sound-card) channels,
+          where Graywolf does the demodulation and checksum itself.
+        </p>
+      </div>
+    </div>
+
     <h2>Packet Log API</h2>
 
     <p>


### PR DESCRIPTION
Documents the Dashboard's **Bad FCS** metric in the Handbook, addressing GitHub issue #430.

Adds an *Understanding "Bad FCS"* section to the Monitoring page covering:

- **What it means** — frame-shaped signals that demodulated to a closing HDLC flag but failed their CRC-16/CCITT checksum and were dropped. Only plausible candidates are counted (not noise, runts, or aborts).
- **Why it's a trend, not an exact count** — the modem reports the tally from one representative bit-slicer rather than summing all parallel slicers, so the number is a signal-quality indicator to watch over time.
- **What counts as "high"** — there is no fixed threshold; the bad:good *ratio* and the *trend* matter, not the raw number. A high count alongside a healthy good-frame rate (e.g. a busy APRS receiver hearing collisions and weak DX) is usually benign; high bad with *few* good frames points at a local fault.
- **Diagnostic steps** — check the good-frame rate, audio level, `graywolf-modem --decode` on a captured clip (level/twist), gain tuning, and EMI hunting.
- Notes that hardware KISS TNC channels always show 0 since the TNC validates the FCS itself.

Closes #430