### PR TITLE
fix(kiss): decode frames sharing a single FEND delimiter

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1429,6 +1429,35 @@ deliberately double-feeds (RF hook *and* OnISSent); that is harmless because
 for both legs so the fix keeps `rfRank` 0 (our own transmission, never
 counted as RF-reachability evidence).
 
+### 58. KISS FEND is a frame delimiter: the decoder syncs once, then never discards frame bytes
+
+`kiss.Decoder` (`pkg/kiss/framing.go`) discards leading bytes only until the
+**first** FEND on a stream (`synced` flag) — that handles a TNC text banner or
+a mid-stream connect. After that first delimiter it never discards again: the
+byte immediately following a frame's closing FEND is the *start of the next
+frame*, and the read loop's `len(buf)==0` skip absorbs any run of delimiters
+(leading FENDs, empty frames, a shared single FEND between back-to-back
+frames).
+
+*Why:* KISS FEND (0xC0) is a delimiter, not a per-frame wrapper. Real TNCs vary:
+some send `C0 <frame> C0 C0 <frame> C0` (double FEND), some share one FEND
+(`C0 f1 C0 f2 C0`), and some emit only a trailing FEND per frame with no
+leading FEND at all. The original decoder re-ran "skip until the next FEND" on
+every `Next()` call, so after emitting a frame it threw away the following
+frame's bytes while hunting for a leading FEND that shared/trailing-only TNCs
+never send — silent RX loss (every-other frame, or effectively all frames when
+packets arrive with idle gaps). This was the "connects fine but sees no
+packets" report against the tcp-client path; the server/serial paths share the
+same decoder and had the same latent bug. Only the first pre-sync frame in
+trailing-FEND-only framing is (unavoidably) lost.
+
+*How to apply:* do not reintroduce a discard-until-FEND step that runs per
+frame. Regression guards: `TestDecodeSharedDelimiter`, `TestDecodeTrailingFendOnly`,
+`TestDecodeMultipleFrames`, `TestDecodeSkipsLeadingFends` in
+[`../../pkg/kiss/framing_test.go`](../../pkg/kiss/framing_test.go).
+
+Source: [`../../pkg/kiss/framing.go`](../../pkg/kiss/framing.go) (`Decoder.synced`, `Decoder.Next`).
+
 Source: [`../../pkg/beacon/scheduler.go`](../../pkg/beacon/scheduler.go)
 (`sendBeaconWith` IS leg, `Options.OnISSent`),
 [`../../pkg/app/wiring.go`](../../pkg/app/wiring.go)

--- a/pkg/kiss/framing.go
+++ b/pkg/kiss/framing.go
@@ -83,6 +83,12 @@ type Decoder struct {
 	br *bufio.Reader
 	// Max payload size; frames larger than this return an error.
 	MaxFrame int
+	// synced becomes true once the first FEND on the stream has been
+	// seen. Until then we discard leading bytes (a TNC's pre-KISS text
+	// banner, or a partial frame from a mid-stream connect) to find the
+	// first delimiter. After sync we never discard frame bytes again —
+	// see Next for why.
+	synced bool
 }
 
 // NewDecoder wraps r in a buffered KISS decoder. MaxFrame defaults to 4096.
