### PR TITLE
Per-conversation send path & resend control (#453)

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -159,6 +159,20 @@ The split is enforced by [invariant 9](invariants.md).
 
 See [invariant 23](invariants.md) for the TX-gating contract.
 
+## Per-conversation message routing (issue #453)
+
+Overrides the global `MessagePreferences` on a single DM/tactical thread,
+set from the gear popover in the message thread header. Two knobs; a
+thread inherits the global defaults until the operator changes one.
+
+| Concern | Where |
+|---|---|
+| Storage | `pkg/configstore/models.go` — `ConversationPrefs` (unique on `thread_kind`+`thread_key`; `SendPath` `''`/`rf_only`/`is_only`/`both`, `WaitForAck` bool **with no gorm default** — a `default:true` bool would be dropped from INSERT when false, silently re-enabling resend). CRUD in `messages.go`; registered in `store.go` AutoMigrate. Sparse: `UpsertConversationPrefs` deletes the row when both fields are default. |
+| Send-time apply | `pkg/messages/service.go` — `SendMessage` looks up prefs by `(kind, To)`, stamps `Message.SendPath` (new column, `models.go`) for retry fidelity, uses it as the initial-dispatch policy, and skips retry enrollment when `WaitForAck=false` (no-ACK contact → sent once). One-shot `req.FallbackPolicyOverride` still wins for the initial send but is not persisted. |
+| Retry apply | `pkg/messages/retry.go` — `retryOne`/`Resend` route via `SendWithPolicy(cur, cur.SendPath)` so an `rf_only` contact never leaks onto APRS-IS on retry. |
+| REST | `webapi/messages.go` — GET/PUT `/api/messages/conversations/{kind}/{key}/prefs`; DTO + validation in `webapi/dto/messages.go`. GET returns inherited defaults (not 404) for an unset thread. |
+| UI | `web/src/components/messages/ConversationRoutingMenu.svelte` (gear popover: send-path radios + "Automatic Resend until ACK" checkbox, DM only), mounted in `ThreadHeader.svelte`; client in `api/messages.js`. |
+
 ### Channel TX test signal
 
 | Surface | Where |

--- a/pkg/configstore/conversation_prefs_test.go
+++ b/pkg/configstore/conversation_prefs_test.go
@@ -1,0 +1,96 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+)
+
+// TestConversationPrefs_GetMissingReturnsNil asserts the common case:
+// a conversation with no override row returns (nil, nil) so callers can
+// fall back to the global defaults without special-casing an error.
+func TestConversationPrefs_GetMissingReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	got, err := s.GetConversationPrefs(ctx, "dm", "W5XYZ")
+	if err != nil {
+		t.Fatalf("GetConversationPrefs: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for missing row, got %+v", got)
+	}
+}
+
+// TestConversationPrefs_UpsertRoundTrips writes an override and reads it
+// back, then updates it in place (no duplicate row).
+func TestConversationPrefs_UpsertRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	if err := s.UpsertConversationPrefs(ctx, &ConversationPrefs{
+		ThreadKind: "dm", ThreadKey: "W5XYZ", SendPath: "rf_only", WaitForAck: true,
+	}); err != nil {
+		t.Fatalf("UpsertConversationPrefs: %v", err)
+	}
+	got, err := s.GetConversationPrefs(ctx, "dm", "W5XYZ")
+	if err != nil || got == nil {
+		t.Fatalf("GetConversationPrefs: got=%+v err=%v", got, err)
+	}
+	if got.SendPath != "rf_only" || !got.WaitForAck {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	// Update in place — WaitForAck off (no-ack contact).
+	if err := s.UpsertConversationPrefs(ctx, &ConversationPrefs{
+		ThreadKind: "dm", ThreadKey: "W5XYZ", SendPath: "rf_only", WaitForAck: false,
+	}); err != nil {
+		t.Fatalf("update UpsertConversationPrefs: %v", err)
+	}
+	var count int64
+	if err := s.db.WithContext(ctx).Model(&ConversationPrefs{}).
+		Where("thread_kind = ? AND thread_key = ?", "dm", "W5XYZ").
+		Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 row after update, got %d", count)
+	}
+	got, _ = s.GetConversationPrefs(ctx, "dm", "W5XYZ")
+	if got.WaitForAck {
+		t.Fatalf("expected WaitForAck=false after update, got %+v", got)
+	}
+}
+
+// TestConversationPrefs_UpsertDefaultsDeletesRow verifies the
+// sparse-table contract: writing the default state (inherit send path +
+// resend on) removes any existing override row so the table only holds
+// customized conversations.
+func TestConversationPrefs_UpsertDefaultsDeletesRow(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	if err := s.UpsertConversationPrefs(ctx, &ConversationPrefs{
+		ThreadKind: "dm", ThreadKey: "W5XYZ", SendPath: "is_only", WaitForAck: true,
+	}); err != nil {
+		t.Fatalf("seed override: %v", err)
+	}
+	// Reset to defaults.
+	if err := s.UpsertConversationPrefs(ctx, &ConversationPrefs{
+		ThreadKind: "dm", ThreadKey: "W5XYZ", SendPath: "", WaitForAck: true,
+	}); err != nil {
+		t.Fatalf("reset to defaults: %v", err)
+	}
+	got, err := s.GetConversationPrefs(ctx, "dm", "W5XYZ")
+	if err != nil {
+		t.Fatalf("GetConversationPrefs: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected row deleted on reset-to-defaults, got %+v", got)
+	}
+	// Resetting a non-existent conversation is a no-op, not an error.
+	if err := s.UpsertConversationPrefs(ctx, &ConversationPrefs{
+		ThreadKind: "dm", ThreadKey: "NOPE", SendPath: "", WaitForAck: true,
+	}); err != nil {
+		t.Fatalf("reset of missing row should be a no-op: %v", err)
+	}
+}

--- a/pkg/configstore/messages.go
+++ b/pkg/configstore/messages.go
@@ -66,6 +66,51 @@ func (s *Store) seedMessagePreferences(ctx context.Context) error {
 }
 
 // ---------------------------------------------------------------------------
