### PR TITLE
igate: drop duplicate TCPIP from IS→RF third-party inner path

### DIFF
--- a/pkg/igate/third_party.go
+++ b/pkg/igate/third_party.go
@@ -58,6 +58,15 @@ func wrapThirdParty(inner *ax25.Frame, igateCall string) (*ax25.Frame, error) {
 		// inner path is informational and the '*' marker would
 		// confuse downstream parsers.
 		a.Repeated = false
+		// Drop any inbound internet-routing marker (TCPIP/TCPXX). We
+		// append the canonical ",TCPIP,IGATECALL*" below; re-emitting an
+		// existing TCPIP produced a duplicate ",TCPIP,TCPIP,…" that some
+		// receivers (notably Kenwood handhelds) refuse to parse as a
+		// directed message, so the message never reaches the operator's
+		// inbox. direwolf synthesizes the same single-TCPIP marker.
+		if u := strings.ToUpper(a.String()); u == "TCPIP" || u == "TCPXX" {
+			continue
+		}
 		hdr.WriteByte(',')
 		hdr.WriteString(a.String())
 	}

--- a/pkg/igate/third_party_test.go
+++ b/pkg/igate/third_party_test.go
@@ -110,6 +110,31 @@ func TestWrapThirdPartyPreservesPath(t *testing.T) {
 	}
 }
 
+// TestWrapThirdPartyDropsInboundTCPIP verifies the inbound APRS-IS
+// routing marker (TCPIP) is not re-emitted, so the inner header carries
+// exactly one canonical ",TCPIP,IGATECALL*" rather than the malformed
+// ",TCPIP,TCPIP,…" that Kenwood handhelds refuse to parse as a directed
+// message. Regression for the IS→RF message-delivery bug.
+func TestWrapThirdPartyDropsInboundTCPIP(t *testing.T) {
+	// A real APRS-IS message line: path carries TCPIP*,qAC,<server>.
+	inner, err := parseTNC2("REPEAT>APZ100,TCPIP*,qAC,T2RDU::K0TFU-7  :ack32")
+	if err != nil {
+		t.Fatalf("parseTNC2: %v", err)
+	}
+	wrapped, err := wrapThirdParty(inner, "K0TFU-1")
+	if err != nil {
+		t.Fatalf("wrapThirdParty: %v", err)
+	}
+	got := string(wrapped.Info)
+	if strings.Contains(got, "TCPIP,TCPIP") {
+		t.Fatalf("duplicate TCPIP in inner header: %s", got)
+	}
+	want := "}REPEAT>APZ100,TCPIP,K0TFU-1*::K0TFU-7  :ack32"
+	if got != want {
+		t.Fatalf("inner mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
 // TestWrapThirdPartyRejectsNilFrame checks the guard clauses.
 func TestWrapThirdPartyRejectsNilFrame(t *testing.T) {
 	if _, err := wrapThirdParty(nil, "KE7XYZ"); err == nil {


### PR DESCRIPTION
Fixes #488.

## Problem

When the iGate gates a directed message from APRS-IS to RF, `wrapThirdParty`
re-emitted the inbound `TCPIP` path element and then appended its own
canonical `,TCPIP,IGATECALL*` marker, producing a malformed
`...,TCPIP,TCPIP,IGATE*` inner path. Kenwood handhelds refuse to parse that
as a directed message, so **IS→RF message delivery to a Kenwood was broken**
even when the target station is in direct RF range. See #488 for the full
analysis and on-air packet-log evidence.

## Fix

Skip any inbound `TCPIP`/`TCPXX` marker in the retained inner path before
appending the canonical `,TCPIP,IGATECALL*` (genuine `WIDEn-N` elements are
preserved). This matches direwolf's single-`TCPIP` third-party form.

```
before: }REPEAT>APZ100,TCPIP,TCPIP,K0TFU-1*::K0TFU-7  :ack32
after:  }REPEAT>APZ100,TCPIP,K0TFU-1*::K0TFU-7  :ack32
```

## Testing

- New unit test `TestWrapThirdPartyDropsInboundTCPIP`.
- Existing `pkg/igate` tests pass; `go vet ./pkg/igate/` clean.
- Verified on-air: a Kenwood TH-D75 that previously dropped every igated
  message now displays and ACKs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
