### PR TITLE
Add call-sign blocklist for messages (#465)

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -173,6 +173,20 @@ thread inherits the global defaults until the operator changes one.
 | REST | `webapi/messages.go` — GET/PUT `/api/messages/conversations/{kind}/{key}/prefs`; DTO + validation in `webapi/dto/messages.go`. GET returns inherited defaults (not 404) for an unset thread. |
 | UI | `web/src/components/messages/ConversationRoutingMenu.svelte` (gear popover: send-path radios + "Automatic Resend until ACK" checkbox, DM only), mounted in `ThreadHeader.svelte`; client in `api/messages.js`. |
 
+## Message call-sign blocklist (issue #465)
+
+Mutes inbound messages from specific senders (e.g. a station that
+repeatedly fires certificate-claim messages during APRS Thursday).
+Mirrors the tactical-callsign machinery end-to-end.
+
+| Concern | Where |
+|---|---|
+| Storage | `pkg/configstore/models.go` — `BlockedCallsign` (`callsign` uniqueIndex uppercased via `BeforeSave`, optional `note`, `enabled` bool **with no gorm default**). CRUD in `configstore/messages.go`; registered in `store.go` AutoMigrate. |
+| Router filter | `pkg/messages/blocklist_set.go` — `BlocklistSet` (atomic-pointer snapshot, same pattern as `TacticalSet`). `Blocked(source)` matches the full SSID-aware source **and** its base call, so a bare-callsign entry mutes every SSID while an SSID-qualified entry mutes only that station. Checked in `router.go` `classify` right after the self-filter, before persist/auto-ACK; a hit increments the `blocked` outcome on `messages_router_classified_total`. |
+| Reload | `pkg/messages/service.go` — `ReloadBlockedCallsigns` (called at `Start` and by the `messagesReload` drainer in `pkg/app/wiring.go`); swaps the enabled set into `BlocklistSet`. |
+| REST | `webapi/messages_blocklist.go` — GET/POST/PUT/DELETE `/api/messages/blocklist`; DTO in `webapi/dto/messages.go`; op-ids in `webapi/docs/op_ids.go`. Mutations call `reloadBlocklist` (inline reload + `signalMessagesReload`). Rejects blocking your own call sign. |
+| UI | `web/src/routes/MessagesSettings.svelte` — "Blocked call signs" Box (inline add form + list with enable toggle + remove); client in `api/messages.js`. |
+
 ### Channel TX test signal
 
 | Surface | Where |

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -2915,6 +2915,9 @@ func (a *App) messagesComponent() namedComponent {
 							if err := a.msgSvc.ReloadTacticalCallsigns(ctx); err != nil {
 								a.logger.Warn("messages reload tactical callsigns", "err", err)
 							}
+							if err := a.msgSvc.ReloadBlockedCallsigns(ctx); err != nil {
+								a.logger.Warn("messages reload blocked callsigns", "err", err)
+							}
 							if err := a.msgSvc.ReloadPreferences(ctx); err != nil {
 								a.logger.Warn("messages reload preferences", "err", err)
 							}

--- a/pkg/configstore/messages.go
+++ b/pkg/configstore/messages.go
@@ -178,3 +178,55 @@ func (s *Store) GetTacticalCallsignByCallsign(ctx context.Context, callsign stri
 	}
 	return &t, nil
 }
+
+// ---------------------------------------------------------------------------
+// BlockedCallsign CRUD
+// ---------------------------------------------------------------------------
+
+// CreateBlockedCallsign inserts a new blocklist entry. Callsign is
+// normalized to uppercase by the BlockedCallsign.BeforeSave hook.
+func (s *Store) CreateBlockedCallsign(ctx context.Context, b *BlockedCallsign) error {
+	return s.db.WithContext(ctx).Create(b).Error
+}
+
+// UpdateBlockedCallsign saves changes to an existing row. Callsign
+// re-normalization happens via BeforeSave.
+func (s *Store) UpdateBlockedCallsign(ctx context.Context, b *BlockedCallsign) error {
+	return s.db.WithContext(ctx).Save(b).Error
+}
+
+// DeleteBlockedCallsign removes a blocklist entry by id. Historical
+// message rows already persisted are unaffected — the block only
+// applies to inbound traffic received after the entry is enabled.
+func (s *Store) DeleteBlockedCallsign(ctx context.Context, id uint32) error {
+	return s.db.WithContext(ctx).Delete(&BlockedCallsign{}, id).Error
+}
+
+// GetBlockedCallsign returns a single blocklist entry by id. Returns
+// (nil, nil) on not-found to match the other getters.
+func (s *Store) GetBlockedCallsign(ctx context.Context, id uint32) (*BlockedCallsign, error) {
+	var b BlockedCallsign
+	err := s.db.WithContext(ctx).First(&b, id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+// ListBlockedCallsigns returns every blocklist entry (enabled or not),
+// ordered by callsign for stable UI display.
+func (s *Store) ListBlockedCallsigns(ctx context.Context) ([]BlockedCallsign, error) {
+	var out []BlockedCallsign
+	return out, s.db.WithContext(ctx).Order("callsign").Find(&out).Error
+}
+
+// ListEnabledBlockedCallsigns returns only the entries with
+// Enabled=true. The router uses this at startup and on reload to
+// rebuild its in-memory blocklist set.
+func (s *Store) ListEnabledBlockedCallsigns(ctx context.Context) ([]BlockedCallsign, error) {
+	var out []BlockedCallsign
+	return out, s.db.WithContext(ctx).Where("enabled = ?", true).Order("callsign").Find(&out).Error
+}

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -916,6 +916,37 @@ func (t *TacticalCallsign) BeforeSave(_ *gorm.DB) error {
 	return nil
 }
 
+// BlockedCallsign is one sender the operator has muted for inbound
+// messages. When Enabled, the router drops any inbound message whose
+// source matches Callsign before it is persisted or auto-ACKed, so the
+// station's traffic never reaches the inbox. Motivating case: a station
+// that repeatedly fires certificate-claim messages during APRS Thursday
+// (upstream #465).
+//
+// Match semantics live in the router's BlocklistSet: a bare-callsign
+// entry (no SSID, e.g. "N0CALL") blocks every SSID of that base call,
+// while an SSID-qualified entry (e.g. "N0CALL-7") blocks only that exact
+// station. Callsign is normalized to uppercase via BeforeSave.
+type BlockedCallsign struct {
+	ID       uint32 `gorm:"primaryKey;autoIncrement" json:"id"`
+	Callsign string `gorm:"size:9;not null;uniqueIndex" json:"callsign"` // 1-9 [A-Z0-9-], uppercase; optional -SSID
+	Note     string `gorm:"size:128" json:"note"`                        // optional free-text reason
+	// Enabled: like TacticalCallsign, no default:true. The handler sets
+	// the intended value explicitly, and a GORM default:true would
+	// silently override a caller passing false (GORM treats the Go zero
+	// value as "use the DB default").
+	Enabled   bool      `gorm:"not null" json:"enabled"`
+	CreatedAt time.Time `json:"-"`
+	UpdatedAt time.Time `json:"-"`
+}
+
+// BeforeSave normalizes Callsign to uppercase and trims whitespace so
+// the router's cached set always matches against a canonical value.
+func (b *BlockedCallsign) BeforeSave(_ *gorm.DB) error {
+	b.Callsign = strings.ToUpper(strings.TrimSpace(b.Callsign))
+	return nil
+}
+
 // Action is one operator-defined trigger. Identified by Name (used as
 // the message keyword). Type switches between command and webhook
 // execution; the type-specific fields are nullable.

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -164,6 +164,7 @@ func (s *Store) Migrate() error {
 		&MessagePreferences{},
 		&ConversationPrefs{},
 		&TacticalCallsign{},
+		&BlockedCallsign{},
 		&StationConfig{},
 		&UpdatesConfig{},
 		&UnitsConfig{},

--- a/pkg/messages/blocklist_set.go
+++ b/pkg/messages/blocklist_set.go
@@ -1,0 +1,81 @@
+package messages
+
+import (
+	"strings"
+	"sync/atomic"
+)
+
+// BlocklistSet is a lock-free read-side cache of the enabled blocked
+// call signs. The router hits Blocked() on every inbound message packet
+// to decide whether to drop it before persistence; CRUD mutations swap
+// in a new snapshot via Store().
+//
+// The snapshot is kept behind atomic.Pointer[map[...]] so readers never
+// contend with writers. Empty state is a non-nil empty map so Blocked()
+// never observes nil.
+//
+// Match semantics (see BlockedCallsign): an entry stored without an SSID
+// (a bare base callsign, e.g. "N0CALL") blocks every SSID of that base
+// call; an SSID-qualified entry (e.g. "N0CALL-7") blocks only that exact
+// station. Blocked() implements both by checking the full source and its
+// base call against the set.
+type BlocklistSet struct {
+	current atomic.Pointer[map[string]struct{}]
+}
+
+// NewBlocklistSet constructs an empty set. Seed via Store to populate.
+func NewBlocklistSet() *BlocklistSet {
+	s := &BlocklistSet{}
+	empty := make(map[string]struct{})
+	s.current.Store(&empty)
+	return s
+}
+
+// Store atomically replaces the active set. Keys are normalized to
+// uppercase/trimmed so readers don't have to worry about provenance. A
+// nil newSet is treated as "empty" — the set never observes nil.
+func (s *BlocklistSet) Store(newSet map[string]struct{}) {
+	if newSet == nil {
+		empty := make(map[string]struct{})
+		s.current.Store(&empty)
+		return
+	}
+	normalized := make(map[string]struct{}, len(newSet))
+	for k := range newSet {
+		nk := strings.ToUpper(strings.TrimSpace(k))
+		if nk == "" {
+			continue
+		}
+		normalized[nk] = struct{}{}
+	}
+	s.current.Store(&normalized)
+}
+
+// load returns the current snapshot, never nil.
+func (s *BlocklistSet) load() map[string]struct{} {
+	p := s.current.Load()
+	if p == nil {
+		return map[string]struct{}{}
+	}
+	return *p
+}
+
+// Blocked reports whether an inbound message from source should be
+// dropped. It matches on the full (SSID-aware) source and, so a
+// bare-callsign entry mutes every SSID, on the source's base call.
+func (s *BlocklistSet) Blocked(source string) bool {
+	full := strings.ToUpper(strings.TrimSpace(source))
+	if full == "" {
+		return false
+	}
+	m := s.load()
+	if _, ok := m[full]; ok {
+		return true
+	}
+	if base := baseCall(full); base != full {
+		if _, ok := m[base]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/messages/blocklist_set_test.go
+++ b/pkg/messages/blocklist_set_test.go
@@ -1,0 +1,61 @@
+package messages
+
+import "testing"
+
+func TestBlocklistSet_EmptyBlocksNothing(t *testing.T) {
+	s := NewBlocklistSet()
+	if s.Blocked("N0CALL") {
+		t.Fatal("empty set should block nothing")
+	}
+	if s.Blocked("") {
+		t.Fatal("empty source should never be blocked")
+	}
+}
+
+func TestBlocklistSet_BareCallsignBlocksAllSSIDs(t *testing.T) {
+	s := NewBlocklistSet()
+	s.Store(map[string]struct{}{"N0CALL": {}})
+
+	cases := map[string]bool{
+		"N0CALL":     true,
+		"N0CALL-7":   true,
+		"n0call-13":  true, // case-insensitive
+		"N0CALLX":    false,
+		"N0CALL-A":   true, // any SSID of the base call
+		"OTHER":      false,
+		"OTHER-1":    false,
+	}
+	for src, want := range cases {
+		if got := s.Blocked(src); got != want {
+			t.Errorf("Blocked(%q) = %v, want %v", src, got, want)
+		}
+	}
+}
+
+func TestBlocklistSet_SSIDQualifiedBlocksOnlyThatStation(t *testing.T) {
+	s := NewBlocklistSet()
+	s.Store(map[string]struct{}{"N0CALL-7": {}})
+
+	if !s.Blocked("N0CALL-7") {
+		t.Error("exact SSID match should be blocked")
+	}
+	if s.Blocked("N0CALL") {
+		t.Error("bare base call should NOT be blocked by an SSID-qualified entry")
+	}
+	if s.Blocked("N0CALL-3") {
+		t.Error("a different SSID should NOT be blocked")
+	}
+}
+
+func TestBlocklistSet_StoreNormalizesAndClears(t *testing.T) {
+	s := NewBlocklistSet()
+	s.Store(map[string]struct{}{"  n0call ": {}, "": {}})
+	if !s.Blocked("N0CALL") {
+		t.Error("stored key should be trimmed+uppercased for matching")
+	}
+	// Empty keys are dropped, and a later Store replaces the snapshot.
+	s.Store(nil)
+	if s.Blocked("N0CALL") {
+		t.Error("Store(nil) should clear the set")
+	}
+}

--- a/pkg/messages/router.go
+++ b/pkg/messages/router.go
@@ -41,6 +41,10 @@ type RouterConfig struct {
 	OurCall       func() string // returns our primary callsign (possibly with SSID)
 	LocalTxRing   *LocalTxRing
 	TacticalSet   *TacticalSet
+	// BlockedSet is the enabled call-sign blocklist. Optional: when nil
+	// the router constructs an empty set so nothing is blocked. Swapped
+	// by Service.ReloadBlockedCallsigns on CRUD mutations.
+	BlockedSet    *BlocklistSet
 	EventHub      *EventHub
 	Logger        *slog.Logger
 	Registerer    prometheus.Registerer
@@ -148,6 +152,10 @@ func NewRouter(cfg RouterConfig) (*Router, error) {
 	}
 	if cfg.TacticalSet == nil {
 		return nil, errors.New("messages: router requires TacticalSet")
+	}
+	// BlockedSet is optional; an empty set blocks nothing.
+	if cfg.BlockedSet == nil {
+		cfg.BlockedSet = NewBlocklistSet()
 	}
 	if cfg.EventHub == nil {
 		return nil, errors.New("messages: router requires EventHub")
@@ -353,6 +361,16 @@ func (r *Router) classify(ctx context.Context, pkt *aprs.DecodedAPRSPacket) {
 	}
 	if r.cfg.LocalTxRing.Contains(source, effMsg.MessageID) {
 		r.mClassified.WithLabelValues("self_filter").Inc()
+		return
+	}
+
+	// Blocklist filter. A muted sender's traffic is dropped here — before
+	// addressee classification, persistence, and auto-ACK — so blocked
+	// certificate-claim style messages never reach the inbox and we never
+	// ACK them back. Checked after the self-filter so we can't accidentally
+	// block our own echo path. See upstream #465.
+	if r.cfg.BlockedSet.Blocked(source) {
+		r.mClassified.WithLabelValues("blocked").Inc()
 		return
 	}
 

--- a/pkg/messages/router_blocklist_test.go
+++ b/pkg/messages/router_blocklist_test.go
@@ -1,0 +1,126 @@
+package messages
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/aprs"
+	"github.com/chrissnell/graywolf/pkg/configstore"
+)
+
+// buildRouterWithBlocklist mirrors buildRouter but seeds a BlocklistSet
+// and monitors "NET" as a tactical so both DM and tactical inbound paths
+// can be exercised against the blocklist filter.
+func buildRouterWithBlocklist(t *testing.T, ourCall string, blocked []string) (*Router, *Store, *fakeTxSink, func()) {
+	t.Helper()
+	cs, err := configstore.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	store := NewStore(cs.DB())
+	sink := &fakeTxSink{}
+	ring := NewLocalTxRing(16, time.Minute)
+	tact := NewTacticalSet()
+	tact.Store(map[string]struct{}{"NET": {}})
+	block := NewBlocklistSet()
+	if len(blocked) > 0 {
+		m := make(map[string]struct{}, len(blocked))
+		for _, k := range blocked {
+			m[k] = struct{}{}
+		}
+		block.Store(m)
+	}
+	hub := NewEventHub(16)
+	r, err := NewRouter(RouterConfig{
+		Store:       store,
+		TxSink:      sink,
+		IGateSender: &fakeIGateSender{},
+		OurCall:     func() string { return ourCall },
+		LocalTxRing: ring,
+		TacticalSet: tact,
+		BlockedSet:  block,
+		EventHub:    hub,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Clock:       &fakeClock{now: time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)},
+	})
+	if err != nil {
+		t.Fatalf("NewRouter: %v", err)
+	}
+	r.Start(context.Background())
+	cleanup := func() {
+		r.Stop()
+		_ = cs.Close()
+	}
+	return r, store, sink, cleanup
+}
+
+func TestRouterBlockedSenderDroppedNoPersistNoAutoACK(t *testing.T) {
+	r, store, sink, cleanup := buildRouterWithBlocklist(t, "N0CALL", []string{"W1ABC"})
+	defer cleanup()
+
+	// DM addressed to us, but from a blocked sender.
+	pkt := makeMessagePacket(t, "W1ABC", "N0CALL", "cert claim", "001", aprs.DirectionRF)
+	_ = r.SendPacket(context.Background(), pkt)
+	time.Sleep(50 * time.Millisecond)
+
+	ms, _, _ := store.List(context.Background(), Filter{})
+	if len(ms) != 0 {
+		t.Fatalf("blocked sender must not persist, got %d rows", len(ms))
+	}
+	if got := len(sink.list()); got != 0 {
+		t.Fatalf("blocked sender must not be auto-ACKed, got %d", got)
+	}
+}
+
+func TestRouterBlockedBareCallBlocksSSID(t *testing.T) {
+	r, store, _, cleanup := buildRouterWithBlocklist(t, "N0CALL", []string{"W1ABC"})
+	defer cleanup()
+
+	// Blocklist holds the bare base call; a message from any SSID of it
+	// must be dropped.
+	pkt := makeMessagePacket(t, "W1ABC-9", "N0CALL", "cert claim", "002", aprs.DirectionRF)
+	_ = r.SendPacket(context.Background(), pkt)
+	time.Sleep(50 * time.Millisecond)
+
+	ms, _, _ := store.List(context.Background(), Filter{})
+	if len(ms) != 0 {
+		t.Fatalf("bare-call block must cover all SSIDs, got %d rows", len(ms))
+	}
+}
+
+func TestRouterUnblockedSenderStillDelivered(t *testing.T) {
+	r, store, _, cleanup := buildRouterWithBlocklist(t, "N0CALL", []string{"W1ABC"})
+	defer cleanup()
+
+	// A different sender is not blocked and should persist normally.
+	pkt := makeMessagePacket(t, "K1XYZ", "N0CALL", "hello", "003", aprs.DirectionRF)
+	_ = r.SendPacket(context.Background(), pkt)
+	waitFor(t, time.Second, func() bool {
+		ms, _, _ := store.List(context.Background(), Filter{})
+		return len(ms) == 1
+	}, "unblocked message persisted")
+
+	ms, _, _ := store.List(context.Background(), Filter{})
+	if ms[0].FromCall != "K1XYZ" {
+		t.Fatalf("FromCall = %q, want K1XYZ", ms[0].FromCall)
+	}
+}
+
+func TestRouterBlockedTacticalSenderDropped(t *testing.T) {
+	r, store, _, cleanup := buildRouterWithBlocklist(t, "N0CALL", []string{"W1ABC"})
+	defer cleanup()
+
+	// Blocked sender posting to a monitored tactical is also dropped —
+	// the block applies to the source regardless of thread kind.
+	pkt := makeMessagePacket(t, "W1ABC", "NET", "spam", "004", aprs.DirectionRF)
+	_ = r.SendPacket(context.Background(), pkt)
+	time.Sleep(50 * time.Millisecond)
+
+	ms, _, _ := store.List(context.Background(), Filter{})
+	if len(ms) != 0 {
+		t.Fatalf("blocked tactical sender must not persist, got %d rows", len(ms))
+	}
+}

--- a/pkg/messages/router_blocklist_test.go
+++ b/pkg/messages/router_blocklist_test.go
@@ -109,6 +109,76 @@ func TestRouterUnblockedSenderStillDelivered(t *testing.T) {
 	}
 }
 
+// TestRouterDisabledBlocklistEntryAdmitsTraffic wires the real
+// enabled-only reload contract (ListEnabledBlockedCallsigns → BlocklistSet)
+// against a router: a disabled row must NOT block, an enabled one must.
+// This guards the core enable/disable toggle end to end at the store level.
+func TestRouterDisabledBlocklistEntryAdmitsTraffic(t *testing.T) {
+	t.Helper()
+	cs, err := configstore.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+	ctx := context.Background()
+	// One disabled block (W1ABC) and one enabled block (K9ZZZ).
+	if err := cs.CreateBlockedCallsign(ctx, &configstore.BlockedCallsign{Callsign: "W1ABC", Enabled: false}); err != nil {
+		t.Fatalf("create disabled: %v", err)
+	}
+	if err := cs.CreateBlockedCallsign(ctx, &configstore.BlockedCallsign{Callsign: "K9ZZZ", Enabled: true}); err != nil {
+		t.Fatalf("create enabled: %v", err)
+	}
+
+	store := NewStore(cs.DB())
+	block := NewBlocklistSet()
+	// Mirror Service.ReloadBlockedCallsigns exactly.
+	rows, err := cs.ListEnabledBlockedCallsigns(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledBlockedCallsigns: %v", err)
+	}
+	set := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		set[row.Callsign] = struct{}{}
+	}
+	block.Store(set)
+
+	r, err := NewRouter(RouterConfig{
+		Store:       store,
+		TxSink:      &fakeTxSink{},
+		IGateSender: &fakeIGateSender{},
+		OurCall:     func() string { return "N0CALL" },
+		LocalTxRing: NewLocalTxRing(16, time.Minute),
+		TacticalSet: NewTacticalSet(),
+		BlockedSet:  block,
+		EventHub:    NewEventHub(16),
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Clock:       &fakeClock{now: time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)},
+	})
+	if err != nil {
+		t.Fatalf("NewRouter: %v", err)
+	}
+	r.Start(ctx)
+	defer r.Stop()
+
+	// Disabled entry: traffic must be delivered.
+	_ = r.SendPacket(ctx, makeMessagePacket(t, "W1ABC", "N0CALL", "still here", "005", aprs.DirectionRF))
+	waitFor(t, time.Second, func() bool {
+		ms, _, _ := store.List(ctx, Filter{})
+		return len(ms) == 1
+	}, "disabled-block sender delivered")
+
+	// Enabled entry: traffic must be dropped (row count stays at 1).
+	_ = r.SendPacket(ctx, makeMessagePacket(t, "K9ZZZ", "N0CALL", "spam", "006", aprs.DirectionRF))
+	time.Sleep(50 * time.Millisecond)
+	ms, _, _ := store.List(ctx, Filter{})
+	if len(ms) != 1 {
+		t.Fatalf("expected only the disabled-block sender to persist, got %d rows", len(ms))
+	}
+	if ms[0].FromCall != "W1ABC" {
+		t.Fatalf("FromCall = %q, want W1ABC", ms[0].FromCall)
+	}
+}
+
 func TestRouterBlockedTacticalSenderDropped(t *testing.T) {
 	r, store, _, cleanup := buildRouterWithBlocklist(t, "N0CALL", []string{"W1ABC"})
 	defer cleanup()

--- a/pkg/messages/service.go
+++ b/pkg/messages/service.go
@@ -31,6 +31,7 @@ var ErrInvalidInvite = errors.New("messages: invite requires a valid invite_tact
 type ServiceConfigReader interface {
 	MessagePreferencesReader
 	ListEnabledTacticalCallsigns(ctx context.Context) ([]configstore.TacticalCallsign, error)
+	ListEnabledBlockedCallsigns(ctx context.Context) ([]configstore.BlockedCallsign, error)
 }
 
 // ServiceConfig wires the Service constructor.
@@ -96,6 +97,7 @@ type Service struct {
 	hub       *EventHub
 	ring      *LocalTxRing
 	tactSet   *TacticalSet
+	blockSet  *BlocklistSet
 	preflight *Preflight
 
 	// TxHook unregister closure — nil before Start, set in Start.
@@ -142,6 +144,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	if tactSet == nil {
 		tactSet = NewTacticalSet()
 	}
+	blockSet := NewBlocklistSet()
 	hub := cfg.EventHub
 	if hub == nil {
 		hub = NewEventHub(DefaultSubscriberBuffer)
@@ -210,6 +213,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		OurCall:     cfg.OurCall,
 		LocalTxRing: ring,
 		TacticalSet: tactSet,
+		BlockedSet:  blockSet,
 		EventHub:    hub,
 		Logger:      logger.With("component", "messages-router"),
 		Clock:       clock,
@@ -229,6 +233,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		hub:       hub,
 		ring:      ring,
 		tactSet:   tactSet,
+		blockSet:  blockSet,
 		preflight: pf,
 	}, nil
 }
@@ -250,6 +255,10 @@ func (s *Service) Start(ctx context.Context) error {
 		if err := s.ReloadTacticalCallsigns(ctx); err != nil {
 			s.logger.Warn("messages tactical callsigns initial load failed", "error", err)
 			// Not fatal.
+		}
+		if err := s.ReloadBlockedCallsigns(ctx); err != nil {
+			s.logger.Warn("messages blocked callsigns initial load failed", "error", err)
+			// Not fatal — an empty blocklist blocks nothing.
 		}
 		_, unreg := s.cfg.TxHookReg.AddTxHook(s.sender.onTxComplete)
 		s.unregTxHook = unreg
@@ -377,6 +386,22 @@ func (s *Service) ReloadTacticalCallsigns(ctx context.Context) error {
 		set[row.Callsign] = struct{}{}
 	}
 	s.tactSet.Store(set)
+	return nil
+}
+
+// ReloadBlockedCallsigns refetches the enabled call-sign blocklist and
+// swaps it into the router's cache. Called at Start and by the Phase 4
+// messagesReload channel consumer after a blocklist CRUD mutation.
+func (s *Service) ReloadBlockedCallsigns(ctx context.Context) error {
+	rows, err := s.cfg.ConfigStore.ListEnabledBlockedCallsigns(ctx)
+	if err != nil {
+		return err
+	}
+	set := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		set[row.Callsign] = struct{}{}
+	}
+	s.blockSet.Store(set)
 	return nil
 }
 

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1421,7 +1421,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1469,7 +1468,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1526,7 +1524,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1567,7 +1564,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1760,7 +1756,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1802,7 +1797,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -8040,8 +8034,7 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer",
-                        "format": "int32"
+                        "type": "integer"
                     }
                 },
                 "source": {
@@ -8291,8 +8284,7 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -8307,8 +8299,7 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -8318,8 +8309,7 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -8327,8 +8317,7 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -8340,8 +8329,7 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -8356,12 +8344,10 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "table": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 }
             }
         },
