### PR TITLE
Revert "Render a flat conventional map compass"

### DIFF
--- a/web/src/lib/map/maplibre-map.svelte
+++ b/web/src/lib/map/maplibre-map.svelte
@@ -225,13 +225,10 @@
     // twist is ignored. Desktop right-drag rotate (dragRotate) and the
     // compass reset are untouched, so this needs no settings switch.
     map.touchZoomRotate.disableRotation();
-    // Plain flat compass, like most maps: the needle rotates with bearing
-    // and resets north on click. visualizePitch is left off so the needle
-    // stays 2D instead of tilting into a 3D perspective as the map pitches.
     map.addControl(
       new maplibregl.NavigationControl({
         showCompass: true,
-        visualizePitch: false,
+        visualizePitch: true,
       }),
       'top-right',
     );


### PR DESCRIPTION
Reverts #480. That compass change was landed on the wrong repo — the flat conventional compass belongs on the ADS-B Enjoyer app, not Graywolf. This restores `visualizePitch: true` on the web map's `NavigationControl`, putting the compass back to its prior tilted-pitch behavior.

The equivalent work is being reimplemented on the ADS-B Enjoyer repo separately.
