### PR TITLE
Show '(Callsign not set)' in red when beacon callsign is unset

### DIFF
--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -634,7 +634,7 @@
               <span class="beacon-callsign">{stationCallsign}</span>
               <span class="beacon-callsign-inherited">(inherited)</span>
             {:else}
-              <span class="beacon-callsign beacon-callsign-unset">(not set)</span>
+              <span class="beacon-callsign beacon-callsign-unset">(Callsign not set)</span>
             {/if}
           </div>
           <div class="beacon-badges">
@@ -1426,7 +1426,7 @@
   }
   .beacon-callsign-unset {
     font-style: italic;
-    color: var(--text-muted, var(--color-text-muted, #888));
+    color: var(--color-danger, #f85149);
   }
 
   /* Phase 2 — TX-capability blocking callout. Replaces the prior


### PR DESCRIPTION
When a beacon has no callsign and the station callsign is also unset, the beacon card rendered a muted `(not set)`. This changes the text to `(Callsign not set)` and renders it in the danger (red) color so operators immediately notice the missing callsign.

Only touches the unset-callsign branch of the beacon identity in `web/src/routes/Beacons.svelte`; the inherited and object-owner cases are unchanged.

Verified with `vite build`.