### PR TITLE
Add per-message TX channel override to new-message dialog (#472)

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -173,6 +173,19 @@ thread inherits the global defaults until the operator changes one.
 | REST | `webapi/messages.go` — GET/PUT `/api/messages/conversations/{kind}/{key}/prefs`; DTO + validation in `webapi/dto/messages.go`. GET returns inherited defaults (not 404) for an unset thread. |
 | UI | `web/src/components/messages/ConversationRoutingMenu.svelte` (gear popover: send-path radios + "Automatic Resend until ACK" checkbox, DM only), mounted in `ThreadHeader.svelte`; client in `api/messages.js`. |
 
+## Per-send TX channel override (issue #472)
+
+Lets an operator running multiple radios on one instance pick which RF
+channel a single message goes out on, from a collapsed "Advanced" section
+in the new-message dialog. Zero = the configured default `tx_channel`.
+
+| Concern | Where |
+|---|---|
+| Request field | `pkg/messages/service.go` — `SendMessageRequest.Channel uint32` (0 = default). `SendMessage` stamps it onto the existing `Message.Channel` column so retries reuse it. |
+| Send-time apply | `pkg/messages/sender.go` — `channelFor(row)` returns `row.Channel` when non-zero else the live default `txChannel`; `sendRF` (packet-mode check, availability, `TxSink.Submit`, logs) and `rfAvailable(channel)` route on it. Retry/Resend re-read the persisted row, so no extra plumbing. |
+| REST | `webapi/messages.go` — `sendMessage` copies `dto.SendMessageRequest.Channel` (`*uint32`, already in the DTO) into `svcReq.Channel`. |
+| UI | `web/src/components/messages/ComposeNewModal.svelte` — `<details class="advanced">` with a channel `Select` (non-packet channels + "Default" sentinel, same filter as `MessagesSettings.svelte`); threaded through `Messages.svelte` `handleNewSend`/`optimisticSend` → `sendMessage({channel})`. |
+
 ## Message call-sign blocklist (issue #465)
 
 Mutes inbound messages from specific senders (e.g. a station that

--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -183,8 +183,8 @@ in the new-message dialog. Zero = the configured default `tx_channel`.
 |---|---|
 | Request field | `pkg/messages/service.go` — `SendMessageRequest.Channel uint32` (0 = default). `SendMessage` stamps it onto the existing `Message.Channel` column so retries reuse it. |
 | Send-time apply | `pkg/messages/sender.go` — `channelFor(row)` returns `row.Channel` when non-zero else the live default `txChannel`; `sendRF` (packet-mode check, availability, `TxSink.Submit`, logs) and `rfAvailable(channel)` route on it. Retry/Resend re-read the persisted row, so no extra plumbing. |
-| REST | `webapi/messages.go` — `sendMessage` copies `dto.SendMessageRequest.Channel` (`*uint32`, already in the DTO) into `svcReq.Channel`. |
-| UI | `web/src/components/messages/ComposeNewModal.svelte` — `<details class="advanced">` with a channel `Select` (non-packet channels + "Default" sentinel, same filter as `MessagesSettings.svelte`); threaded through `Messages.svelte` `handleNewSend`/`optimisticSend` → `sendMessage({channel})`. |
+| REST | `webapi/messages.go` — `sendMessage` copies `dto.SendMessageRequest.Channel` (`*uint32`, already in the DTO) into `svcReq.Channel`, and rejects a packet-mode override with 400 (same `ModeForChannel` guard as `putMessagesConfig`; a missing row reads as APRS, matching the fail-open TX-gating convention, so existence is not hard-validated). |
+| UI | `web/src/components/messages/ComposeNewModal.svelte` — `<details class="advanced">` with a channel `Select` (non-packet channels + "Default" sentinel, same filter as `MessagesSettings.svelte`); threaded through `Messages.svelte` `handleNewSend`/`optimisticSend` → `sendMessage({channel})`. The override resets on the modal's open→true transition (NOT in `close()`), because `ComposeBar` calls `onSend`/`close` once per part of a multi-part message — resetting on close would zero the channel after part 1. |
 
 ## Message call-sign blocklist (issue #465)
 

--- a/pkg/messages/sender.go
+++ b/pkg/messages/sender.go
@@ -257,7 +257,7 @@ func (s *Sender) SendWithPolicy(ctx context.Context, row *configstore.Message, o
 	} else {
 		policy = NormalizeFallbackPolicy(s.cfg.Preferences.Current().FallbackPolicy)
 	}
-	rfAvailable := s.rfAvailable()
+	rfAvailable := s.rfAvailable(s.channelFor(row))
 
 	switch policy {
 	case FallbackPolicyRFOnly:
@@ -283,8 +283,11 @@ func (s *Sender) SendWithPolicy(ctx context.Context, row *configstore.Message, o
 // before the rfAvailable check because a misconfigured TxChannel is an
 // operator error that shouldn't be hidden by a transient bridge stop.
 func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailable bool) SendResult {
+	// ch is the effective TX channel for this row: a per-send override
+	// when set (compose dialog Advanced), else the live default.
+	ch := s.channelFor(row)
 	if s.cfg.ChannelModes != nil {
-		mode, _ := s.cfg.ChannelModes.ModeForChannel(ctx, s.txChannel.Load())
+		mode, _ := s.cfg.ChannelModes.ModeForChannel(ctx, ch)
 		if mode == configstore.ChannelModePacket {
 			err := errors.New("messages: tx channel is packet-mode")
 			row.FailureReason = truncReason(err.Error())
@@ -292,7 +295,7 @@ func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailab
 			s.logger.Warn("message rf send failed",
 				"reason", "tx channel is packet-mode",
 				"id", row.ID, "to", row.ToCall, "msg_id", row.MsgID,
-				"kind", row.ThreadKind, "channel", s.txChannel.Load())
+				"kind", row.ThreadKind, "channel", ch)
 			return SendResult{Path: SendPathRF, Err: err, Retryable: false}
 		}
 	}
@@ -307,7 +310,7 @@ func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailab
 		s.logger.Warn("message rf send failed",
 			"reason", "frame encode error",
 			"id", row.ID, "to", row.ToCall, "msg_id", row.MsgID,
-			"kind", row.ThreadKind, "channel", s.txChannel.Load(), "error", err)
+			"kind", row.ThreadKind, "channel", ch, "error", err)
 		return SendResult{Path: SendPathRF, Err: err}
 	}
 	// Record (source, msg_id) in the LocalTxRing BEFORE submit so a
@@ -328,7 +331,7 @@ func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailab
 	// wire. Opting out of dedup is correct for message TX; we keep the
 	// governor's other admission controls (rate limits, DCD-aware
 	// CSMA, queue capacity) active.
-	submitErr := s.cfg.TxSink.Submit(ctx, s.txChannel.Load(), frame, txgovernor.SubmitSource{
+	submitErr := s.cfg.TxSink.Submit(ctx, ch, frame, txgovernor.SubmitSource{
 		Kind:      SubmitKindMessages,
 		Priority:  txgovernor.PriorityIGateMsg,
 		SkipDedup: true,
@@ -365,7 +368,7 @@ func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailab
 		s.logger.Warn("message rf send deferred",
 			"reason", "governor queue full",
 			"id", row.ID, "to", row.ToCall, "msg_id", row.MsgID,
-			"kind", row.ThreadKind, "channel", s.txChannel.Load())
+			"kind", row.ThreadKind, "channel", ch)
 		return SendResult{Path: SendPathRF, Err: submitErr, Retryable: true}
 	case errors.Is(submitErr, txgovernor.ErrStopped):
 		// Governor shut down — RF will not recover on its own.
@@ -376,7 +379,7 @@ func (s *Sender) sendRF(ctx context.Context, row *configstore.Message, rfAvailab
 		s.logger.Warn("message rf send failed",
 			"reason", "governor submit error",
 			"id", row.ID, "to", row.ToCall, "msg_id", row.MsgID,
-			"kind", row.ThreadKind, "channel", s.txChannel.Load(), "error", submitErr)
+			"kind", row.ThreadKind, "channel", ch, "error", submitErr)
 		return SendResult{Path: SendPathRF, Err: submitErr, Retryable: row.ThreadKind == ThreadKindDM}
 	}
 }
@@ -393,7 +396,7 @@ func (s *Sender) finalizeRFFailure(ctx context.Context, row *configstore.Message
 	s.logger.Warn("message rf send failed",
 		"reason", reason,
 		"id", row.ID, "to", row.ToCall, "msg_id", row.MsgID,
-		"kind", row.ThreadKind, "channel", s.txChannel.Load(), "error", cause)
+		"kind", row.ThreadKind, "channel", s.channelFor(row), "error", cause)
 	return SendResult{Path: SendPathRF, Err: cause, Retryable: false}
 }
 
@@ -535,12 +538,24 @@ func (s *Sender) readOnlyIS() bool {
 // sender's view. Returns true when the caller didn't inject a bridge
 // (tests). The channel argument lets the wiring layer answer
 // "yes" when a KISS-TNC backend is attached even if the modem
-// subprocess isn't running.
-func (s *Sender) rfAvailable() bool {
+// subprocess isn't running — and lets a per-send channel override be
+// checked against its own backend rather than the default channel's.
+func (s *Sender) rfAvailable(channel uint32) bool {
 	if s.bridge == nil {
 		return true
 	}
-	return s.bridge.IsRunningForChannel(s.txChannel.Load())
+	return s.bridge.IsRunningForChannel(channel)
+}
+
+// channelFor resolves the RF TX channel for a single send. A non-zero
+// row.Channel is a per-send operator override (compose dialog Advanced
+// section, issue #472) persisted so retries reuse it; zero defers to
+// the live default TX channel set from the messages config.
+func (s *Sender) channelFor(row *configstore.Message) uint32 {
+	if row != nil && row.Channel != 0 {
+		return row.Channel
+	}
+	return s.txChannel.Load()
 }
 
 // buildFrame constructs the AX.25 UI frame carrying the APRS message

--- a/pkg/messages/sender_test.go
+++ b/pkg/messages/sender_test.go
@@ -271,6 +271,40 @@ func TestSender_RF_HappyPath_SentAtOnlyFlipsOnHookFire(t *testing.T) {
 	}
 }
 
+// A non-zero row.Channel is a per-send override (compose dialog
+// Advanced section, issue #472) and must drive the governor Submit
+// instead of the sender's default TX channel. A zero row.Channel
+// defers to the default. buildSender seeds TxChannel=1.
+func TestSender_RF_PerSendChannelOverride(t *testing.T) {
+	rig := buildSender(t, FallbackPolicyRFOnly, true)
+	defer rig.close()
+
+	override := newOutboundDM(t, rig, "N0CALL", "W1ABC", "band B")
+	override.Channel = 7
+	if err := rig.store.Update(context.Background(), override); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if res := rig.sender.Send(context.Background(), override); res.Err != nil {
+		t.Fatalf("Send override: %v", res.Err)
+	}
+
+	deflt := newOutboundDM(t, rig, "N0CALL", "W1ABC", "default band")
+	if res := rig.sender.Send(context.Background(), deflt); res.Err != nil {
+		t.Fatalf("Send default: %v", res.Err)
+	}
+
+	got := rig.sink.list()
+	if len(got) != 2 {
+		t.Fatalf("submitted = %d, want 2", len(got))
+	}
+	if got[0].Channel != 7 {
+		t.Errorf("override submit channel = %d, want 7", got[0].Channel)
+	}
+	if got[1].Channel != 1 {
+		t.Errorf("default submit channel = %d, want 1 (seeded TxChannel)", got[1].Channel)
+	}
+}
+
 func TestSender_RF_QueueFull_RetryableShortRetry(t *testing.T) {
 	rig := buildSender(t, FallbackPolicyRFOnly, true)
 	defer rig.close()

--- a/pkg/messages/service.go
+++ b/pkg/messages/service.go
@@ -435,6 +435,12 @@ type SendMessageRequest struct {
 	// transport). Applies only to the initial dispatch — retry-manager
 	// re-attempts use the stored preference.
 	FallbackPolicyOverride string
+	// Channel is a per-send RF TX channel override sourced from the
+	// compose dialog's Advanced section (issue #472). Zero means "use
+	// the operator's configured default TX channel". A non-zero value
+	// is stamped on the persisted row so retry re-attempts transmit on
+	// the same channel as the initial send.
+	Channel uint32
 }
 
 // SendMessage persists the outbound row via store.Insert (allocating
@@ -514,6 +520,7 @@ func (s *Service) SendMessage(ctx context.Context, req SendMessageRequest) (*con
 		Kind:           bodyKind,
 		InviteTactical: inviteTactical,
 		SendPath:       rowSendPath,
+		Channel:        req.Channel,
 	}
 	// DM requires a msgid; tactical may omit.
 	if kind == ThreadKindDM {

--- a/pkg/messages/service_test.go
+++ b/pkg/messages/service_test.go
@@ -258,6 +258,56 @@ func TestService_SendMessage_PersistsAndDispatches(t *testing.T) {
 	}
 }
 
+func TestService_SendMessage_ChannelOverridePersistsAndDispatches(t *testing.T) {
+	svc, rig, _, cleanup := buildService(t)
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	// Compose with a per-send channel override (issue #472). The seeded
+	// default TxChannel is 1; the override picks channel 4.
+	row, err := svc.SendMessage(ctx, SendMessageRequest{
+		OurCall: "N0CALL",
+		To:      "W1ABC",
+		Text:    "band B",
+		Channel: 4,
+	})
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if row.Channel != 4 {
+		t.Errorf("row.Channel = %d, want 4 (persisted override)", row.Channel)
+	}
+	reloaded, err := rig.store.GetByID(ctx, row.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if reloaded.Channel != 4 {
+		t.Errorf("persisted Channel = %d, want 4", reloaded.Channel)
+	}
+
+	// The async dispatch must submit on the override channel, not the
+	// seeded default.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if len(rig.sink.list()) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	got := rig.sink.list()
+	if len(got) == 0 {
+		t.Fatal("no RF submit after SendMessage")
+	}
+	if got[0].Channel != 4 {
+		t.Errorf("submit channel = %d, want 4 (override)", got[0].Channel)
+	}
+}
+
 func TestService_SendMessage_TacticalDerivedFromSet(t *testing.T) {
 	svc, rig, _, cleanup := buildService(t)
 	defer cleanup()

--- a/pkg/webapi/messages.go
+++ b/pkg/webapi/messages.go
@@ -277,6 +277,12 @@ func (s *Server) sendMessage(w http.ResponseWriter, r *http.Request) {
 		Text:    req.Text,
 		OurCall: ourCall,
 	}
+	// Per-send channel override from the compose dialog's Advanced
+	// section. Nil defers to the operator's configured default TX
+	// channel; non-zero is persisted on the row so retries reuse it.
+	if req.Channel != nil {
+		svcReq.Channel = *req.Channel
+	}
 	if isInvite {
 		svcReq.Kind = messages.MessageKindInvite
 		svcReq.InviteTactical = strings.ToUpper(strings.TrimSpace(req.InviteTactical))

--- a/pkg/webapi/messages.go
+++ b/pkg/webapi/messages.go
@@ -272,14 +272,28 @@ func (s *Server) sendMessage(w http.ResponseWriter, r *http.Request) {
 		badRequest(w, "cannot send a message to our own callsign")
 		return
 	}
+	// Per-send channel override from the compose dialog's Advanced
+	// section. Nil (or 0) defers to the operator's configured default TX
+	// channel; non-zero is persisted on the row so retries reuse it.
+	// Reject a packet-mode override up front — the same guard putMessagesConfig
+	// applies to the global tx_channel — so an operator gets a clear 400
+	// instead of a message that silently fails RF or falls back to IS.
+	if req.Channel != nil && *req.Channel != 0 {
+		mode, err := s.store.ModeForChannel(r.Context(), *req.Channel)
+		if err != nil {
+			s.internalError(w, r, "mode-for-channel lookup", err)
+			return
+		}
+		if mode == configstore.ChannelModePacket {
+			badRequest(w, "channel is packet-mode; choose an aprs or aprs+packet channel")
+			return
+		}
+	}
 	svcReq := messages.SendMessageRequest{
 		To:      to,
 		Text:    req.Text,
 		OurCall: ourCall,
 	}
-	// Per-send channel override from the compose dialog's Advanced
-	// section. Nil defers to the operator's configured default TX
-	// channel; non-zero is persisted on the row so retries reuse it.
 	if req.Channel != nil {
 		svcReq.Channel = *req.Channel
 	}

--- a/pkg/webapi/messages_test.go
+++ b/pkg/webapi/messages_test.go
@@ -308,6 +308,68 @@ func TestSendMessage_202(t *testing.T) {
 	}
 }
 
+func TestSendMessage_ChannelOverridePassedThrough(t *testing.T) {
+	sentCh := make(chan messages.SendMessageRequest, 1)
+	svc := &fakeMessagesSvc{
+		sendFn: func(ctx context.Context, req messages.SendMessageRequest) (*configstore.Message, error) {
+			sentCh <- req
+			return &configstore.Message{
+				ID: 7, Direction: "out", OurCall: req.OurCall, FromCall: req.OurCall,
+				ToCall: req.To, Text: req.Text, ThreadKind: messages.ThreadKindDM,
+				ThreadKey: req.To, MsgID: "002", CreatedAt: time.Now(),
+				AckState: messages.AckStateNone, Channel: req.Channel,
+			}, nil
+		},
+	}
+	_, mux, _ := newMessagesTestServer(t, svc)
+
+	// Channel 4 does not exist in this fixture; ModeForChannel treats a
+	// missing row as APRS (non-packet) so it passes validation and flows
+	// through to the service request unchanged.
+	body := `{"to":"W1ABC","text":"hi","channel":4}`
+	req := httptest.NewRequest(http.MethodPost, "/api/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got := <-sentCh
+	if got.Channel != 4 {
+		t.Errorf("svcReq.Channel = %d, want 4", got.Channel)
+	}
+}
+
+func TestSendMessage_RejectsPacketModeChannel(t *testing.T) {
+	srv, mux, _ := newMessagesTestServer(t, &fakeMessagesSvc{})
+	ctx := context.Background()
+	dev := &configstore.AudioDevice{
+		Name: "test", Direction: "input", SourceType: "flac",
+		SourcePath: "/tmp/x.flac", SampleRate: 44100, Channels: 1, Format: "s16le",
+	}
+	if err := srv.store.CreateAudioDevice(ctx, dev); err != nil {
+		t.Fatalf("CreateAudioDevice: %v", err)
+	}
+	ch := &configstore.Channel{
+		Name: "p", InputDeviceID: configstore.U32Ptr(dev.ID),
+		ModemType: "afsk", BitRate: 1200, MarkFreq: 1200, SpaceFreq: 2200,
+		Profile: "A", NumSlicers: 1, FixBits: "none",
+		Mode: configstore.ChannelModePacket,
+	}
+	if err := srv.store.CreateChannel(ctx, ch); err != nil {
+		t.Fatalf("create packet channel: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"to":"W1ABC","text":"hi","channel":%d}`, ch.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400 for packet-mode channel", rec.Code, rec.Body.String())
+	}
+}
+
 func TestSendMessage_BadAddressee(t *testing.T) {
 	_, mux, _ := newMessagesTestServer(t, &fakeMessagesSvc{})
 	body := `{"to":"","text":"hi"}`

--- a/web/src/components/messages/ComposeNewModal.svelte
+++ b/web/src/components/messages/ComposeNewModal.svelte
@@ -33,6 +33,21 @@
   let channel = $state(0);
   let advancedOpen = $state(false);
 
+  // Reset the override when a fresh compose session opens rather than on
+  // close(). A long message is split into several parts and ComposeBar
+  // awaits onSend() once per part; each of those calls close(). Resetting
+  // in close() would zero the channel after part 1, silently sending the
+  // remaining parts on the default channel. Keying the reset off the
+  // open→true transition keeps the choice stable for the whole batch.
+  let wasOpen = false;
+  $effect(() => {
+    if (open && !wasOpen) {
+      channel = 0;
+      advancedOpen = false;
+    }
+    wasOpen = open;
+  });
+
   // Populate the channel list only when Advanced is expanded — most
   // sends never touch it, so we don't poll on every compose.
   $effect(() => {
@@ -50,9 +65,8 @@
 
   function close() {
     open = false;
-    // Reset the override so it never leaks into the next compose.
-    channel = 0;
-    advancedOpen = false;
+    // The override is reset on the next open (see the effect above), not
+    // here — close() fires once per part of a multi-part send.
     onClose?.();
   }
 

--- a/web/src/components/messages/ComposeNewModal.svelte
+++ b/web/src/components/messages/ComposeNewModal.svelte
@@ -9,13 +9,14 @@
   // navigates straight into the tactical thread's compose bar with
   // the locked-pill To.
 
-  import { Button, Icon, Modal } from '@chrissnell/chonky-ui';
+  import { Icon, Modal, Select } from '@chrissnell/chonky-ui';
   import CallsignAutocomplete from './CallsignAutocomplete.svelte';
   import ComposeBar from './ComposeBar.svelte';
+  import { channelsStore, start as startChannels } from '../../lib/stores/channels.svelte.js';
 
   /** @type {{
    *    open: boolean,
-   *    onSend?: (text: string, to: string) => Promise<any>,
+   *    onSend?: (text: string, to: string, channel: number) => Promise<any>,
    *    onClose?: () => void,
    *  }}
    */
@@ -26,16 +27,39 @@
   } = $props();
 
   let to = $state('');
+  // Per-send TX channel override (issue #472). 0 = use the operator's
+  // configured default channel. Tucked behind the Advanced disclosure,
+  // collapsed by default so the normal compose flow stays uncluttered.
+  let channel = $state(0);
+  let advancedOpen = $state(false);
+
+  // Populate the channel list only when Advanced is expanded — most
+  // sends never touch it, so we don't poll on every compose.
+  $effect(() => {
+    if (advancedOpen) startChannels();
+  });
+
+  // Same selection semantics as Settings → Messages → Transmit channel:
+  // offer APRS-eligible (non-packet) channels plus a "default" sentinel.
+  const channelOptions = $derived([
+    { value: 0, label: 'Default (configured TX channel)' },
+    ...channelsStore.list
+      .filter((c) => c.mode !== 'packet')
+      .map((c) => ({ value: c.id, label: c.name })),
+  ]);
 
   function close() {
     open = false;
+    // Reset the override so it never leaks into the next compose.
+    channel = 0;
+    advancedOpen = false;
     onClose?.();
   }
 
   async function send(text, targetOverride) {
     const target = (targetOverride || to || '').trim().toUpperCase();
     if (!target) return;
-    await onSend?.(text, target);
+    await onSend?.(text, target, channel);
     close();
   }
 </script>
@@ -69,6 +93,28 @@
       embedded={true}
       onSend={(text) => send(text)}
     />
+    <!-- Advanced (collapsed by default). Per-station channel selection
+         for operators running multiple radios on one instance. -->
+    <details class="advanced" bind:open={advancedOpen}>
+      <summary class="advanced-trigger">
+        <span class="chev" aria-hidden="true">{advancedOpen ? '▾' : '▸'}</span>
+        Advanced
+      </summary>
+      <div class="advanced-body">
+        <span class="advanced-label">Transmit channel</span>
+        <Select
+          value={channel}
+          onValueChange={(v) => (channel = Number(v))}
+          options={channelOptions}
+          aria-label="Message transmit channel"
+        />
+        <p class="advanced-hint">
+          Sends this message on a specific radio channel instead of your
+          configured default. Useful when multiple radios on different
+          bands share this station.
+        </p>
+      </div>
+    </details>
   </Modal.Body>
 </Modal>
 
@@ -90,6 +136,53 @@
     font-weight: 700;
     letter-spacing: 1px;
     text-transform: uppercase;
+    color: var(--color-text-dim);
+  }
+
+  .advanced {
+    margin-top: 12px;
+    border: 1px solid var(--color-border, #ddd);
+    border-radius: 6px;
+  }
+  .advanced-trigger {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 12px;
+    color: var(--color-text, #222);
+    user-select: none;
+    list-style: none;
+  }
+  /* Hide the default <details> disclosure marker on every browser. */
+  .advanced-trigger::-webkit-details-marker { display: none; }
+  .advanced-trigger::marker { content: ''; }
+  .advanced-trigger:hover { background: var(--color-surface, #f4f4f4); }
+  .advanced[open] .advanced-trigger { border-bottom: 1px solid var(--color-border, #ddd); }
+  .chev {
+    display: inline-block;
+    width: 12px;
+    color: var(--color-text-muted, #888);
+    font-size: 11px;
+  }
+  .advanced-body {
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .advanced-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--color-text-dim);
+  }
+  .advanced-hint {
+    margin: 0;
+    font-size: 11px;
+    line-height: 1.4;
     color: var(--color-text-dim);
   }
 </style>

--- a/web/src/routes/Messages.svelte
+++ b/web/src/routes/Messages.svelte
@@ -213,7 +213,7 @@
   });
 
   // ---------- compose / optimistic send ----------
-  async function optimisticSend(text, to) {
+  async function optimisticSend(text, to, channel) {
     if (!to || !text) return;
     const clientId = (typeof crypto !== 'undefined' && crypto.randomUUID)
       ? crypto.randomUUID()
@@ -243,11 +243,17 @@
       // too — the server echo would set this anyway, but computing
       // it locally avoids a flicker-in on long sends.
       extended: (text?.length || 0) > DEFAULT_MAX_MESSAGE_TEXT,
+      // Non-zero = per-send channel override from the compose Advanced
+      // section; null so the metadata panel hides "Channel" for default
+      // sends, matching the server echo (channel omitted when 0).
+      channel: channel || null,
     };
     store.addPendingSend(clientId, optimistic);
 
     try {
-      const res = await sendMessage({ to: threadKey, text, client_id: clientId });
+      const payload = { to: threadKey, text, client_id: clientId };
+      if (channel) payload.channel = channel;
+      const res = await sendMessage(payload);
       store.reconcilePending(clientId, res);
       return res;
     } catch (err) {
@@ -262,8 +268,8 @@
     refreshNow();
   }
 
-  async function handleNewSend(text, to) {
-    const res = await optimisticSend(text, to);
+  async function handleNewSend(text, to, channel) {
+    const res = await optimisticSend(text, to, channel);
     refreshNow();
     // Navigate to the thread we just opened.
     const threadKind = store.tacticals.has(to.toUpperCase()) ? 'tactical' : 'dm';


### PR DESCRIPTION
## Summary

Adds per-message TX channel selection to the new-message dialog, tucked behind a collapsed **Advanced** section so the normal compose flow is unchanged. This addresses #472 for operators running multiple radios (different bands/frequencies) on a single instance who want to pick which channel an individual message goes out on.

- **Default is unchanged.** With Advanced collapsed (the default), messages transmit on the configured `tx_channel` exactly as before.
- **Persisted per message.** The chosen channel is stamped on the message row, so ack retries and resends reuse the same channel as the initial send.

## Changes

**Backend**
- `messages.SendMessageRequest` gains a `Channel uint32` field (0 = use default); `SendMessage` stamps it onto the existing `Message.Channel` column.
- `sender.go` resolves the effective channel per row (`channelFor`): a non-zero `row.Channel` wins, else the live default. Packet-mode refusal, RF-availability, `TxSink.Submit`, and logging all route on the effective channel. Retry/Resend re-read the persisted row, so no extra plumbing is needed.
- `webapi/messages.go` copies the already-present `dto.SendMessageRequest.Channel` (`*uint32`) into the service request.

**Frontend**
- `ComposeNewModal.svelte` adds a collapsed `<details class="advanced">` with a channel `Select` (non-packet channels + a "Default" sentinel — same filter as Settings → Messages → Transmit channel). The channel list is only fetched when Advanced is expanded, and the override resets when the dialog closes.
- Threaded through `Messages.svelte` (`handleNewSend` / `optimisticSend`) into `sendMessage({ channel })`.

## Tests

- `TestSender_RF_PerSendChannelOverride` — a non-zero `row.Channel` drives the governor submit; zero defers to the seeded default.
- `TestService_SendMessage_ChannelOverridePersistsAndDispatches` — the override persists on the row and the async dispatch submits on it.
- All existing `pkg/messages`, `pkg/webapi`, and web unit tests pass; frontend production build is clean.

Docs: added a "Per-send TX channel override" entry to `docs/wiki/code-map.md`.

Closes #472
