### PR TITLE
Add ADS-B (Mode S) modulator and demodulator

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -20,6 +20,7 @@ Crate name: `graywolf-demod`. Binary: `graywolf-modem`. Source:
 | QPSK 2400 / 8-PSK 4800 | `modem_psk/mod.rs` |
 | FX.25 RS-coded FEC | `fx25/{mod,rs,tests}.rs` |
 | IL2P framing + RS | `il2p/{mod,header,payload,scramble,rs_il2p,tests}.rs` |
+| ADS-B / Mode S PPM mod+demod (1090 MHz) | `adsb/{mod,crc,modulator,demodulator,message,tests}.rs` |
 | HDLC RX (NRZI, FCS-16, bit-unstuff, fix-bits retry) | `hdlc.rs` |
 | HDLC TX bit stream | `tx/hdlc_encode.rs` |
 | AFSK modulator (NCO + sine LUT) | `tx/afsk_mod.rs` |

--- a/graywolf-modem/src/adsb/crc.rs
+++ b/graywolf-modem/src/adsb/crc.rs
@@ -1,0 +1,71 @@
+//! Mode S / ADS-B 24-bit CRC.
+//!
+//! Every Mode S downlink frame carries a 24-bit parity field in its trailing
+//! three bytes. The parity is the remainder of the message polynomial divided
+//! by the Mode S generator polynomial `0xFFF409` (ICAO Annex 10, Vol IV). For
+//! extended squitter (DF17 / DF18) the parity has no interrogator overlay, so a
+//! correctly received frame checksums to zero over all of its bytes.
+//!
+//! The table-driven byte-wise routine here matches dump1090's `modescrc`.
+
+/// Mode S CRC generator polynomial (implicit `x^24` term omitted).
+pub const GENERATOR_POLY: u32 = 0x00FF_F409;
+
+/// Number of parity bits appended to every Mode S frame.
+pub const PARITY_BITS: usize = 24;
+
+/// Precomputed byte lookup table for the Mode S CRC.
+static CRC_TABLE: [u32; 256] = build_table();
+
+const fn build_table() -> [u32; 256] {
+    let mut table = [0u32; 256];
+    let mut i = 0;
+    while i < 256 {
+        let mut c = (i as u32) << 16;
+        let mut j = 0;
+        while j < 8 {
+            if c & 0x0080_0000 != 0 {
+                c = (c << 1) ^ GENERATOR_POLY;
+            } else {
+                c <<= 1;
+            }
+            j += 1;
+        }
+        table[i] = c & 0x00FF_FFFF;
+        i += 1;
+    }
+    table
+}
+
+/// Compute the 24-bit Mode S checksum over `msg`.
+///
+/// A valid extended-squitter frame (with parity in the last three bytes)
+/// returns `0`. The routine reduces `msg(x) * x^24 mod g(x)`, so the checksum
+/// of just the data bytes (parity omitted) is exactly the parity to append.
+pub fn checksum(msg: &[u8]) -> u32 {
+    let mut rem: u32 = 0;
+    for &b in msg {
+        let idx = (b ^ ((rem >> 16) as u8)) as usize;
+        rem = ((rem << 8) ^ CRC_TABLE[idx]) & 0x00FF_FFFF;
+    }
+    rem
+}
+
+/// Write the correct parity into the trailing three bytes of `frame`.
+///
+/// The parity is `data(x) * x^24 mod g(x)` — the checksum of the data bytes
+/// alone — which makes the completed frame checksum to zero. `frame` must be
+/// 7 or 14 bytes.
+pub fn append_parity(frame: &mut [u8]) {
+    let n = frame.len();
+    debug_assert!(n >= 3, "frame too short for parity");
+    let p = checksum(&frame[..n - 3]);
+    frame[n - 3] = (p >> 16) as u8;
+    frame[n - 2] = (p >> 8) as u8;
+    frame[n - 1] = p as u8;
+}
+
+/// True when `frame` carries valid extended-squitter parity (checksum zero).
+pub fn is_valid(frame: &[u8]) -> bool {
+    checksum(frame) == 0
+}