@@ -93,14 +99,30 @@ func NewDecoder(r io.Reader) *Decoder {
 // Next reads the next complete frame. Returns io.EOF when the underlying
 // reader is exhausted cleanly.
 func (d *Decoder) Next() (*Frame, error) {
-	// Skip leading FENDs and any stray bytes until we see a FEND.
-	for {
-		b, err := d.br.ReadByte()
-		if err != nil {
-			return nil, err
-		}
-		if b == FEND {
-			break
+	// Initial sync only: discard leading bytes until the first FEND on
+	// the stream. This handles a TNC that emits a text banner before
+	// entering KISS mode, or a mid-stream connect that lands us partway
+	// through a frame. It runs at most once per stream.
+	//
+	// It must NOT run on subsequent calls. FEND is a frame *delimiter*:
+	// the byte immediately after a frame's closing FEND is the start of
+	// the next frame. Many TNCs emit only a trailing FEND per frame (no
+	// per-frame leading FEND), or share a single FEND between back-to-back
+	// frames — re-discarding "until the next FEND" on every call would
+	// throw those frames away (silent RX loss; see TestDecodeSharedDelimiter
+	// and TestDecodeTrailingFendOnly). Once synced, the read loop below
+	// handles delimiter runs (empty frames / leading FENDs) via its
+	// len(buf)==0 skip.
+	if !d.synced {
+		for {
+			b, err := d.br.ReadByte()
+			if err != nil {
+				return nil, err
+			}
+			if b == FEND {
+				d.synced = true
+				break
+			}
 		}
 	}
 	// Now read until next FEND, unescaping as we go.

--- a/pkg/kiss/framing_test.go
+++ b/pkg/kiss/framing_test.go
@@ -74,6 +74,60 @@ func TestDecodeMultipleFrames(t *testing.T) {
 	}
 }
 
+// TestDecodeSharedDelimiter covers TNCs that place a single FEND
+// between back-to-back frames (C0 f1 C0 f2 C0) rather than a full
+// C0..C0 wrapper per frame. Every frame must decode: the byte after a
+// frame's closing FEND is the next frame's type byte, not junk to skip.
+func TestDecodeSharedDelimiter(t *testing.T) {
+	// FEND, then <type> data <type> data <type> data, FEND-separated.
+	var buf bytes.Buffer
+	buf.WriteByte(FEND)
+	for _, s := range []string{"one", "two", "three"} {
+		buf.WriteByte(0x00) // type: port 0, data frame
+		buf.WriteString(s)
+		buf.WriteByte(FEND)
+	}
+	d := NewDecoder(&buf)
+	for _, want := range []string{"one", "two", "three"} {
+		f, err := d.Next()
+		if err != nil {
+			t.Fatalf("frame %q: %v", want, err)
+		}
+		if string(f.Data) != want {
+			t.Errorf("got %q want %q", f.Data, want)
+		}
+	}
+	if _, err := d.Next(); !errors.Is(err, io.EOF) {
+		t.Errorf("expected EOF, got %v", err)
+	}
+}
+
+// TestDecodeTrailingFendOnly covers TNCs that emit only a trailing FEND
+// per frame with no leading FEND at all. The first frame (before any
+// delimiter) is unavoidably discarded while syncing on the first FEND;
+// every frame after that must decode.
+func TestDecodeTrailingFendOnly(t *testing.T) {
+	var buf bytes.Buffer
+	for _, s := range []string{"lost", "two", "three"} {
+		buf.WriteByte(0x00)
+		buf.WriteString(s)
+		buf.WriteByte(FEND)
+	}
+	d := NewDecoder(&buf)
+	for _, want := range []string{"two", "three"} {
+		f, err := d.Next()
+		if err != nil {
+			t.Fatalf("frame %q: %v", want, err)
+		}
+		if string(f.Data) != want {
+			t.Errorf("got %q want %q", f.Data, want)
+		}
+	}
+	if _, err := d.Next(); !errors.Is(err, io.EOF) {
+		t.Errorf("expected EOF, got %v", err)
+	}
+}
+
 func TestDecodeInvalidEscape(t *testing.T) {
 	raw := []byte{FEND, 0x00, FESC, 0x99, FEND}
 	d := NewDecoder(bytes.NewReader(raw))


### PR DESCRIPTION
## Problem

A user running Graywolf as a KISS TNC client (tcp-client), dialing a real hardware TNC over the network, reported receiving no packets — while other apps connected to the same TNC saw traffic fine. This is a recurring "connects fine but no packets" report.

## Root cause

`kiss.Decoder.Next()` ran a "skip bytes until the next FEND" resync at the top of **every** call. But FEND (0xC0) is a frame *delimiter*, not a per-frame wrapper — the byte immediately after a frame's closing FEND is the start of the next frame.

The decoder only worked for TNCs that wrap every frame `C0 <frame> C0` (a leading FEND per frame). TNCs that instead:

- share a single FEND between back-to-back frames (`C0 f1 C0 f2 C0`), or
- emit only a trailing FEND per frame (no leading FEND),

had their frames thrown away: after emitting one frame (and consuming its trailing FEND), the next `Next()` discarded the following frame's bytes while hunting for a leading FEND that never comes. Result: every-other frame lost, or effectively *all* frames when packets arrive with idle gaps between them.

The server-listen and serial paths share the same decoder and had the same latent bug; it just surfaced most visibly on the newer tcp-client-to-real-TNC path.

## Fix

Sync on the **first** FEND once per stream (still discards a TNC text banner or a mid-stream-connect partial frame), then never discard frame bytes again. The read loop's existing empty-frame skip (`len(buf)==0 → continue`) already absorbs leading FENDs, empty frames, and shared delimiters. Only the first pre-sync frame in trailing-FEND-only framing is unavoidably lost (standard KISS sync behavior).

## Tests

- `TestDecodeSharedDelimiter` — three frames sharing one FEND each → all decode.
- `TestDecodeTrailingFendOnly` — trailing-FEND-only stream → first (pre-sync) frame lost, rest decode.
- Existing `TestDecodeMultipleFrames`, `TestDecodeSkipsLeadingFends`, round-trip and escape tests still pass.

`go test ./pkg/kiss/...` and `./pkg/app/...` green; `go build ./...` and `go vet ./pkg/kiss/...` clean.

Wiki: added invariant #58 documenting the FEND-delimiter contract so this isn't reintroduced.
