### PR TITLE
Enforce a consistent minimum password length between setup and web login

### DIFF
--- a/cmd/graywolf/authcli/authcli.go
+++ b/cmd/graywolf/authcli/authcli.go
@@ -104,7 +104,7 @@ func runSetPassword(args []string, buildVersion string) error {
 		user = "admin"
 	}
 
-	fmt.Printf("Enter password for %s: ", user)
+	fmt.Printf("Enter password for %s (at least %d characters): ", user, webauth.MinPasswordBytes)
 	var password string
 	fmt.Scanln(&password)
 	if password == "" {

--- a/docs/handbook/installation.html
+++ b/docs/handbook/installation.html
@@ -291,6 +291,9 @@ nssm start Graywolf</code></pre>
           run &mdash; when no users exist yet &mdash; the login screen shows
           a <strong>Create Admin Account</strong> form. Enter a username and
           password there and you&rsquo;re done; no command line needed.
+          The password must be at least 8 characters &mdash; the same
+          requirement the web login enforces, so a password set here always
+          works at sign-in.
         </p>
 
         <p>
@@ -484,7 +487,10 @@ sudo packaging/scripts/postinstall.sh</code></pre>
     <h2>Set a Password</h2>
 
     <p>
-      Before exposing the web UI on your network, set an admin password:
+      Before exposing the web UI on your network, set an admin password.
+      The password must be at least 8 characters &mdash; the same minimum
+      the web login enforces, so the credential you set here always works
+      at sign-in:
     </p>
 
 <pre><code>sudo graywolf auth set-password --user admin</code></pre>

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1415,6 +1415,29 @@ Source: [`../../cmd/graywolf/main.go`](../../cmd/graywolf/main.go)
 (leftover-positional hint),
 [`../../cmd/graywolf/authcli/authcli.go`](../../cmd/graywolf/authcli/authcli.go).
 
+### 56b. Password length policy has one source of truth and is enforced only at creation
+
+*Why:* `webauth.MinPasswordBytes` (8) and `webauth.MaxPasswordBytes` (72) are
+the single source of truth for the password-length policy. Every
+*creation* path routes through `webauth.HashPassword`, which rejects both
+bounds, so the web setup form (`POST /api/auth/setup`), the `graywolf auth
+set-password` CLI, and the server handler can never disagree — the bug in
+graywolf#476 was setup accepting a sub-8 password the web login then
+refused. Enforcement is at creation ONLY: `HandleLogin` and `CheckPassword`
+do not length-check, so an account whose password predates the minimum
+still authenticates (a login-side minimum locked such users out). The web
+`Login.svelte` mirrors this — it validates min/max/confirm only in
+`setupMode`, never on sign-in. If you change a bound, change the constant
+and the operator docs (`docs/handbook/installation.html`), not a scattered
+literal.
+
+Source: [`../../pkg/webauth/auth.go`](../../pkg/webauth/auth.go)
+(constants + `HashPassword`),
+[`../../pkg/webauth/handlers.go`](../../pkg/webauth/handlers.go)
+(`CreateFirstUser` vs `HandleLogin`),
+[`../../web/src/routes/Login.svelte`](../../web/src/routes/Login.svelte)
+(`validate`).
+
 ### 57. A station's own beacon reaches the map via the TX path, so every transmit leg must feed the station cache
 
 *Why:* The Live Map plots stations from the `stationcache`, and the only

--- a/packaging/aur/graywolf-aprs.install
+++ b/packaging/aur/graywolf-aprs.install
@@ -9,7 +9,7 @@ post_install() {
   echo "  Enable and start the service:"
   echo "    systemctl enable --now graywolf-aprs.service"
   echo ""
-  echo "  Set a web UI password:"
+  echo "  Set a web UI password (must be at least 8 characters):"
   echo "    sudo -u graywolf-aprs graywolf auth set-password --user admin --config /var/lib/graywolf-aprs/graywolf.db"
   echo ""
   echo "  Web UI: http://localhost:8080"

--- a/pkg/webauth/auth.go
+++ b/pkg/webauth/auth.go
@@ -17,9 +17,22 @@ import (
 // rather than surfacing the library's internal message.
 const MaxPasswordBytes = 72
 
+// MinPasswordBytes is the shortest password accepted at creation time.
+// This is the single source of truth for the minimum-length policy: the
+// web UI, the /api/auth/setup handler, and the `graywolf auth
+// set-password` CLI all enforce it through HashPassword so a password
+// accepted by one path can never be rejected by another (issue #476).
+// bcrypt is byte-oriented, so the bound is measured in bytes; for the
+// ASCII passwords this covers it matches "8 characters".
+const MinPasswordBytes = 8
+
 // ErrPasswordTooLong is returned by HashPassword when the password exceeds
 // MaxPasswordBytes. Callers should map it to a client-facing 400.
 var ErrPasswordTooLong = errors.New("password exceeds 72 bytes")
+
+// ErrPasswordTooShort is returned by HashPassword when the password is
+// shorter than MinPasswordBytes. Callers should map it to a client-facing 400.
+var ErrPasswordTooShort = errors.New("password must be at least 8 characters")
 
 const (
 	bcryptCost = 10
@@ -34,6 +47,9 @@ const (
 
 // HashPassword returns a bcrypt hash suitable for storage.
 func HashPassword(password string) (string, error) {
+	if len(password) < MinPasswordBytes {
+		return "", ErrPasswordTooShort
+	}
 	if len(password) > MaxPasswordBytes {
 		return "", ErrPasswordTooLong
 	}

--- a/pkg/webauth/auth_test.go
+++ b/pkg/webauth/auth_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/glebarez/sqlite"
+	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
@@ -42,14 +43,14 @@ func testAuthStore(t *testing.T) *AuthStore {
 }
 
 func TestHashAndCheckPassword(t *testing.T) {
-	hash, err := HashPassword("hunter2")
+	hash, err := HashPassword("hunter2!")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hash == "" || hash == "hunter2" {
+	if hash == "" || hash == "hunter2!" {
 		t.Fatal("hash should be a bcrypt string")
 	}
-	if err := CheckPassword(hash, "hunter2"); err != nil {
+	if err := CheckPassword(hash, "hunter2!"); err != nil {
 		t.Fatal("correct password should match")
 	}
 	if err := CheckPassword(hash, "wrong"); err == nil {
@@ -67,6 +68,51 @@ func TestHashPasswordTooLong(t *testing.T) {
 	_, err := HashPassword(strings.Repeat("a", MaxPasswordBytes+1))
 	if !errors.Is(err, ErrPasswordTooLong) {
 		t.Fatalf("expected ErrPasswordTooLong, got %v", err)
+	}
+}
+
+func TestHashPasswordTooShort(t *testing.T) {
+	// Exactly at the minimum must hash.
+	if _, err := HashPassword(strings.Repeat("a", MinPasswordBytes)); err != nil {
+		t.Fatalf("%d-byte password should hash, got %v", MinPasswordBytes, err)
+	}
+	// One byte under must be rejected with the sentinel.
+	_, err := HashPassword(strings.Repeat("a", MinPasswordBytes-1))
+	if !errors.Is(err, ErrPasswordTooShort) {
+		t.Fatalf("expected ErrPasswordTooShort, got %v", err)
+	}
+}
+
+// TestCreateFirstUserPasswordTooShort is the regression for issue #476: a
+// too-short password must come back as a clean 400 with an actionable
+// message so the setup path can't create a credential the web login
+// would later refuse.
+func TestCreateFirstUserPasswordTooShort(t *testing.T) {
+	s := testAuthStore(t)
+	h := &Handlers{Auth: s}
+
+	body, _ := json.Marshal(setupRequest{
+		Username: "admin",
+		Password: "short",
+	})
+	req := httptest.NewRequest("POST", "/api/auth/setup", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.CreateFirstUser(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	if got := resp["error"]; got != "password must be at least 8 characters" {
+		t.Fatalf("unexpected error message: %q", got)
+	}
+
+	// No user should have been created.
+	if count, _ := s.UserCount(context.Background()); count != 0 {
+		t.Fatalf("expected 0 users after rejected setup, got %d", count)
 	}
 }
 
@@ -329,7 +375,7 @@ func TestFirstRunSetup(t *testing.T) {
 	h := &Handlers{Auth: s}
 
 	// First setup should succeed.
-	body, _ := json.Marshal(setupRequest{Username: "admin", Password: "secret"})
+	body, _ := json.Marshal(setupRequest{Username: "admin", Password: "secret12"})
 	req := httptest.NewRequest("POST", "/api/auth/setup", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	h.CreateFirstUser(rec, req)
@@ -338,7 +384,7 @@ func TestFirstRunSetup(t *testing.T) {
 	}
 
 	// Second setup should be forbidden.
-	body, _ = json.Marshal(setupRequest{Username: "hacker", Password: "evil"})
+	body, _ = json.Marshal(setupRequest{Username: "hacker", Password: "evilevil"})
 	req = httptest.NewRequest("POST", "/api/auth/setup", bytes.NewReader(body))
 	rec = httptest.NewRecorder()
 	h.CreateFirstUser(rec, req)
@@ -347,12 +393,37 @@ func TestFirstRunSetup(t *testing.T) {
 	}
 }
 
+// TestLoginAcceptsLegacyShortPassword guards the #476 fix: enforcing a
+// minimum length at creation must not lock out accounts whose password
+// was set before the minimum existed. Login validates the hash only, so a
+// sub-minimum password stored directly still authenticates.
+func TestLoginAcceptsLegacyShortPassword(t *testing.T) {
+	s := testAuthStore(t)
+	ctx := context.Background()
+	h := &Handlers{Auth: s}
+
+	// Bypass HashPassword to mimic a legacy short-password hash.
+	raw, err := bcrypt.GenerateFromPassword([]byte("short"), bcryptCost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.CreateUser(ctx, "admin", string(raw), "")
+
+	body, _ := json.Marshal(loginRequest{Username: "admin", Password: "short"})
+	req := httptest.NewRequest("POST", "/api/auth/login", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.HandleLogin(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for legacy short password, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestLoginLogout(t *testing.T) {
 	s := testAuthStore(t)
 	ctx := context.Background()
 	h := &Handlers{Auth: s}
 
-	hash, _ := HashPassword("correct")
+	hash, _ := HashPassword("correct1")
 	s.CreateUser(ctx, "admin", hash, "")
 
 	// Wrong password → 401
@@ -365,7 +436,7 @@ func TestLoginLogout(t *testing.T) {
 	}
 
 	// Correct password → 200 + set-cookie
-	body, _ = json.Marshal(loginRequest{Username: "admin", Password: "correct"})
+	body, _ = json.Marshal(loginRequest{Username: "admin", Password: "correct1"})
 	req = httptest.NewRequest("POST", "/api/auth/login", bytes.NewReader(body))
 	rec = httptest.NewRecorder()
 	h.HandleLogin(rec, req)
@@ -495,7 +566,7 @@ func TestCreateFirstUserErrorSanitization(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	body, _ := json.Marshal(setupRequest{Username: "newbie", Password: "secret"})
+	body, _ := json.Marshal(setupRequest{Username: "newbie", Password: "secret12"})
 	req := httptest.NewRequest("POST", "/api/auth/setup", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	h.CreateFirstUser(rec, req)

--- a/pkg/webauth/handlers.go
+++ b/pkg/webauth/handlers.go
@@ -248,6 +248,10 @@ func (h *Handlers) CreateFirstUser(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "username and password required")
 		return
 	}
+	if len(req.Password) < MinPasswordBytes {
+		jsonError(w, http.StatusBadRequest, "password must be at least 8 characters")
+		return
+	}
 	if len(req.Password) > MaxPasswordBytes {
 		jsonError(w, http.StatusBadRequest, "password must not exceed 72 bytes")
 		return
@@ -255,6 +259,10 @@ func (h *Handlers) CreateFirstUser(w http.ResponseWriter, r *http.Request) {
 
 	hash, err := HashPassword(req.Password)
 	if err != nil {
+		if errors.Is(err, ErrPasswordTooShort) {
+			jsonError(w, http.StatusBadRequest, "password must be at least 8 characters")
+			return
+		}
 		if errors.Is(err, ErrPasswordTooLong) {
 			jsonError(w, http.StatusBadRequest, "password must not exceed 72 bytes")
 			return

--- a/pkg/webauth/release_notes_seed_test.go
+++ b/pkg/webauth/release_notes_seed_test.go
@@ -110,7 +110,7 @@ func TestSetupHandlerSeedsFromHandlerVersion(t *testing.T) {
 	h := &Handlers{Auth: s, BuildVersion: "0.11.0"}
 
 	req := httptest.NewRequest("POST", "/api/auth/setup",
-		strings.NewReader(`{"username":"admin","password":"pw"}`))
+		strings.NewReader(`{"username":"admin","password":"password1"}`))
 	rec := httptest.NewRecorder()
 	h.CreateFirstUser(rec, req)
 	if rec.Code != 201 {

--- a/web/src/routes/Login.svelte
+++ b/web/src/routes/Login.svelte
@@ -27,10 +27,16 @@
     const e = {};
     if (!username.trim()) e.username = 'Username is required';
     if (!password) e.password = 'Password is required';
-    if (password.length < 8) e.password = 'Minimum 8 characters';
-    // bcrypt rejects anything past 72 bytes; measure UTF-8 length so a
-    // multibyte password can't slip past a naive character count.
-    if (new TextEncoder().encode(password).length > 72) e.password = 'Maximum 72 characters';
+    // Length policy is enforced only when creating an account. On login we
+    // must accept whatever the account was created with — gating a correct
+    // password on length here locked out users whose password was set via
+    // `graywolf auth set-password` before the minimum was consistent (#476).
+    else if (setupMode) {
+      if (password.length < 8) e.password = 'Minimum 8 characters';
+      // bcrypt rejects anything past 72 bytes; measure UTF-8 length so a
+      // multibyte password can't slip past a naive character count.
+      else if (new TextEncoder().encode(password).length > 72) e.password = 'Maximum 72 characters';
+    }
     if (setupMode && password !== passwordConfirm) e.passwordConfirm = 'Passwords do not match';
     errors = e;
     return Object.keys(e).length === 0;


### PR DESCRIPTION
Fixes #476.

The web login form required a minimum of 8 characters, but the setup path — both `POST /api/auth/setup` and the `graywolf auth set-password` CLI shown in the install instructions — accepted any non-empty password. An operator who set a short password during setup was then refused at the web login screen, locking them out of the config UI.

## Root cause

Password length was validated in three places that disagreed:

- **Web login** (`Login.svelte`) enforced min 8 / max 72 on *both* setup and sign-in.
- **Setup handler** (`CreateFirstUser`) enforced only the max.
- **CLI `set-password`** enforced nothing beyond non-empty.

## Fix

Single source of truth, enforced at creation only:

- Add `webauth.MinPasswordBytes` (8) and `ErrPasswordTooShort`. `HashPassword` now rejects both bounds, so the setup form, the setup handler, and the CLI all share one rule.
- `CreateFirstUser` maps the too-short case to a clean `400` with an actionable message.
- `Login.svelte` validates min/max/confirm only in setup mode — sign-in no longer length-gates a *correct* password, so any account whose password predates this minimum still authenticates.
- Document the 8-character requirement in the handbook and the package post-install output, and record the invariant in the wiki.

## Tests

- `HashPassword` rejects sub-minimum with the sentinel; setup returns 400 with the actionable message.
- Regression: a legacy sub-8 password stored directly still logs in via `HandleLogin`.
- `go test ./pkg/webauth/... ./pkg/webapi/... ./cmd/graywolf/...` passes.