+// ConversationPrefs (per-thread overrides)
+// ---------------------------------------------------------------------------
+
+// GetConversationPrefs returns the override row for one thread, or
+// (nil, nil) when none exists (the common case — most conversations
+// inherit the global defaults, so no row is written). Callers treat a
+// nil result as "SendPath inherit, WaitForAck true". Kind/key are
+// matched exactly; callers normalize key to uppercase before calling.
+func (s *Store) GetConversationPrefs(ctx context.Context, kind, key string) (*ConversationPrefs, error) {
+	var c ConversationPrefs
+	err := s.db.WithContext(ctx).
+		Where("thread_kind = ? AND thread_key = ?", kind, key).
+		First(&c).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// UpsertConversationPrefs stores the override row for (kind, key),
+// adopting the existing row's ID when one is present so Save updates in
+// place rather than inserting a duplicate. When the incoming prefs carry
+// only default values (inherit SendPath + WaitForAck true), any existing
+// row is deleted instead so the table stays sparse.
+func (s *Store) UpsertConversationPrefs(ctx context.Context, cfg *ConversationPrefs) error {
+	existing, err := s.GetConversationPrefs(ctx, cfg.ThreadKind, cfg.ThreadKey)
+	if err != nil {
+		return err
+	}
+	if cfg.SendPath == "" && cfg.WaitForAck {
+		if existing != nil {
+			return s.db.WithContext(ctx).Delete(&ConversationPrefs{}, existing.ID).Error
+		}
+		return nil
+	}
+	if existing != nil {
+		cfg.ID = existing.ID
+	}
+	return s.db.WithContext(ctx).Save(cfg).Error
+}
+
+// ---------------------------------------------------------------------------
 // TacticalCallsign CRUD
 // ---------------------------------------------------------------------------
 

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -785,6 +785,14 @@ type Message struct {
 	IsBulletin     bool           `gorm:"not null;default:false" json:"is_bulletin"`
 	IsNWS          bool           `gorm:"column:is_nws;not null;default:false" json:"is_nws"`
 	PreferIS       bool           `gorm:"column:prefer_is;not null;default:false" json:"prefer_is"`
+	// SendPath is the effective per-message transport override stamped
+	// from the conversation's ConversationPrefs at send time. Empty ('')
+	// means "defer to the global MessagePreferences.FallbackPolicy".
+	// Persisted so retry re-attempts route the same way as the initial
+	// send — critical for "RF only" contacts, where a global fallback
+	// must never leak a local message onto APRS-IS on retry. Reuses the
+	// FallbackPolicy vocabulary (rf_only | is_only | both).
+	SendPath       string         `gorm:"column:send_path;size:16;not null;default:''" json:"send_path"`
 	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
 	ThreadKind     string         `gorm:"size:10;not null;default:'dm';index:idx_msg_thread,priority:1" json:"thread_kind"` // dm | tactical
 	ThreadKey      string         `gorm:"size:9;not null;default:'';index:idx_msg_thread,priority:2" json:"thread_key"`     // peer callsign for dm, tactical label for tactical
@@ -845,6 +853,40 @@ type MessagePreferences struct {
 	MaxMessageTextOverride uint32    `gorm:"not null;default:0" json:"max_message_text_override"`
 	CreatedAt              time.Time `json:"-"`
 	UpdatedAt              time.Time `json:"-"`
+}
+
+// ConversationPrefs holds per-conversation overrides for one message
+// thread, keyed by (ThreadKind, ThreadKey) — the same identity the
+// Message rows carry. A row exists only when the operator has changed a
+// default from the thread's Routing control; absence means "inherit the
+// global MessagePreferences." This keeps the table sparse (one row per
+// customized contact, not one per contact).
+//
+// Two independent knobs, matching the ThreadHeader popover:
+//   - SendPath: per-conversation transport override. Empty ('') defers
+//     to the global FallbackPolicy; otherwise one of rf_only | is_only |
+//     both. Answers issue #453's "keep my local radio messages off
+//     APRS-IS" — set a contact to rf_only and every message (including
+//     retries) stays on RF.
+//   - WaitForAck: when false, outbound DMs to this contact are sent once
+//     and NOT enrolled in the retry ladder. Answers #453's "some
+//     handhelds (e.g. TIDRadio TD-H9) never ACK" — disable re-sends for
+//     just that contact instead of burning airtime retrying a device
+//     that will never answer. Defaults true (normal ack-and-retry).
+type ConversationPrefs struct {
+	ID         uint32    `gorm:"primaryKey;autoIncrement" json:"-"`
+	ThreadKind string    `gorm:"size:10;not null;uniqueIndex:idx_convpref_thread,priority:1" json:"thread_kind"` // dm | tactical
+	ThreadKey  string    `gorm:"size:9;not null;uniqueIndex:idx_convpref_thread,priority:2" json:"thread_key"`   // peer callsign (dm) or tactical label
+	SendPath   string    `gorm:"size:16;not null;default:''" json:"send_path"`                                   // '' inherit | rf_only | is_only | both
+	// WaitForAck carries NO gorm default tag on purpose. A bool with
+	// `default:true` hits GORM's omit-zero-value-on-INSERT behavior:
+	// WaitForAck=false (a no-ACK contact — the whole point of the
+	// field) would be dropped from the INSERT and the DB default true
+	// would silently win. Every write path sets this field explicitly,
+	// so no DB-level default is needed.
+	WaitForAck bool      `gorm:"not null" json:"wait_for_ack"`
+	CreatedAt  time.Time `json:"-"`
+	UpdatedAt  time.Time `json:"-"`
 }
 
 // TacticalCallsign is one monitored tactical addressee label. Operators

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -162,6 +162,7 @@ func (s *Store) Migrate() error {
 		&Message{},
 		&MessageCounter{},
 		&MessagePreferences{},
+		&ConversationPrefs{},
 		&TacticalCallsign{},
 		&StationConfig{},
 		&UpdatesConfig{},

--- a/pkg/messages/retry.go
+++ b/pkg/messages/retry.go
@@ -177,7 +177,7 @@ func (r *RetryManager) Resend(ctx context.Context, id uint64) (SendResult, error
 	if err := r.cfg.Store.Update(ctx, row); err != nil {
 		return SendResult{}, err
 	}
-	result := r.cfg.Sender.Send(ctx, row)
+	result := r.cfg.Sender.SendWithPolicy(ctx, row, row.SendPath)
 	if result.Err == nil && result.Retryable && row.ThreadKind == ThreadKindDM {
 		// Re-enroll: schedule the next attempt per the backoff.
 		r.scheduleNext(ctx, row)
@@ -312,7 +312,10 @@ func (r *RetryManager) retryOne(ctx context.Context, row configstore.Message) {
 		return
 	}
 	cur.Attempts++
-	result := r.cfg.Sender.Send(ctx, cur)
+	// Route re-attempts via the row's stamped SendPath (empty defers to
+	// the global policy) so an "RF only" contact never leaks onto
+	// APRS-IS on retry. See configstore.ConversationPrefs / issue #453.
+	result := r.cfg.Sender.SendWithPolicy(ctx, cur, cur.SendPath)
 	if result.Err == nil {
 		// Submit accepted — schedule the next ack timeout.
 		r.scheduleNext(ctx, cur)

--- a/pkg/messages/retry.go
+++ b/pkg/messages/retry.go
@@ -178,11 +178,26 @@ func (r *RetryManager) Resend(ctx context.Context, id uint64) (SendResult, error
 		return SendResult{}, err
 	}
 	result := r.cfg.Sender.SendWithPolicy(ctx, row, row.SendPath)
-	if result.Err == nil && result.Retryable && row.ThreadKind == ThreadKindDM {
+	if result.Err == nil && result.Retryable && row.ThreadKind == ThreadKindDM && !r.suppressRetry(ctx, row) {
 		// Re-enroll: schedule the next attempt per the backoff.
 		r.scheduleNext(ctx, row)
 	}
 	return result, nil
+}
+
+// suppressRetry reports whether this conversation has opted out of the
+// ack-and-resend ladder (ConversationPrefs.WaitForAck=false — a no-ACK
+// contact). Mirrors the gate Service.SendMessage applies on the initial
+// send so a manual /resend on such a contact submits once without
+// re-arming the retry loop. A missing row or lookup error means "resend
+// normally" — the operator's explicit action should not be silently
+// dropped on a transient store hiccup.
+func (r *RetryManager) suppressRetry(ctx context.Context, row *configstore.Message) bool {
+	prefs, err := r.cfg.Store.GetConversationPrefs(ctx, row.ThreadKind, row.ThreadKey)
+	if err != nil || prefs == nil {
+		return false
+	}
+	return !prefs.WaitForAck
 }
 
 // CancelRetry clears NextRetryAt and removes the row from the

--- a/pkg/messages/retry_test.go
+++ b/pkg/messages/retry_test.go
@@ -37,6 +37,83 @@ func buildRetry(t *testing.T, policy string) *retryRig {
 	return &retryRig{senderRig: sr, mgr: mgr}
 }
 
+// TestRetry_HonorsStampedSendPath proves the anti-leak invariant: a row
+// stamped SendPath=rf_only stays on RF when retried, even though the
+// global policy is "both" (which would otherwise fan out to APRS-IS).
+// This is the core guarantee of issue #453 — an RF-only contact must
+// never leak a local message onto the internet on a retry.
+func TestRetry_HonorsStampedSendPath(t *testing.T) {
+	rig := buildRetry(t, FallbackPolicyBoth)
+	defer rig.close()
+	ctx := context.Background()
+
+	row := newOutboundDM(t, rig.senderRig, "N0CALL", "W1ABC", "local only")
+	row.SendPath = FallbackPolicyRFOnly
+	if err := rig.store.Update(ctx, row); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	rig.mgr.retryOne(ctx, *row)
+
+	if got := len(rig.sink.list()); got != 1 {
+		t.Errorf("RF submits = %d, want 1 (rf_only override on retry)", got)
+	}
+	if got := len(rig.igate.list()); got != 0 {
+		t.Errorf("IS lines = %d, want 0 — rf_only leaked onto APRS-IS on retry", got)
+	}
+}
+
+// TestResend_SuppressedForNoAckContact verifies that a manual /resend of
+// a message to a WaitForAck=false conversation submits once but does NOT
+// re-arm the retry ladder — otherwise disabling auto-resend for a no-ACK
+// handheld would be undone the moment the operator hits Resend.
+func TestResend_SuppressedForNoAckContact(t *testing.T) {
+	rig := buildRetry(t, FallbackPolicyRFOnly)
+	defer rig.close()
+	ctx := context.Background()
+
+	if err := rig.cs.UpsertConversationPrefs(ctx, &configstore.ConversationPrefs{
+		ThreadKind: ThreadKindDM, ThreadKey: "W1ABC", SendPath: "", WaitForAck: false,
+	}); err != nil {
+		t.Fatalf("seed prefs: %v", err)
+	}
+	row := newOutboundDM(t, rig.senderRig, "N0CALL", "W1ABC", "hi")
+
+	if _, err := rig.mgr.Resend(ctx, row.ID); err != nil {
+		t.Fatalf("Resend: %v", err)
+	}
+	if got := len(rig.sink.list()); got != 1 {
+		t.Fatalf("RF submits = %d, want 1 (resend sends once)", got)
+	}
+	cur, err := rig.store.GetByID(ctx, row.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if cur.NextRetryAt != nil {
+		t.Errorf("NextRetryAt = %v, want nil (no re-enrollment for no-ACK contact)", cur.NextRetryAt)
+	}
+}
+
+// TestResend_ReenrollsNormalContact is the positive control: a normal
+// conversation (no prefs row) re-arms the retry ladder on resend.
+func TestResend_ReenrollsNormalContact(t *testing.T) {
+	rig := buildRetry(t, FallbackPolicyRFOnly)
+	defer rig.close()
+	ctx := context.Background()
+
+	row := newOutboundDM(t, rig.senderRig, "N0CALL", "W1ABC", "hi")
+	if _, err := rig.mgr.Resend(ctx, row.ID); err != nil {
+		t.Fatalf("Resend: %v", err)
+	}
+	cur, err := rig.store.GetByID(ctx, row.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if cur.NextRetryAt == nil {
+		t.Error("NextRetryAt = nil, want a scheduled retry for a normal contact")
+	}
+}
+
 func TestRetry_BackoffLadder(t *testing.T) {
 	rig := buildRetry(t, FallbackPolicyRFOnly)
 	defer rig.close()

--- a/pkg/messages/service.go
+++ b/pkg/messages/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/chrissnell/graywolf/pkg/configstore"
@@ -457,6 +458,25 @@ func (s *Service) SendMessage(ctx context.Context, req SendMessageRequest) (*con
 		}
 	}
 
+	// Per-conversation overrides (issue #453). Absent row → inherit the
+	// global defaults. SendPath is stamped on the row so retry re-attempts
+	// route the same way as the initial send; WaitForAck=false disables
+	// retry enrollment below so a no-ACK contact (e.g. TIDRadio TD-H9) is
+	// sent once and not re-transmitted. A one-shot req.FallbackPolicyOverride
+	// (e.g. an Actions reply echoing inbound transport) still wins for the
+	// initial dispatch, but is NOT persisted to row.SendPath so it doesn't
+	// bleed into that contact's retries.
+	convPrefs, err := s.cfg.Store.GetConversationPrefs(ctx, kind, strings.ToUpper(req.To))
+	if err != nil {
+		return nil, err
+	}
+	rowSendPath := ""
+	suppressRetry := false
+	if convPrefs != nil {
+		rowSendPath = convPrefs.SendPath
+		suppressRetry = !convPrefs.WaitForAck
+	}
+
 	row := &configstore.Message{
 		Direction:      "out",
 		OurCall:        req.OurCall,
@@ -468,6 +488,7 @@ func (s *Service) SendMessage(ctx context.Context, req SendMessageRequest) (*con
 		Unread:         false,
 		Kind:           bodyKind,
 		InviteTactical: inviteTactical,
+		SendPath:       rowSendPath,
 	}
 	// DM requires a msgid; tactical may omit.
 	if kind == ThreadKindDM {
@@ -491,7 +512,12 @@ func (s *Service) SendMessage(ctx context.Context, req SendMessageRequest) (*con
 	// reflect writes). Without the copy, -race flags this as a data
 	// race between handler response-serialization and background send.
 	rowCopy := *row
+	// Initial-dispatch policy: an explicit one-shot override wins, else
+	// the conversation's stamped SendPath, else (empty) the global pref.
 	policyOverride := req.FallbackPolicyOverride
+	if policyOverride == "" {
+		policyOverride = rowSendPath
+	}
 	go func() {
 		sendCtx := s.ctx
 		if sendCtx == nil {
@@ -504,8 +530,10 @@ func (s *Service) SendMessage(ctx context.Context, req SendMessageRequest) (*con
 		}
 		// Enroll in the retry ladder for DM when the first attempt
 		// queues successfully or returned a retryable error. Tactical
-		// rows do not participate in the retry scheduler.
-		if result.Retryable && rowCopy.ThreadKind == ThreadKindDM {
+		// rows do not participate in the retry scheduler. A conversation
+		// with WaitForAck=false (no-ACK contact) is sent once and skips
+		// enrollment entirely — no re-sends.
+		if result.Retryable && rowCopy.ThreadKind == ThreadKindDM && !suppressRetry {
 			// Re-read the row — Sender may have flipped fields.
 			cur, err := s.cfg.Store.GetByID(sendCtx, rowCopy.ID)
 			if err == nil {

--- a/pkg/messages/service_convprefs_test.go
+++ b/pkg/messages/service_convprefs_test.go
@@ -1,0 +1,87 @@
+package messages
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/configstore"
+)
+
+// TestService_SendMessage_StampsConversationSendPath asserts that a
+// per-conversation SendPath override is stamped onto the outbound row
+// so retry re-attempts route the same way as the initial send.
+func TestService_SendMessage_StampsConversationSendPath(t *testing.T) {
+	svc, rig, _, cleanup := buildService(t)
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	if err := rig.cs.UpsertConversationPrefs(ctx, &configstore.ConversationPrefs{
+		ThreadKind: ThreadKindDM, ThreadKey: "W1ABC", SendPath: FallbackPolicyRFOnly, WaitForAck: true,
+	}); err != nil {
+		t.Fatalf("seed prefs: %v", err)
+	}
+
+	row, err := svc.SendMessage(ctx, SendMessageRequest{OurCall: "N0CALL", To: "W1ABC", Text: "hi"})
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if row.SendPath != FallbackPolicyRFOnly {
+		t.Fatalf("row.SendPath = %q, want %q", row.SendPath, FallbackPolicyRFOnly)
+	}
+}
+
+// TestService_SendMessage_WaitForAckFalseSkipsRetry asserts that a
+// conversation with WaitForAck=false sends once and does NOT enroll the
+// row in the retry ladder — the no-ACK-device case (issue #453).
+func TestService_SendMessage_WaitForAckFalseSkipsRetry(t *testing.T) {
+	svc, rig, _, cleanup := buildService(t)
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	if err := rig.cs.UpsertConversationPrefs(ctx, &configstore.ConversationPrefs{
+		ThreadKind: ThreadKindDM, ThreadKey: "W1ABC", SendPath: "", WaitForAck: false,
+	}); err != nil {
+		t.Fatalf("seed prefs: %v", err)
+	}
+
+	row, err := svc.SendMessage(ctx, SendMessageRequest{OurCall: "N0CALL", To: "W1ABC", Text: "hi"})
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	// Wait for the async initial send to hit the RF sink.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if len(rig.sink.list()) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(rig.sink.list()) == 0 {
+		t.Fatal("no RF submit after SendMessage")
+	}
+	// Give the (skipped) enrollment path a beat to run if it were going to.
+	time.Sleep(20 * time.Millisecond)
+
+	cur, err := rig.store.GetByID(ctx, row.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if cur.NextRetryAt != nil {
+		t.Errorf("NextRetryAt = %v, want nil (no retry enrollment for no-ACK contact)", cur.NextRetryAt)
+	}
+	if cur.Attempts != 0 {
+		t.Errorf("Attempts = %d, want 0 (not enrolled)", cur.Attempts)
+	}
+}

--- a/pkg/messages/store.go
+++ b/pkg/messages/store.go
@@ -219,6 +219,23 @@ func (s *Store) GetByID(ctx context.Context, id uint64) (*configstore.Message, e
 	return &m, nil
 }
 
+// GetConversationPrefs returns the per-thread override row for
+// (kind, key), or (nil, nil) when the conversation inherits defaults.
+// Callers normalize key to uppercase. See configstore.ConversationPrefs.
+func (s *Store) GetConversationPrefs(ctx context.Context, kind, key string) (*configstore.ConversationPrefs, error) {
+	var c configstore.ConversationPrefs
+	err := s.db.WithContext(ctx).
+		Where("thread_kind = ? AND thread_key = ?", kind, key).
+		First(&c).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
 // List returns a page of messages matching the filter. The returned
 // cursor points at the last row in the page and can be fed back into a
 // subsequent List call to page forward deterministically.

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1421,7 +1421,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1469,7 +1468,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1526,7 +1524,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1567,7 +1564,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1760,7 +1756,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1802,7 +1797,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -7837,8 +7831,7 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer",
-                        "format": "int32"
+                        "type": "integer"
                     }
                 },
                 "source": {
@@ -8088,8 +8081,7 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -8104,8 +8096,7 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -8115,8 +8106,7 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -8124,8 +8114,7 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -8137,8 +8126,7 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -8153,12 +8141,10 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "table": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 }
             }
         },
@@ -8168,8 +8154,7 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number",
-                        "format": "float64"
+                        "type": "number"
                     }
                 },
                 "analogHas": {
@@ -8185,8 +8170,7 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -8202,8 +8186,7 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -8211,8 +8194,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -8287,21 +8269,17 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain24Hour": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rainSinceMid": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -8309,8 +8287,7 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -8318,8 +8295,7 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -8331,13 +8307,11 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 }
             }
         },
@@ -11331,11 +11305,6 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
-            "x-enum-descriptions": [
-                "heard on the air",
-                "transmitted by us",
-                "APRS-IS upload/download (iGate)"
-            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -11650,8 +11619,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -11744,8 +11712,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1421,6 +1421,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1468,6 +1469,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1524,6 +1526,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1564,6 +1567,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1756,6 +1760,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1797,6 +1802,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -4803,6 +4809,122 @@
                 }
             }
         },
+        "/messages/conversations/{kind}/{key}/prefs": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "messages"
+                ],
+                "summary": "Get conversation preferences",
+                "operationId": "getConversationPrefs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "thread kind (dm|tactical)",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "peer callsign or tactical label",
+                        "name": "key",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ConversationPrefsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "messages"
+                ],
+                "summary": "Update conversation preferences",
+                "operationId": "putConversationPrefs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "thread kind (dm|tactical)",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "peer callsign or tactical label",
+                        "name": "key",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Preferences",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ConversationPrefsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ConversationPrefsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/messages/events": {
             "get": {
                 "security": [
@@ -7715,7 +7837,8 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "int32"
                     }
                 },
                 "source": {
@@ -7965,7 +8088,8 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -7980,7 +8104,8 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -7990,7 +8115,8 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -7998,7 +8124,8 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -8010,7 +8137,8 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -8025,10 +8153,12 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "table": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 }
             }
         },
@@ -8038,7 +8168,8 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number"
+                        "type": "number",
+                        "format": "float64"
                     }
                 },
                 "analogHas": {
@@ -8054,7 +8185,8 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -8070,7 +8202,8 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -8078,7 +8211,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -8153,17 +8287,21 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rain24Hour": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rainSinceMid": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -8171,7 +8309,8 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -8179,7 +8318,8 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -8191,11 +8331,13 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 }
             }
         },