@@ -8371,8 +8357,7 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number",
-                        "format": "float64"
+                        "type": "number"
                     }
                 },
                 "analogHas": {
@@ -8388,8 +8373,7 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -8405,8 +8389,7 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -8414,8 +8397,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -8490,21 +8472,17 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain24Hour": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rainSinceMid": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -8512,8 +8490,7 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -8521,8 +8498,7 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -8534,13 +8510,11 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 }
             }
         },
@@ -11571,11 +11545,6 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
-            "x-enum-descriptions": [
-                "heard on the air",
-                "transmitted by us",
-                "APRS-IS upload/download (iGate)"
-            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -11890,8 +11859,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -11984,8 +11952,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1421,6 +1421,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1468,6 +1469,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1524,6 +1526,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1564,6 +1567,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1756,6 +1760,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1797,6 +1802,7 @@
                 "parameters": [
                     {
                         "type": "integer",
+                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -4662,6 +4668,209 @@
                     },
                     "503": {
                         "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/messages/blocklist": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "messages"
+                ],
+                "summary": "List blocked call signs",
+                "operationId": "listBlockedCallsigns",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.BlockedCallsignResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "messages"
+                ],
+                "summary": "Block a call sign",
+                "operationId": "createBlockedCallsign",
+                "parameters": [
+                    {
+                        "description": "Blocklist entry",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.BlockedCallsignRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.BlockedCallsignResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/messages/blocklist/{id}": {
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "messages"
+                ],
+                "summary": "Update a blocked call sign",
+                "operationId": "updateBlockedCallsign",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Blocklist entry id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Blocklist entry",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.BlockedCallsignRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.BlockedCallsignResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "tags": [
+                    "messages"
+                ],
+                "summary": "Unblock a call sign",
+                "operationId": "deleteBlockedCallsign",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Blocklist entry id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/webtypes.ErrorResponse"
                         }
