### PR TITLE
Show APRS-IS-only beacons on the local map (#438)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1397,3 +1397,41 @@ Source: [`../../cmd/graywolf/main.go`](../../cmd/graywolf/main.go)
 [`../../pkg/app/flags.go`](../../pkg/app/flags.go)
 (leftover-positional hint),
 [`../../cmd/graywolf/authcli/authcli.go`](../../cmd/graywolf/authcli/authcli.go).
+
+### 57. A station's own beacon reaches the map via the TX path, so every transmit leg must feed the station cache
+
+*Why:* The Live Map plots stations from the `stationcache`, and the only
+thing that puts the *local* station's own beacon into that cache is the
+transmit side re-extracting the frame it just sent — there is no RX copy of
+your own beacon (APRS-IS does not echo self-originated traffic back, and the
+iGate's local-origin suppression would drop it if it did). A beacon has two
+independent transmit legs, and **each leg owns its own cache feed**:
+
+- *RF leg* → `pkg/app/wiring.go` governor TX hook (`source.Kind == "beacon"`)
+  re-parses the frame as it hits the air and calls
+  `stationcache.ExtractEntry(pkt, "beacon", "TX", channel)`.
+- *APRS-IS leg* → `beacon.Options.OnISSent` (wired in the same spot) does the
+  identical extract after a successful `isSink.SendLine`. The scheduler fires
+  it from `sendBeaconWith` only on IS-send success.
+
+The IS leg bypasses the governor entirely (`sendRF := b.SendPath !=
+SendPathISOnly`), so it never reaches the RF TX hook. Before #438 only the RF
+hook existed, so an `is_only` beacon — the natural config for a radioless or
+RX-only iGate — was logged and reached aprs.fi but **never plotted on the
+local map** (the "my position" GPS marker is a separate path and is *not* a
+substitute). graywolf GitHub #438.
+
+*How to apply:* if you add a third transmit destination, or split/rename the
+send legs, wire a station-cache feed for it too — the map's view of your own
+station is exactly the set of legs that re-extract. The `"both"` path
+deliberately double-feeds (RF hook *and* OnISSent); that is harmless because
+`MemCache.Update` collapses same-fix copies (invariant #54). Use `dir == "TX"`
+for both legs so the fix keeps `rfRank` 0 (our own transmission, never
+counted as RF-reachability evidence).
+
+Source: [`../../pkg/beacon/scheduler.go`](../../pkg/beacon/scheduler.go)
+(`sendBeaconWith` IS leg, `Options.OnISSent`),
+[`../../pkg/app/wiring.go`](../../pkg/app/wiring.go)
+(governor TX hook + `OnISSent` wiring),
+[`../../pkg/beacon/scheduler_test.go`](../../pkg/beacon/scheduler_test.go)
+(`TestOnISSent_FiresForISOnly`, `TestOnISSent_NotFiredForRFOnly`).

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -593,6 +593,24 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 		Observer:     &beaconObserver{m: a.metrics},
 		Version:      a.cfg.Version,
 		ChannelModes: a.store, // *configstore.Store satisfies ChannelModeLookup
+		// IS-leg counterpart of the governor TX hook above (wiring.go ~498):
+		// feed our own beacon position into the station cache so an
+		// APRS-IS-only beacon (radioless / RX-only iGate) plots on the local
+		// map, not just aprs.fi (graywolf#438). The RF leg is covered by the
+		// governor hook; this covers the leg that never touches the governor.
+		OnISSent: func(frame *ax25.Frame, channel uint32) {
+			if frame == nil || !frame.IsUI() {
+				return
+			}
+			pkt, err := aprs.Parse(frame)
+			if err != nil || pkt == nil {
+				return
+			}
+			pkt.Channel = int(channel)
+			if entries := stationcache.ExtractEntry(pkt, "beacon", "TX", channel); len(entries) > 0 {
+				a.stationCache.Update(entries)
+			}
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("beacon scheduler init: %w", err)

--- a/pkg/beacon/scheduler.go
+++ b/pkg/beacon/scheduler.go
@@ -53,6 +53,7 @@ type Scheduler struct {
 	maxFires     int
 	workers      chan struct{} // counting semaphore sized to maxFires
 	channelModes configstore.ChannelModeLookup
+	onISSent     func(frame *ax25.Frame, channel uint32)
 
 	mu       sync.Mutex
 	beacons  []Config
@@ -79,6 +80,14 @@ type Options struct {
 	// does-anything behavior). Lookup errors are silently ignored
 	// (fail-open): a DB failure does not suppress beaconing.
 	ChannelModes configstore.ChannelModeLookup
+	// OnISSent fires after a beacon frame is successfully uploaded to
+	// APRS-IS. It is the IS-leg counterpart of the governor's RF TX hook,
+	// which is what feeds a station's own beacon position into the station
+	// cache so it plots on the local map. Without it an APRS-IS-only
+	// beacon (a radioless / RX-only iGate) never enters the cache and the
+	// station is invisible on the map even though aprs.fi shows it
+	// (graywolf#438). nil = no-op.
+	OnISSent func(frame *ax25.Frame, channel uint32)
 }
 
 // New constructs a Scheduler.
@@ -110,6 +119,7 @@ func New(opts Options) (*Scheduler, error) {
 		workers:      make(chan struct{}, maxFires),
 		reloadCh:     make(chan struct{}, 1),
 		channelModes: opts.ChannelModes,
+		onISSent:     opts.OnISSent,
 	}, nil
 }
 
@@ -474,6 +484,12 @@ func (s *Scheduler) sendBeaconWith(ctx context.Context, b Config, skipDedup bool
 			} else {
 				s.logger.Info("beacon sent to aprs-is", "id", b.ID, "send_path", b.SendPath, "line", line)
 				sent = true
+				// Feed our own position into the station cache so an
+				// APRS-IS-only beacon plots on the local map, mirroring the
+				// RF leg's governor TX hook (graywolf#438).
+				if s.onISSent != nil {
+					s.onISSent(frame, b.Channel)
+				}
 			}
 		}
 	}

--- a/pkg/beacon/scheduler_test.go
+++ b/pkg/beacon/scheduler_test.go
@@ -731,3 +731,59 @@ func TestBeaconISLine_UsesTCPIP(t *testing.T) {
 		t.Errorf("IS line must not carry the RF digipeater path; got %q", line)
 	}
 }
+
+// TestOnISSent_FiresForISOnly is the graywolf#438 regression: an
+// APRS-IS-only beacon never touches the governor (RF) sink, so the
+// governor's RF TX hook — the thing that feeds a station's own position
+// into the station cache — never runs. The OnISSent hook is the IS-leg
+// counterpart; without it the station is invisible on the local map even
+// though aprs.fi shows it. It must fire once, carry a UI frame, and report
+// the beacon's channel.
+func TestOnISSent_FiresForISOnly(t *testing.T) {
+	sink := newMockSink(0)
+	is := &fakeISSink{}
+	logger := slog.New(slog.NewTextHandler(logSink{}, nil))
+	var gotFrames []*ax25.Frame
+	var gotChannels []uint32
+	s, err := New(Options{
+		Sink: sink, ISSink: is, Logger: logger,
+		OnISSent: func(frame *ax25.Frame, channel uint32) {
+			gotFrames = append(gotFrames, frame)
+			gotChannels = append(gotChannels, channel)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := mkPathBeacon(SendPathISOnly)
+	b.Channel = 3
+	s.sendBeacon(context.Background(), b)
+
+	if len(gotFrames) != 1 {
+		t.Fatalf("OnISSent fired %d times, want 1", len(gotFrames))
+	}
+	if gotFrames[0] == nil || !gotFrames[0].IsUI() {
+		t.Errorf("OnISSent frame = %v, want a non-nil UI frame", gotFrames[0])
+	}
+	if gotChannels[0] != 3 {
+		t.Errorf("OnISSent channel = %d, want 3", gotChannels[0])
+	}
+}
+
+// TestOnISSent_NotFiredForRFOnly proves the hook is gated on the IS leg
+// actually running: an RF-only beacon must not invoke OnISSent (its
+// position reaches the cache through the governor TX hook instead).
+func TestOnISSent_NotFiredForRFOnly(t *testing.T) {
+	sink := newMockSink(1)
+	is := &fakeISSink{}
+	logger := slog.New(slog.NewTextHandler(logSink{}, nil))
+	fired := 0
+	s, _ := New(Options{
+		Sink: sink, ISSink: is, Logger: logger,
+		OnISSent: func(*ax25.Frame, uint32) { fired++ },
+	})
+	s.sendBeacon(context.Background(), mkPathBeacon(SendPathRF))
+	if fired != 0 {
+		t.Fatalf("OnISSent fired %d times for RF-only beacon, want 0", fired)
+	}
+}


### PR DESCRIPTION
Fixes #438.

## Problem

After reverting an iGate from RX/TX back to RX-only (beaconing to APRS-IS only), the operator's own beacon stopped appearing on the local Live Map, even though it was still logged in Graywolf and showed correctly on aprs.fi.

## Root cause

A station's own beacon position only ever reached the Live Map's station cache through the **RF transmit path**. The governor TX hook in `pkg/app/wiring.go` re-extracts each frame as it hits the air and feeds it into the station cache via `stationcache.ExtractEntry(pkt, "beacon", "TX", channel)`.

An **APRS-IS-only** beacon (`send_path = is_only`, the natural config for a radioless or RX-only iGate) bypasses the governor entirely — `sendRF := b.SendPath != SendPathISOnly` — so it never reaches that RF TX hook. There is no RX copy of your own beacon to fall back on: APRS-IS does not echo self-originated traffic, and the iGate's local-origin suppression would drop it if it did. So the beacon was logged (via `beaconISSink`) and uploaded to APRS-IS, but never entered the cache the map draws from. The "my position" GPS marker is a separate path and is not a substitute.

## Fix

Give the APRS-IS leg its own station-cache feed, mirroring the RF leg:

- `pkg/beacon/scheduler.go` — new `Options.OnISSent` hook, fired from `sendBeaconWith` only on a **successful** APRS-IS send.
- `pkg/app/wiring.go` — wires `OnISSent` to the same `stationcache.ExtractEntry`/`Update` the RF TX hook already uses.

Notes:
- Both legs use `dir == "TX"`, so the fix keeps `rfRank` 0 (our own transmission is never miscounted as RF-reachability evidence, and the "RF Only" filter — which excludes TX entries by direction — is unaffected).
- The `both` path now double-feeds (RF hook + `OnISSent`); this is harmless because `MemCache.Update` collapses same-fix copies.

## Tests / docs

- Added `TestOnISSent_FiresForISOnly` (the regression) and `TestOnISSent_NotFiredForRFOnly`.
- `go build` / `go vet` clean; full `pkg/beacon` and `pkg/app` suites pass; `gofmt` clean.
- Documented the rule as invariant #57 in the wiki: a station's own beacon reaches the map via the transmit path, so every transmit leg must feed the station cache.