@@ -9376,6 +9518,36 @@
                 },
                 "space_freq": {
                     "type": "integer"
+                }
+            }
+        },
+        "dto.ConversationPrefsRequest": {
+            "type": "object",
+            "properties": {
+                "send_path": {
+                    "description": "SendPath overrides transport for this conversation. Empty ('')\nmeans \"inherit the global fallback policy\"; otherwise one of\nrf_only | is_only | both.",
+                    "type": "string"
+                },
+                "wait_for_ack": {
+                    "description": "WaitForAck, when false, sends DMs to this contact once and skips\nthe retry ladder (no re-sends) — for handhelds that never ACK.\nDefaults true.",
+                    "type": "boolean"
+                }
+            }
+        },
+        "dto.ConversationPrefsResponse": {
+            "type": "object",
+            "properties": {
+                "send_path": {
+                    "type": "string"
+                },
+                "thread_key": {
+                    "type": "string"
+                },
+                "thread_kind": {
+                    "type": "string"
+                },
+                "wait_for_ack": {
+                    "type": "boolean"
                 }
             }
         },
@@ -11159,6 +11331,11 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
+            "x-enum-descriptions": [
+                "heard on the air",
+                "transmitted by us",
+                "APRS-IS upload/download (iGate)"
+            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -11473,7 +11650,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -11566,7 +11744,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,6 +50,7 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
+          format: int32
           type: integer
         type: array
       source:
@@ -228,6 +229,7 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
+        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -239,6 +241,7 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
+        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -246,12 +249,14 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
+        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
+        format: float64
         type: number
       phg:
         allOf:
@@ -259,6 +264,7 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
+        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -269,14 +275,17 @@ definitions:
   aprs.Symbol:
     properties:
       code:
+        format: int32
         type: integer
       table:
+        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
+          format: float64
           type: number
         type: array
       analogHas:
@@ -289,6 +298,7 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
+        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -300,11 +310,13 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
+        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -357,25 +369,31 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
+        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
+        format: float64
         type: number
       rain24Hour:
+        format: float64
         type: number
       rainSinceMid:
+        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
+        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
+        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -385,9 +403,11 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
+        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
+        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -1182,6 +1202,32 @@ definitions:
         $ref: '#/definitions/dto.ChannelPtt'
       space_freq:
         type: integer
+    type: object
+  dto.ConversationPrefsRequest:
+    properties:
+      send_path:
+        description: |-
+          SendPath overrides transport for this conversation. Empty ('')
+          means "inherit the global fallback policy"; otherwise one of
+          rf_only | is_only | both.
+        type: string
+      wait_for_ack:
+        description: |-
+          WaitForAck, when false, sends DMs to this contact once and skips
+          the retry ladder (no re-sends) — for handhelds that never ACK.
+          Defaults true.
+        type: boolean
+    type: object
+  dto.ConversationPrefsResponse:
+    properties:
+      send_path:
+        type: string
+      thread_key:
+        type: string
+      thread_kind:
+        type: string
+      wait_for_ack:
+        type: boolean
     type: object
   dto.ConversationSummary:
     properties:
@@ -2525,6 +2571,10 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
+    x-enum-descriptions:
+      - heard on the air
+      - transmitted by us
+      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2746,6 +2796,7 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -2812,6 +2863,7 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -3981,6 +4033,7 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4001,6 +4054,7 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4031,6 +4085,7 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4072,6 +4127,7 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4192,6 +4248,7 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4212,6 +4269,7 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
+          format: int32
           in: path
           name: id
           required: true
@@ -6290,6 +6348,81 @@ paths:
       security:
         - CookieAuth: []
       summary: List conversations
+      tags:
+        - messages
+  /messages/conversations/{kind}/{key}/prefs:
+    get:
+      operationId: getConversationPrefs
+      parameters:
+        - description: thread kind (dm|tactical)
+          in: path
+          name: kind
+          required: true
+          type: string
+        - description: peer callsign or tactical label
+          in: path
+          name: key
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ConversationPrefsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Get conversation preferences
+      tags:
+        - messages
+    put:
+      consumes:
+        - application/json
+      operationId: putConversationPrefs
+      parameters:
+        - description: thread kind (dm|tactical)
+          in: path
+          name: kind
+          required: true
+          type: string
+        - description: peer callsign or tactical label
+          in: path
+          name: key
+          required: true
+          type: string
+        - description: Preferences
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/dto.ConversationPrefsRequest'
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.ConversationPrefsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Update conversation preferences
       tags:
         - messages
   /messages/events:

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,7 +50,6 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
-          format: int32
           type: integer
         type: array
       source:
@@ -229,7 +228,6 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
-        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -241,7 +239,6 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
-        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -249,14 +246,12 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
-        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
-        format: float64
         type: number
       phg:
         allOf:
@@ -264,7 +259,6 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
-        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -275,17 +269,14 @@ definitions:
   aprs.Symbol:
     properties:
       code:
-        format: int32
         type: integer
       table:
-        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
-          format: float64
           type: number
         type: array
       analogHas:
@@ -298,7 +289,6 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
-        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -310,13 +300,11 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
-        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -369,31 +357,25 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
-        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
-        format: float64
         type: number
       rain24Hour:
-        format: float64
         type: number
       rainSinceMid:
-        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
-        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
-        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -403,11 +385,9 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
-        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
-        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -2571,10 +2551,6 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
-    x-enum-descriptions:
-      - heard on the air
-      - transmitted by us
-      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2796,7 +2772,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -2863,7 +2838,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -4033,7 +4007,6 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4054,7 +4027,6 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4085,7 +4057,6 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4127,7 +4098,6 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4248,7 +4218,6 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4269,7 +4238,6 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true

--- a/pkg/webapi/docs/op_ids.go
+++ b/pkg/webapi/docs/op_ids.go
@@ -247,6 +247,8 @@ const (
 	OpMarkMessageUnread       = "markMessageUnread"
 	OpResendMessage           = "resendMessage"
 	OpListConversations       = "listConversations"
+	OpGetConversationPrefs    = "getConversationPrefs"
+	OpPutConversationPrefs    = "putConversationPrefs"
 	OpStreamMessageEvents     = "streamMessageEvents"
 	OpGetMessagePreferences   = "getMessagePreferences"
 	OpPutMessagePreferences   = "putMessagePreferences"

--- a/pkg/webapi/dto/messages.go
+++ b/pkg/webapi/dto/messages.go
@@ -482,6 +482,82 @@ func MessagePreferencesFromModel(m configstore.MessagePreferences) MessagePrefer
 	}
 }
 
