### PR TITLE
Recover the live map from an unrecoverable WebGL context loss (#461)

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -279,6 +279,26 @@ the last-known region list when offline.
 PMTiles infrastructure (manifest gen, R2 sync, Cloudflare Worker) is in
 `~/dev/graywolf-maps`, not here. See [invariant 7](invariants.md).
 
+**WebGL context-loss recovery (graywolf#461).** A fresh MapLibre `Map`
+(a new WebGL context) is created on every navigation to `/map` and torn
+down on leave. Browsers cap live WebGL contexts per page, and maplibre-gl
+5.x nulls `map.style` on a context loss it can't restore, so a later
+`getLayer()` throws `this.style is undefined` and the canvas goes black
+(maplibre-gl-js #7022/#7710, unfixed in the 5.x line). `maplibre-map.svelte`
+listens for `webglcontextlost`/`webglcontextrestored` on the canvas and, if
+no restore arrives within 400ms, fires an `oncontextlost` prop.
+`LiveMapV2.svelte` responds by bumping a `mapGeneration` `$state` that keys
+the `{#key}` block around `<MaplibreMap>`, remounting it with a live
+context (capped at `MAX_CONTEXT_RECOVERIES` to avoid a loop on a wedged
+GPU). Because a remount re-fires `oncreate` without unmounting `LiveMapV2`,
+`onMapReady` first calls `teardownMapGeneration()` (the map-tied half of the
+old `onDestroy`) to drop the dead generation's layers/popups/poll; the
+component-lifetime stores (radar-frame poller, fronts poller, 1s tick, media
+query) survive the swap and are still cleared in `onDestroy`. Two supporting
+leak fixes live in the map shell: the async `onMount` bails on a `destroyed`
+flag so navigating away mid-load can't orphan a never-removed map, and
+`onDestroy` clears `window.__gwMap` so the dead map/context can be GC'd.
+
 ## Live updates
 
 [`../../pkg/updatescheck/checker.go`](../../pkg/updatescheck/checker.go)

--- a/web/src/lib/map/layers/direct-rx-heatmap.js
+++ b/web/src/lib/map/layers/direct-rx-heatmap.js
@@ -77,8 +77,14 @@ export function mountHeatmapLayer(map, { visible = false, opacity = 0.8 } = {}) 
   }
 
   function destroy() {
-    if (map.getLayer(LYR)) map.removeLayer(LYR);
-    if (map.getSource(SRC)) map.removeSource(SRC);
+    // Guard: on the context-loss remount path (graywolf#461) this runs
+    // against a map whose remove() already nulled map.style, so getLayer()
+    // would throw. Match the other GL layers (trails, radar, hover-path) so a
+    // stale-map teardown can't strand the rest of teardownMapGeneration().
+    try {
+      if (map.getLayer(LYR)) map.removeLayer(LYR);
+      if (map.getSource(SRC)) map.removeSource(SRC);
+    } catch { /* map already removed */ }
   }
 
   ensure();

--- a/web/src/lib/map/maplibre-map.svelte
+++ b/web/src/lib/map/maplibre-map.svelte
@@ -19,11 +19,27 @@
   import { absolutizeStyleUrls } from './style-urls.js';
   import { markConnected, markDisconnected } from '../stores/connection.js';
 
-  let { initialCenter = [-98, 39], initialZoom = 4, oncreate = null } = $props();
+  let {
+    initialCenter = [-98, 39],
+    initialZoom = 4,
+    oncreate = null,
+    oncontextlost = null,
+  } = $props();
 
   let container;
   let map = null;
   let bearerToken = $state(null);
+  // Set in onDestroy. The onMount below is async and only creates the map
+  // after several awaited fetches; if the operator navigates away during
+  // that window, onDestroy runs first (with map still null, so map.remove()
+  // is a no-op) and the awaited map creation would otherwise leak a live
+  // WebGL context that is never torn down. Bailing on this flag prevents the
+  // orphan map -- accumulated orphan contexts are what push the browser past
+  // its per-page WebGL context budget and trigger the context loss in #461.
+  let destroyed = false;
+  // Debounce between 'webglcontextlost' and a possible 'webglcontextrestored'
+  // so we only escalate to a remount when the loss is permanent.
+  let ctxRestoreTimer = null;
 
   // Set context synchronously during component init -- setContext after
   // an await throws lifecycle_outside_component because Svelte's
@@ -191,6 +207,10 @@
     ]);
     await syncToken();
     const initialStyle = await buildStyle();
