### PR TITLE
Explain RF-reachable stations in the station popup (#482)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1266,11 +1266,26 @@ qualifies. RF Only is the looser companion to Direct RX (#48): it keeps
 RF-digipeated stations (`hops > 0`) and drops only APRS-IS and Internet-to-RF
 gated current fixes.
 
+*Surfacing the divergence in the popup (graywolf #482).* The badge-vs-`positions[0]`
+divergence above reads as a filter bug to operators: a station badged `APRS-IS`
+that stays visible under RF Only looks wrong even though it is correct. #482 was
+the second report of exactly this. The popup now renders an `RF-reachable`
+note (`popup.js`, class `.stn-rf-reachable`) whenever
+`rfReachableDespiteNonRfLatest(s)` holds -- the plotted fix (`positions[0]`)
+qualifies as RF-heard while the **latest** packet did not arrive over RF
+(`s.direction !== 'RX' || s.gated`). The RF Only toggle also carries a `title`
+tooltip stating the "ever RF-reachable at the current fix" semantics. This is a
+labeling affordance only; it does **not** change the predicate. If you ever make
+RF Only key on current-packet recency instead (the #482 option 2), retire this
+note too.
+
 Source: [`../../web/src/lib/map/rf-only-core.js`](../../web/src/lib/map/rf-only-core.js)
-(`isRfOnly`),
+(`isRfOnly`, `rfReachableDespiteNonRfLatest`),
 [`../../web/src/lib/map/rf-only-core.test.js`](../../web/src/lib/map/rf-only-core.test.js),
 [`../../web/src/routes/LiveMapV2.svelte`](../../web/src/routes/LiveMapV2.svelte)
-(filter `$effect`, `rfOnlyStationCount`),
+(filter `$effect`, `rfOnlyStationCount`, RF Only toggle `title`, `.stn-rf-reachable` CSS),
+[`../../web/src/lib/map/popup.js`](../../web/src/lib/map/popup.js)
+(`.stn-rf-reachable` note),
 [`../../web/src/lib/map/popup-helpers.js`](../../web/src/lib/map/popup-helpers.js)
 (`viaText`).
 

--- a/web/src/lib/map/popup.js
+++ b/web/src/lib/map/popup.js
@@ -5,6 +5,7 @@
 // .via-rf-hops, .path-link) are defined :global() in LiveMapV2.svelte.
 
 import { esc, timeAgo, fmtLat, fmtLon, viaCls, viaText, formatWeatherRows } from './popup-helpers.js';
+import { rfReachableDespiteNonRfLatest } from './rf-only-core.js';
 import { unitsState } from '../settings/units-store.svelte.js';
 
 // renderStationPopupHTML(station, { hasStation }) -> HTML string
@@ -49,6 +50,24 @@ export function renderStationPopupHTML(s, { hasStation = null } = {}) {
   if (meta.length) html += `<div class="stn-meta">${meta.join(' · ')}</div>`;
 
   html += `<div class="stn-via ${viaCls(s)}">${viaText(s)}</div>`;
+
+  // RF-reachability note. The badge and via line above reflect the *latest*
+  // packet (station-level fields, overwritten unconditionally by every
+  // arrival), but the marker is plotted at positions[0], whose reception the
+  // server pins to the most RF-reachable copy of that fix (stationcache
+  // rfRank). When the latest packet arrived via APRS-IS (or Internet-to-RF
+  // gated) yet the plotted fix was heard on RF, the station still -- correctly
+  // -- qualifies for the "RF Only" filter. Surface that here so the "APRS-IS" via
+  // doesn't read as a filter bug (graywolf #482, the second report of this
+  // divergence after #394).
+  if (rfReachableDespiteNonRfLatest(s)) {
+    const heard = pos.hops > 0
+      ? `via ${pos.hops} hop${pos.hops > 1 ? 's' : ''}`
+      : 'direct';
+    html +=
+      `<div class="stn-rf-reachable" title="This station's plotted position was heard on RF (radio), so it stays visible under the RF Only filter even though its most recent packet arrived via APRS-IS.">` +
+      `RF-reachable &middot; plotted fix heard on RF (${heard})</div>`;
+  }
 
   if (s.hops > 0 && s.path && s.path.length) {
     const pathHtml = s.path

--- a/web/src/lib/map/popup.js
+++ b/web/src/lib/map/popup.js
@@ -65,7 +65,7 @@ export function renderStationPopupHTML(s, { hasStation = null } = {}) {
       ? `via ${pos.hops} hop${pos.hops > 1 ? 's' : ''}`
       : 'direct';
     html +=
-      `<div class="stn-rf-reachable" title="This station's plotted position was heard on RF (radio), so it stays visible under the RF Only filter even though its most recent packet arrived via APRS-IS.">` +
+      `<div class="stn-rf-reachable" title="This station's plotted position was heard on RF (radio), so it stays visible under the RF Only filter even though its most recent packet did not arrive over RF (APRS-IS or Internet-to-RF gated).">` +
       `RF-reachable &middot; plotted fix heard on RF (${heard})</div>`;
   }
 

--- a/web/src/lib/map/rf-only-core.js
+++ b/web/src/lib/map/rf-only-core.js
@@ -19,3 +19,17 @@ export function isRfOnly(station) {
   const p = station?.positions?.[0];
   return !!p && p.direction === 'RX' && !p.gated;
 }
+
+// rfReachableDespiteNonRfLatest reports the popup "RF-reachable" note case:
+// the plotted fix (positions[0]) qualifies as RF-heard (isRfOnly) yet the
+// station's *latest* packet -- the one that drives the popup badge / via line
+// (station-level direction/gated, overwritten by every arrival) -- did NOT
+// arrive over RF. That divergence is why a station badged "APRS-IS" can still,
+// correctly, survive the RF Only filter: the marker is drawn at positions[0],
+// which the server pins to the most RF-reachable copy of the fix via rfRank.
+// The popup uses this to explain the visibility instead of reading as a bug
+// (graywolf #482, the second report of this after #394).
+export function rfReachableDespiteNonRfLatest(station) {
+  const latestIsRf = station?.direction === 'RX' && !station?.gated;
+  return !latestIsRf && isRfOnly(station);
+}

--- a/web/src/lib/map/rf-only-core.test.js
+++ b/web/src/lib/map/rf-only-core.test.js
@@ -111,3 +111,22 @@ test('no RF-reachable note when the plotted fix is Internet-to-RF gated', () => 
   };
   assert.equal(rfReachableDespiteNonRfLatest(station), false);
 });
+
+test('RF-reachable note fires when the latest packet is our own TX but the fix was RF-heard', () => {
+  // Our own beacon digipeated back and heard on RF (RX plotted fix), then a
+  // later TX beacon flips the station-level direction to TX. TX is not RF
+  // reception, so the note fires — the tooltip wording is deliberately generic
+  // ("did not arrive over RF") rather than APRS-IS-specific to stay truthful here.
+  const station = {
+    direction: 'TX',
+    positions: [{ direction: 'RX', hops: 1 }],
+  };
+  assert.equal(rfReachableDespiteNonRfLatest(station), true);
+});
+
+test('no RF-reachable note for missing/empty positions or undefined station', () => {
+  assert.equal(rfReachableDespiteNonRfLatest({ direction: 'IS', positions: [] }), false);
+  assert.equal(rfReachableDespiteNonRfLatest({ direction: 'IS' }), false);
+  assert.equal(rfReachableDespiteNonRfLatest({}), false);
+  assert.equal(rfReachableDespiteNonRfLatest(null), false);
+});

--- a/web/src/lib/map/rf-only-core.test.js
+++ b/web/src/lib/map/rf-only-core.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { isRfOnly } from './rf-only-core.js';
+import { isRfOnly, rfReachableDespiteNonRfLatest } from './rf-only-core.js';
 
 test('station whose current fix was heard directly on RF qualifies', () => {
   const station = { positions: [{ direction: 'RX', hops: 0 }] };
@@ -53,4 +53,61 @@ test('missing or empty positions are excluded', () => {
   assert.equal(isRfOnly({ positions: [] }), false);
   assert.equal(isRfOnly({}), false);
   assert.equal(isRfOnly(null), false);
+});
+
+// rfReachableDespiteNonRfLatest — the popup "RF-reachable" note case (#482):
+// plotted fix is RF-heard but the latest packet arrived some other way.
+
+test('RF-reachable note fires when plotted fix is RF but latest packet is APRS-IS', () => {
+  // The K4MMG-10 shape from #482: rfRank-protected RX head, latest packet IS.
+  const station = {
+    direction: 'IS',
+    gated: false,
+    positions: [{ direction: 'RX', hops: 0 }],
+  };
+  assert.equal(rfReachableDespiteNonRfLatest(station), true);
+});
+
+test('RF-reachable note fires for a digipeated RF fix with an APRS-IS latest packet', () => {
+  const station = {
+    direction: 'IS',
+    positions: [{ direction: 'RX', hops: 2 }],
+  };
+  assert.equal(rfReachableDespiteNonRfLatest(station), true);
+});
+
+test('RF-reachable note fires when the latest packet is Internet-to-RF gated', () => {
+  // Latest arrival gated (not RF), plotted fix still RF-heard.
+  const station = {
+    direction: 'RX',
+    gated: true,
+    positions: [{ direction: 'RX', hops: 0 }],
+  };
+  assert.equal(rfReachableDespiteNonRfLatest(station), true);
+});
+
+test('no RF-reachable note when the latest packet itself arrived over RF', () => {
+  // Badge/via already say RF — nothing to disambiguate.
+  const station = {
+    direction: 'RX',
+    gated: false,
+    positions: [{ direction: 'RX', hops: 0 }],
+  };
+  assert.equal(rfReachableDespiteNonRfLatest(station), false);
+});
+
+test('no RF-reachable note for a pure APRS-IS station (plotted fix is IS)', () => {
+  const station = {
+    direction: 'IS',
+    positions: [{ direction: 'IS' }],
+  };
+  assert.equal(rfReachableDespiteNonRfLatest(station), false);
+});
+
+test('no RF-reachable note when the plotted fix is Internet-to-RF gated', () => {
+  const station = {
+    direction: 'IS',
+    positions: [{ direction: 'RX', gated: true }],
+  };
+  assert.equal(rfReachableDespiteNonRfLatest(station), false);
 });

--- a/web/src/routes/LiveMapV2.svelte
+++ b/web/src/routes/LiveMapV2.svelte
@@ -1358,7 +1358,10 @@
           />
           <span>Direct RX</span>
         </label>
-        <label class="toggle-row">
+        <label
+          class="toggle-row"
+          title="Show only stations whose plotted position was heard on RF (radio), including RF-digipeated. A station stays visible if its last fix reached us over the air, even when its most recent packet later arrived via APRS-IS."
+        >
           <input
             type="checkbox"
             checked={layerToggles.rfOnly}
@@ -2133,6 +2136,15 @@
   :global(.via-rf) { color: var(--color-success); }
   :global(.via-rf-hops) { color: var(--color-warning); }
   :global(.via-is) { color: #c39bff; }
+  /* RF-reachability note: shown when the latest packet is APRS-IS but the
+     plotted fix was heard on RF (why it survives the RF Only filter). RF
+     green with a help cursor to invite the explanatory tooltip. */
+  :global(.stn-rf-reachable) {
+    color: var(--color-success);
+    font-size: 11px;
+    margin-top: 2px;
+    cursor: help;
+  }
   :global(.stn-path) { color: var(--color-text-dim); font-size: 11px; }
   :global(.stn-path .path-link) { color: #6eb5ff; text-decoration: none; cursor: pointer; }
   :global(.stn-path .path-link:hover) { text-decoration: underline; }


### PR DESCRIPTION
## Explain RF-reachable stations in the station popup

Follow-up to the #482 investigation. Implements option (1): keep the RF Only behavior, fix the confusion.

### Background

A station heard on RF at its current fix stays visible under the Live Map **RF Only** filter even after it re-beacons via APRS-IS. That is correct: the marker is plotted at `positions[0]`, which `stationcache` pins to the most RF-reachable copy of that fix (`rfRank`, invariant #48/#52). The popup badge and via line, however, read the *latest* packet's station-level fields, so they flip to `APRS-IS`. Operators see an APRS-IS station surviving RF Only and reasonably read it as a filter bug — this was graywolf #482, the second report of it after #394.

### Change

Surface the divergence instead of leaving it to look like a bug. **No predicate change** — RF Only still keys on `positions[0]`.

- `popup.js` renders an **RF-reachable** note whenever the plotted fix qualifies as RF-heard but the latest packet did not arrive over RF, noting whether the fix was heard direct or via N hops.
- New pure predicate `rfReachableDespiteNonRfLatest(station)` in `rf-only-core.js` (the node-testable module), with tests covering the IS-latest, gated-latest, digipeated, and non-diverging cases.
- The **RF Only** toggle gains a `title` tooltip stating the "ever RF-reachable at the current fix" semantics.
- Invariant #52 updated to document the affordance.

### Verification

- `npm test` (web): 471 pass, 0 fail (6 new tests for `rfReachableDespiteNonRfLatest`).
- `npm run build`: clean production build.

### Note

If RF Only is ever changed to track current-packet recency instead (the #482 option 2), this note and tooltip should be retired along with it.