### PR TITLE
Stop steering SignaLink USB users to serial PTT (GH #451)

### DIFF
--- a/docs/handbook/ptt.html
+++ b/docs/handbook/ptt.html
@@ -235,6 +235,23 @@
       </div>
     </div>
 
+    <div class="callout info">
+      <span class="callout-icon">&#9432;</span>
+      <div class="callout-body">
+        <p>
+          <strong>SignaLink USB users:</strong> this is your PTT method. The
+          SignaLink USB has no serial port &mdash; it presents only a USB
+          sound card and keys the radio with its own internal VOX circuit.
+          It will therefore never appear in the <code>serial_rts</code> or
+          <code>serial_dtr</code> device list. Select <code>vox</code>, leave
+          the PTT device unset, and set the SignaLink's front-panel
+          <code>DLY</code> (delay) knob short enough that it releases between
+          packets. Graywolf's 500&nbsp;ms lead-in tone drives the SignaLink's
+          VOX directly, so no radio-side VOX setting is required.
+        </p>
+      </div>
+    </div>
+
     <h2 id="digirig-tone-ptt">Digirig Lite Tone PTT</h2>
 
     <p>
@@ -301,8 +318,12 @@
 
     <p>
       Serial RTS or DTR is the most common PTT method. The modem asserts
-      the chosen pin when transmitting and de-asserts it when done. Most
-      USB sound card interfaces (Digirig, SignaLink USB) use this approach.
+      the chosen pin when transmitting and de-asserts it when done. Many
+      USB interfaces use this approach, including the Digirig Mobile and
+      plain FTDI / CP210x / CH340 USB-serial cables. The
+      <strong>SignaLink USB is not one of them</strong> &mdash; it has no
+      serial port and keys the radio with its own VOX circuit
+      (see <a href="#vox-ptt">VOX PTT</a>).
     </p>
 
 <pre><code># Find your serial device

--- a/pkg/pttdevice/usb_devices.go
+++ b/pkg/pttdevice/usb_devices.go
@@ -59,7 +59,7 @@ var knownUSBDevices = []usbDevice{
 	{VID: "0403", PID: "6014", Name: "FTDI FT232H USB-Serial", LikelyPTT: true},
 	{VID: "0403", PID: "6015", Name: "FTDI FT-X USB-Serial", LikelyPTT: true},
 	{VID: "067b", PID: "2303", Name: "Prolific PL2303 USB-Serial", LikelyPTT: true},
-	{VID: "10c4", PID: "ea60", Name: "CP2102 USB-Serial (SignaLink, Digirig)", LikelyPTT: true},
+	{VID: "10c4", PID: "ea60", Name: "CP2102 USB-Serial (Digirig)", LikelyPTT: true},
 	{VID: "10c4", PID: "ea70", Name: "CP2105 Dual USB-Serial", LikelyPTT: true},
 
 	// Known-but-not-PTT: dev boards. Named so Detect Devices shows what

--- a/pkg/pttdevice/usb_devices_test.go
+++ b/pkg/pttdevice/usb_devices_test.go
@@ -51,7 +51,7 @@ func TestLookupUSB(t *testing.T) {
 		{
 			name:          "CP2102 is a likely PTT serial chipset",
 			vid:           "10c4", pid: "ea60",
-			wantName:      "CP2102 USB-Serial (SignaLink, Digirig)",
+			wantName:      "CP2102 USB-Serial (Digirig)",
 			wantLikelyPTT: true,
 		},
 		{


### PR DESCRIPTION
## Problem

GitHub issue #451: a SignaLink USB user finds the device under Audio Devices but not under serial-RTS PTT, and sees only an unhelpful list of unidentifiable `tty` devices.

Root cause is not a bug in enumeration -- it's a category error the docs/labels invited. The **SignaLink USB has no serial port**. It presents only a USB sound card and keys the radio with an internal VOX circuit driven by transmit audio ([Tigertronics FAQ](https://tigertronics.com/slusbfaq.htm): "the SignaLink NEVER uses a serial port"). So it can never appear in the serial-RTS/DTR device list, and no package will make it.

Two places in graywolf implied the opposite and would have led the user straight to serial RTS:

- `pkg/pttdevice/usb_devices.go` labeled the CP2102 chipset (`10c4:ea60`) as `CP2102 USB-Serial (SignaLink, Digirig)`. The CP2102 is the **Digirig Mobile's** chip; the SignaLink USB contains none and exposes no `/dev/tty*`.
- The handbook Serial PTT section listed "SignaLink USB" as a serial-RTS interface.

## Changes

- Drop `SignaLink` from the CP2102 device name (and its test assertion).
- Correct the handbook Serial PTT section, and add a VOX-section callout telling SignaLink users to select the `vox` method with no PTT device -- the only way to key a SignaLink from graywolf.

The correct operator answer: set the channel's PTT method to **VOX**, leave the device unset, and set the SignaLink's front-panel DLY knob short. Graywolf's 500 ms lead-in tone drives the SignaLink VOX directly.