### PR TITLE
Blue dot tracks live GPS on the Live Map

### DIFF
--- a/web/src/lib/map/data-store.svelte.js
+++ b/web/src/lib/map/data-store.svelte.js
@@ -240,7 +240,11 @@ export function createDataStore() {
         schedule();
         return;
       }
-      await fetchOnce();
+      // Refresh own position on every tick so the blue dot follows live GPS
+      // instead of freezing at the page-load fix (GH #473). It's an in-memory
+      // read on the server and independent of the stations bbox, so run it
+      // alongside fetchOnce rather than gating it on that call.
+      await Promise.all([fetchOnce(), fetchMyPosition()]);
       if (started) schedule();
     }, backoff);
   }
@@ -249,7 +253,8 @@ export function createDataStore() {
     if (typeof document === 'undefined') return;
     if (document.visibilityState === 'visible' && started) {
       // Immediate catch-up; clearTimeout inside schedule() prevents double-chains.
-      fetchOnce().then(() => {
+      // Refresh the blue dot too so it isn't stale after the tab was hidden.
+      Promise.all([fetchOnce(), fetchMyPosition()]).then(() => {
         if (started) schedule();
       });
     }

--- a/web/src/lib/map/data-store.svelte.js
+++ b/web/src/lib/map/data-store.svelte.js
@@ -65,7 +65,8 @@ export function createDataStore() {
   let etag = null;                       // last response ETag, used in If-None-Match
   let sinceCursor = null;                // RFC3339Nano string of newest last_heard seen
   let timer = null;                      // setTimeout handle
-  let inFlight = false;                  // dedupe overlapping fetches
+  let inFlight = false;                  // dedupe overlapping /api/stations fetches
+  let posInFlight = false;               // dedupe overlapping /api/position fetches
   let backoff = POLL_BASE_MS;            // current delay; doubles on error
   let started = false;                   // start()/stop() guard
   let visibilityHandler = null;          // bound listener for cleanup
@@ -219,6 +220,10 @@ export function createDataStore() {
   }
 
   async function fetchMyPosition() {
+    // Dedupe so a visibility catch-up firing mid-tick can't race a scheduled
+    // poll and let the older of two near-identical fixes win the assignment.
+    if (posInFlight) return;
+    posInFlight = true;
     try {
       const res = await fetch('/api/position', { credentials: 'same-origin' });
       if (!res.ok) return;
@@ -226,6 +231,8 @@ export function createDataStore() {
       myPosition = pos && pos.valid ? pos : null;
     } catch (_) {
       // Non-fatal; leave myPosition unchanged.
+    } finally {
+      posInFlight = false;
     }
   }
 

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1117,6 +1117,11 @@
   // box of every callsign heard in the last hour. Suppressed when a
   // persisted view exists — restoring that view is what the operator
   // wants on reload.
+  //
+  // myPosition now refreshes on every poll tick (data-store follows live
+  // GPS), so this effect re-runs continuously. The didAutoFit guard is what
+  // keeps the recenter one-shot — without it the camera would snap back to
+  // the blue dot on every fix and fight the operator's panning.
   $effect(() => {
     const my = dataStore.myPosition;
     if (!my || !mapRef || didAutoFit) return;


### PR DESCRIPTION
## Summary

The Live Map fetched `GET /api/position` **only once**, at page load, and never again. The 5-second poll loop only refreshed `/api/stations`, so the own-position marker (blue dot) froze at whatever fix was present when the map opened and never moved as the operator travelled -- even though the server tracks live GPS continuously (the Android GPS bridge streams fixes into the station-position cache, and `/api/position` always returns the latest).

This restores the intended behavior: the blue dot now follows the current GPS fix.

## Change

In `web/src/lib/map/data-store.svelte.js`, refresh `myPosition` on every poll tick alongside the stations fetch, and on the tab-visibility catch-up:

- Poll loop: `await Promise.all([fetchOnce(), fetchMyPosition()])`
- Visibility handler: same, so the dot isn't stale after the tab was hidden.

`fetchMyPosition()` is an in-memory read on the server and independent of the stations bbox, so it runs alongside `fetchOnce()` rather than being gated on it. The one-shot camera recenter (`didAutoFit`) is untouched, so continuous updates move only the dot -- the camera stays where the operator left it (a "follow me" affordance remains separate future work).

## Testing

- `npm run build` -- succeeds.
- `npm test` -- 465/465 pass.

Fixes #473.
