### PR TITLE
Link '(Callsign not set)' to the callsign settings page

### DIFF
--- a/web/src/routes/Beacons.svelte
+++ b/web/src/routes/Beacons.svelte
@@ -634,7 +634,7 @@
               <span class="beacon-callsign">{stationCallsign}</span>
               <span class="beacon-callsign-inherited">(inherited)</span>
             {:else}
-              <span class="beacon-callsign beacon-callsign-unset">(Callsign not set)</span>
+              <a href="#/callsign" class="beacon-callsign beacon-callsign-unset">(Callsign not set)</a>
             {/if}
           </div>
           <div class="beacon-badges">
@@ -1427,6 +1427,10 @@
   .beacon-callsign-unset {
     font-style: italic;
     color: var(--color-danger, #f85149);
+    text-decoration: underline;
+  }
+  .beacon-callsign-unset:hover {
+    text-decoration: none;
   }
 
   /* Phase 2 — TX-capability blocking callout. Replaces the prior


### PR DESCRIPTION
Follow-up to #458. Turns the red `(Callsign not set)` indicator on the beacon card into a link to `#/callsign`, so operators can click straight through to the page that sets the station callsign. Keeps the danger-red styling and adds an underline to signal it's clickable (removed on hover).

Uses the same `<a href="#/...">` internal-link pattern already used elsewhere in the app (e.g. the Channels page links to the same route). Verified with `vite build`.