+// --- Conversation prefs (per-thread overrides) ---------------------------
+
+// ConversationPrefsRequest is the body accepted by PUT
+// /api/messages/conversations/{kind}/{key}/prefs. Both fields are
+// always present (the client sends the full state of the Routing
+// popover); the server deletes the row when they equal the defaults so
+// the table stays sparse.
+type ConversationPrefsRequest struct {
+	// SendPath overrides transport for this conversation. Empty ('')
+	// means "inherit the global fallback policy"; otherwise one of
+	// rf_only | is_only | both.
+	SendPath string `json:"send_path"`
+	// WaitForAck, when false, sends DMs to this contact once and skips
+	// the retry ladder (no re-sends) — for handhelds that never ACK.
+	// Defaults true.
+	WaitForAck bool `json:"wait_for_ack"`
+}
+
+// Validate constrains SendPath to the inherit-or-enum set. is_fallback
+// is rejected as an override: it is identical to inherit ('') and
+// accepting both would give two encodings for the same behavior.
+func (r ConversationPrefsRequest) Validate() error {
+	switch r.SendPath {
+	case "",
+		messages.FallbackPolicyRFOnly,
+		messages.FallbackPolicyISOnly,
+		messages.FallbackPolicyBoth:
+		return nil
+	default:
+		return fmt.Errorf("send_path %q is not one of (empty)|rf_only|is_only|both", r.SendPath)
+	}
+}
+
+// ToModel builds a configstore row for (kind, key). Key is uppercased
+// so lookups at send time (which also uppercase) hit the same row.
+func (r ConversationPrefsRequest) ToModel(kind, key string) configstore.ConversationPrefs {
+	return configstore.ConversationPrefs{
+		ThreadKind: strings.ToLower(strings.TrimSpace(kind)),
+		ThreadKey:  strings.ToUpper(strings.TrimSpace(key)),
+		SendPath:   r.SendPath,
+		WaitForAck: r.WaitForAck,
+	}
+}
+
+// ConversationPrefsResponse is returned by GET/PUT on the prefs
+// endpoint. A conversation with no stored row returns the defaults
+// (inherit + wait_for_ack true) rather than 404 so the client can
+// render the Routing control without a special-case.
+type ConversationPrefsResponse struct {
+	ThreadKind string `json:"thread_kind"`
+	ThreadKey  string `json:"thread_key"`
+	SendPath   string `json:"send_path"`
+	WaitForAck bool   `json:"wait_for_ack"`
+}
+
+// ConversationPrefsDefaults returns the response a thread with no stored
+// override row surfaces: inherit transport, ack-and-resend on.
+func ConversationPrefsDefaults(kind, key string) ConversationPrefsResponse {
+	return ConversationPrefsResponse{
+		ThreadKind: strings.ToLower(strings.TrimSpace(kind)),
+		ThreadKey:  strings.ToUpper(strings.TrimSpace(key)),
+		SendPath:   "",
+		WaitForAck: true,
+	}
+}
+
+// ConversationPrefsFromModel renders a stored row.
+func ConversationPrefsFromModel(m configstore.ConversationPrefs) ConversationPrefsResponse {
+	return ConversationPrefsResponse{
+		ThreadKind: m.ThreadKind,
+		ThreadKey:  m.ThreadKey,
+		SendPath:   m.SendPath,
+		WaitForAck: m.WaitForAck,
+	}
+}
+
 // --- Tactical callsigns --------------------------------------------------
 
 // TacticalCallsignRequest is the body accepted by POST + PUT on