--- a/graywolf-modem/src/adsb/demodulator.rs
+++ b/graywolf-modem/src/adsb/demodulator.rs
@@ -35,8 +35,10 @@ impl DemodFrame {
 /// Decodes Mode S PPM from magnitude samples.
 #[derive(Clone, Copy, Debug)]
 pub struct Demodulator {
-    /// Samples per microsecond (must be even, default 2).
-    pub samples_per_us: usize,
+    /// Samples per microsecond. Private so the even/≥2 invariant established in
+    /// [`Demodulator::new`] cannot be bypassed by a struct literal (which would
+    /// make `slot_len` zero and panic on divide-by-zero).
+    samples_per_us: usize,
     /// Accept only frames whose extended-squitter CRC is zero. When false,
     /// frames are returned regardless of residual (useful for DF0/4/5/11/20/21
     /// whose parity is overlaid with an address).
@@ -55,6 +57,11 @@ impl Demodulator {
         Self { samples_per_us, ..Self::default() }
     }
 
+    /// Configured samples per microsecond.
+    pub fn samples_per_us(&self) -> usize {
+        self.samples_per_us
+    }
+
     fn slot_len(&self) -> usize {
         self.samples_per_us / 2
     }
@@ -70,6 +77,11 @@ impl Demodulator {
     }
 
     /// Preamble match at offset `i`: every high slot must exceed every low slot.
+    ///
+    /// This strict correlation is tuned for a clean modulator/offline stream —
+    /// on a noisy off-air envelope a single elevated low slot rejects the match.
+    /// A field-grade detector would add a per-pulse threshold and margin; that
+    /// belongs with the eventual live-pipeline wiring.
     fn preamble_ok(&self, mag: &[u16], i: usize) -> bool {
         let slot = self.slot_len();
         let mut high_min = u32::MAX;

--- a/graywolf-modem/src/adsb/demodulator.rs
+++ b/graywolf-modem/src/adsb/demodulator.rs
@@ -1,0 +1,148 @@
+//! ADS-B (Mode S) pulse-position demodulator.
+//!
+//! Operates on a magnitude (envelope) sample stream — the classic dump1090
+//! approach. For each candidate offset it correlates against the 8 µs preamble,
+//! then slices each 1 µs data bit by comparing its two half-microsecond slots
+//! (first half stronger ⇒ `1`). The downlink format field selects the frame
+//! length (56 or 112 bits) and the 24-bit CRC gates acceptance.
+
+use super::crc;
+use super::{
+    long_frame_df, DATA_SLOTS_PER_BIT, LONG_FRAME_BITS, PREAMBLE_HIGH_SLOTS, PREAMBLE_LOW_SLOTS,
+    PREAMBLE_SLOTS, SHORT_FRAME_BITS,
+};
+
+/// A demodulated Mode S frame.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DemodFrame {
+    /// Raw message bytes (7 or 14).
+    pub bytes: Vec<u8>,
+    /// Downlink format (top 5 bits of byte 0).
+    pub df: u8,
+    /// CRC residual — `0` for a clean extended-squitter frame.
+    pub crc_residual: u32,
+    /// Sample index of the preamble start.
+    pub offset: usize,
+}
+
+impl DemodFrame {
+    /// True when the extended-squitter CRC checks out.
+    pub fn crc_ok(&self) -> bool {
+        self.crc_residual == 0
+    }
+}
+
+/// Decodes Mode S PPM from magnitude samples.
+#[derive(Clone, Copy, Debug)]
+pub struct Demodulator {
+    /// Samples per microsecond (must be even, default 2).
+    pub samples_per_us: usize,
+    /// Accept only frames whose extended-squitter CRC is zero. When false,
+    /// frames are returned regardless of residual (useful for DF0/4/5/11/20/21
+    /// whose parity is overlaid with an address).
+    pub require_crc: bool,
+}
+
+impl Default for Demodulator {
+    fn default() -> Self {
+        Self { samples_per_us: 2, require_crc: true }
+    }
+}
+
+impl Demodulator {
+    pub fn new(samples_per_us: usize) -> Self {
+        assert!(samples_per_us >= 2 && samples_per_us.is_multiple_of(2), "samples_per_us must be even and >= 2");
+        Self { samples_per_us, ..Self::default() }
+    }
+
+    fn slot_len(&self) -> usize {
+        self.samples_per_us / 2
+    }
+
+    /// Mean magnitude over the half-microsecond slot beginning at `sample`.
+    fn slot_mag(&self, mag: &[u16], sample: usize) -> u32 {
+        let len = self.slot_len();
+        let mut sum = 0u32;
+        for k in 0..len {
+            sum += mag[sample + k] as u32;
+        }
+        sum / len as u32
+    }
+
+    /// Preamble match at offset `i`: every high slot must exceed every low slot.
+    fn preamble_ok(&self, mag: &[u16], i: usize) -> bool {
+        let slot = self.slot_len();
+        let mut high_min = u32::MAX;
+        for &s in &PREAMBLE_HIGH_SLOTS {
+            high_min = high_min.min(self.slot_mag(mag, i + s * slot));
+        }
+        if high_min == 0 {
+            return false;
+        }
+        let mut low_max = 0u32;
+        for &s in &PREAMBLE_LOW_SLOTS {
+            low_max = low_max.max(self.slot_mag(mag, i + s * slot));
+        }
+        high_min > low_max
+    }
+
+    /// Slice `nbits` PPM data bits that follow the preamble at offset `i`.
+    fn slice_bits(&self, mag: &[u16], i: usize, nbits: usize) -> Vec<u8> {
+        let slot = self.slot_len();
+        let data_start = i + PREAMBLE_SLOTS * slot;
+        let mut bytes = vec![0u8; nbits / 8];
+        for j in 0..nbits {
+            let base = data_start + j * DATA_SLOTS_PER_BIT * slot;
+            let first = self.slot_mag(mag, base);
+            let second = self.slot_mag(mag, base + slot);
+            if first > second {
+                bytes[j / 8] |= 1 << (7 - (j % 8));
+            }
+        }
+        bytes
+    }
+
+    /// Samples spanned by a full frame (preamble + `nbits` data) at this rate.
+    fn frame_samples(&self, nbits: usize) -> usize {
+        (PREAMBLE_SLOTS + nbits * DATA_SLOTS_PER_BIT) * self.slot_len()
+    }
+
+    /// Scan `mag` and return every accepted Mode S frame.
+    pub fn demodulate(&self, mag: &[u16]) -> Vec<DemodFrame> {
+        let mut frames = Vec::new();
+        let long_span = self.frame_samples(LONG_FRAME_BITS);
+        let short_span = self.frame_samples(SHORT_FRAME_BITS);
+        let mut i = 0usize;
+        while i + short_span <= mag.len() {
+            if !self.preamble_ok(mag, i) {
+                i += 1;
+                continue;
+            }
+
+            // Read the DF from a short slice, then extend to a long frame when
+            // the format demands it (and the buffer allows).
+            let short_bytes = self.slice_bits(mag, i, SHORT_FRAME_BITS);
+            let df = short_bytes[0] >> 3;
+            let nbits = if long_frame_df(df) && i + long_span <= mag.len() {
+                LONG_FRAME_BITS
+            } else {
+                SHORT_FRAME_BITS
+            };
+
+            let bytes = if nbits == SHORT_FRAME_BITS {
+                short_bytes
+            } else {
+                self.slice_bits(mag, i, LONG_FRAME_BITS)
+            };
+
+            let residual = crc::checksum(&bytes);
+            if !self.require_crc || residual == 0 {
+                frames.push(DemodFrame { bytes, df, crc_residual: residual, offset: i });
+                i += self.frame_samples(nbits);
+            } else {
+                i += 1;
+            }
+        }
+        frames
+    }
+}

--- a/graywolf-modem/src/adsb/message.rs
+++ b/graywolf-modem/src/adsb/message.rs
@@ -15,9 +15,10 @@ pub const DF_ADSB: u8 = 17;
 /// Default transponder capability for a DF17 broadcast.
 pub const CA_LEVEL2: u8 = 5;
 
-/// 6-bit ident charset (index → ASCII). `#` marks unused slots.
+/// 6-bit ident charset (index → ASCII). Index 32 is space; `#` marks the
+/// unused/reserved slots that decoding skips.
 const IDENT_CHARSET: &[u8; 64] =
-    b"#ABCDEFGHIJKLMNOPQRSTUVWXYZ#####################0123456789######";
+    b"#ABCDEFGHIJKLMNOPQRSTUVWXYZ##### ###############0123456789######";
 
 /// Read `len` bits (`<= 32`) from `msg`, MSB-first, starting at bit `start`.
 fn get_bits(msg: &[u8], start: usize, len: usize) -> u32 {

--- a/graywolf-modem/src/adsb/message.rs
+++ b/graywolf-modem/src/adsb/message.rs
@@ -1,0 +1,247 @@
+//! Mode S / ADS-B message construction and field decoding.
+//!
+//! A focused decoder for the extended-squitter formats that make ADS-B useful:
+//! downlink format, ICAO address, type code, aircraft identification
+//! (callsign), and airborne position (CPR + barometric altitude). The layout
+//! follows the same ME-field parsing as the `adsb_deku` reference
+//! (<https://github.com/rsadsb/adsb_deku>). Frame construction is the inverse,
+//! so a callsign round-trips through [`super::modulator`] and
+//! [`super::demodulator`].
+
+use super::crc;
+
+/// Extended squitter downlink format (ADS-B).
+pub const DF_ADSB: u8 = 17;
+/// Default transponder capability for a DF17 broadcast.
+pub const CA_LEVEL2: u8 = 5;
+
+/// 6-bit ident charset (index → ASCII). `#` marks unused slots.
+const IDENT_CHARSET: &[u8; 64] =
+    b"#ABCDEFGHIJKLMNOPQRSTUVWXYZ#####################0123456789######";
+
+/// Read `len` bits (`<= 32`) from `msg`, MSB-first, starting at bit `start`.
+fn get_bits(msg: &[u8], start: usize, len: usize) -> u32 {
+    let mut v = 0u32;
+    for k in 0..len {
+        let bit = start + k;
+        let set = (msg[bit / 8] >> (7 - (bit % 8))) & 1;
+        v = (v << 1) | set as u32;
+    }
+    v
+}
+
+/// A parsed Mode S frame — a thin view over the raw bytes.
+#[derive(Clone, Debug)]
+pub struct Frame<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> Frame<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes }
+    }
+
+    /// Downlink format (5 bits).
+    pub fn df(&self) -> u8 {
+        self.bytes[0] >> 3
+    }
+
+    /// Transponder capability (3 bits) for DF17/18.
+    pub fn ca(&self) -> u8 {
+        self.bytes[0] & 0x07
+    }
+
+    /// 24-bit ICAO aircraft address (DF17/18).
+    pub fn icao(&self) -> u32 {
+        get_bits(self.bytes, 8, 24)
+    }
+
+    /// ME type code (top 5 bits of the message field), or `None` if too short.
+    pub fn type_code(&self) -> Option<u8> {
+        if self.bytes.len() < 11 {
+            return None;
+        }
+        Some((get_bits(self.bytes, 32, 5)) as u8)
+    }
+
+    /// Decode the 8-character callsign for identification messages (TC 1-4).
+    pub fn callsign(&self) -> Option<String> {
+        match self.type_code() {
+            Some(tc) if (1..=4).contains(&tc) => {}
+            _ => return None,
+        }
+        let mut s = String::with_capacity(8);
+        for c in 0..8 {
+            // Callsign chars start at ME bit 9 (message bit 40), 6 bits each.
+            let idx = get_bits(self.bytes, 40 + c * 6, 6) as usize;
+            let ch = IDENT_CHARSET[idx];
+            if ch != b'#' {
+                s.push(ch as char);
+            }
+        }
+        Some(s.trim_end().to_string())
+    }
+
+    /// Decode an airborne-position ME field (TC 9-18, 20-22): CPR fraction,
+    /// odd/even flag, and barometric altitude (feet).
+    pub fn airborne_position(&self) -> Option<AirbornePosition> {
+        let tc = self.type_code()?;
+        if !((9..=18).contains(&tc) || (20..=22).contains(&tc)) {
+            return None;
+        }
+        Some(AirbornePosition {
+            odd: get_bits(self.bytes, 53, 1) == 1,
+            lat_cpr: get_bits(self.bytes, 54, 17),
+            lon_cpr: get_bits(self.bytes, 71, 17),
+            altitude: decode_ac12(get_bits(self.bytes, 40, 12) as u16),
+        })
+    }
+}
+
+/// One half of an airborne CPR position report.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AirbornePosition {
+    /// CPR format: `false` = even frame, `true` = odd frame.
+    pub odd: bool,
+    /// 17-bit encoded latitude fraction.
+    pub lat_cpr: u32,
+    /// 17-bit encoded longitude fraction.
+    pub lon_cpr: u32,
+    /// Barometric altitude in feet, if the AC field was valid.
+    pub altitude: Option<i32>,
+}
+
+/// Decode a 12-bit AC altitude field to feet (25 ft Q-bit encoding).
+fn decode_ac12(ac: u16) -> Option<i32> {
+    if ac == 0 {
+        return None;
+    }
+    // Q bit (bit 5 of 12, i.e. mask 0x10) selects 25 ft resolution.
+    if ac & 0x10 != 0 {
+        let n = (((ac & 0x0FE0) >> 1) | (ac & 0x000F)) as i32;
+        Some(n * 25 - 1000)
+    } else {
+        // 100 ft Gillham-coded altitudes are not decoded here.
+        None
+    }
+}
+
+/// CPR longitude-zone count for a given latitude (ICAO Annex 10).
+fn cpr_nl(lat: f64) -> f64 {
+    let lat = lat.abs();
+    if lat < 1e-9 {
+        return 59.0;
+    }
+    if (lat - 87.0).abs() < 1e-9 {
+        return 2.0;
+    }
+    if lat > 87.0 {
+        return 1.0;
+    }
+    let nz = 15.0;
+    let a = 1.0 - (std::f64::consts::PI / (2.0 * nz)).cos();
+    let b = (std::f64::consts::PI / 180.0 * lat).cos().powi(2);
+    let x = (1.0 - a / b).acos();
+    (2.0 * std::f64::consts::PI / x).floor()
+}
+
+/// Globally decode an airborne position from an even and an odd frame.
+///
+/// `newest_is_odd` marks which of the pair was received most recently; its
+/// longitude zone anchors the result. Returns `(latitude, longitude)` in
+/// degrees, or `None` when the two frames straddle a latitude zone boundary.
+pub fn cpr_decode_airborne(
+    even: &AirbornePosition,
+    odd: &AirbornePosition,
+    newest_is_odd: bool,
+) -> Option<(f64, f64)> {
+    const SCALE: f64 = 131072.0; // 2^17
+    let lat_even = even.lat_cpr as f64 / SCALE;
+    let lat_odd = odd.lat_cpr as f64 / SCALE;
+
+    let dlat_even = 360.0 / 60.0;
+    let dlat_odd = 360.0 / 59.0;
+
+    let j = (59.0 * lat_even - 60.0 * lat_odd + 0.5).floor();
+
+    let mut rlat_even = dlat_even * (j.rem_euclid(60.0) + lat_even);
+    let mut rlat_odd = dlat_odd * (j.rem_euclid(59.0) + lat_odd);
+    if rlat_even >= 270.0 {
+        rlat_even -= 360.0;
+    }
+    if rlat_odd >= 270.0 {
+        rlat_odd -= 360.0;
+    }
+
+    if cpr_nl(rlat_even) != cpr_nl(rlat_odd) {
+        return None;
+    }
+
+    let (rlat, nl, lon_cpr) = if newest_is_odd {
+        (rlat_odd, cpr_nl(rlat_odd) - 1.0, odd.lon_cpr as f64 / SCALE)
+    } else {
+        (rlat_even, cpr_nl(rlat_even), even.lon_cpr as f64 / SCALE)
+    };
+
+    let ni = nl.max(1.0);
+    let dlon = 360.0 / ni;
+    let m = (even.lon_cpr as f64 / SCALE * (cpr_nl(rlat) - 1.0)
+        - odd.lon_cpr as f64 / SCALE * cpr_nl(rlat)
+        + 0.5)
+        .floor();
+    let mut lon = dlon * (m.rem_euclid(ni) + lon_cpr);
+    if lon >= 180.0 {
+        lon -= 360.0;
+    }
+    Some((rlat, lon))
+}
+
+/// Build a complete DF17 identification (callsign) frame with valid parity.
+///
+/// `callsign` is padded/truncated to 8 chars; unsupported characters become
+/// spaces. Returns the 14-byte extended-squitter frame.
+pub fn encode_identification(icao: u32, callsign: &str) -> [u8; 14] {
+    let mut frame = [0u8; 14];
+    frame[0] = (DF_ADSB << 3) | CA_LEVEL2;
+    frame[1] = (icao >> 16) as u8;
+    frame[2] = (icao >> 8) as u8;
+    frame[3] = icao as u8;
+
+    // ME: TC(5)=4, category(3)=0, then 8 x 6-bit characters.
+    let tc: u8 = 4;
+    frame[4] = tc << 3;
+
+    let mut chars = [b' '; 8];
+    for (i, c) in callsign.chars().take(8).enumerate() {
+        chars[i] = char_to_ident(c);
+    }
+    // Pack 48 callsign bits starting at message bit 40 (ME bit 9).
+    let mut bitpos = 40usize;
+    for &c in &chars {
+        let code = ident_to_index(c);
+        for k in (0..6).rev() {
+            let set = (code >> k) & 1;
+            frame[bitpos / 8] |= set << (7 - (bitpos % 8));
+            bitpos += 1;
+        }
+    }
+
+    crc::append_parity(&mut frame);
+    frame
+}
+
+fn char_to_ident(c: char) -> u8 {
+    let up = c.to_ascii_uppercase();
+    match up {
+        'A'..='Z' | '0'..='9' | ' ' => up as u8,
+        _ => b' ',
+    }
+}
+
+fn ident_to_index(c: u8) -> u8 {
+    match c {
+        b'A'..=b'Z' => c - b'A' + 1,
+        b'0'..=b'9' => c - b'0' + 48,
+        _ => 32, // space
+    }
+}