+    // The operator may have navigated away while the awaits above were in
+    // flight; onDestroy has already run. Don't build a map that will never
+    // be torn down (a leaked WebGL context).
+    if (destroyed) return;
     map = new maplibregl.Map({
       container,
       style: initialStyle,
@@ -287,8 +307,40 @@
     } else {
       map.once('style.load', () => oncreate?.(map));
     }
+    // WebGL context-loss recovery. When the browser loses the canvas'
+    // context (it happens on repeated create/destroy of the map across SPA
+    // navigations -- the browser has a hard per-page WebGL context budget),
+    // maplibre-gl 5.x calls painter.destroy() and sets map.style = null. If
+    // the browser then fires 'webglcontextrestored', maplibre rebuilds the
+    // style itself and we do nothing. If it does NOT -- the context was
+    // evicted for good -- the canvas stays black and any later map.getLayer()
+    // throws "this.style is undefined" (maplibre-gl-js #7022 / #7710, unfixed
+    // in the 5.x line). preventDefault keeps the context restorable; if no
+    // restore arrives shortly we treat the loss as permanent and ask the
+    // parent to remount us, which frees the stale context and builds a fresh
+    // one -- the same recovery the operator gets today by leaving the page
+    // and coming back (graywolf#461).
+    const canvas = map.getCanvas();
+    canvas.addEventListener('webglcontextlost', onContextLost, false);
+    canvas.addEventListener('webglcontextrestored', onContextRestored, false);
     if (typeof window !== 'undefined') window.__gwMap = map;
   });
+
+  function onContextLost(e) {
+    e.preventDefault();
+    if (ctxRestoreTimer) clearTimeout(ctxRestoreTimer);
+    ctxRestoreTimer = setTimeout(() => {
+      ctxRestoreTimer = null;
+      if (!destroyed) oncontextlost?.();
+    }, 400);
+  }
+
+  function onContextRestored() {
+    if (ctxRestoreTimer) {
+      clearTimeout(ctxRestoreTimer);
+      ctxRestoreTimer = null;
+    }
+  }
 
   // Track source/registered/completed-downloads changes; re-apply the
   // style. setStyle preserves user-added sources/layers as long as
@@ -316,8 +368,30 @@
   });
 
   onDestroy(() => {
-    map?.remove();
+    destroyed = true;
+    if (ctxRestoreTimer) {
+      clearTimeout(ctxRestoreTimer);
+      ctxRestoreTimer = null;
+    }
+    if (map) {
+      const canvas = map.getCanvas?.();
+      canvas?.removeEventListener('webglcontextlost', onContextLost, false);
+      canvas?.removeEventListener('webglcontextrestored', onContextRestored, false);
+    }
+    try {
+      // On the context-loss remount path (graywolf#461) this runs against a
+      // map whose GL context is already gone; maplibre's remove() pokes the
+      // (destroyed) painter/context, so guard against a throw leaving the
+      // teardown half-done.
+      map?.remove();
+    } catch {
+      /* map already torn down by the lost-context handler */
+    }
     map = null;
+    // Drop the debug handle so the removed map (and its now-dead canvas /
+    // WebGL context) can be garbage-collected instead of lingering pinned to
+    // the global until the next visit overwrites it.
+    if (typeof window !== 'undefined' && window.__gwMap) window.__gwMap = null;
   });
 </script>
 

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -117,7 +117,13 @@
   // infinite remount loop.
   let mapGeneration = $state(0);
   let contextLossRecoveries = 0;
+  let contextRecoveryResetTimer = null;
   const MAX_CONTEXT_RECOVERIES = 3;