@@ -7831,7 +8040,8 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "int32"
                     }
                 },
                 "source": {
@@ -8081,7 +8291,8 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -8096,7 +8307,8 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -8106,7 +8318,8 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -8114,7 +8327,8 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -8126,7 +8340,8 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -8141,10 +8356,12 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "table": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 }
             }
         },
@@ -8154,7 +8371,8 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number"
+                        "type": "number",
+                        "format": "float64"
                     }
                 },
                 "analogHas": {
@@ -8170,7 +8388,8 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -8186,7 +8405,8 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int32"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -8194,7 +8414,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -8269,17 +8490,21 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rain24Hour": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rainSinceMid": {
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -8287,7 +8512,8 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -8295,7 +8521,8 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -8307,11 +8534,13 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number"
+                    "type": "number",
+                    "format": "float64"
                 }
             }
         },
@@ -9127,6 +9356,43 @@
             "properties": {
                 "status": {
                     "description": "\"sent\"",
+                    "type": "string"
+                }
+            }
+        },
+        "dto.BlockedCallsignRequest": {
+            "type": "object",
+            "properties": {
+                "callsign": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "note": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.BlockedCallsignResponse": {
+            "type": "object",
+            "properties": {
+                "callsign": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "note": {
+                    "type": "string"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }
@@ -11305,6 +11571,11 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
+            "x-enum-descriptions": [
+                "heard on the air",
+                "transmitted by us",
+                "APRS-IS upload/download (iGate)"
+            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -11619,7 +11890,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -11712,7 +11984,8 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,7 +50,6 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
-          format: int32
           type: integer
         type: array
       source:
@@ -229,7 +228,6 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
-        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -241,7 +239,6 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
-        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -249,14 +246,12 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
-        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
-        format: float64
         type: number
       phg:
         allOf:
@@ -264,7 +259,6 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
-        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -275,17 +269,14 @@ definitions:
   aprs.Symbol:
     properties:
       code:
-        format: int32
         type: integer
       table:
-        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
-          format: float64
           type: number
         type: array
       analogHas:
@@ -298,7 +289,6 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
-        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -310,13 +300,11 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
-        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -369,31 +357,25 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
-        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
-        format: float64
         type: number
       rain24Hour:
-        format: float64
         type: number
       rainSinceMid:
-        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
-        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
-        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -403,11 +385,9 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
-        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
-        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -2595,10 +2575,6 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
-    x-enum-descriptions:
-      - heard on the air
-      - transmitted by us
-      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2820,7 +2796,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -2887,7 +2862,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -4057,7 +4031,6 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4078,7 +4051,6 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4109,7 +4081,6 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4151,7 +4122,6 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4272,7 +4242,6 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4293,7 +4262,6 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,6 +50,7 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
+          format: int32
           type: integer
         type: array
       source:
@@ -228,6 +229,7 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
+        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -239,6 +241,7 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
+        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -246,12 +249,14 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
+        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
+        format: float64
         type: number
       phg:
         allOf:
@@ -259,6 +264,7 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
+        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -269,14 +275,17 @@ definitions:
   aprs.Symbol:
     properties:
       code:
+        format: int32
         type: integer
       table:
+        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
+          format: float64
           type: number
         type: array
       analogHas:
@@ -289,6 +298,7 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
+        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -300,11 +310,13 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
+        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -357,25 +369,31 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
+        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
+        format: float64
         type: number
       rain24Hour:
+        format: float64
         type: number
       rainSinceMid:
+        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
+        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
+        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -385,9 +403,11 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
+        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
+        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -939,6 +959,30 @@ definitions:
     properties:
       status:
         description: '"sent"'
+        type: string
+    type: object
+  dto.BlockedCallsignRequest:
+    properties:
+      callsign:
+        type: string
+      enabled:
+        type: boolean
+      note:
+        type: string
+    type: object
+  dto.BlockedCallsignResponse:
+    properties:
+      callsign:
+        type: string
+      created_at:
+        type: string
+      enabled:
+        type: boolean
+      id:
+        type: integer
+      note:
+        type: string
+      updated_at:
         type: string
     type: object
   dto.BlocklistEntryRequest:
@@ -2551,6 +2595,10 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
+    x-enum-descriptions:
+      - heard on the air
+      - transmitted by us
+      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2772,6 +2820,7 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -2838,6 +2887,7 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -4007,6 +4057,7 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4027,6 +4078,7 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4057,6 +4109,7 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4098,6 +4151,7 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4218,6 +4272,7 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
+          format: int32
           in: path
           name: id
           required: true
@@ -4238,6 +4293,7 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
+          format: int32
           in: path
           name: id
           required: true
@@ -6232,6 +6288,135 @@ paths:
       security:
         - CookieAuth: []
       summary: Mark message unread
+      tags:
+        - messages
+  /messages/blocklist:
+    get:
+      operationId: listBlockedCallsigns
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/dto.BlockedCallsignResponse'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: List blocked call signs
+      tags:
+        - messages
+    post:
+      consumes:
+        - application/json
+      operationId: createBlockedCallsign
+      parameters:
+        - description: Blocklist entry
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/dto.BlockedCallsignRequest'
+      produces:
+        - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.BlockedCallsignResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Block a call sign
+      tags:
+        - messages
+  /messages/blocklist/{id}:
+    delete:
+      operationId: deleteBlockedCallsign
+      parameters:
+        - description: Blocklist entry id
+          in: path
+          name: id
+          required: true
+          type: integer
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Unblock a call sign
+      tags:
+        - messages
+    put:
+      consumes:
+        - application/json
+      operationId: updateBlockedCallsign
+      parameters:
+        - description: Blocklist entry id
+          in: path
+          name: id
+          required: true
+          type: integer
+        - description: Blocklist entry
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/dto.BlockedCallsignRequest'
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.BlockedCallsignResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Update a blocked call sign
       tags:
         - messages
   /messages/config:

--- a/pkg/webapi/docs/op_ids.go
+++ b/pkg/webapi/docs/op_ids.go
@@ -365,6 +365,11 @@ const (
 const (
 	OpGetMessagesConfig = "getMessagesConfig"
 	OpPutMessagesConfig = "putMessagesConfig"
+
+	OpListBlockedCallsigns  = "listBlockedCallsigns"
+	OpCreateBlockedCallsign = "createBlockedCallsign"
+	OpUpdateBlockedCallsign = "updateBlockedCallsign"
+	OpDeleteBlockedCallsign = "deleteBlockedCallsign"
 )
 
 // Maps offline downloads — /api/maps/downloads (Plan 2). Per-state

--- a/pkg/webapi/dto/messages.go
+++ b/pkg/webapi/dto/messages.go
@@ -613,6 +613,62 @@ func TacticalCallsignFromModel(m configstore.TacticalCallsign) TacticalCallsignR
 	}
 }
 
+// --- Blocked call signs --------------------------------------------------
+
+// BlockedCallsignRequest is the body accepted by POST + PUT on
+// /api/messages/blocklist.
+type BlockedCallsignRequest struct {
+	Callsign string `json:"callsign"`
+	Note     string `json:"note,omitempty"`
+	Enabled  bool   `json:"enabled"`
+}
+
+// Validate enforces addressee syntax and a non-empty callsign. An
+// SSID-qualified entry (e.g. "N0CALL-7") is accepted and blocks only
+// that station; a bare callsign blocks every SSID of the base call.
+func (r BlockedCallsignRequest) Validate() error {
+	if strings.TrimSpace(r.Callsign) == "" {
+		return fmt.Errorf("callsign is required")
+	}
+	if err := ValidateAddressee(r.Callsign); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ToModel builds a configstore row from the request. Callsign is
+// uppercased by the model's BeforeSave hook; we upper here too so
+// validation and collision checks use the canonical form.
+func (r BlockedCallsignRequest) ToModel() configstore.BlockedCallsign {
+	return configstore.BlockedCallsign{
+		Callsign: strings.ToUpper(strings.TrimSpace(r.Callsign)),
+		Note:     r.Note,
+		Enabled:  r.Enabled,
+	}
+}
+
+// BlockedCallsignResponse is the body returned by GET/POST/PUT.
+type BlockedCallsignResponse struct {
+	ID        uint32    `json:"id"`
+	Callsign  string    `json:"callsign"`
+	Note      string    `json:"note,omitempty"`
+	Enabled   bool      `json:"enabled"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// BlockedCallsignFromModel renders one row.
+func BlockedCallsignFromModel(m configstore.BlockedCallsign) BlockedCallsignResponse {
+	return BlockedCallsignResponse{
+		ID:        m.ID,
+		Callsign:  m.Callsign,
+		Note:      m.Note,
+		Enabled:   m.Enabled,
+		CreatedAt: m.CreatedAt.UTC(),
+		UpdatedAt: m.UpdatedAt.UTC(),
+	}
+}
+
 // AcceptInviteRequest is the body accepted by the accept-invite endpoint
 // (Phase 2 wires POST /api/tacticals/subscribe or similar). Acceptance
 // is tactical-keyed, not message-keyed: the message ID is optional and

--- a/pkg/webapi/messages_blocklist.go
+++ b/pkg/webapi/messages_blocklist.go
@@ -1,0 +1,197 @@
+package webapi
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+// registerMessagesBlocklist installs the /api/messages/blocklist CRUD
+// routes. The blocklist mutes inbound messages from specific call signs
+// so their traffic (e.g. repeated certificate-claim messages) never
+// reaches the inbox. See upstream #465.
+func (s *Server) registerMessagesBlocklist(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/messages/blocklist", s.listBlockedCallsigns)
+	mux.HandleFunc("POST /api/messages/blocklist", s.createBlockedCallsign)
+	mux.HandleFunc("PUT /api/messages/blocklist/{id}", s.updateBlockedCallsign)
+	mux.HandleFunc("DELETE /api/messages/blocklist/{id}", s.deleteBlockedCallsign)
+}
+
+// reloadBlocklist refreshes the router's in-memory blocklist inline and
+// signals the messages-reload channel so the reload also propagates
+// through the app-level drainer. Called after every blocklist mutation.
+func (s *Server) reloadBlocklist(r *http.Request) {
+	if s.messagesService != nil {
+		if err := s.messagesService.ReloadBlockedCallsigns(r.Context()); err != nil {
+			s.logger.Warn("reload blocked callsigns", "err", err)
+		}
+	}
+	s.signalMessagesReload()
+}
+
+// listBlockedCallsigns returns every blocklist entry (enabled or not).
+//
+// @Summary  List blocked call signs
+// @Tags     messages
+// @ID       listBlockedCallsigns
+// @Produce  json
+// @Success  200 {array} dto.BlockedCallsignResponse
+// @Failure  500 {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /messages/blocklist [get]
+func (s *Server) listBlockedCallsigns(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.store.ListBlockedCallsigns(r.Context())
+	if err != nil {
+		s.internalError(w, r, "list blocked callsigns", err)
+		return
+	}
+	out := make([]dto.BlockedCallsignResponse, len(rows))
+	for i, row := range rows {
+		out[i] = dto.BlockedCallsignFromModel(row)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// createBlockedCallsign adds a call sign to the blocklist.
+//
+// @Summary  Block a call sign
+// @Tags     messages
+// @ID       createBlockedCallsign
+// @Accept   json
+// @Produce  json
+// @Param    body body     dto.BlockedCallsignRequest true "Blocklist entry"
+// @Success  201  {object} dto.BlockedCallsignResponse
+// @Failure  400  {object} webtypes.ErrorResponse
+// @Failure  409  {object} webtypes.ErrorResponse
+// @Failure  500  {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /messages/blocklist [post]
+func (s *Server) createBlockedCallsign(w http.ResponseWriter, r *http.Request) {
+	req, err := decodeJSON[dto.BlockedCallsignRequest](r)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	if err := req.Validate(); err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	callsign := strings.ToUpper(strings.TrimSpace(req.Callsign))
+	ourCall, _ := s.resolveOurCall(r.Context())
+	if baseCall(callsign) != "" && baseCall(ourCall) != "" && baseCall(callsign) == baseCall(ourCall) {
+		badRequest(w, "cannot block your own call sign")
+		return
+	}
+	model := req.ToModel()
+	if err := s.store.CreateBlockedCallsign(r.Context(), &model); err != nil {
+		if isUniqueConstraintErr(err) {
+			conflict(w, fmt.Sprintf("call sign %q is already blocked", callsign))
+			return
+		}
+		s.internalError(w, r, "create blocked callsign", err)
+		return
+	}
+	s.reloadBlocklist(r)
+	writeJSON(w, http.StatusCreated, dto.BlockedCallsignFromModel(model))
+}
+
+// updateBlockedCallsign replaces an existing blocklist entry. Used to
+// rename, edit the note, or toggle Enabled.
+//
+// @Summary  Update a blocked call sign
+// @Tags     messages
+// @ID       updateBlockedCallsign
+// @Accept   json
+// @Produce  json
+// @Param    id   path     int                        true "Blocklist entry id"
+// @Param    body body     dto.BlockedCallsignRequest true "Blocklist entry"
+// @Success  200  {object} dto.BlockedCallsignResponse
+// @Failure  400  {object} webtypes.ErrorResponse
+// @Failure  404  {object} webtypes.ErrorResponse
+// @Failure  409  {object} webtypes.ErrorResponse
+// @Failure  500  {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /messages/blocklist/{id} [put]
+func (s *Server) updateBlockedCallsign(w http.ResponseWriter, r *http.Request) {
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid id")
+		return
+	}
+	req, err := decodeJSON[dto.BlockedCallsignRequest](r)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	if err := req.Validate(); err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	existing, err := s.store.GetBlockedCallsign(r.Context(), id)
+	if err != nil {
+		s.internalError(w, r, "get blocked callsign", err)
+		return
+	}
+	if existing == nil {
+		notFound(w)
+		return
+	}
+	callsign := strings.ToUpper(strings.TrimSpace(req.Callsign))
+	ourCall, _ := s.resolveOurCall(r.Context())
+	if baseCall(callsign) != "" && baseCall(ourCall) != "" && baseCall(callsign) == baseCall(ourCall) {
+		badRequest(w, "cannot block your own call sign")
+		return
+	}
+	model := req.ToModel()
+	model.ID = id
+	// Preserve CreatedAt so only UpdatedAt moves.
+	model.CreatedAt = existing.CreatedAt
+	if err := s.store.UpdateBlockedCallsign(r.Context(), &model); err != nil {
+		if isUniqueConstraintErr(err) {
+			conflict(w, fmt.Sprintf("call sign %q is already blocked", callsign))
+			return
+		}
+		s.internalError(w, r, "update blocked callsign", err)
+		return
+	}
+	s.reloadBlocklist(r)
+	writeJSON(w, http.StatusOK, dto.BlockedCallsignFromModel(model))
+}
+
+// deleteBlockedCallsign removes a blocklist entry. Traffic from the call
+// sign is admitted again from the next inbound packet onward.
+//
+// @Summary  Unblock a call sign
+// @Tags     messages
+// @ID       deleteBlockedCallsign
+// @Param    id  path int true "Blocklist entry id"
+// @Success  204 "No Content"
+// @Failure  400 {object} webtypes.ErrorResponse
+// @Failure  404 {object} webtypes.ErrorResponse
+// @Failure  500 {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /messages/blocklist/{id} [delete]
+func (s *Server) deleteBlockedCallsign(w http.ResponseWriter, r *http.Request) {
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		badRequest(w, "invalid id")
+		return
+	}
+	existing, err := s.store.GetBlockedCallsign(r.Context(), id)
+	if err != nil {
+		s.internalError(w, r, "get blocked callsign", err)
+		return
+	}
+	if existing == nil {
+		notFound(w)
+		return
+	}
+	if err := s.store.DeleteBlockedCallsign(r.Context(), id); err != nil {
+		s.internalError(w, r, "delete blocked callsign", err)
+		return
+	}
+	s.reloadBlocklist(r)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/webapi/messages_blocklist_test.go
+++ b/pkg/webapi/messages_blocklist_test.go
@@ -1,0 +1,179 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/configstore"
+	"github.com/chrissnell/graywolf/pkg/messages"
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+// newBlocklistTestServer wires a Server with the real store, a fake
+// messages service (so we can observe ReloadBlockedCallsigns), and the
+// blocklist routes registered.
+func newBlocklistTestServer(t *testing.T) (*Server, *http.ServeMux, *fakeMessagesSvc) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := configstore.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.UpsertStationConfig(ctx, configstore.StationConfig{Callsign: "N0CALL"}); err != nil {
+		t.Fatal(err)
+	}
+	msgStore := messages.NewStore(store.DB())
+	svc := &fakeMessagesSvc{}
+	srv, err := NewServer(Config{
+		Store:  store,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.SetMessagesService(svc)
+	srv.SetMessagesStore(msgStore)
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+	return srv, mux, svc
+}
+
+func TestBlocklist_CreateListDelete(t *testing.T) {
+	srv, mux, svc := newBlocklistTestServer(t)
+
+	reloaded := make(chan struct{}, 4)
+	svc.reloadBlockedFn = func(ctx context.Context) error {
+		select {
+		case reloaded <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+
+	// Create.
+	req := httptest.NewRequest(http.MethodPost, "/api/messages/blocklist",
+		strings.NewReader(`{"callsign":"w1abc","note":"cert spam","enabled":true}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created dto.BlockedCallsignResponse
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	if created.Callsign != "W1ABC" {
+		t.Errorf("Callsign = %q, want uppercased W1ABC", created.Callsign)
+	}
+	if !created.Enabled || created.Note != "cert spam" {
+		t.Errorf("unexpected row: %+v", created)
+	}
+	select {
+	case <-reloaded:
+	case <-time.After(time.Second):
+		t.Error("ReloadBlockedCallsigns not called on create")
+	}
+
+	// Persisted + listed.
+	rows, err := srv.store.ListBlockedCallsigns(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Callsign != "W1ABC" {
+		t.Fatalf("expected one persisted W1ABC row, got %+v", rows)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/messages/blocklist", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", rec.Code)
+	}
+	var list []dto.BlockedCallsignResponse
+	if err := json.NewDecoder(rec.Body).Decode(&list); err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("list len = %d, want 1", len(list))
+	}
+
+	// Delete.
+	id := created.ID
+	req = httptest.NewRequest(http.MethodDelete, "/api/messages/blocklist/"+itoa(id), nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete: expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	rows, _ = srv.store.ListBlockedCallsigns(context.Background())
+	if len(rows) != 0 {
+		t.Fatalf("expected empty after delete, got %+v", rows)
+	}
+}
+
+func TestBlocklist_RejectsDuplicate(t *testing.T) {
+	_, mux, _ := newBlocklistTestServer(t)
+
+	body := `{"callsign":"W1ABC","enabled":true}`
+	for i, wantCode := range []int{http.StatusCreated, http.StatusConflict} {
+		req := httptest.NewRequest(http.MethodPost, "/api/messages/blocklist", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != wantCode {
+			t.Fatalf("post #%d: got %d, want %d: %s", i, rec.Code, wantCode, rec.Body.String())
+		}
+	}
+}
+
+func TestBlocklist_RejectsOwnCallAndBadFormat(t *testing.T) {
+	_, mux, _ := newBlocklistTestServer(t)
+
+	cases := []string{
+		`{"callsign":"N0CALL","enabled":true}`,   // own call
+		`{"callsign":"N0CALL-7","enabled":true}`, // own base call, any SSID
+		`{"callsign":"","enabled":true}`,         // empty
+		`{"callsign":"TOOLONGCALL","enabled":true}`,
+	}
+	for _, body := range cases {
+		req := httptest.NewRequest(http.MethodPost, "/api/messages/blocklist", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body %s: got %d, want 400", body, rec.Code)
+		}
+	}
+}
+
+func TestBlocklist_ToggleEnabledViaPut(t *testing.T) {
+	srv, mux, _ := newBlocklistTestServer(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/messages/blocklist",
+		strings.NewReader(`{"callsign":"W1ABC","enabled":true}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	var created dto.BlockedCallsignResponse
+	_ = json.NewDecoder(rec.Body).Decode(&created)
+
+	req = httptest.NewRequest(http.MethodPut, "/api/messages/blocklist/"+itoa(created.ID),
+		strings.NewReader(`{"callsign":"W1ABC","enabled":false}`))
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	row, err := srv.store.GetBlockedCallsign(context.Background(), created.ID)
+	if err != nil || row == nil {
+		t.Fatalf("lookup after put: %v", err)
+	}
+	if row.Enabled {
+		t.Error("Enabled should be false after PUT toggle")
+	}
+}

--- a/pkg/webapi/messages_test.go
+++ b/pkg/webapi/messages_test.go
@@ -37,6 +37,7 @@ type fakeMessagesSvc struct {
 	markReadFn         func(ctx context.Context, id uint64) error
 	markUnreadFn       func(ctx context.Context, id uint64) error
 	reloadTacticalFn   func(ctx context.Context) error
+	reloadBlockedFn    func(ctx context.Context) error
 	reloadPrefsFn      func(ctx context.Context) error
 	hub                *messages.EventHub
 }
@@ -80,6 +81,12 @@ func (f *fakeMessagesSvc) MarkUnread(ctx context.Context, id uint64) error {
 func (f *fakeMessagesSvc) ReloadTacticalCallsigns(ctx context.Context) error {
 	if f.reloadTacticalFn != nil {
 		return f.reloadTacticalFn(ctx)
+	}
+	return nil
+}
+func (f *fakeMessagesSvc) ReloadBlockedCallsigns(ctx context.Context) error {
+	if f.reloadBlockedFn != nil {
+		return f.reloadBlockedFn(ctx)
 	}
 	return nil
 }

--- a/pkg/webapi/server.go
+++ b/pkg/webapi/server.go
@@ -161,6 +161,7 @@ type MessagesService interface {
 	MarkRead(ctx context.Context, id uint64) error
 	MarkUnread(ctx context.Context, id uint64) error
 	ReloadTacticalCallsigns(ctx context.Context) error
+	ReloadBlockedCallsigns(ctx context.Context) error
 	ReloadPreferences(ctx context.Context) error
 	EventHub() *messages.EventHub
 }
@@ -300,6 +301,7 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	s.registerSmartBeacon(mux)
 	s.registerMessages(mux)
 	s.registerMessagesConfig(mux)
+	s.registerMessagesBlocklist(mux)
 	s.registerAX25Terminal(mux)
 	s.registerAX25TerminalConfig(mux)
 	s.registerAX25Profiles(mux)

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2095,50 +2095,33 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /**
-             * Format: float64
-             * @description meters (0 if none reported)
-             */
+            /** @description meters (0 if none reported) */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /**
-             * Format: int32
-             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
-             */
+            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive north
-             */
+            /** @description decimal degrees, positive north */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive east
-             */
+            /** @description decimal degrees, positive east */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /**
-             * Format: float64
-             * @description knots
-             */
+            /** @description knots */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
-            /** Format: int32 */
             code?: number;
-            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2147,20 +2130,14 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /**
-             * Format: int32
-             * @description bits 0..7 (only lower 8)
-             */
+            /** @description bits 0..7 (only lower 8) */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /**
-             * Format: int32
-             * @description BITS. sense-bits bitmap (active-high per bit)
-             */
+            /** @description BITS. sense-bits bitmap (active-high per bit) */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2188,47 +2165,27 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /**
-             * Format: float64
-             * @description tenths of millibar (e.g. 10132 = 1013.2)
-             */
+            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
             pressure?: number;
-            /**
-             * Format: float64
-             * @description hundredths of an inch
-             */
+            /** @description hundredths of an inch */
             rain1Hour?: number;
-            /** Format: float64 */
             rain24Hour?: number;
-            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /**
-             * Format: float64
-             * @description inches (via 's' after 'g')
-             */
+            /** @description inches (via 's' after 'g') */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /**
-             * Format: float64
-             * @description degrees F
-             */
+            /** @description degrees F */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /**
-             * Format: float64
-             * @description mph (5-minute peak)
-             */
+            /** @description mph (5-minute peak) */
             windGust?: number;
-            /**
-             * Format: float64
-             * @description mph (1-minute sustained)
-             */
+            /** @description mph (1-minute sustained) */
             windSpeed?: number;
         };
         "configstore.Referrer": {

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -1072,6 +1072,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/messages/blocklist": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List blocked call signs */
+        get: operations["listBlockedCallsigns"];
+        put?: never;
+        /** Block a call sign */
+        post: operations["createBlockedCallsign"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/messages/blocklist/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update a blocked call sign */
+        put: operations["updateBlockedCallsign"];
+        post?: never;
+        /** Unblock a call sign */
+        delete: operations["deleteBlockedCallsign"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/messages/config": {
         parameters: {
             query?: never;
@@ -2059,33 +2095,50 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /** @description meters (0 if none reported) */
+            /**
+             * Format: float64
+             * @description meters (0 if none reported)
+             */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
+            /**
+             * Format: int32
+             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
+             */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /** @description decimal degrees, positive north */
+            /**
+             * Format: float64
+             * @description decimal degrees, positive north
+             */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /** @description decimal degrees, positive east */
+            /**
+             * Format: float64
+             * @description decimal degrees, positive east
+             */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /** @description knots */
+            /**
+             * Format: float64
+             * @description knots
+             */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
+            /** Format: int32 */
             code?: number;
+            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2094,14 +2147,20 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /** @description bits 0..7 (only lower 8) */
+            /**
+             * Format: int32
+             * @description bits 0..7 (only lower 8)
+             */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /** @description BITS. sense-bits bitmap (active-high per bit) */
+            /**
+             * Format: int32
+             * @description BITS. sense-bits bitmap (active-high per bit)
+             */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2129,27 +2188,47 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
+            /**
+             * Format: float64
+             * @description tenths of millibar (e.g. 10132 = 1013.2)
+             */
             pressure?: number;
-            /** @description hundredths of an inch */
+            /**
+             * Format: float64
+             * @description hundredths of an inch
+             */
             rain1Hour?: number;
+            /** Format: float64 */
             rain24Hour?: number;
+            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /** @description inches (via 's' after 'g') */
+            /**
+             * Format: float64
+             * @description inches (via 's' after 'g')
+             */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /** @description degrees F */
+            /**
+             * Format: float64
+             * @description degrees F
+             */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /** @description mph (5-minute peak) */
+            /**
+             * Format: float64
+             * @description mph (5-minute peak)
+             */
             windGust?: number;
-            /** @description mph (1-minute sustained) */
+            /**
+             * Format: float64
+             * @description mph (1-minute sustained)
+             */
             windSpeed?: number;
         };
         "configstore.Referrer": {
@@ -2451,6 +2530,19 @@ export interface components {
         "dto.BeaconSendResponse": {
             /** @description "sent" */
             status?: string;
+        };
+        "dto.BlockedCallsignRequest": {
+            callsign?: string;
+            enabled?: boolean;
+            note?: string;
+        };
+        "dto.BlockedCallsignResponse": {
+            callsign?: string;
+            created_at?: string;
+            enabled?: boolean;
+            id?: number;
+            note?: string;
+            updated_at?: string;
         };
         "dto.BlocklistEntryRequest": {
             enabled?: boolean;
@@ -3843,6 +3935,12 @@ export interface components {
         "dto.TxTimingRequest": {
             content: {
                 "application/json": components["schemas"]["dto.TxTimingRequest"];
+            };
+        };
+        /** @description Blocklist entry */
+        "dto.BlockedCallsignRequest": {
+            content: {
+                "application/json": components["schemas"]["dto.BlockedCallsignRequest"];
             };
         };
         /** @description Action definition */
@@ -7908,6 +8006,189 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    listBlockedCallsigns: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.BlockedCallsignResponse"][];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    createBlockedCallsign: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: components["requestBodies"]["dto.BlockedCallsignRequest"];
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.BlockedCallsignResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateBlockedCallsign: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Blocklist entry id */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: components["requestBodies"]["dto.BlockedCallsignRequest"];
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.BlockedCallsignResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteBlockedCallsign: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Blocklist entry id */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["webtypes.ErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["webtypes.ErrorResponse"];
                 };
             };
         };

--- a/web/src/api/messages.js
+++ b/web/src/api/messages.js
@@ -250,6 +250,41 @@ export function getTacticalParticipants(key, params) {
   return api.get(`/messages/tactical/${encodeURIComponent(key)}/participants${qs(params)}`);
 }
 
+// --- Blocked call signs --------------------------------------------
+
+/**
+ * GET /api/messages/blocklist
+ * @returns {Promise<Array<{id: number, callsign: string, note?: string, enabled: boolean, created_at: string, updated_at: string}>>}
+ */
+export function listBlocklist() {
+  return api.get('/messages/blocklist');
+}
+
+/**
+ * POST /api/messages/blocklist
+ * @param {{callsign: string, note?: string, enabled: boolean}} req
+ */
+export function createBlocklistEntry(req) {
+  return api.post('/messages/blocklist', req);
+}
+
+/**
+ * PUT /api/messages/blocklist/{id}
+ * @param {number} id
+ * @param {{callsign: string, note?: string, enabled: boolean}} req
+ */
+export function updateBlocklistEntry(id, req) {
+  return api.put(`/messages/blocklist/${encodeURIComponent(id)}`, req);
+}
+
+/**
+ * DELETE /api/messages/blocklist/{id} — 204.
+ * @param {number} id
+ */
+export function deleteBlocklistEntry(id) {
+  return api.delete(`/messages/blocklist/${encodeURIComponent(id)}`);
+}
+
 // --- Tactical invite accept ----------------------------------------
 
 /**

--- a/web/src/routes/MessagesSettings.svelte
+++ b/web/src/routes/MessagesSettings.svelte
@@ -1,9 +1,13 @@
 <script>
   import { onMount } from 'svelte';
-  import { Toggle, Box, Select } from '@chrissnell/chonky-ui';
+  import { Toggle, Box, Select, Input, Button, Icon } from '@chrissnell/chonky-ui';
   import { messagesPreferencesState } from '../lib/settings/messages-preferences-store.svelte.js';
   import { channelsStore, start as startChannels } from '../lib/stores/channels.svelte.js';
-  import { getMessagesConfig, putMessagesConfig } from '../api/messages.js';
+  import {
+    getMessagesConfig, putMessagesConfig,
+    listBlocklist, createBlocklistEntry, updateBlocklistEntry, deleteBlocklistEntry,
+  } from '../api/messages.js';
+  import { toasts } from '../lib/stores.js';
   import PageHeader from '../components/PageHeader.svelte';
 
   const fallbackPolicyOptions = [
@@ -15,11 +19,20 @@
 
   let txChannel = $state(0);
 
+  // --- Blocked call signs ---
+  /** @type {Array<any>} */
+  let blocklist = $state([]);
+  let newCall = $state('');
+  let newNote = $state('');
+  let blockError = $state('');
+  let addingBlock = $state(false);
+
   onMount(async () => {
     messagesPreferencesState.fetchPreferences();
     startChannels();
     const cfg = await getMessagesConfig().catch(() => null);
     txChannel = cfg?.tx_channel ?? 0;
+    await refreshBlocklist();
   });
 
   let txChannelOptions = $derived([
@@ -37,6 +50,66 @@
     } catch {
       const cfg = await getMessagesConfig().catch(() => null);
       txChannel = cfg?.tx_channel ?? 0;
+    }
+  }
+
+  async function refreshBlocklist() {
+    try {
+      const rows = await listBlocklist();
+      blocklist = rows || [];
+    } catch {
+      // non-fatal
+    }
+  }
+
+  function onNewCallInput(e) {
+    newCall = (e.target.value || '').toUpperCase();
+    if (e.target.value !== newCall) e.target.value = newCall;
+    blockError = '';
+  }
+
+  function validateCall(call) {
+    if (!call) return 'Call sign is required.';
+    if (!/^[A-Z0-9-]{1,9}$/.test(call)) return 'Invalid format — up to 9 characters: A-Z, 0-9, -.';
+    const dup = blocklist.find((r) => (r.callsign || '').toUpperCase() === call);
+    if (dup) return `${call} is already blocked.`;
+    return '';
+  }
+
+  async function addBlock() {
+    const call = (newCall || '').trim().toUpperCase();
+    const err = validateCall(call);
+    if (err) { blockError = err; return; }
+    addingBlock = true;
+    try {
+      await createBlocklistEntry({ callsign: call, note: (newNote || '').trim(), enabled: true });
+      toasts.success(`Blocked ${call}`);
+      newCall = '';
+      newNote = '';
+      await refreshBlocklist();
+    } catch (e) {
+      blockError = e?.message || 'Could not block call sign.';
+    } finally {
+      addingBlock = false;
+    }
+  }
+
+  async function toggleBlock(row, next) {
+    try {
+      await updateBlocklistEntry(row.id, { callsign: row.callsign, note: row.note || '', enabled: next });
+      await refreshBlocklist();
+    } catch (e) {
+      toasts.error(e?.message || 'Update failed');
+    }
+  }
+
+  async function removeBlock(row) {
+    try {
+      await deleteBlocklistEntry(row.id);
+      toasts.success(`Unblocked ${row.callsign}`);
+      await refreshBlocklist();
+    } catch (e) {
+      toasts.error(e?.message || 'Delete failed');
     }
   }
 </script>
@@ -81,6 +154,64 @@
   </p>
 </Box>
 
+<Box title="Blocked call signs">
+  <p class="messages-hint block-intro">
+    Messages from a blocked call sign are dropped before they reach your
+    inbox, and graywolf never acknowledges them. Enter a bare call sign
+    (like <code>N0CALL</code>) to block every SSID, or an SSID-qualified
+    call sign (like <code>N0CALL-7</code>) to block just that station.
+  </p>
+
+  <form class="block-add" onsubmit={(e) => { e.preventDefault(); addBlock(); }}>
+    <Input
+      type="text"
+      value={newCall}
+      oninput={onNewCallInput}
+      placeholder="N0CALL"
+      aria-label="Call sign to block"
+    />
+    <Input
+      type="text"
+      bind:value={newNote}
+      placeholder="Reason (optional)"
+      aria-label="Reason"
+    />
+    <Button variant="primary" type="submit" disabled={addingBlock}>
+      <Icon name="user-x" size="sm" />
+      Block
+    </Button>
+  </form>
+  {#if blockError}
+    <p class="err" role="alert">{blockError}</p>
+  {/if}
+
+  {#if blocklist.length === 0}
+    <p class="messages-hint block-empty">No call signs are blocked.</p>
+  {:else}
+    <ul class="block-rows">
+      {#each blocklist as row (row.id)}
+        <li class="block-row" class:disabled={row.enabled === false}>
+          <div class="block-text">
+            <span class="block-call">{row.callsign}</span>
+            {#if row.note}<span class="block-note">{row.note}</span>{/if}
+          </div>
+          <div class="block-actions">
+            <Toggle
+              checked={row.enabled !== false}
+              onCheckedChange={(v) => toggleBlock(row, v)}
+              label="Blocking"
+              aria-label={`Toggle blocking for ${row.callsign}`}
+            />
+            <Button variant="ghost" size="sm" onclick={() => removeBlock(row)} aria-label={`Unblock ${row.callsign}`}>
+              <Icon name="trash-2" size="sm" />
+            </Button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</Box>
+
 <style>
   .messages-hint {
     margin-top: 12px;
@@ -94,5 +225,68 @@
     font-size: 13px;
     font-weight: 500;
     color: var(--text-default);
+  }
+  .block-intro { margin-top: 0; margin-bottom: 16px; }
+  .block-intro code {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    padding: 1px 4px;
+    border-radius: 4px;
+    background: var(--color-bg-subtle, rgba(127, 127, 127, 0.12));
+  }
+  .block-add {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .block-add :global(input) { min-width: 0; }
+  .err {
+    margin-top: 8px;
+    color: var(--color-danger, #d33);
+    font-size: 13px;
+  }
+  .block-empty { font-style: italic; }
+  .block-rows {
+    list-style: none;
+    margin: 16px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .block-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    background: var(--color-bg-subtle, rgba(127, 127, 127, 0.06));
+  }
+  .block-row.disabled { opacity: 0.55; }
+  .block-text {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    min-width: 0;
+  }
+  .block-call {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    font-size: 14px;
+  }
+  .block-note {
+    font-size: 12px;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .block-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
   }
 </style>


### PR DESCRIPTION
Closes #465.

## What

Adds the ability to block/filter inbound APRS messages from specific call signs, surfaced on the **Messages settings tab**. The motivating case (from Glen M6GSN) is a station that repeatedly fires certificate-claim messages during APRS Thursday check-ins to the ARRS service -- the operator can now block that call sign so its messages never appear.

## How it works

A blocked sender's traffic is dropped in the message router's `classify` step **before persistence and auto-ACK** -- so blocked messages never reach the inbox and graywolf never acknowledges them (which would otherwise keep the sender retrying).

Match semantics:
- A **bare call sign** (e.g. `N0CALL`) blocks every SSID of that base call.
- An **SSID-qualified** entry (e.g. `N0CALL-7`) blocks only that exact station.

The feature mirrors the existing tactical-callsign machinery end to end.

## Changes

- **Storage**: `BlockedCallsign` table (`configstore/models.go`, CRUD in `configstore/messages.go`, registered in AutoMigrate).
- **Router**: `BlocklistSet` (lock-free atomic-pointer snapshot, same pattern as `TacticalSet`) checked in `router.go` `classify`; a hit increments the `blocked` outcome on `messages_router_classified_total`.
- **Service**: `ReloadBlockedCallsigns` loaded at `Start` and on the `messagesReload` channel after any CRUD mutation.
- **REST**: GET/POST/PUT/DELETE `/api/messages/blocklist` (`webapi/messages_blocklist.go`), DTO, op-ids; rejects blocking your own call sign. OpenAPI spec + TS client regenerated.
- **UI**: "Blocked call signs" section on `MessagesSettings.svelte` (add form + list with enable toggle + remove).
- **Tests**: `BlocklistSet` matching, router drop/deliver behavior, and REST CRUD.
- **Wiki**: new section in `docs/wiki/code-map.md`.

## Verification

- `go build ./...`, `go test ./pkg/{messages,configstore,webapi,app}`, `go test -race`, `go vet` -- all pass.
- `make docs-check` / `make docs-lint` pass; strict `api.d.ts` generation matches committed.
- `npm run build` (web) succeeds.