### PR TITLE
Fix auth set-password flag order in Windows docs and add CLI hint

### DIFF
--- a/cmd/graywolf/main.go
+++ b/cmd/graywolf/main.go
@@ -42,6 +42,9 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
 	if len(os.Args) > 1 {
+		// Subcommands are only recognized as os.Args[1]. Keep these cases
+		// in sync with app.Subcommands, which ParseFlags uses to detect a
+		// misplaced subcommand and hint at the correct argument order.
 		switch os.Args[1] {
 		case "auth":
 			if err := authcli.Run(os.Args[2:], logger, Version); err != nil {

--- a/docs/handbook/installation.html
+++ b/docs/handbook/installation.html
@@ -235,12 +235,28 @@ nssm start Graywolf</code></pre>
         <h2>Setting the Admin Password</h2>
 
         <p>
-          Open a command prompt (or PowerShell) and run:
+          The easiest way is through the web interface. With the service
+          running, browse to <code>http://localhost:8080</code>. On first
+          run &mdash; when no users exist yet &mdash; the login screen shows
+          a <strong>Create Admin Account</strong> form. Enter a username and
+          password there and you&rsquo;re done; no command line needed.
         </p>
 
-<pre><code>"C:\Program Files\Graywolf\graywolf.exe" ^
-  -config "C:\ProgramData\Graywolf\graywolf.db" ^
-  auth set-password --user admin</code></pre>
+        <p>
+          If you prefer the command line, open a command prompt (or
+          PowerShell) and run the command below. The <code>auth</code>
+          subcommand must come <em>first</em>, before the <code>-config</code>
+          flag:
+        </p>
+
+<pre><code>"C:\Program Files\Graywolf\graywolf.exe" auth set-password --user admin ^
+  -config "C:\ProgramData\Graywolf\graywolf.db"</code></pre>
+
+        <p>
+          You&rsquo;ll be prompted to enter the password. The path is the
+          same config database the service runs with (see the NSSM command
+          above).
+        </p>
 
       </div>
 

--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -188,6 +188,8 @@ See [invariant 23](invariants.md) for the TX-gating contract.
 | Concern | File |
 |---|---|
 | `graywolf flare` CLI subcommand entry | `cmd/graywolf/flare.go` |
+| `graywolf auth {set-password,list-users,delete-user}` CLI | `cmd/graywolf/authcli/authcli.go` |
+| Subcommand dispatch (`auth`/`flare`/`version` must be `os.Args[1]`) | `cmd/graywolf/main.go` |
 | Diagnostic-flare orchestration (`Collect`, `Options`) | `pkg/diagcollect/collect.go` |
 | Flare DB discovery (graywolf.db) | `pkg/diagcollect/dbpath.go` |
 | Modem locator + listing exec helper | `pkg/diagcollect/modem.go` |

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1376,3 +1376,22 @@ Source: [`../../pkg/beacon/scheduler.go`](../../pkg/beacon/scheduler.go)
 [`../../web/src/lib/trackerBeacon.js`](../../web/src/lib/trackerBeacon.js),
 [`../../web/src/routes/Beacons.svelte`](../../web/src/routes/Beacons.svelte)
 (`ensureSmartBeaconEnabled`).
+
+### 56. CLI subcommands must be the first argument, before any flags
+
+*Why:* `cmd/graywolf/main.go` dispatches on `os.Args[1]` only — `auth`,
+`flare`, and `version` are recognized solely in that position. Anything else
+falls through to the daemon's flag parser (`pkg/app/flags.go`). So
+`graywolf -config X auth set-password` does NOT run the auth subcommand: the
+parser consumes `-config X` and reports the trailing `auth ...` as leftover
+positional arguments. The working order is subcommand first, flags after:
+`graywolf auth set-password --user admin -config X`. `flags.go` detects a known
+subcommand landing in the leftover positionals and returns a hint pointing at
+the correct order; keep that list in sync with the `main.go` dispatch switch if
+you add a subcommand. All operator docs must show the subcommand-first order.
+
+Source: [`../../cmd/graywolf/main.go`](../../cmd/graywolf/main.go)
+(dispatch switch),
+[`../../pkg/app/flags.go`](../../pkg/app/flags.go)
+(leftover-positional hint),
+[`../../cmd/graywolf/authcli/authcli.go`](../../cmd/graywolf/authcli/authcli.go).

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1387,8 +1387,10 @@ parser consumes `-config X` and reports the trailing `auth ...` as leftover
 positional arguments. The working order is subcommand first, flags after:
 `graywolf auth set-password --user admin -config X`. `flags.go` detects a known
 subcommand landing in the leftover positionals and returns a hint pointing at
-the correct order; keep that list in sync with the `main.go` dispatch switch if
-you add a subcommand. All operator docs must show the subcommand-first order.
+the correct order, using the `app.Subcommands` list (the single source of
+truth). If you add a subcommand, add a `case` to the `main.go` dispatch switch
+AND an entry to `app.Subcommands`. All operator docs must show the
+subcommand-first order.
 
 Source: [`../../cmd/graywolf/main.go`](../../cmd/graywolf/main.go)
 (dispatch switch),

--- a/pkg/app/flags.go
+++ b/pkg/app/flags.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // ParseFlags parses the graywolf command-line flags (everything after
@@ -63,6 +64,18 @@ func parseFlagsTo(args []string, w io.Writer) (Config, error) {
 		return Config{}, fmt.Errorf("parse flags: %w", err)
 	}
 	if leftover := fs.Args(); len(leftover) > 0 {
+		// A subcommand placed after a global flag (e.g.
+		// `graywolf -config X auth set-password`) stops flag parsing and
+		// lands here as a positional argument. The dispatch shim only
+		// recognizes a subcommand as os.Args[1], so point the user at the
+		// correct order rather than the opaque "unexpected positional
+		// arguments" message.
+		switch leftover[0] {
+		case "auth", "flare", "version":
+			return Config{}, fmt.Errorf(
+				"%q is a subcommand and must come first, before any flags; for example: graywolf %s -config %s",
+				leftover[0], strings.Join(leftover, " "), cfg.DBPath)
+		}
 		return Config{}, fmt.Errorf("unexpected positional arguments: %v", leftover)
 	}
 	// Derive tile-cache-dir from --config's parent dir when --config was

--- a/pkg/app/flags.go
+++ b/pkg/app/flags.go
@@ -9,6 +9,24 @@ import (
 	"strings"
 )
 
+// Subcommands lists the CLI subcommands the dispatch shim in
+// cmd/graywolf/main.go recognizes as os.Args[1]. It is the single source
+// of truth: keep it in sync with main.go's dispatch switch when adding a
+// subcommand, so ParseFlags can recognize a misplaced subcommand and hint
+// at the correct argument order.
+var Subcommands = []string{"auth", "flare", "version"}
+
+// IsSubcommand reports whether name is one of the recognized CLI
+// subcommands (see Subcommands).
+func IsSubcommand(name string) bool {
+	for _, s := range Subcommands {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
 // ParseFlags parses the graywolf command-line flags (everything after
 // the program name, i.e. os.Args[1:]) into a Config. It uses a fresh
 // flag.FlagSet in ContinueOnError mode so callers get real errors
@@ -70,8 +88,7 @@ func parseFlagsTo(args []string, w io.Writer) (Config, error) {
 		// recognizes a subcommand as os.Args[1], so point the user at the
 		// correct order rather than the opaque "unexpected positional
 		// arguments" message.
-		switch leftover[0] {
-		case "auth", "flare", "version":
+		if IsSubcommand(leftover[0]) {
 			return Config{}, fmt.Errorf(
 				"%q is a subcommand and must come first, before any flags; for example: graywolf %s -config %s",
 				leftover[0], strings.Join(leftover, " "), cfg.DBPath)

--- a/pkg/app/flags_test.go
+++ b/pkg/app/flags_test.go
@@ -139,6 +139,11 @@ func TestParseFlagsErrors(t *testing.T) {
 			args:    []string{"oops"},
 			wantErr: "unexpected positional",
 		},
+		{
+			name:    "subcommand after flag",
+			args:    []string{"-config", "/data/graywolf.db", "auth", "set-password", "--user", "admin"},
+			wantErr: "is a subcommand and must come first",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

A Windows user (xray N4XRY) followed the install docs and ran:

```
"C:\Program Files\Graywolf\graywolf.exe" -config "C:\ProgramData\Graywolf\graywolf.db" auth set-password --user admin
error: unexpected positional arguments: [auth set-password --user admin]
```

The documented command does not parse. Root cause: `cmd/graywolf/main.go` only recognizes a subcommand when it is `os.Args[1]`. With `-config` placed first, the `auth` token never matches the dispatch switch and falls through to the daemon flag parser (`pkg/app/flags.go`), which parses `-config X` and then rejects the trailing `auth ...` as unexpected positional arguments. The Windows docs showed the flags in the wrong order; the Linux docs already had it right (subcommand first).

## Changes

- **Windows docs** (`installation.html`): corrected to subcommand-first order (`graywolf.exe auth set-password --user admin -config ...`), and documented the web UI first-run **Create Admin Account** flow as the simpler, no-CLI path the user eventually found.
- **CLI hint** (`pkg/app/flags.go`): when a known subcommand (`auth`/`flare`/`version`) lands in the leftover positionals, return a message showing the correct invocation instead of the opaque "unexpected positional arguments" error. Test added.
- **Wiki**: recorded the subcommand-position invariant and the `authcli` entry in `code-map.md` / `invariants.md`.

## Testing

`go build ./...`, `go vet`, and `go test ./pkg/app/ -run TestParseFlags` all pass.