+  // A map that stays alive this long after a recovery is considered stable, so
+  // the recovery budget is refilled. This distinguishes a wedged GPU (repeated
+  // losses within milliseconds) from a handful of unrelated losses spread
+  // across a long-running operator session, which should each recover.
+  const CONTEXT_RECOVERY_STABLE_MS = 30_000;
 
   function handleMapContextLost() {
     if (contextLossRecoveries >= MAX_CONTEXT_RECOVERIES) {
@@ -626,6 +632,13 @@
     // belonged to the dead map.
     if (mapRef) teardownMapGeneration();
     mapRef = map;
+    // Refill the recovery budget once this map proves stable (see above). The
+    // timer is cleared in teardownMapGeneration, so a map that loses its
+    // context again before the window elapses does NOT get its budget back.
+    contextRecoveryResetTimer = setTimeout(() => {
+      contextRecoveryResetTimer = null;
+      contextLossRecoveries = 0;
+    }, CONTEXT_RECOVERY_STABLE_MS);
     // Radar first so the raster/fill sits below trails and station markers in
     // the GL stack. DOM layers (stations, weather) always render above the
     // canvas regardless, but GL line layers (trails) would otherwise cover it.
@@ -1228,6 +1241,10 @@
   // 1s tick, the media-query listener -- outlive a generation swap and are
   // cleared in onDestroy instead.
   function teardownMapGeneration() {
+    if (contextRecoveryResetTimer) {
+      clearTimeout(contextRecoveryResetTimer);
+      contextRecoveryResetTimer = null;
+    }
     dataStore.stop();
     closePopup();
     stopHeatmapPolling();
@@ -1252,6 +1269,9 @@
     myPositionLayer = null;
     fixedPointsLayer = null;
     mapRef = null;
+    // Drop the console debug handle so a context-lost/removed map isn't pinned
+    // in the heap after a recovery remount or navigation away (graywolf#461).
+    if (typeof window !== 'undefined' && window.gwMap) window.gwMap = null;
   }
 
   onDestroy(() => {

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -109,6 +109,27 @@
   let heatmapTimer = null;
   let fixedPointsLayer = null;
 
+  // Bumping this key fully remounts <MaplibreMap>, which is how we recover
+  // from a permanent WebGL context loss (graywolf#461): the map component's
+  // onDestroy tears down the old (context-lost, black) map and a fresh one is
+  // built with a live context. Capped so a genuinely wedged GPU (every rebuild
+  // immediately loses its context too) degrades to a toast instead of an
+  // infinite remount loop.
+  let mapGeneration = $state(0);
+  let contextLossRecoveries = 0;
+  const MAX_CONTEXT_RECOVERIES = 3;
+
+  function handleMapContextLost() {
+    if (contextLossRecoveries >= MAX_CONTEXT_RECOVERIES) {
+      toasts.error(
+        'The map lost its graphics context and could not recover. Reload the page to restore it.',
+      );
+      return;
+    }
+    contextLossRecoveries += 1;
+    mapGeneration += 1;
+  }
+
   // Radar overlay settings -- persisted per browser (not per account).
   const radarSettings = $state({
     visible: localStorage.getItem('gw_radar_visible') === '1',
@@ -599,6 +620,11 @@
   }
 
   function onMapReady(map) {
+    // On a context-loss remount (graywolf#461) the previous generation's
+    // layers, popups and station-poll are still live; tear them down before
+    // wiring the fresh map so we don't double-poll or leak DOM markers that
+    // belonged to the dead map.
+    if (mapRef) teardownMapGeneration();
     mapRef = map;
     // Radar first so the raster/fill sits below trails and station markers in
     // the GL stack. DOM layers (stations, weather) always render above the
@@ -1195,11 +1221,15 @@
     };
   });
 
-  onDestroy(() => {
+  // Tear down everything onMapReady wires onto a specific map instance so the
+  // map can be swapped (context-loss remount, graywolf#461) or fully unmounted
+  // cleanly. The persistent stores/timers that are owned by the component and
+  // NOT re-created by onMapReady -- the radar frame poller, fronts poller, the
+  // 1s tick, the media-query listener -- outlive a generation swap and are
+  // cleared in onDestroy instead.
+  function teardownMapGeneration() {
     dataStore.stop();
     closePopup();
-    radarFrames.destroy();
-    stopFrontsPolling();
     stopHeatmapPolling();
     radarLayer?.destroy();
     frontsLayer?.destroy();
@@ -1222,6 +1252,12 @@
     myPositionLayer = null;
     fixedPointsLayer = null;
     mapRef = null;
+  }
+
+  onDestroy(() => {
+    teardownMapGeneration();
+    radarFrames.destroy();
+    stopFrontsPolling();
     if (tickTimer) {
       clearInterval(tickTimer);
       tickTimer = null;
@@ -1232,12 +1268,17 @@
 </script>
 
 <div class="livemap-shell">
-  <!-- Start at planet view; onMapReady fits to recent stations after first poll. -->
-  <MaplibreMap
-    initialCenter={[mapState.mapCenter[1], mapState.mapCenter[0]]}
-    initialZoom={mapState.mapZoom}
-    oncreate={onMapReady}
-  />
+  <!-- Start at planet view; onMapReady fits to recent stations after first poll.
+       Keyed on mapGeneration so an unrecoverable WebGL context loss remounts the
+       map with a fresh context instead of leaving a black canvas (graywolf#461). -->
+  {#key mapGeneration}
+    <MaplibreMap
+      initialCenter={[mapState.mapCenter[1], mapState.mapCenter[0]]}
+      initialZoom={mapState.mapZoom}
+      oncreate={onMapReady}
+      oncontextlost={handleMapContextLost}
+    />
+  {/key}
 
   {#snippet panelBody()}
     <!-- APRS: station/trail/position layers + the time-range filter. -->


### PR DESCRIPTION
Fixes #461 — the live map rendering only on every other visit (black screen with `WebGL context was lost` + `TypeError: can't access property 'getLayer', this.style is undefined`).

## Root cause

The live map creates a brand-new MapLibre `Map` — and therefore a new WebGL context — on every navigation to `/map`, and destroys it on leave. Browsers enforce a hard per-page budget on live WebGL contexts, and when the browser loses a context it cannot restore, **maplibre-gl 5.x sets `map.style = null`** (verified in `src/ui/map.ts` `_contextLost`). After that, any `map.getLayer(...)` throws the exact reported `this.style is undefined` error and the canvas stays black. This is upstream maplibre-gl-js [#7022](https://github.com/maplibre/maplibre-gl-js/issues/7022) / #7710 — the guard that avoids the throw only landed in the v6 prerelease line, so 5.24 (our pin, and the current `latest`) is still affected. The create/destroy churn of SPA remounting is what provokes the loss; leaving and returning "resets" it because it gives the browser a chance to release the stale context.

## Fix

- `maplibre-map.svelte` listens for `webglcontextlost` / `webglcontextrestored` on the canvas. It `preventDefault()`s the loss (keeping it restorable) and, if maplibre/the browser doesn't restore within 400ms, fires a new `oncontextlost` prop.
- `LiveMapV2.svelte` handles that by bumping a `mapGeneration` `$state` that keys a `{#key}` block around `<MaplibreMap>`, cleanly remounting the map with a fresh context — the same recovery the operator gets today by leaving and coming back, done automatically. Capped at 3 recoveries so a genuinely wedged GPU degrades to a toast instead of an infinite remount loop.
- `onMapReady` now tears down the previous generation (`teardownMapGeneration()`, the map-tied half of the old `onDestroy`) before wiring the fresh map; component-lifetime pollers/timers survive the swap and are still cleared in `onDestroy`.
- Two supporting leak fixes: the async `onMount` bails on a `destroyed` flag so navigating away mid-load can't orphan a never-removed map (leaked context), and `onDestroy` clears `window.__gwMap` so the dead map/context can be garbage-collected.

Wiki updated (`docs/wiki/code-map.md`) with the context-loss recovery mechanism.

## Verification

- `npm run build` — clean.
- `npm test` — 465/465 pass.

Manual browser confirmation on the reporter's licensed/online setup (repeatedly navigating dashboard ⇆ live map) is still worth doing, since the loss itself is GPU/driver-timing dependent and can't be reproduced headlessly.