### PR TITLE
Fix conversation routing menu leaking state across threads (#453)

### DIFF
--- a/web/src/components/messages/ThreadHeader.routing_key.test.js
+++ b/web/src/components/messages/ThreadHeader.routing_key.test.js
@@ -1,0 +1,29 @@
+// web/src/components/messages/ThreadHeader.routing_key.test.js
+//
+// Regression for issue #453 follow-up: ConversationRoutingMenu holds local
+// per-conversation $state (send path, wait-for-ack, loaded, open). Svelte
+// reuses the component instance when only threadKey changes, so without a
+// forced remount one conversation's routing bled into the next (open DM A,
+// set APRS-IS only; open DM B, it wrongly showed APRS-IS only). Each mount
+// must be wrapped in {#key <threadKey>} so a new conversation gets a fresh
+// component with default state.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const HEADER_PATH = new URL('./ThreadHeader.svelte', import.meta.url);
+
+test('DM routing menu is keyed by thread.key', async () => {
+  const src = await readFile(HEADER_PATH, 'utf8');
+  const m = src.match(/\{#key thread\.key\}[\s\S]*?<ConversationRoutingMenu kind="dm"[\s\S]*?\{\/key\}/);
+  assert.ok(m,
+    'DM ConversationRoutingMenu must be wrapped in {#key thread.key} so switching conversations remounts it with clean routing state');
+});
+
+test('tactical routing menu is keyed by tacticalKey', async () => {
+  const src = await readFile(HEADER_PATH, 'utf8');
+  const m = src.match(/\{#key tacticalKey\}[\s\S]*?<ConversationRoutingMenu kind="tactical"[\s\S]*?\{\/key\}/);
+  assert.ok(m,
+    'tactical ConversationRoutingMenu must be wrapped in {#key tacticalKey} so switching conversations remounts it with clean routing state');
+});

--- a/web/src/components/messages/ThreadHeader.svelte
+++ b/web/src/components/messages/ThreadHeader.svelte
@@ -73,7 +73,9 @@
     </div>
     {#if !isTactical && thread?.key}
       <div class="actions">
-        <ConversationRoutingMenu kind="dm" threadKey={thread.key} />
+        {#key thread.key}
+          <ConversationRoutingMenu kind="dm" threadKey={thread.key} />
+        {/key}
         {#if onActionsToggle}
           <Tooltip>
             <Tooltip.Trigger>
@@ -95,7 +97,9 @@
     {#if isTactical}
       <div class="actions">
         {#if tacticalKey}
-          <ConversationRoutingMenu kind="tactical" threadKey={tacticalKey} />
+          {#key tacticalKey}
+            <ConversationRoutingMenu kind="tactical" threadKey={tacticalKey} />
+          {/key}
         {/if}
         <div class="monitor">
           <Toggle


### PR DESCRIPTION
Follow-up to #455. A user testing the merged per-conversation routing feature reported that changing the Send Path / "Automatic resend until ACK" on one direct message caused a different direct message to show the same settings (https://github.com/chrissnell/graywolf/issues/453#issuecomment-4910363328).

## Cause

`ConversationRoutingMenu` keeps its per-conversation choices in local `$state` (`sendPath`, `waitForAck`, plus `loaded`/`open`). When the operator switches threads, only the `threadKey` prop changes, so Svelte reuses the same component instance and the previous conversation's state stays on screen until a fresh fetch happens on next open.

## Fix

Wrap each `ConversationRoutingMenu` mount in `ThreadHeader.svelte` with `{#key threadKey}`, so switching conversations remounts the menu with clean default state and it lazily reloads that conversation's real prefs. This resets all local state at once and stays correct if more state is added later, rather than hand-resetting each field.

Added a source-level regression test asserting both the DM and tactical menus are keyed.

Verified: `vite build` succeeds and the new test passes.