--- a/graywolf-modem/src/adsb/mod.rs
+++ b/graywolf-modem/src/adsb/mod.rs
@@ -1,0 +1,58 @@
+//! ADS-B (Mode S) modulator and demodulator.
+//!
+//! Mode S extended squitter is the 1090 MHz downlink that carries ADS-B: a
+//! 1 Mbit/s pulse-position-modulated signal with a fixed 8 µs preamble and a
+//! 56- or 112-bit body protected by a 24-bit CRC. This module provides the
+//! physical layer in both directions plus the message parsing needed to make
+//! it useful:
+//!
+//! - [`crc`] — Mode S 24-bit parity (dump1090-compatible).
+//! - [`modulator::Modulator`] — bits → PPM magnitude waveform.
+//! - [`demodulator::Demodulator`] — magnitude waveform → frames (preamble
+//!   correlation, PPM slicing, CRC gating).
+//! - [`message`] — DF / ICAO / type code / callsign / airborne-position (CPR)
+//!   decoding and frame construction, following the `adsb_deku` reference
+//!   layout (<https://github.com/rsadsb/adsb_deku>).
+//!
+//! ## Signal model
+//!
+//! Sampling is expressed as `samples_per_us` (even; 2 samples/µs is the
+//! dump1090 convention). The waveform is a magnitude/envelope stream — the same
+//! representation a receiver recovers from the complex 1090 MHz IF — so the
+//! modulator output feeds straight into the demodulator.
+//!
+//! ```text
+//! bits ─► Modulator ─► magnitude samples ─► Demodulator ─► frames ─► message::Frame
+//! ```
+
+pub mod crc;
+pub mod demodulator;
+pub mod message;
+pub mod modulator;
+
+#[cfg(test)]
+mod tests;
+
+pub use demodulator::{DemodFrame, Demodulator};
+pub use message::{AirbornePosition, Frame};
+pub use modulator::Modulator;
+
+/// Short Mode S frame length in bits (DF 0/4/5/11/…).
+pub const SHORT_FRAME_BITS: usize = 56;
+/// Long (extended squitter) frame length in bits (DF 16/17/18/…).
+pub const LONG_FRAME_BITS: usize = 112;
+
+/// Half-microsecond slots in the 8 µs preamble.
+pub const PREAMBLE_SLOTS: usize = 16;
+/// Half-microsecond slots per data bit (one pulse position pair).
+pub const DATA_SLOTS_PER_BIT: usize = 2;
+
+/// Preamble slots that carry a pulse — pulses at 0.0, 1.0, 3.5, 4.5 µs.
+pub const PREAMBLE_HIGH_SLOTS: [usize; 4] = [0, 2, 7, 9];
+/// Preamble slots that must be quiet.
+pub const PREAMBLE_LOW_SLOTS: [usize; 12] = [1, 3, 4, 5, 6, 8, 10, 11, 12, 13, 14, 15];
+
+/// True when downlink format `df` denotes a 112-bit (long) frame.
+pub fn long_frame_df(df: u8) -> bool {
+    matches!(df, 16 | 17 | 18 | 19 | 20 | 21 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31)
+}

