### PR TITLE
Fix Block button alignment on Messages blocklist form

### DIFF
--- a/web/src/routes/MessagesSettings.svelte
+++ b/web/src/routes/MessagesSettings.svelte
@@ -240,7 +240,10 @@
     align-items: center;
     flex-wrap: wrap;
   }
-  .block-add :global(input) { min-width: 0; }
+  /* chonky inputs carry a 1rem bottom margin (stacked-form default); in
+     this single row it inflates the wrapper so align-items:center drops
+     the Block button below the fields. Zero it so input and button align. */
+  .block-add :global(input) { min-width: 0; margin-bottom: 0; }
   .err {
     margin-top: 8px;
     color: var(--color-danger, #d33);


### PR DESCRIPTION
## Problem

On the Messages settings tab, the **Block** button in the "Blocked call signs" add form sat lower than the two text fields instead of lining up with them.

## Cause

chonky's `Input` wraps its `<input>` in a `.input-wrapper`, and the base `input` style carries `margin-bottom: 1rem` (the stacked-form default). In this single-row form that phantom margin makes each input wrapper ~16px taller than the button, so `align-items: center` centered the wrapper and dropped the button ~8px below the visible field boxes. Same class of issue we've handled on other inline input rows.

## Fix

Zero the input's bottom margin within `.block-add` so the wrapper height matches the button and the row aligns. CSS-only, one line.
