### PR TITLE
docs: document --group-add audio for Docker sound-card access

### DIFF
--- a/docs/handbook/audio.html
+++ b/docs/handbook/audio.html
@@ -100,6 +100,23 @@
       right there.
     </p>
 
+    <div class="callout warn">
+      <span class="callout-icon">&#9888;</span>
+      <div class="callout-body">
+        <p>
+          <strong>Running in Docker and Detect Devices finds nothing?</strong>
+          Detection opens each sound card to probe it, which needs
+          <code>audio</code>-group access to <code>/dev/snd</code>. The
+          container image runs as a non-root user, so besides
+          <code>--device /dev/snd</code> you must add
+          <code>--group-add audio</code> (Compose: <code>group_add: [audio]</code>).
+          Without it, <code>arecord -l</code> still lists the card &mdash; it
+          only reads <code>/proc/asound</code> &mdash; but detection comes up
+          empty. See <a href="installation.html">Installation &rarr; Docker</a>.
+        </p>
+      </div>
+    </div>
+
     <h2>Source Types</h2>
 
     <div class="box">

--- a/docs/handbook/installation.html
+++ b/docs/handbook/installation.html
@@ -324,6 +324,7 @@ nssm start Graywolf</code></pre>
   --name graywolf \
   --restart unless-stopped \
   --device /dev/snd \
+  --group-add audio \
   -p 8080:8080/tcp \
   -v graywolf-data:/data \
   ghcr.io/chrissnell/graywolf:latest \
@@ -338,6 +339,18 @@ nssm start Graywolf</code></pre>
               For serial PTT or GPS, pass the serial device as well
               (e.g., <code>--device /dev/ttyUSB0</code>).
             </p>
+            <p>
+              The image runs as a non-root user, so
+              <code>--group-add audio</code> is also required &mdash;
+              without it the modem cannot open the sound-card device nodes
+              (<code>/dev/snd/pcmC*</code>, owned <code>root:audio</code>)
+              and <strong>Detect Devices</strong> finds nothing even though
+              <code>arecord -l</code> lists the card. If the
+              <code>audio</code> group name doesn't resolve inside the
+              container, use its numeric GID instead (GID 29 on Raspberry
+              Pi OS / Debian; confirm with <code>getent group audio</code>
+              on the host).
+            </p>
           </div>
         </div>
 
@@ -351,6 +364,8 @@ nssm start Graywolf</code></pre>
     restart: unless-stopped
     devices:
       - /dev/snd:/dev/snd
+    group_add:
+      - audio
     ports:
       - "8080:8080/tcp"
     volumes:


### PR DESCRIPTION
The Docker image runs as a non-root user, so `--device /dev/snd` alone is not enough to open the sound-card device nodes (owned `root:audio`, mode 0660). Without `--group-add audio`, **Detect Devices** finds nothing even though `arecord -l` still lists the card (it only reads `/proc/asound`). This was the root cause in #479.

Changes:
- Add `--group-add audio` to the Docker Run and Docker Compose examples, with a note on using the numeric GID (29 on Pi OS/Debian) when the group name doesn't resolve.
- Add a troubleshooting callout on the Audio Devices page for the "Detect Devices finds nothing in Docker" case.