### PR TITLE
Fix AX.25 Terminal connect failures, stale session, and Ctrl-] menu (#456)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1495,3 +1495,41 @@ Source: [`../../pkg/stationcache/heatmap.go`](../../pkg/stationcache/heatmap.go)
 (`RecordRxEvent`, `QueryHeatmap`, `Prune`),
 [`../../pkg/historydb/heatmap_test.go`](../../pkg/historydb/heatmap_test.go),
 [`../../pkg/stationcache/heatmap_test.go`](../../pkg/stationcache/heatmap_test.go).
+
+### 59. An ax25conn session self-removes from the manager on terminal DISCONNECTED
+
+`ax25conn.Manager` keys live sessions by the `(channel, local, peer)`
+triple and rejects a second `Open` on the same triple with
+`ErrSessionExists`. A session is removed from that table only when its
+`Run` goroutine returns — the manager runs `go func(){ s.Run(ctx);
+m.remove(key,id) }()`.
+
+The invariant: **every transition into `StateDisconnected` from a live
+state ends the session's life.** `setState` sets `s.terminated` whenever
+`ns == StateDisconnected` (the initial DISCONNECTED never trips it —
+`setState` short-circuits on an unchanged state), and `handle` returns
+`false` when `terminated` is set, so `Run` exits, `cleanup` emits the
+final DISCONNECTED, and `remove` frees the triple. This covers all
+terminal paths: SABM/N2 timeout and DM-reject during setup, a peer DROP
+while connected, and the DISC/UA release handshake.
+
+*Why:* Before this, terminal transitions returned `true` and the session
+parked in DISCONNECTED forever, leaking a goroutine + manager slot on
+**every** disconnect. The operator-visible symptom (graywolf #456) was a
+reconnect to the same peer failing with "ax25conn: session already
+exists for this triple" until graywolf was restarted; the bridge's
+`Close()` cancels only the bridge/pump context, not the session, so it
+could not clear the stale entry on its own. Relatedly, a frame that
+can't be handed to the TX backend now raises a one-shot `tx-failed`
+error (guarded by `txFailNotified`) so a channel with no TNC/KISS/modem
+backend surfaces the real reason instead of the misleading "no response
+to SABM after N2 retries."
+
+Source: [`../../pkg/ax25conn/session.go`](../../pkg/ax25conn/session.go)
+(`terminated`, `setState`, `handle`, `Run`),
+[`../../pkg/ax25conn/manager.go`](../../pkg/ax25conn/manager.go)
+(`Open`, `remove`, `ErrSessionExists`),
+[`../../pkg/ax25conn/transitions_disconnected.go`](../../pkg/ax25conn/transitions_disconnected.go)
+(`submit` tx-failed emit),
+[`../../pkg/ax25conn/manager_test.go`](../../pkg/ax25conn/manager_test.go)
+(`TestManager_FreesTripleAfterFailedConnect`).

--- a/pkg/ax25conn/manager_test.go
+++ b/pkg/ax25conn/manager_test.go
@@ -252,6 +252,44 @@ func TestManager_CloseCancelsSessions(t *testing.T) {
 	// races by polling above.)
 }
 
+// TestManager_FreesTripleAfterFailedConnect guards against graywolf
+// #456: a link that never comes up must not leave its (channel, local,
+// peer) triple bound. Before the fix the session parked in DISCONNECTED
+// forever, so the operator's next connect to the same peer failed with
+// ErrSessionExists until graywolf was restarted.
+func TestManager_FreesTripleAfterFailedConnect(t *testing.T) {
+	m := newTestManager(t)
+	defer m.Close()
+	_, s := openTestSession(t, m, 1, "KE7XYZ-1", "BBS-3", "op1")
+
+	// Drive the link: SABM out, then the peer refuses with DM(F=1),
+	// which is the fast terminal path into DISCONNECTED.
+	s.Submit(Event{Kind: EventConnect})
+	m.Dispatch(1, &Frame{
+		Source:  mustParse(t, "BBS-3"),
+		Dest:    mustParse(t, "KE7XYZ-1"),
+		Control: Control{Kind: FrameDM, PF: true},
+	})
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && m.Count() != 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if m.Count() != 0 {
+		t.Fatalf("triple not freed after failed connect; Count=%d", m.Count())
+	}
+
+	// The operator must be able to reconnect to the same peer without a
+	// restart.
+	if _, _, err := m.Open(SessionConfig{
+		Local:   mustParse(t, "KE7XYZ-1"),
+		Peer:    mustParse(t, "BBS-3"),
+		Channel: 1,
+	}, "op1"); err != nil {
+		t.Fatalf("reconnect to same triple must succeed, got %v", err)
+	}
+}
+
 func TestManager_OpenAfterCloseFails(t *testing.T) {
 	m := newTestManager(t)
 	m.Close()

--- a/pkg/ax25conn/session.go
+++ b/pkg/ax25conn/session.go
@@ -103,6 +103,26 @@ type Session struct {
 	stats   LinkStats
 	pending [128]*Frame // I-frame retransmit buffer keyed by NS
 	txBuf   []byte      // operator bytes pending TX
+
+	// terminated is set by setState the first time the link reaches
+	// StateDisconnected from a live state (SABM failure, DM reject, a
+	// completed DISC handshake, or a dropped connection). It signals the
+	// run loop to exit so the manager can remove the session from its
+	// triple table — otherwise a dead session lingers and a reconnect to
+	// the same (channel, local, peer) fails with ErrSessionExists until
+	// the process restarts (graywolf #456). The initial DISCONNECTED
+	// state never sets it: setState short-circuits when the state is
+	// unchanged, so only a real transition into DISCONNECTED trips it.
+	terminated bool
+
+	// txFailNotified guards the one-shot operator-facing error emitted
+	// when a frame cannot be handed to the TX backend (e.g. the channel
+	// has no KISS/modem backend, or the wrong channel was selected).
+	// Without it, a failed SABM submit is silently logged and the link
+	// setup marches to N2 retries and reports the misleading "no
+	// response to SABM" -- even though nothing was ever transmitted
+	// (graywolf #456).
+	txFailNotified bool
 }
 
 // Snapshot returns a goroutine-safe copy of the current LinkStats.
@@ -313,19 +333,28 @@ func (s *Session) handle(ctx context.Context, ev Event) bool {
 		s.statsTick()
 		return true
 	}
+	var cont bool
 	switch s.state {
 	case StateDisconnected:
-		return s.onDisconnected(ctx, ev)
+		cont = s.onDisconnected(ctx, ev)
 	case StateAwaitingConnection:
-		return s.onAwaitingConnection(ctx, ev)
+		cont = s.onAwaitingConnection(ctx, ev)
 	case StateConnected:
-		return s.onConnected(ctx, ev)
+		cont = s.onConnected(ctx, ev)
 	case StateTimerRecovery:
-		return s.onTimerRecovery(ctx, ev)
+		cont = s.onTimerRecovery(ctx, ev)
 	case StateAwaitingRelease:
-		return s.onAwaitingRelease(ctx, ev)
+		cont = s.onAwaitingRelease(ctx, ev)
+	default:
+		return false
 	}
-	return false
+	// A transition into terminal DISCONNECTED ends the session's life;
+	// exit the run loop so cleanup() runs and the manager removes the
+	// session from its triple table.
+	if s.terminated {
+		return false
+	}
+	return cont
 }
 
 func (s *Session) cleanup() {
@@ -358,6 +387,11 @@ func (s *Session) setState(ns State) {
 	s.emit(OutEvent{Kind: OutLinkStats, Stats: s.Snapshot()})
 	if ns == StateConnected {
 		s.tStats.reset()
+	}
+	if ns == StateDisconnected {
+		// Terminal transition: the link has fully torn down. Flag the run
+		// loop to exit so the manager frees this triple (graywolf #456).
+		s.terminated = true
 	}
 }
 

--- a/pkg/ax25conn/transitions_awaiting_connection_test.go
+++ b/pkg/ax25conn/transitions_awaiting_connection_test.go
@@ -2,8 +2,46 @@ package ax25conn
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/ax25"
+	"github.com/chrissnell/graywolf/pkg/txgovernor"
 )
+
+// failSink rejects every Submit, standing in for a channel with no TX
+// backend registered.
+type failSink struct{}
+
+func (failSink) Submit(_ context.Context, _ uint32, _ *ax25.Frame, _ txgovernor.SubmitSource) error {
+	return errors.New("no backend for channel")
+}
+
+// TestAwaitingConnection_TxFailureSurfacesOnce guards graywolf #456: a
+// SABM that can't be transmitted must raise one operator-facing
+// tx-failed error rather than silently retrying to the misleading "no
+// response to SABM" timeout.
+func TestAwaitingConnection_TxFailureSurfacesOnce(t *testing.T) {
+	var emits []OutEvent
+	s := newTestSession(t, func(c *SessionConfig) {
+		c.TxSink = failSink{}
+		c.Observer = func(e OutEvent) { emits = append(emits, e) }
+	})
+	s.handle(context.Background(), Event{Kind: EventConnect})
+	// Two more SABM attempts on T1 expiry must not re-raise the error.
+	s.handle(context.Background(), Event{Kind: EventT1Expiry})
+	s.handle(context.Background(), Event{Kind: EventT1Expiry})
+
+	n := 0
+	for _, e := range emits {
+		if e.Kind == OutError && e.ErrCode == "tx-failed" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly one tx-failed OutError, got %d (emits=%+v)", n, emits)
+	}
+}
 
 // putState forces the session into the requested state and zeroes the
 // counters. Used by transition tests that bypass the Connect path.

--- a/pkg/ax25conn/transitions_disconnected.go
+++ b/pkg/ax25conn/transitions_disconnected.go
@@ -2,6 +2,7 @@ package ax25conn
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chrissnell/graywolf/pkg/ax25"
 	"github.com/chrissnell/graywolf/pkg/txgovernor"
@@ -120,7 +121,17 @@ func (s *Session) submit(f *Frame) {
 		SkipDedup: true,
 	}
 	if err := s.cfg.TxSink.Submit(context.Background(), s.cfg.Channel, wrapper, src); err != nil {
-		s.cfg.Logger.Warn("ax25conn: tx submit failed", "err", err)
+		s.cfg.Logger.Warn("ax25conn: tx submit failed", "err", err, "channel", s.cfg.Channel)
+		// Surface the real reason to the operator once. Otherwise a
+		// channel that can't transmit (no KISS/modem backend, wrong
+		// channel picked) fails silently and the link setup reports the
+		// misleading "no response to SABM" after N2 retries (graywolf
+		// #456).
+		if !s.txFailNotified {
+			s.txFailNotified = true
+			s.emit(OutEvent{Kind: OutError, ErrCode: "tx-failed",
+				ErrMsg: fmt.Sprintf("could not transmit on channel %d: %v (check the channel has a TNC/KISS or modem backend)", s.cfg.Channel, err)})
+		}
 		return
 	}
 	s.mutateStats(func(st *LinkStats) {

--- a/web/src/components/terminal/PreConnectForm.svelte
+++ b/web/src/components/terminal/PreConnectForm.svelte
@@ -6,6 +6,7 @@
   import { profilesStore, profileLabel } from '../../lib/terminal/profiles.svelte.js';
   import { api } from '../../lib/api.js';
   import { isStationCallsignMissing } from '../../lib/callsign.js';
+  import { loadAdvanced, saveAdvanced } from '../../lib/settings/terminal-advanced-store.svelte.js';
 
   let { onSubmit, onRawTail } = $props();
 
@@ -71,16 +72,20 @@
 
   // Advanced (collapsed by default). Only one operator in fifty cares
   // about these knobs; default everything to 0 (server picks kernel
-  // defaults) and tuck the controls behind a disclosure.
+  // defaults) and tuck the controls behind a disclosure. Seed from the
+  // device-local store so an operator's tuned retry/timing settings
+  // survive across sessions (graywolf #456); handleSubmit persists the
+  // values actually used on each connect.
+  const savedAdvanced = loadAdvanced();
   let advancedOpen = $state(false);
-  let mod128 = $state(false);
-  let paclen = $state(0);
-  let maxframe = $state(0);
-  let n2 = $state(0);
-  let t1ms = $state(0);
-  let t2ms = $state(0);
-  let t3ms = $state(0);
-  let backoff = $state('linear');
+  let mod128 = $state(savedAdvanced.mod128);
+  let paclen = $state(savedAdvanced.paclen);
+  let maxframe = $state(savedAdvanced.maxframe);
+  let n2 = $state(savedAdvanced.n2);
+  let t1ms = $state(savedAdvanced.t1ms);
+  let t2ms = $state(savedAdvanced.t2ms);
+  let t3ms = $state(savedAdvanced.t3ms);
+  let backoff = $state(savedAdvanced.backoff);
 
   let selectedChannel = $derived(
     channelsStore.list.find((c) => String(c.id) === String(channelId)) ?? null
@@ -188,6 +193,10 @@
       t3_ms: Number(t3ms) || 0,
       backoff,
     };
+
+    // Remember the advanced knobs on this device so the next session
+    // opens with the same retry/timing settings (graywolf #456).
+    saveAdvanced({ mod128, paclen, maxframe, n2, t1ms, t2ms, t3ms, backoff });
 
     const id = terminalSessions.open(initial);
     if (id === null) {

--- a/web/src/lib/settings/terminal-advanced-store.svelte.js
+++ b/web/src/lib/settings/terminal-advanced-store.svelte.js
@@ -1,0 +1,70 @@
+// Device-local AX.25 Terminal "Advanced timing & windowing" settings.
+// Like the log/ui-scale prefs, these are intentionally NOT synced to the
+// server: retry count (N2), the T1/T2/T3 timers, paclen, window size,
+// modulo, and backoff are per-device tuning an operator dials in once for
+// their radio + TNC and expects to persist across sessions rather than
+// resetting to the server defaults on every new connect (graywolf #456).
+//
+// Persisted as one JSON blob so adding a knob later doesn't strand old
+// keys. Unknown / malformed storage falls back to defaults field by
+// field, so a partial or corrupt entry never breaks the form.
+
+const LS_KEY = 'ax25-terminal-advanced';
+
+export const advancedDefaults = Object.freeze({
+  mod128: false,
+  paclen: 0,
+  maxframe: 0,
+  n2: 0,
+  t1ms: 0,
+  t2ms: 0,
+  t3ms: 0,
+  backoff: 'linear',
+});
+
+// loadAdvanced returns the persisted settings merged over the defaults.
+// Never throws: a missing key, disabled storage, or bad JSON yields the
+// defaults.
+export function loadAdvanced() {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return { ...advancedDefaults };
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return { ...advancedDefaults };
+    return {
+      mod128: typeof parsed.mod128 === 'boolean' ? parsed.mod128 : advancedDefaults.mod128,
+      paclen: Number.isFinite(parsed.paclen) ? parsed.paclen : advancedDefaults.paclen,
+      maxframe: Number.isFinite(parsed.maxframe) ? parsed.maxframe : advancedDefaults.maxframe,
+      n2: Number.isFinite(parsed.n2) ? parsed.n2 : advancedDefaults.n2,
+      t1ms: Number.isFinite(parsed.t1ms) ? parsed.t1ms : advancedDefaults.t1ms,
+      t2ms: Number.isFinite(parsed.t2ms) ? parsed.t2ms : advancedDefaults.t2ms,
+      t3ms: Number.isFinite(parsed.t3ms) ? parsed.t3ms : advancedDefaults.t3ms,
+      backoff: typeof parsed.backoff === 'string' ? parsed.backoff : advancedDefaults.backoff,
+    };
+  } catch {
+    return { ...advancedDefaults };
+  }
+}
+
+// saveAdvanced persists the current settings. Best-effort: storage errors
+// (private mode, quota) are swallowed so a connect never fails on a
+// preference write.
+export function saveAdvanced(s) {
+  try {
+    localStorage.setItem(
+      LS_KEY,
+      JSON.stringify({
+        mod128: !!s.mod128,
+        paclen: Number(s.paclen) || 0,
+        maxframe: Number(s.maxframe) || 0,
+        n2: Number(s.n2) || 0,
+        t1ms: Number(s.t1ms) || 0,
+        t2ms: Number(s.t2ms) || 0,
+        t3ms: Number(s.t3ms) || 0,
+        backoff: s.backoff || 'linear',
+      })
+    );
+  } catch {
+    // Non-fatal: settings just won't persist on this device.
+  }
+}

--- a/web/src/routes/Terminal.svelte
+++ b/web/src/routes/Terminal.svelte
@@ -12,6 +12,11 @@
   const FATAL_ERROR_CODES = new Set([
     'link-establish-timeout',
     'peer-rejected',
+    // The channel could not transmit at all (no TNC/KISS or modem
+    // backend, or the wrong channel was picked). Surface it up front so
+    // the operator sees the real cause instead of waiting out N2
+    // retries for the misleading "no response to SABM" (graywolf #456).
+    'tx-failed',
   ]);
 
   import TabBar from '../components/terminal/TabBar.svelte';
@@ -96,6 +101,7 @@
       return 'Link did not come up';
     }
     if (code === 'peer-rejected') return 'Peer refused the connection';
+    if (code === 'tx-failed') return 'Could not transmit';
     return 'Session error';
   }
 
@@ -106,8 +112,14 @@
 
   function handleKey(e) {
     // Ctrl-] (or Cmd-]) opens the command bar from anywhere on the
-    // route.
-    if ((e.ctrlKey || e.metaKey) && e.key === ']') {
+    // route. Match on e.code (layout-stable physical key) as well as
+    // e.key: on Safari/macOS holding Ctrl makes e.key report the GS
+    // control character (U+001D) or an empty string instead of ']', so
+    // the e.key === ']' test alone never fired there (graywolf #456).
+    if (
+      (e.ctrlKey || e.metaKey) &&
+      (e.key === ']' || e.code === 'BracketRight')
+    ) {
       e.preventDefault();
       commandBarOpen = true;
       return;


### PR DESCRIPTION
Fixes several problems reported in #456 with the AX.25 Terminal.

### 1. Reconnect fails with "session already exists for this triple"
`ax25conn` sessions were never removed from the manager's `(channel, local, peer)` table on disconnect. The session goroutine parked in `DISCONNECTED` forever, leaking a goroutine and a manager slot on **every** disconnect. The operator-visible symptom was that a second connect to the same peer failed with `ax25conn: session already exists for this triple` until graywolf was restarted (the bridge's `Close()` cancels only the bridge/pump context, not the session).

Now every transition into terminal `DISCONNECTED` ends the session's life: `setState` flags the session, the run loop exits, `cleanup` emits the final `DISCONNECTED`, and the manager frees the triple. Covers SABM/N2 timeout, DM-reject, a dropped connection, and the DISC/UA release handshake. Regression test: `TestManager_FreesTripleAfterFailedConnect`.

### 2. "No response to SABM" was hiding a can't-transmit condition
When a frame could not be handed to the TX backend (channel with no TNC/KISS/modem backend, or the wrong channel selected), the submit failure was only logged; the link setup marched to N2 retries and reported the misleading `no response to SABM after N2 retries`. It now raises a one-shot `tx-failed` error surfaced to the operator naming the channel and the real reason. This is a likely explanation for connects failing in graywolf while the same TNC works with Dire Wolf / Paracon and the Dashboard still decodes RX. Test: `TestAwaitingConnection_TxFailureSurfacesOnce`.

### 3. Ctrl-] did not open the command bar in Safari
The handler matched only `e.key === ']'`, but Safari/macOS reports the GS control character (U+001D) for `e.key` while Ctrl is held, so it never fired. Now also matches the layout-stable `e.code === 'BracketRight'`.

### 4. Advanced retry/timing settings reset every session
The Advanced timing & windowing knobs (N2 retries, T1/T2/T3, paclen, window, modulo, backoff) are now persisted per-device (localStorage, same pattern as the log/ui-scale prefs) and restored on the next connect.

### Verification
- `go test ./pkg/ax25conn/... ./pkg/ax25termws/...` (incl. `-race`) and `go vet` pass.
- `npm run build` succeeds; `npm test` — 463 passing.
- Wiki: added invariant #59 documenting the session-removal lifecycle.