--- a/pkg/webapi/messages.go
+++ b/pkg/webapi/messages.go
@@ -33,6 +33,8 @@ func (s *Server) registerMessages(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/messages", s.listMessages)
 	mux.HandleFunc("POST /api/messages", s.sendMessage)
 	mux.HandleFunc("GET /api/messages/conversations", s.listConversations)
+	mux.HandleFunc("GET /api/messages/conversations/{kind}/{key}/prefs", s.getConversationPrefs)
+	mux.HandleFunc("PUT /api/messages/conversations/{kind}/{key}/prefs", s.putConversationPrefs)
 	mux.HandleFunc("GET /api/messages/events", s.streamMessageEvents)
 	mux.HandleFunc("GET /api/messages/preferences", s.getMessagePreferences)
 	mux.HandleFunc("PUT /api/messages/preferences", s.putMessagePreferences)
@@ -755,6 +757,114 @@ func (s *Server) putMessagePreferences(w http.ResponseWriter, r *http.Request) {
 	}
 	s.signalMessagesReload()
 	writeJSON(w, http.StatusOK, dto.MessagePreferencesFromModel(model))
+}
+
+// --- Conversation prefs (per-thread overrides) ---------------------------
+
+// parseThreadKind validates the {kind} path segment against the two
+// legal thread kinds, returning the normalized value.
+func parseThreadKind(raw string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case messages.ThreadKindDM:
+		return messages.ThreadKindDM, true
+	case messages.ThreadKindTactical:
+		return messages.ThreadKindTactical, true
+	default:
+		return "", false
+	}
+}
+
+// getConversationPrefs returns the per-thread override row, or the
+// inherited defaults when no row exists.
+//
+// @Summary  Get conversation preferences
+// @Tags     messages
+// @ID       getConversationPrefs
+// @Produce  json
+// @Param    kind path     string true "thread kind (dm|tactical)"
+// @Param    key  path     string true "peer callsign or tactical label"
+// @Success  200  {object} dto.ConversationPrefsResponse
+// @Failure  400  {object} webtypes.ErrorResponse
+// @Failure  500  {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /messages/conversations/{kind}/{key}/prefs [get]
+func (s *Server) getConversationPrefs(w http.ResponseWriter, r *http.Request) {
+	kind, ok := parseThreadKind(r.PathValue("kind"))
+	if !ok {
+		badRequest(w, "kind must be dm or tactical")
+		return
+	}
+	key := strings.ToUpper(strings.TrimSpace(r.PathValue("key")))
+	if key == "" {
+		badRequest(w, "key is required")
+		return
+	}
+	prefs, err := s.store.GetConversationPrefs(r.Context(), kind, key)
+	if err != nil {
+		s.internalError(w, r, "get conversation prefs", err)
+		return
+	}
+	if prefs == nil {
+		writeJSON(w, http.StatusOK, dto.ConversationPrefsDefaults(kind, key))
+		return
+	}
+	writeJSON(w, http.StatusOK, dto.ConversationPrefsFromModel(*prefs))
+}
+
+// putConversationPrefs upserts the per-thread override. Sending the
+// default state (inherit + wait_for_ack true) clears any stored row so
+// the overrides table holds only customized conversations.
+//
+// @Summary  Update conversation preferences
+// @Tags     messages
+// @ID       putConversationPrefs
+// @Accept   json
+// @Produce  json
+// @Param    kind path     string true "thread kind (dm|tactical)"
+// @Param    key  path     string true "peer callsign or tactical label"
+// @Param    body body     dto.ConversationPrefsRequest true "Preferences"
+// @Success  200  {object} dto.ConversationPrefsResponse
+// @Failure  400  {object} webtypes.ErrorResponse
+// @Failure  500  {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /messages/conversations/{kind}/{key}/prefs [put]
+func (s *Server) putConversationPrefs(w http.ResponseWriter, r *http.Request) {
+	kind, ok := parseThreadKind(r.PathValue("kind"))
+	if !ok {
+		badRequest(w, "kind must be dm or tactical")
+		return
+	}
+	key := strings.ToUpper(strings.TrimSpace(r.PathValue("key")))
+	if key == "" {
+		badRequest(w, "key is required")
+		return
+	}
+	req, err := decodeJSON[dto.ConversationPrefsRequest](r)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	if err := req.Validate(); err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	model := req.ToModel(kind, key)
+	if err := s.store.UpsertConversationPrefs(r.Context(), &model); err != nil {
+		s.internalError(w, r, "upsert conversation prefs", err)
+		return
+	}
+	// Read back so the response reflects the sparse-table delete (a
+	// reset-to-defaults PUT returns the inherited defaults, not a row).
+	prefs, err := s.store.GetConversationPrefs(r.Context(), kind, key)
+	if err != nil {
+		s.internalError(w, r, "reload conversation prefs", err)
+		return
+	}
+	if prefs == nil {
+		writeJSON(w, http.StatusOK, dto.ConversationPrefsDefaults(kind, key))
+		return
+	}
+	writeJSON(w, http.StatusOK, dto.ConversationPrefsFromModel(*prefs))
 }
 
 // --- Tactical callsigns --------------------------------------------------

