### PR TITLE
Fix AX.25 terminal: mod-128 inbound decode and Ctrl-] menu

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1637,3 +1637,46 @@ Source: [`../../pkg/messages/router.go`](../../pkg/messages/router.go)
 `TestMatchAddresseeSSIDAware`),
 [`../../pkg/actions/classifier.go`](../../pkg/actions/classifier.go)
 (`Classify`).
+
+### 62. Inbound connected-mode frames decode with the owning session's negotiated modulus
+
+The RX fanout hands every non-UI frame to `ax25conn.Manager.DispatchRaw`,
+which resolves the owning session from the address header (modulus-
+independent), reads that session's negotiated modulus race-free via
+`Session.Mod128()`, and only then decodes the control field. The fanout
+goroutine must **not** decode with a fixed modulus: a mod-128 (SABME)
+link's I- and S-frames carry a **2-octet** control field, and decoding
+them as mod-8 corrupts `N(S)`/`N(R)` so every inbound frame is dropped
+and the link stalls.
+
+Two sub-invariants make this work:
+
+- **Control-field width is variable under mod-128.** U-frames
+  (SABM/SABME/UA/DM/DISC/FRMR/UI/XID/TEST) stay **1 octet** under either
+  modulus (v2.2 §4.2.2); only I/S frames grow to 2 octets. `Decode` sizes
+  the control field by peeking the low two bits of the first control
+  octet (`11` => U-frame => 1 octet). Assuming 2 octets for all mod-128
+  frames rejects every U-frame — including the UA that completes the
+  handshake — with "missing control field."
+- **The modulus mirror is atomic.** The session goroutine negotiates the
+  modulus at SABM/SABME time; `DispatchRaw` reads it from another
+  goroutine. All writes go through `Session.setMod128`, which mirrors
+  `cfg.Mod128` into an `atomic.Bool` that `Mod128()` reads, so the
+  cross-goroutine read never races the negotiation write.
+
+*Why:* the web AX.25 terminal exposes a "Negotiate modulo-128 (SABME)"
+toggle, so mod-128 links are reachable in production. Before this, the
+fanout decoded every connected-mode frame as mod-8, so an operator who
+enabled extended mode received the BBS welcome but never any further
+frames (graywolf #456).
+
+Source: [`../../pkg/app/rxfanout.go`](../../pkg/app/rxfanout.go)
+(`dispatchRxFrame` -> `DispatchRaw`),
+[`../../pkg/ax25conn/manager.go`](../../pkg/ax25conn/manager.go)
+(`DispatchRaw`),
+[`../../pkg/ax25conn/frame.go`](../../pkg/ax25conn/frame.go)
+(`Decode` control-width peek),
+[`../../pkg/ax25conn/session.go`](../../pkg/ax25conn/session.go)
+(`setMod128`, `Mod128`),
+[`../../pkg/ax25conn/manager_test.go`](../../pkg/ax25conn/manager_test.go)
+(`TestManager_DispatchRawMod128Delivers`).

--- a/pkg/app/rxfanout.go
+++ b/pkg/app/rxfanout.go
@@ -7,7 +7,6 @@ import (
 	"github.com/chrissnell/graywolf/pkg/app/ingress"
 	"github.com/chrissnell/graywolf/pkg/aprs"
 	"github.com/chrissnell/graywolf/pkg/ax25"
-	"github.com/chrissnell/graywolf/pkg/ax25conn"
 	pb "github.com/chrissnell/graywolf/pkg/ipcproto"
 	"github.com/chrissnell/graywolf/pkg/packetlog"
 	"github.com/chrissnell/graywolf/pkg/stationcache"
@@ -205,12 +204,12 @@ func (a *App) dispatchRxFrame(ctx context.Context, item rxFanoutItem, aprsSubmit
 			}
 		}
 	} else if a.ax25Mgr != nil {
-		// Connected-mode dispatch: any non-UI frame that decodes goes to
-		// the LAPB manager. Mismatch on (channel, local, peer) is silent —
-		// the manager has no session for it.
-		if cmFrame, err := ax25conn.Decode(rf.Data, false); err == nil {
-			a.ax25Mgr.Dispatch(rf.Channel, cmFrame)
-		}
+		// Connected-mode dispatch: any non-UI frame goes to the LAPB
+		// manager, which decodes it with the owning session's negotiated
+		// modulus (mod-8 vs mod-128) and drops it if no session matches
+		// (channel, local, peer). Decoding here with a fixed modulus would
+		// corrupt mod-128 sessions' N(S)/N(R) — see graywolf #456.
+		a.ax25Mgr.DispatchRaw(rf.Channel, rf.Data)
 	}
 	a.plog.Record(e)
 }