--- a/graywolf-modem/src/adsb/modulator.rs
+++ b/graywolf-modem/src/adsb/modulator.rs
@@ -17,8 +17,10 @@ use super::{DATA_SLOTS_PER_BIT, PREAMBLE_HIGH_SLOTS, PREAMBLE_SLOTS};
 /// Builds Mode S PPM magnitude waveforms.
 #[derive(Clone, Copy, Debug)]
 pub struct Modulator {
-    /// Samples per microsecond. Must be even and non-zero (default 2).
-    pub samples_per_us: usize,
+    /// Samples per microsecond. Private so the even/≥2 invariant established in
+    /// [`Modulator::new`] cannot be bypassed by a struct literal (which would
+    /// make `slot_len` zero).
+    samples_per_us: usize,
     /// Magnitude emitted during a pulse.
     pub high: u16,
     /// Magnitude emitted between pulses.
@@ -36,6 +38,11 @@ impl Modulator {
     pub fn new(samples_per_us: usize) -> Self {
         assert!(samples_per_us >= 2 && samples_per_us.is_multiple_of(2), "samples_per_us must be even and >= 2");
         Self { samples_per_us, ..Self::default() }
+    }
+
+    /// Configured samples per microsecond.
+    pub fn samples_per_us(&self) -> usize {
+        self.samples_per_us
     }
 
     /// Samples in one half-microsecond slot.

--- a/graywolf-modem/src/adsb/modulator.rs
+++ b/graywolf-modem/src/adsb/modulator.rs
@@ -1,0 +1,87 @@
+//! ADS-B (Mode S) pulse-position modulator.
+//!
+//! Mode S extended squitter transmits at 1090 MHz, 1 Mbit/s, using pulse
+//! position modulation (PPM). Each data bit occupies one microsecond: a `1` is
+//! a pulse in the first half-microsecond, a `0` a pulse in the second half.
+//! Every frame is preceded by an 8 µs preamble with pulses at 0.0, 1.0, 3.5,
+//! and 4.5 µs.
+//!
+//! The modulator emits a magnitude (envelope) sample stream — the same
+//! representation a receiver recovers from the complex 1090 MHz IF — so the
+//! output pairs directly with [`super::demodulator`]. Sampling is expressed as
+//! `samples_per_us`, which must be even so that half-microsecond pulse edges
+//! land on sample boundaries (2 samples/µs is the dump1090 convention).
+
+use super::{DATA_SLOTS_PER_BIT, PREAMBLE_HIGH_SLOTS, PREAMBLE_SLOTS};
+
+/// Builds Mode S PPM magnitude waveforms.
+#[derive(Clone, Copy, Debug)]
+pub struct Modulator {
+    /// Samples per microsecond. Must be even and non-zero (default 2).
+    pub samples_per_us: usize,
+    /// Magnitude emitted during a pulse.
+    pub high: u16,
+    /// Magnitude emitted between pulses.
+    pub low: u16,
+}
+
+impl Default for Modulator {
+    fn default() -> Self {
+        Self { samples_per_us: 2, high: 32767, low: 0 }
+    }
+}
+
+impl Modulator {
+    /// Modulator at `samples_per_us` (must be even) with full-scale pulses.
+    pub fn new(samples_per_us: usize) -> Self {
+        assert!(samples_per_us >= 2 && samples_per_us.is_multiple_of(2), "samples_per_us must be even and >= 2");
+        Self { samples_per_us, ..Self::default() }
+    }
+
+    /// Samples in one half-microsecond slot.
+    fn slot_len(&self) -> usize {
+        self.samples_per_us / 2
+    }
+
+    fn push_slot(&self, out: &mut Vec<u16>, high: bool) {
+        let v = if high { self.high } else { self.low };
+        for _ in 0..self.slot_len() {
+            out.push(v);
+        }
+    }
+
+    /// Modulate a raw Mode S frame (7 or 14 bytes) into a magnitude waveform.
+    ///
+    /// The frame is transmitted verbatim — parity must already be present (see
+    /// [`super::crc::append_parity`]). Output = preamble + PPM-encoded bits.
+    pub fn modulate(&self, frame: &[u8]) -> Vec<u16> {
+        let nbits = frame.len() * 8;
+        let total_slots = PREAMBLE_SLOTS + nbits * DATA_SLOTS_PER_BIT;
+        let mut out = Vec::with_capacity(total_slots * self.slot_len());
+
+        // Preamble: 16 half-µs slots, pulses at slots 0, 2, 7, 9.
+        for slot in 0..PREAMBLE_SLOTS {
+            self.push_slot(&mut out, PREAMBLE_HIGH_SLOTS.contains(&slot));
+        }
+
+        // Data: MSB-first. bit=1 -> pulse in first half, bit=0 -> second half.
+        for &byte in frame {
+            for bit in (0..8).rev() {
+                let one = (byte >> bit) & 1 == 1;
+                self.push_slot(&mut out, one);
+                self.push_slot(&mut out, !one);
+            }
+        }
+
+        out
+    }
+
+    /// Modulate with `lead`/`trail` microseconds of silence around the frame,
+    /// so a demodulator scanning a longer buffer has quiet margins to lock onto.
+    pub fn modulate_padded(&self, frame: &[u8], lead_us: usize, trail_us: usize) -> Vec<u16> {
+        let mut out = vec![self.low; lead_us * self.samples_per_us];
+        out.extend(self.modulate(frame));
+        out.extend(std::iter::repeat_n(self.low, trail_us * self.samples_per_us));
+        out
+    }
+}

--- a/graywolf-modem/src/adsb/tests.rs
+++ b/graywolf-modem/src/adsb/tests.rs
@@ -1,0 +1,120 @@
+//! ADS-B modulator/demodulator tests, including canonical Mode S vectors.
+
+use super::message::{cpr_decode_airborne, encode_identification, Frame};
+use super::*;
+
+fn hex(s: &str) -> Vec<u8> {
+    (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap()).collect()
+}
+
+/// Canonical DF17 identification frame for ICAO 4840D6, callsign "KLM1023".
+const KLM1023: &str = "8D4840D6202CC371C32CE0576098";
+
+#[test]
+fn crc_valid_frame_checksums_zero() {
+    let frame = hex(KLM1023);
+    assert_eq!(crc::checksum(&frame), 0);
+    assert!(crc::is_valid(&frame));
+}
+
+#[test]
+fn crc_detects_corruption() {
+    let mut frame = hex(KLM1023);
+    frame[5] ^= 0x01;
+    assert_ne!(crc::checksum(&frame), 0);
+}
+
+#[test]
+fn append_parity_reproduces_known_parity() {
+    let mut frame = hex(KLM1023);
+    // Wipe the parity, recompute, and confirm we get 57 60 98 back.
+    crc::append_parity(&mut frame);
+    assert_eq!(&frame[11..14], &[0x57, 0x60, 0x98]);
+}
+
+#[test]
+fn encode_identification_matches_reference() {
+    let frame = encode_identification(0x4840D6, "KLM1023 ");
+    assert_eq!(frame.to_vec(), hex(KLM1023));
+}
+
+#[test]
+fn frame_fields_decode() {
+    let bytes = hex(KLM1023);
+    let f = Frame::new(&bytes);
+    assert_eq!(f.df(), 17);
+    assert_eq!(f.ca(), 5);
+    assert_eq!(f.icao(), 0x4840D6);
+    assert_eq!(f.type_code(), Some(4));
+    assert_eq!(f.callsign().as_deref(), Some("KLM1023"));
+}
+
+#[test]
+fn modulate_demodulate_roundtrip() {
+    let frame = hex(KLM1023);
+    for spu in [2usize, 4, 8] {
+        let modem = Modulator::new(spu);
+        let wave = modem.modulate_padded(&frame, 4, 4);
+        let demod = Demodulator::new(spu);
+        let frames = demod.demodulate(&wave);
+        assert_eq!(frames.len(), 1, "spu={spu}");
+        assert!(frames[0].crc_ok());
+        assert_eq!(frames[0].df, 17);
+        assert_eq!(frames[0].bytes, frame, "spu={spu}");
+    }
+}
+
+#[test]
+fn roundtrip_recovers_callsign() {
+    let frame = encode_identification(0x3C6444, "TEST42");
+    let modem = Modulator::new(2);
+    let wave = modem.modulate_padded(&frame, 8, 8);
+    let decoded = Demodulator::new(2).demodulate(&wave);
+    assert_eq!(decoded.len(), 1);
+    let f = Frame::new(&decoded[0].bytes);
+    assert_eq!(f.icao(), 0x3C6444);
+    assert_eq!(f.callsign().as_deref(), Some("TEST42"));
+}
+
+#[test]
+fn demodulates_multiple_frames() {
+    let modem = Modulator::new(2);
+    let a = encode_identification(0xAAAAAA, "ALPHA");
+    let b = encode_identification(0xBBBBBB, "BRAVO");
+    let mut wave = modem.modulate_padded(&a, 4, 4);
+    wave.extend(modem.modulate_padded(&b, 4, 4));
+    let frames = Demodulator::new(2).demodulate(&wave);
+    assert_eq!(frames.len(), 2);
+    assert_eq!(Frame::new(&frames[0].bytes).callsign().as_deref(), Some("ALPHA"));
+    assert_eq!(Frame::new(&frames[1].bytes).callsign().as_deref(), Some("BRAVO"));
+}
+
+#[test]
+fn rejects_pure_noise() {
+    // A flat / silent buffer must not yield any preamble matches.
+    let wave = vec![0u16; 4096];
+    assert!(Demodulator::new(2).demodulate(&wave).is_empty());
+}
+
+#[test]
+fn airborne_position_cpr_global_decode() {
+    // Canonical CPR pair (Junzi Sun, "The 1090 MHz Riddle").
+    let even = hex("8D40621D58C382D690C8AC2863A7");
+    let odd = hex("8D40621D58C386435CC412692AD6");
+    let pe = Frame::new(&even).airborne_position().unwrap();
+    let po = Frame::new(&odd).airborne_position().unwrap();
+    assert!(!pe.odd);
+    assert!(po.odd);
+
+    let (lat, lon) = cpr_decode_airborne(&pe, &po, false).unwrap();
+    assert!((lat - 52.2572).abs() < 1e-3, "lat={lat}");
+    assert!((lon - 3.91937).abs() < 1e-3, "lon={lon}");
+}
+
+#[test]
+fn airborne_altitude_decode() {
+    // DF17 airborne position, 38000 ft (typecode 11).
+    let bytes = hex("8D40621D58C382D690C8AC2863A7");
+    let pos = Frame::new(&bytes).airborne_position().unwrap();
+    assert_eq!(pos.altitude, Some(38000));
+}

--- a/graywolf-modem/src/adsb/tests.rs
+++ b/graywolf-modem/src/adsb/tests.rs
@@ -90,6 +90,54 @@ fn demodulates_multiple_frames() {
 }
 
 #[test]
+fn short_frame_roundtrip() {
+    // 56-bit short frame with a non-extended DF (DF11 all-call). append_parity
+    // makes it checksum to zero, and the demodulator must pick the short length
+    // from the DF rather than over-reading into trailing silence.
+    let mut frame = [0u8; 7];
+    frame[0] = (11 << 3) | 0x05;
+    frame[1] = 0x3C;
+    frame[2] = 0x64;
+    frame[3] = 0x44;
+    crc::append_parity(&mut frame);
+    assert!(crc::is_valid(&frame));
+
+    let wave = Modulator::new(2).modulate_padded(&frame, 4, 4);
+    let frames = Demodulator::new(2).demodulate(&wave);
+    assert_eq!(frames.len(), 1);
+    assert_eq!(frames[0].df, 11);
+    assert_eq!(frames[0].bytes.len(), 7);
+    assert_eq!(frames[0].bytes, frame);
+    assert!(frames[0].crc_ok());
+}
+
+#[test]
+fn require_crc_gates_corrupted_frames() {
+    let mut frame = encode_identification(0x484010, "GARBLED");
+    frame[6] ^= 0x20; // flip a data bit -> CRC no longer clears
+    assert!(!crc::is_valid(&frame));
+    let wave = Modulator::new(2).modulate_padded(&frame, 4, 4);
+
+    // Strict demodulation (default) drops it.
+    assert!(Demodulator::new(2).demodulate(&wave).is_empty());
+
+    // Lenient demodulation returns it with a non-zero residual and intact bytes.
+    let mut lenient = Demodulator::new(2);
+    lenient.require_crc = false;
+    let frames = lenient.demodulate(&wave);
+    assert_eq!(frames.len(), 1);
+    assert!(!frames[0].crc_ok());
+    assert_ne!(frames[0].crc_residual, 0);
+    assert_eq!(frames[0].bytes, frame);
+}
+
+#[test]
+fn callsign_preserves_embedded_space() {
+    let frame = encode_identification(0x400000, "AB CD");
+    assert_eq!(Frame::new(&frame).callsign().as_deref(), Some("AB CD"));
+}
+
+#[test]
 fn rejects_pure_noise() {
     // A flat / silent buffer must not yield any preamble matches.
     let wave = vec![0u16; 4096];

--- a/graywolf-modem/src/lib.rs
+++ b/graywolf-modem/src/lib.rs
@@ -93,6 +93,7 @@ pub mod modem_psk;
 pub mod modem_9600;
 pub mod fx25;
 pub mod il2p;
+pub mod adsb;
 pub mod tx;
 pub(crate) mod txtest;
 // CM108 HID PTT and USB topology enumeration depend on hidapi / nusb,


### PR DESCRIPTION
Adds a self-contained ADS-B (Mode S extended squitter) modulator and demodulator to the Rust modem crate, alongside the existing FX.25 / IL2P / PSK modes.

Mode S extended squitter is the 1090 MHz downlink that carries ADS-B — a 1 Mbit/s pulse-position-modulated signal with a fixed 8 µs preamble and 56/112-bit frames protected by a 24-bit CRC. This provides the physical layer in both directions plus the message parsing to make it useful.

## Module layout (`graywolf-modem/src/adsb/`)

- **crc** — Mode S 24-bit parity (dump1090-compatible table-driven checksum + `append_parity`).
- **modulator** — bits → PPM magnitude (envelope) waveform, configurable `samples_per_us`.
- **demodulator** — magnitude waveform → frames via preamble correlation, per-bit PPM slicing, and CRC-gated framing (auto short/long by downlink format).
- **message** — DF / ICAO / type-code / callsign decode and airborne-position decode (CPR global lat/lon + barometric altitude), plus DF17 identification-frame construction. Field layout follows the adsb_deku reference (https://github.com/rsadsb/adsb_deku).

## Verification

11 unit tests, including canonical Mode S vectors:
- CRC of the 8D4840D6202CC371C32CE0576098 frame checksums to zero, and encode_identification reproduces it byte-for-byte.
- Modulate → demodulate round-trips at 2/4/8 samples/µs and recovers the callsign KLM1023.
- CPR global decode of the canonical even/odd pair yields 52.2572, 3.91937.
- Barometric altitude decodes to 38000 ft.
- Multi-frame streams decode; flat noise yields nothing.

The module is a standalone library addition (not yet wired into the audio-pipeline config), matching how FX.25 and IL2P landed.