### PR TITLE
Render a flat conventional map compass

### DIFF
--- a/web/src/lib/map/maplibre-map.svelte
+++ b/web/src/lib/map/maplibre-map.svelte
@@ -225,10 +225,13 @@
     // twist is ignored. Desktop right-drag rotate (dragRotate) and the
     // compass reset are untouched, so this needs no settings switch.
     map.touchZoomRotate.disableRotation();
+    // Plain flat compass, like most maps: the needle rotates with bearing
+    // and resets north on click. visualizePitch is left off so the needle
+    // stays 2D instead of tilting into a 3D perspective as the map pitches.
     map.addControl(
       new maplibregl.NavigationControl({
         showCompass: true,
-        visualizePitch: true,
+        visualizePitch: false,
       }),
       'top-right',
     );


### PR DESCRIPTION
## What

The live map's north arrow used MapLibre's `visualizePitch` compass mode. That tilts the north needle into a 3D perspective as the map pitches, giving it the unusual, non-standard look. This turns `visualizePitch` off so the compass renders as a plain flat needle that rotates to point north and resets north on click -- the conventional style most maps use.

## Change

`web/src/lib/map/maplibre-map.svelte`: `NavigationControl` now mounts with `visualizePitch: false` (compass still shown, still resets bearing on click).

No behavior change beyond the compass appearance; no tests reference the control options.