--- a/pkg/ax25conn/frame.go
+++ b/pkg/ax25conn/frame.go
@@ -91,8 +91,15 @@ func Decode(raw []byte, mod128 bool) (*Frame, error) {
 		return nil, err
 	}
 	off := hdr.AddrLen
+	if off >= len(raw) {
+		return nil, fmt.Errorf("ax25conn: missing control field")
+	}
+	// Control-field width: 1 octet for mod-8, and for mod-128 U-frames
+	// (SABM/SABME/UA/DM/DISC/FRMR/UI/XID/TEST), which stay 1 octet under
+	// either modulus (v2.2 §4.2.2). Mod-128 I- and S-frames are 2 octets.
+	// Peek the low two bits of the first control octet: 11 => U-frame.
 	ctlSize := 1
-	if mod128 {
+	if mod128 && raw[off]&0x03 != 0x03 {
 		ctlSize = 2
 	}
 	if len(raw) < off+ctlSize {

--- a/pkg/ax25conn/manager.go
+++ b/pkg/ax25conn/manager.go
@@ -164,6 +164,42 @@ func (m *Manager) remove(k sessionKey, id uint64) {
 	delete(m.byID, id)
 }
 
+// DispatchRaw decodes connected-mode frame bytes with the owning
+// session's negotiated modulus, then routes them. The RX-fanout caller
+// cannot know whether a link negotiated SABME (mod-128), and decoding a
+// mod-128 control field as mod-8 corrupts N(S)/N(R) so every inbound
+// frame is dropped and the link stalls (graywolf #456). We resolve the
+// session from the address header (modulus-independent) first, read its
+// modulus race-free, then decode. Unmatched frames are dropped silently,
+// same as Dispatch.
+func (m *Manager) DispatchRaw(channel uint32, raw []byte) {
+	hdr, err := ax25.DecodeAddressBlock(raw)
+	if err != nil {
+		return
+	}
+	key := sessionKey{
+		Channel: channel,
+		Local:   hdr.Dest.String(),
+		Peer:    hdr.Source.String(),
+	}
+	m.mu.Lock()
+	ms := m.byKey[key]
+	m.mu.Unlock()
+	if ms == nil {
+		return
+	}
+	f, err := Decode(raw, ms.s.Mod128())
+	if err != nil {
+		return
+	}
+	// Deliver to the session we already resolved (and whose modulus we
+	// decoded with) rather than re-looking-up by key: a fast reconnect
+	// that rebound the triple between the two lookups would otherwise
+	// hand this frame to a different session than the one it was decoded
+	// for.
+	m.deliver(ms, f)
+}
+
 // Dispatch routes a non-UI frame to the matching session. Caller is
 // the pkg/app rxfanout; per the brainstorm §4.1, the frame is
 // guaranteed non-UI by the caller.
@@ -178,13 +214,19 @@ func (m *Manager) Dispatch(channel uint32, f *Frame) {
 	}
 	m.mu.Lock()
 	ms := m.byKey[key]
-	if ms != nil {
-		ms.lastPath = m.normalizeInboundPath(f)
-	}
 	m.mu.Unlock()
 	if ms == nil {
 		return
 	}
+	m.deliver(ms, f)
+}
+
+// deliver records the frame's inbound digipeater path on ms and submits
+// it to the session goroutine. Shared by Dispatch and DispatchRaw.
+func (m *Manager) deliver(ms *managedSession, f *Frame) {
+	m.mu.Lock()
+	ms.lastPath = m.normalizeInboundPath(f)
+	m.mu.Unlock()
 	ms.s.Submit(Event{Kind: EventFrameRX, Frame: f})
 }
 

--- a/pkg/ax25conn/manager_test.go
+++ b/pkg/ax25conn/manager_test.go
@@ -177,6 +177,82 @@ func TestManager_DispatchRoutes(t *testing.T) {
 	}
 }
 