--- a/pkg/webapi/messages_test.go
+++ b/pkg/webapi/messages_test.go
@@ -928,6 +928,87 @@ func TestPutPreferences_RoundTrip(t *testing.T) {
 	}
 }
 
+// --- Conversation prefs --------------------------------------------------
+
+func TestGetConversationPrefs_DefaultsWhenUnset(t *testing.T) {
+	_, mux, _ := newMessagesTestServer(t, &fakeMessagesSvc{})
+	req := httptest.NewRequest(http.MethodGet, "/api/messages/conversations/dm/W5XYZ/prefs", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got dto.ConversationPrefsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.SendPath != "" || !got.WaitForAck {
+		t.Fatalf("unset conversation should inherit defaults, got %+v", got)
+	}
+}
+
+func TestPutConversationPrefs_RoundTripAndReset(t *testing.T) {
+	_, mux, _ := newMessagesTestServer(t, &fakeMessagesSvc{})
+
+	// Set an override: RF only + no resend (no-ACK contact).
+	body := `{"send_path":"rf_only","wait_for_ack":false}`
+	req := httptest.NewRequest(http.MethodPut, "/api/messages/conversations/dm/w5xyz/prefs", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got dto.ConversationPrefsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.SendPath != "rf_only" || got.WaitForAck || got.ThreadKey != "W5XYZ" {
+		t.Fatalf("PUT round-trip mismatch (key should be uppercased): %+v", got)
+	}
+
+	// GET reflects the stored override.
+	req = httptest.NewRequest(http.MethodGet, "/api/messages/conversations/dm/W5XYZ/prefs", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.SendPath != "rf_only" || got.WaitForAck {
+		t.Fatalf("GET after PUT mismatch: %+v", got)
+	}
+
+	// Reset to defaults clears the row; GET returns inherited defaults.
+	body = `{"send_path":"","wait_for_ack":true}`
+	req = httptest.NewRequest(http.MethodPut, "/api/messages/conversations/dm/W5XYZ/prefs", strings.NewReader(body))
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reset PUT expected 200, got %d", rec.Code)
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.SendPath != "" || !got.WaitForAck {
+		t.Fatalf("reset should return defaults, got %+v", got)
+	}
+}
+
+func TestPutConversationPrefs_Validation(t *testing.T) {
+	_, mux, _ := newMessagesTestServer(t, &fakeMessagesSvc{})
+	// Bad send_path.
+	req := httptest.NewRequest(http.MethodPut, "/api/messages/conversations/dm/W5XYZ/prefs",
+		strings.NewReader(`{"send_path":"nope","wait_for_ack":true}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad send_path: expected 400, got %d", rec.Code)
+	}
+	// Bad kind.
+	req = httptest.NewRequest(http.MethodPut, "/api/messages/conversations/bogus/W5XYZ/prefs",
+		strings.NewReader(`{"send_path":"","wait_for_ack":true}`))
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad kind: expected 400, got %d", rec.Code)
+	}
+}
+
 // --- Tactical CRUD -------------------------------------------------------
 
 func TestCreateTactical_201(t *testing.T) {

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2059,50 +2059,33 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /**
-             * Format: float64
-             * @description meters (0 if none reported)
-             */
+            /** @description meters (0 if none reported) */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /**
-             * Format: int32
-             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
-             */
+            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive north
-             */
+            /** @description decimal degrees, positive north */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive east
-             */
+            /** @description decimal degrees, positive east */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /**
-             * Format: float64
-             * @description knots
-             */
+            /** @description knots */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
-            /** Format: int32 */
             code?: number;
-            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2111,20 +2094,14 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /**
-             * Format: int32
-             * @description bits 0..7 (only lower 8)
-             */
+            /** @description bits 0..7 (only lower 8) */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /**
-             * Format: int32
-             * @description BITS. sense-bits bitmap (active-high per bit)
-             */
+            /** @description BITS. sense-bits bitmap (active-high per bit) */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2152,47 +2129,27 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /**
-             * Format: float64
-             * @description tenths of millibar (e.g. 10132 = 1013.2)
-             */
+            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
             pressure?: number;
-            /**
-             * Format: float64
-             * @description hundredths of an inch
-             */
+            /** @description hundredths of an inch */
             rain1Hour?: number;
-            /** Format: float64 */
             rain24Hour?: number;
-            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /**
-             * Format: float64
-             * @description inches (via 's' after 'g')
-             */
+            /** @description inches (via 's' after 'g') */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /**
-             * Format: float64
-             * @description degrees F
-             */
+            /** @description degrees F */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /**
-             * Format: float64
-             * @description mph (5-minute peak)
-             */
+            /** @description mph (5-minute peak) */
             windGust?: number;
-            /**
-             * Format: float64
-             * @description mph (1-minute sustained)
-             */
+            /** @description mph (1-minute sustained) */
             windSpeed?: number;
         };
         "configstore.Referrer": {

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -1107,6 +1107,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/messages/conversations/{kind}/{key}/prefs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get conversation preferences */
+        get: operations["getConversationPrefs"];
+        /** Update conversation preferences */
+        put: operations["putConversationPrefs"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/messages/events": {
         parameters: {
             query?: never;
@@ -2041,33 +2059,50 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /** @description meters (0 if none reported) */
+            /**
+             * Format: float64
+             * @description meters (0 if none reported)
+             */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
+            /**
+             * Format: int32
+             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
+             */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /** @description decimal degrees, positive north */
+            /**
+             * Format: float64
+             * @description decimal degrees, positive north
+             */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /** @description decimal degrees, positive east */
+            /**
+             * Format: float64
+             * @description decimal degrees, positive east
+             */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /** @description knots */
+            /**
+             * Format: float64
+             * @description knots
+             */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
+            /** Format: int32 */
             code?: number;
+            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2076,14 +2111,20 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /** @description bits 0..7 (only lower 8) */
+            /**
+             * Format: int32
+             * @description bits 0..7 (only lower 8)
+             */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /** @description BITS. sense-bits bitmap (active-high per bit) */
+            /**
+             * Format: int32
+             * @description BITS. sense-bits bitmap (active-high per bit)
+             */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2111,27 +2152,47 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
+            /**
+             * Format: float64
+             * @description tenths of millibar (e.g. 10132 = 1013.2)
+             */
             pressure?: number;
-            /** @description hundredths of an inch */
+            /**
+             * Format: float64
+             * @description hundredths of an inch
+             */
             rain1Hour?: number;
+            /** Format: float64 */
             rain24Hour?: number;
+            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /** @description inches (via 's' after 'g') */
+            /**
+             * Format: float64
+             * @description inches (via 's' after 'g')
+             */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /** @description degrees F */
+            /**
+             * Format: float64
+             * @description degrees F
+             */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /** @description mph (5-minute peak) */
+            /**
+             * Format: float64
+             * @description mph (5-minute peak)
+             */
             windGust?: number;
-            /** @description mph (1-minute sustained) */
+            /**
+             * Format: float64
+             * @description mph (1-minute sustained)
+             */
             windSpeed?: number;
         };
         "configstore.Referrer": {
@@ -2556,6 +2617,26 @@ export interface components {
             profile?: string;
             ptt?: components["schemas"]["dto.ChannelPtt"];
             space_freq?: number;
+        };
+        "dto.ConversationPrefsRequest": {
+            /**
+             * @description SendPath overrides transport for this conversation. Empty ('')
+             *     means "inherit the global fallback policy"; otherwise one of
+             *     rf_only | is_only | both.
+             */
+            send_path?: string;
+            /**
+             * @description WaitForAck, when false, sends DMs to this contact once and skips
+             *     the retry ladder (no re-sends) — for handhelds that never ACK.
+             *     Defaults true.
+             */
+            wait_for_ack?: boolean;
+        };
+        "dto.ConversationPrefsResponse": {
+            send_path?: string;
+            thread_key?: string;
+            thread_kind?: string;
+            wait_for_ack?: boolean;
         };
         "dto.ConversationSummary": {
             alias?: string;
@@ -7987,6 +8068,97 @@ export interface operations {
             };
             /** @description Service Unavailable */
             503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    getConversationPrefs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description thread kind (dm|tactical) */
+                kind: string;
+                /** @description peer callsign or tactical label */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.ConversationPrefsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    putConversationPrefs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description thread kind (dm|tactical) */
+                kind: string;
+                /** @description peer callsign or tactical label */
+                key: string;
+            };
+            cookie?: never;
+        };
+        /** @description Preferences */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["dto.ConversationPrefsRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.ConversationPrefsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/web/src/api/messages.js
+++ b/web/src/api/messages.js
@@ -140,6 +140,29 @@ export function listConversations(params) {
   return api.get(`/messages/conversations${qs(params)}`);
 }
 
+/**
+ * GET /api/messages/conversations/{kind}/{key}/prefs — per-thread
+ * routing overrides. Returns the inherited defaults (send_path '',
+ * wait_for_ack true) when no override row exists, never 404.
+ * @param {string} kind 'dm' | 'tactical'
+ * @param {string} key  peer callsign (dm) or tactical label
+ * @returns {Promise<{thread_kind: string, thread_key: string, send_path: string, wait_for_ack: boolean}>}
+ */
+export function getConversationPrefs(kind, key) {
+  return api.get(`/messages/conversations/${encodeURIComponent(kind)}/${encodeURIComponent(key)}/prefs`);
+}
+
+/**
+ * PUT /api/messages/conversations/{kind}/{key}/prefs — upsert the
+ * override. Sending the defaults clears the row server-side.
+ * @param {string} kind 'dm' | 'tactical'
+ * @param {string} key  peer callsign (dm) or tactical label
+ * @param {{send_path: string, wait_for_ack: boolean}} req
+ */
+export function putConversationPrefs(kind, key, req) {
+  return api.put(`/messages/conversations/${encodeURIComponent(kind)}/${encodeURIComponent(key)}/prefs`, req);
+}
+
 // --- Preferences ----------------------------------------------------
 
 /**

--- a/web/src/components/messages/ConversationRoutingMenu.svelte
+++ b/web/src/components/messages/ConversationRoutingMenu.svelte
@@ -1,0 +1,223 @@
+<script>
+  // Per-conversation routing control (issue #453). A single quiet
+  // gear button in the thread header that opens a small popover with:
+  //   - Send path: Use default / RF only / APRS-IS only (tactical + DM)
+  //   - Automatic Resend until ACK: on by default; off = send once,
+  //     no re-sends, for no-ACK handhelds like the TIDRadio TD-H9 (DM
+  //     only — tactical rows never enroll in the retry ladder).
+  //
+  // The button stays visually silent (muted, no dot) while the thread
+  // inherits the global defaults, so the compose area and header are
+  // uncluttered until the operator deliberately customizes a contact.
+  //
+  // Persistence is lazy: prefs are fetched the first time the popover
+  // opens, and every change PUTs the full state. A reset back to the
+  // defaults deletes the row server-side (the response echoes the
+  // inherited defaults), keeping the overrides table sparse.
+
+  import { Icon, Radio, RadioGroup, Checkbox, Tooltip } from '@chrissnell/chonky-ui';
+  import { getConversationPrefs, putConversationPrefs } from '../../api/messages.js';
+  import { toasts } from '../../lib/stores.js';
+
+  /** @type {{ kind: 'dm' | 'tactical', threadKey: string }} */
+  let { kind, threadKey } = $props();
+
+  let open = $state(false);
+  let loaded = $state(false);
+  let saving = $state(false);
+  // sendPath: '' (inherit) | 'rf_only' | 'is_only'. waitForAck default true.
+  let sendPath = $state('');
+  let waitForAck = $state(true);
+
+  let overridden = $derived(sendPath !== '' || waitForAck === false);
+
+  const sendPathLabel = $derived(
+    sendPath === 'rf_only' ? 'RF only'
+      : sendPath === 'is_only' ? 'APRS-IS only'
+      : sendPath === 'both' ? 'RF + APRS-IS'
+      : 'Default path',
+  );
+
+  async function load() {
+    if (loaded || !threadKey) return;
+    try {
+      const p = await getConversationPrefs(kind, threadKey);
+      sendPath = p?.send_path ?? '';
+      waitForAck = p?.wait_for_ack ?? true;
+      loaded = true;
+    } catch {
+      // Leave defaults; a failed load still lets the operator set values.
+    }
+  }
+
+  async function toggle() {
+    open = !open;
+    if (open) await load();
+  }
+
+  async function persist(next) {
+    const prev = { sendPath, waitForAck };
+    sendPath = next.sendPath;
+    waitForAck = next.waitForAck;
+    saving = true;
+    try {
+      const resp = await putConversationPrefs(kind, threadKey, {
+        send_path: sendPath,
+        wait_for_ack: waitForAck,
+      });
+      // Echo the server's canonical state (a reset returns defaults).
+      sendPath = resp?.send_path ?? '';
+      waitForAck = resp?.wait_for_ack ?? true;
+    } catch {
+      sendPath = prev.sendPath;
+      waitForAck = prev.waitForAck;
+      toasts.error("Couldn't save routing for this conversation — try again.");
+    } finally {
+      saving = false;
+    }
+  }
+
+  function onSendPath(v) {
+    if (v === sendPath) return;
+    persist({ sendPath: v, waitForAck });
+  }
+  function onWaitForAck(v) {
+    if (v === waitForAck) return;
+    persist({ sendPath, waitForAck: v });
+  }
+
+  // Close on outside click / Escape.
+  function onWindowClick(e) {
+    if (!open) return;
+    if (e.target instanceof Node && rootEl && !rootEl.contains(e.target)) open = false;
+  }
+  function onKeydown(e) {
+    if (e.key === 'Escape') open = false;
+  }
+  let rootEl = $state(null);
+</script>
+
+<svelte:window onclick={onWindowClick} onkeydown={onKeydown} />
+
+<div class="routing" bind:this={rootEl}>
+  <Tooltip>
+    <Tooltip.Trigger>
+      <button
+        type="button"
+        class="routing-btn"
+        class:active={overridden}
+        aria-label="Conversation routing"
+        aria-haspopup="true"
+        aria-expanded={open}
+        onclick={toggle}
+        data-testid="conversation-routing-toggle"
+      >
+        <Icon name="settings" size="md" />
+        {#if overridden}<span class="dot" aria-hidden="true"></span>{/if}
+      </button>
+    </Tooltip.Trigger>
+    <Tooltip.Content>Routing{overridden ? ` — ${sendPathLabel}${!waitForAck ? ', no resend' : ''}` : ''}</Tooltip.Content>
+  </Tooltip>
+
+  {#if open}
+    <div class="panel" role="dialog" aria-label="Conversation routing" data-testid="conversation-routing-panel">
+      <p class="panel-title">Send path</p>
+      <RadioGroup value={sendPath} onValueChange={onSendPath} disabled={saving}>
+        <div class="opts">
+          <Radio value="" label="Use default" />
+          <Radio value="rf_only" label="RF only" />
+          <Radio value="is_only" label="APRS-IS only" />
+        </div>
+      </RadioGroup>
+      <p class="panel-hint">Overrides the global send path for this conversation only. Retries follow the same path.</p>
+
+      {#if kind === 'dm'}
+        <hr class="sep" />
+        <label class="ack-row">
+          <Checkbox checked={waitForAck} onCheckedChange={onWaitForAck} disabled={saving} />
+          <span>Automatic Resend until ACK</span>
+        </label>
+        <p class="panel-hint">On: resend until the recipient acknowledges. Turn off for radios that never send acks (e.g. TIDRadio TD-H9) so a message is sent once, with no re-sends.</p>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .routing {
+    position: relative;
+    display: inline-flex;
+  }
+  .routing-btn {
+    position: relative;
+    background: transparent;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: var(--radius);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .routing-btn:hover {
+    color: var(--color-text-default);
+    background: var(--color-surface-hover, rgba(127, 127, 127, 0.12));
+  }
+  .routing-btn.active {
+    color: var(--color-accent, var(--color-text-default));
+  }
+  .dot {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-accent, currentColor);
+  }
+  .panel {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 40;
+    width: 260px;
+    padding: 12px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+  }
+  .panel-title {
+    margin: 0 0 8px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--color-text-dim);
+  }
+  .opts {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .panel-hint {
+    margin: 8px 0 0;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--color-text-muted);
+  }
+  .sep {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: 12px 0;
+  }
+  .ack-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--color-text-default);
+    cursor: pointer;
+  }
+</style>

--- a/web/src/components/messages/ConversationRoutingMenu.svelte
+++ b/web/src/components/messages/ConversationRoutingMenu.svelte
@@ -46,7 +46,11 @@
       waitForAck = p?.wait_for_ack ?? true;
       loaded = true;
     } catch {
-      // Leave defaults; a failed load still lets the operator set values.
+      // Loaded stays false → the controls remain disabled so the operator
+      // can't unknowingly overwrite a stored override with the default
+      // state we're showing. Surface the failure and let them reopen to
+      // retry the fetch.
+      toasts.error("Couldn't load routing for this conversation — try again.");
     }
   }
 
@@ -122,7 +126,7 @@
   {#if open}
     <div class="panel" role="dialog" aria-label="Conversation routing" data-testid="conversation-routing-panel">
       <p class="panel-title">Send path</p>
-      <RadioGroup value={sendPath} onValueChange={onSendPath} disabled={saving}>
+      <RadioGroup value={sendPath} onValueChange={onSendPath} disabled={saving || !loaded}>
         <div class="opts">
           <Radio value="" label="Use default" />
           <Radio value="rf_only" label="RF only" />
@@ -134,7 +138,7 @@
       {#if kind === 'dm'}
         <hr class="sep" />
         <label class="ack-row">
-          <Checkbox checked={waitForAck} onCheckedChange={onWaitForAck} disabled={saving} />
+          <Checkbox checked={waitForAck} onCheckedChange={onWaitForAck} disabled={saving || !loaded} />
           <span>Automatic Resend until ACK</span>
         </label>
         <p class="panel-hint">On: resend until the recipient acknowledges. Turn off for radios that never send acks (e.g. TIDRadio TD-H9) so a message is sent once, with no re-sends.</p>

--- a/web/src/components/messages/ThreadHeader.svelte
+++ b/web/src/components/messages/ThreadHeader.svelte
@@ -8,6 +8,7 @@
 
   import { Icon, Toggle, Tooltip } from '@chrissnell/chonky-ui';
   import ParticipantChips from './ParticipantChips.svelte';
+  import ConversationRoutingMenu from './ConversationRoutingMenu.svelte';
   import InviteToTacticalModal from './InviteToTacticalModal.svelte';
   import { relativeLong } from './time.js';
 
@@ -70,26 +71,32 @@
         <span class="sub">Last heard {lastHeard}</span>
       {/if}
     </div>
-    {#if !isTactical && onActionsToggle}
+    {#if !isTactical && thread?.key}
       <div class="actions">
-        <Tooltip>
-          <Tooltip.Trigger>
-            <button
-              type="button"
-              class="zap-btn"
-              onclick={() => onActionsToggle?.()}
-              aria-label="Toggle remote actions drawer"
-              data-testid="thread-actions-toggle"
-            >
-              <span class="bolt" aria-hidden="true">⚡</span>
-            </button>
-          </Tooltip.Trigger>
-          <Tooltip.Content>Remote Actions</Tooltip.Content>
-        </Tooltip>
+        <ConversationRoutingMenu kind="dm" threadKey={thread.key} />
+        {#if onActionsToggle}
+          <Tooltip>
+            <Tooltip.Trigger>
+              <button
+                type="button"
+                class="zap-btn"
+                onclick={() => onActionsToggle?.()}
+                aria-label="Toggle remote actions drawer"
+                data-testid="thread-actions-toggle"
+              >
+                <span class="bolt" aria-hidden="true">⚡</span>
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>Remote Actions</Tooltip.Content>
+          </Tooltip>
+        {/if}
       </div>
     {/if}
     {#if isTactical}
       <div class="actions">
+        {#if tacticalKey}
+          <ConversationRoutingMenu kind="tactical" threadKey={tacticalKey} />
+        {/if}
         <div class="monitor">
           <Toggle
             checked={!muted}


### PR DESCRIPTION
Closes the two asks in #453 without cluttering the messaging UI. Both settings live in a single gear popover in the message thread header and default to inheriting the global messaging preferences, so untouched conversations behave exactly as before.

## What it does

- **Per-conversation send path** — override the global send path for one DM or tactical thread: *Use default* / *RF only* / *APRS-IS only*. Keeps local-radio contacts off APRS-IS (and WXBOT-style contacts on it) without touching the global policy.
- **Automatic Resend until ACK** (DM only) — on by default (resend until acked, up to the retry cap); turn it off for handhelds that never send an ack (e.g. TIDRadio TD-H9) so a message is sent once with no re-sends.

## How it's wired

- `ConversationPrefs` table, keyed by `(thread_kind, thread_key)`. **Sparse**: a row exists only when a thread is customized; resetting to defaults deletes it.
- The chosen send path is **stamped onto the outbound `Message` row**, so retries route the same way as the initial send — an `rf_only` contact never leaks onto APRS-IS on a retry.
- `WaitForAck=false` **skips retry enrollment** entirely (sent once, no resends).
- REST: `GET`/`PUT /api/messages/conversations/{kind}/{key}/prefs` (GET returns the inherited defaults for an unset thread, not 404).
- UI: `ConversationRoutingMenu.svelte` popover in `ThreadHeader.svelte`; the compose bar is untouched.

## Notes

- `WaitForAck` intentionally has **no** gorm `default:true` — a `default`-tagged bool would be dropped from the INSERT when `false`, silently re-enabling resends. Covered by a test.
- Regenerated OpenAPI spec + TS client; wiki (`code-map.md`) updated.

## Tests

- configstore CRUD (round-trip, in-place update, sparse-delete)
- service (send-path stamping, no-ack suppression of retry enrollment)
- webapi handlers (defaults, round-trip + reset, validation)
- Go `-race` clean; full web test suite (463) + `tsc` client check pass.