+// TestManager_DispatchRawMod128Delivers is the regression guard for
+// graywolf #456: inbound connected-mode frames must be decoded with the
+// owning session's negotiated modulus. A mod-128 I-frame's control field
+// is 2 octets; decoding it as mod-8 corrupts N(S)/N(R) so the payload is
+// never delivered and the link stalls. DispatchRaw honors Session.Mod128.
+func TestManager_DispatchRawMod128Delivers(t *testing.T) {
+	m := newTestManager(t)
+	defer m.Close()
+
+	rxCh := make(chan []byte, 4)
+	scfg := SessionConfig{
+		Local:   mustParse(t, "KE7XYZ-1"),
+		Peer:    mustParse(t, "BBS-3"),
+		Channel: 1,
+		Mod128:  true,
+		Observer: func(ev OutEvent) {
+			if ev.Kind == OutDataRX {
+				rxCh <- append([]byte(nil), ev.Data...)
+			}
+		},
+	}
+	// Open starts the session's Run loop internally; do not spawn another.
+	_, s, err := m.Open(scfg, "op1")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	// Operator connect → session sends SABME; peer answers UA to
+	// establish the mod-128 link.
+	s.Submit(Event{Kind: EventConnect})
+	ua := &Frame{
+		Source: mustParse(t, "BBS-3"), Dest: mustParse(t, "KE7XYZ-1"),
+		Control: Control{Kind: FrameUA, PF: true},
+		Mod128:  true,
+	}
+	raw, err := ua.Encode()
+	if err != nil {
+		t.Fatalf("encode UA: %v", err)
+	}
+	m.DispatchRaw(1, raw)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && s.Snapshot().State != StateConnected {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if s.Snapshot().State != StateConnected {
+		t.Fatalf("link never reached CONNECTED, state=%v", s.Snapshot().State)
+	}
+
+	// Inbound mod-128 I-frame N(S)=0 carrying data. Its 2-octet control
+	// field only decodes correctly when the manager honors the session's
+	// negotiated modulus.
+	iframe := &Frame{
+		Source: mustParse(t, "BBS-3"), Dest: mustParse(t, "KE7XYZ-1"),
+		Control:   Control{Kind: FrameI, NS: 0, NR: 0, PF: false},
+		PID:       0xF0,
+		Info:      []byte("welcome"),
+		IsCommand: true,
+		Mod128:    true,
+	}
+	raw, err = iframe.Encode()
+	if err != nil {
+		t.Fatalf("encode I: %v", err)
+	}
+	m.DispatchRaw(1, raw)
+
+	select {
+	case got := <-rxCh:
+		if string(got) != "welcome" {
+			t.Fatalf("payload drift: %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("mod-128 I-frame never delivered as OutDataRX")
+	}
+}
+
 func TestManager_DispatchUnknownTripleNoOp(t *testing.T) {
 	m := newTestManager(t)
 	defer m.Close()

--- a/pkg/ax25conn/session.go
+++ b/pkg/ax25conn/session.go
@@ -115,6 +115,13 @@ type Session struct {
 	// unchanged, so only a real transition into DISCONNECTED trips it.
 	terminated bool
 
+	// mod128Bit mirrors cfg.Mod128 as an atomic so Manager.DispatchRaw,
+	// running on the RX-fanout goroutine, can pick the right control-field
+	// octet count (mod-8 vs mod-128) without racing the session goroutine
+	// that negotiates the modulus at SABM/SABME time. Always written via
+	// setMod128; read via Mod128().
+	mod128Bit atomic.Bool
+
 	// txFailNotified guards the one-shot operator-facing error emitted
 	// when a frame cannot be handed to the TX backend (e.g. the channel
 	// has no KISS/modem backend, or the wrong channel was selected).
@@ -159,6 +166,7 @@ func NewSession(cfg SessionConfig) (*Session, error) {
 		wakeup: make(chan struct{}, 1),
 		state:  StateDisconnected,
 	}
+	s.mod128Bit.Store(cfg.Mod128)
 	s.t1 = newTimer(cfg.Clock, cfg.T1, func() { s.signalTimer(pendT1) })
 	s.t2 = newTimer(cfg.Clock, cfg.T2, func() { s.signalTimer(pendT2) })
 	s.t3 = newTimer(cfg.Clock, cfg.T3, func() { s.signalTimer(pendT3) })
@@ -174,6 +182,19 @@ func (s *Session) modulus() int {
 	}
 	return 8
 }
+
+// setMod128 updates the active modulus. Called only from the session
+// goroutine; mirrors the value into an atomic so Manager.DispatchRaw can
+// decode inbound control fields with the matching octet count without
+// racing this write.
+func (s *Session) setMod128(v bool) {
+	s.cfg.Mod128 = v
+	s.mod128Bit.Store(v)
+}
+
+// Mod128 reports the session's active modulus race-free. Safe to call
+// from any goroutine, unlike the cfg field it mirrors.
+func (s *Session) Mod128() bool { return s.mod128Bit.Load() }
 
 // nextT1 returns the T1 duration to set on the next reset. Mirrors
 // ax25_calculate_t1 in net/ax25/ax25_subr.c:220-258. The kernel

--- a/pkg/ax25conn/transitions_awaiting_connection.go
+++ b/pkg/ax25conn/transitions_awaiting_connection.go
@@ -24,14 +24,14 @@ func (s *Session) onAwaitingConnection(_ context.Context, ev Event) bool {
 			}
 			// Peer sent SABM (collision or simultaneous-open). Kernel:
 			// emit UA, set modulus=8, stay in state 1.
-			s.cfg.Mod128 = false
+			s.setMod128(false)
 			s.cfg.Window = DefaultWindowMod8
 			s.sendUA(f.Control.PF)
 		case FrameSABME:
 			if !f.IsCommand {
 				return true
 			}
-			s.cfg.Mod128 = true
+			s.setMod128(true)
 			s.cfg.Window = DefaultWindowMod128
 			s.sendUA(f.Control.PF)
 		case FrameDISC:
@@ -56,7 +56,7 @@ func (s *Session) onAwaitingConnection(_ context.Context, ev Event) bool {
 			if s.cfg.Mod128 {
 				// Kernel ax25_std_in.c:84-87: downgrade to mod-8, keep
 				// T1 running, retry as SABM on next T1 expiry.
-				s.cfg.Mod128 = false
+				s.setMod128(false)
 				s.cfg.Window = DefaultWindowMod8
 				return true
 			}
@@ -70,7 +70,7 @@ func (s *Session) onAwaitingConnection(_ context.Context, ev Event) bool {
 			if s.cfg.Mod128 {
 				// Kernel ax25_std_timer.c:128-133: auto-fall-back to
 				// mod-8 with a fresh N2 budget.
-				s.cfg.Mod128 = false
+				s.setMod128(false)
 				s.cfg.Window = DefaultWindowMod8
 				s.v.N2Count = 0
 				s.sendSABM(false)

--- a/pkg/ax25conn/transitions_connected.go
+++ b/pkg/ax25conn/transitions_connected.go
@@ -23,7 +23,7 @@ func (s *Session) onConnected(_ context.Context, ev Event) bool {
 			// Graceful rebind in place: full reset of seq vars, requeue
 			// pending I-frames so kick re-sends them under fresh
 			// numbers. ax25_std_in.c:146-165.
-			s.cfg.Mod128 = f.Control.Kind == FrameSABME
+			s.setMod128(f.Control.Kind == FrameSABME)
 			if s.cfg.Mod128 {
 				s.cfg.Window = DefaultWindowMod128
 			} else {

--- a/pkg/ax25conn/transitions_timer_recovery.go
+++ b/pkg/ax25conn/transitions_timer_recovery.go
@@ -22,7 +22,7 @@ func (s *Session) onTimerRecovery(_ context.Context, ev Event) bool {
 			if !f.IsCommand {
 				break
 			}
-			s.cfg.Mod128 = f.Control.Kind == FrameSABME
+			s.setMod128(f.Control.Kind == FrameSABME)
 			if s.cfg.Mod128 {
 				s.cfg.Window = DefaultWindowMod128
 			} else {

--- a/web/src/components/terminal/TerminalViewport.svelte
+++ b/web/src/components/terminal/TerminalViewport.svelte
@@ -17,7 +17,12 @@
   // fitToWidth=true grows the column count to fill the host container
   // and dynamically resizes on window resize. Use for monitor-mode
   // sessions where there is no LAPB peer enforcing 80-column screens.
-  let { session, preset = 'classic', narrowMin = 768, fitToWidth = false } = $props();
+  // onMenuChord fires when the operator presses Ctrl-] / Cmd-] while the
+  // terminal canvas has focus. xterm would otherwise swallow that keydown
+  // (it maps to the GS control code and xterm calls stopPropagation), so
+  // the route-level <svelte:window> handler never sees it — see the
+  // attachCustomKeyEventHandler wiring below (graywolf #456).
+  let { session, preset = 'classic', narrowMin = 768, fitToWidth = false, onMenuChord } = $props();
 
   let host = $state(null);
   let term = null;
@@ -98,6 +103,30 @@
     });
     term.loadAddon(new WebLinksAddon());
     term.loadAddon(new SearchAddon());
+    // Intercept Ctrl-] / Cmd-] before xterm processes it. Returning false
+    // tells xterm to leave the key alone, so it does not send the stray GS
+    // (0x1D) byte down the link. We also preventDefault + stopPropagation
+    // ourselves so this path is self-contained: preventDefault kills the
+    // macOS Cmd-] browser forward-navigation binding, and stopPropagation
+    // keeps the event from also reaching the route's <svelte:window>
+    // handler (which stays as the fallback for when the canvas is NOT
+    // focused — xterm's key handler only runs on a focused terminal).
+    // Without this interceptor, xterm's own cancel() stopPropagations the
+    // keydown because Ctrl-] maps to a control code, so the window handler
+    // never fired and the menu could not open while focused (graywolf #456).
+    term.attachCustomKeyEventHandler((ev) => {
+      if (
+        ev.type === 'keydown' &&
+        (ev.ctrlKey || ev.metaKey) &&
+        (ev.key === ']' || ev.code === 'BracketRight')
+      ) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        onMenuChord?.();
+        return false;
+      }
+      return true;
+    });
     term.open(host);
     // Pull keyboard focus into the canvas so operators can type
     // immediately on session open without an extra click. SR users

--- a/web/src/routes/Terminal.svelte
+++ b/web/src/routes/Terminal.svelte
@@ -111,11 +111,14 @@
   }
 
   function handleKey(e) {
-    // Ctrl-] (or Cmd-]) opens the command bar from anywhere on the
-    // route. Match on e.code (layout-stable physical key) as well as
-    // e.key: on Safari/macOS holding Ctrl makes e.key report the GS
-    // control character (U+001D) or an empty string instead of ']', so
-    // the e.key === ']' test alone never fired there (graywolf #456).
+    // Ctrl-] (or Cmd-]) opens the command bar. This window-level handler
+    // is the FALLBACK for when focus is outside the terminal canvas; when
+    // the canvas has focus, xterm swallows the keydown (stopPropagation on
+    // the GS control code) and it never reaches here, so the primary path
+    // is TerminalViewport's attachCustomKeyEventHandler (graywolf #456).
+    // Match on e.code (layout-stable physical key) as well as e.key: on
+    // Safari/macOS holding Ctrl makes e.key report the GS control character
+    // (U+001D) or an empty string instead of ']'.
     if (
       (e.ctrlKey || e.metaKey) &&
       (e.key === ']' || e.code === 'BracketRight')
@@ -239,7 +242,7 @@
             </Button>
           </div>
           <MacroToolbar session={activeSession} onEdit={() => (macroEditorOpen = true)} />
-          <TerminalViewport session={activeSession} />
+          <TerminalViewport session={activeSession} onMenuChord={() => (commandBarOpen = true)} />
           <StatusBar session={activeSession} />
         </div>
       {/key}


### PR DESCRIPTION
Fixes two connected-mode AX.25 terminal bugs reported on #456 (IC-705 over USB to a packet BBS).

## 1. mod-128 (SABME) sessions: no inbound frames after the handshake

`pkg/app/rxfanout.go` decoded every inbound connected-mode frame with the modulus hardcoded to mod-8 (`ax25conn.Decode(rf.Data, false)`). A mod-128 link's I/S frames carry a **2-octet** control field, so decoding them as mod-8 corrupts `N(S)`/`N(R)` and the session drops every frame -- the operator sees the BBS welcome, then nothing.

- New `Manager.DispatchRaw` resolves the owning session from the (modulus-independent) address header, reads its negotiated modulus race-free via a new `Session.Mod128()` atomic mirror, then decodes.
- `Decode` now sizes the control field correctly under mod-128: U-frames (SABM/SABME/UA/DM/DISC/...) stay **1 octet**, only I/S grow to 2. The old blanket 2-octet assumption rejected the UA that completes the handshake with "missing control field" -- caught while adding the regression test.

The web terminal exposes a "Negotiate modulo-128 (SABME)" toggle, so this path is reachable in production. (Not the specific failure jfbabb hit -- his mod-8 welcome arrived -- but a real correctness bug on the same feature.)

## 2. Ctrl-] / Cmd-] command bar never opens while the canvas has focus

The shortcut lived only on `<svelte:window onkeydown>`, but xterm maps Ctrl-] to the GS control code (`0x1D`) and calls `stopPropagation()` on that keydown, so the window handler never fires. Since the canvas auto-focuses, the shortcut was effectively dead -- browser-agnostic, matching both the Safari and Firefox reports.

Fix intercepts the chord via `term.attachCustomKeyEventHandler`, returning `false` so xterm leaves the key alone (no stray `0x1D` down the link) and the command bar opens directly. The window handler stays as the out-of-focus fallback.

## Still open (needs operator data, not in this PR)

The primary #456 symptom -- link falls to `TIMER_RECOVERY` after the first typed command while the BBS keeps sending -- points to the half-duplex soundcard RX turnaround, not the state machine. Awaiting a log capture + PTT/tail config before touching modem timing.

## Verification

- `go build ./...`, `go vet ./pkg/ax25conn/... ./pkg/app/...` -- clean.
- `go test -race ./pkg/ax25conn/...` and `go test ./pkg/app/...` -- pass, including the new `TestManager_DispatchRawMod128Delivers` (end-to-end mod-128 handshake + I-frame delivery).
- Web changes are lint/type-checked by CI (no `node_modules` in this environment to build locally).

Wiki: adds invariant #60 (modulus-aware inbound decode + variable mod-128 control width).
