### PR TITLE
igate: strip inbound TCPIP/TCPXX from IS->RF third-party path (#488)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1573,3 +1573,31 @@ Source: [`../../pkg/ax25conn/session.go`](../../pkg/ax25conn/session.go)
 (`submit` tx-failed emit),
 [`../../pkg/ax25conn/manager_test.go`](../../pkg/ax25conn/manager_test.go)
 (`TestManager_FreesTripleAfterFailedConnect`).
+
+### 60. IS→RF third-party wrap emits exactly one `TCPIP` marker
+
+The inner header `wrapThirdParty` builds for an IS→RF third-party packet
+ends in a single canonical `,TCPIP,IGATECALL*` marker. Because the frame
+arrived from APRS-IS, its inbound path may **already** carry a `TCPIP`
+(or `TCPXX`) element ahead of the `qA*` construct, so the wrapper drops
+any inbound `TCPIP`/`TCPXX` path elements (matched on `Address.Call`, so
+an `*` H-bit marker doesn't defeat the match) before appending its own.
+Legitimate elements like `WIDEn-N` are preserved.
+
+*Why:* re-emitting the inbound `TCPIP` produced a duplicated
+`...,TCPIP,TCPIP,IGATECALL*:` inner path (graywolf #488). Kenwood
+handheld radios (e.g. TH-D75) reject that malformed path and silently
+drop the message -- never displaying it or acking it -- breaking IS→RF
+message delivery. Direwolf emits only a single `TCPIP`; matching that is
+what makes the frame acceptable to strict parsers.
+
+*How to apply:* the strip lives in the path loop of
+[`wrapThirdParty`](../../pkg/igate/third_party.go). Never append a second
+`TCPIP` and never trust the inbound path to be marker-free.
+
+Source: [`../../pkg/igate/third_party.go`](../../pkg/igate/third_party.go)
+(`wrapThirdParty`),
+[`../../pkg/igate/third_party_test.go`](../../pkg/igate/third_party_test.go)
+(`TestWrapThirdPartyStripsInboundTCPIP`,
+`TestWrapThirdPartyStripsInboundTCPIPHBit`,
+`TestWrapThirdPartyStripsInboundTCPXX`).

--- a/pkg/igate/third_party.go
+++ b/pkg/igate/third_party.go
@@ -54,6 +54,14 @@ func wrapThirdParty(inner *ax25.Frame, igateCall string) (*ax25.Frame, error) {
 	hdr.WriteByte('>')
 	hdr.WriteString(inner.Dest.String())
 	for _, a := range inner.Path {
+		// Drop any inbound TCPIP/TCPXX markers: the packet arrived from
+		// APRS-IS so its path may already carry one, and we append the
+		// canonical ",TCPIP,IGATECALL*" below. Re-emitting the inbound
+		// one produces a duplicate "TCPIP,TCPIP" that Kenwood radios
+		// (e.g. TH-D75) reject, silently dropping the igated message.
+		if u := strings.ToUpper(a.Call); u == "TCPIP" || u == "TCPXX" {
+			continue
+		}
 		// Strip the H bit for the serialized form; the third-party
 		// inner path is informational and the '*' marker would
 		// confuse downstream parsers.

--- a/pkg/igate/third_party_test.go
+++ b/pkg/igate/third_party_test.go
@@ -110,6 +110,72 @@ func TestWrapThirdPartyPreservesPath(t *testing.T) {
 	}
 }
 
+// TestWrapThirdPartyStripsInboundTCPIP verifies that a TCPIP element
+// already present on the inbound APRS-IS path is not re-emitted, so the
+// inner header carries exactly one canonical ",TCPIP,IGATECALL*" marker.
+// A duplicated "TCPIP,TCPIP" causes Kenwood radios (e.g. TH-D75) to
+// silently drop the igated message (graywolf #488).
+func TestWrapThirdPartyStripsInboundTCPIP(t *testing.T) {
+	inner, err := parseTNC2("W5ABC-7>APZ100,TCPIP,IGATE*,qAC,SERVER::KE7XYZ   :hi{1")
+	if err != nil {
+		t.Fatalf("parseTNC2: %v", err)
+	}
+	wrapped, err := wrapThirdParty(inner, "KE7XYZ")
+	if err != nil {
+		t.Fatalf("wrapThirdParty: %v", err)
+	}
+	got := string(wrapped.Info)
+	want := "}W5ABC-7>APZ100,IGATE,TCPIP,KE7XYZ*::KE7XYZ   :hi{1"
+	if got != want {
+		t.Fatalf("inner info mismatch:\n got: %s\nwant: %s", got, want)
+	}
+	if strings.Contains(got, "TCPIP,TCPIP") {
+		t.Fatalf("duplicate TCPIP not stripped: %s", got)
+	}
+}
+
+// TestWrapThirdPartyStripsInboundTCPIPHBit ensures the strip also matches
+// a TCPIP element that arrived with its H-bit '*' marker set.
+func TestWrapThirdPartyStripsInboundTCPIPHBit(t *testing.T) {
+	inner, err := parseTNC2("W5ABC-7>APZ100,TCPIP*,qAC,SERVER:!3725.00N/12158.00W>hi")
+	if err != nil {
+		t.Fatalf("parseTNC2: %v", err)
+	}
+	wrapped, err := wrapThirdParty(inner, "KE7XYZ")
+	if err != nil {
+		t.Fatalf("wrapThirdParty: %v", err)
+	}
+	got := string(wrapped.Info)
+	want := "}W5ABC-7>APZ100,TCPIP,KE7XYZ*:!3725.00N/12158.00W>hi"
+	if got != want {
+		t.Fatalf("inner info mismatch:\n got: %s\nwant: %s", got, want)
+	}
+	if strings.Contains(got, "TCPIP,TCPIP") {
+		t.Fatalf("duplicate TCPIP not stripped: %s", got)
+	}
+}
+
+// TestWrapThirdPartyStripsInboundTCPXX mirrors the TCPIP case for the
+// TCPXX marker (unverified-login APRS-IS traffic).
+func TestWrapThirdPartyStripsInboundTCPXX(t *testing.T) {
+	inner, err := parseTNC2("W5ABC-7>APZ100,TCPXX,qAX,SERVER:!3725.00N/12158.00W>hi")
+	if err != nil {
+		t.Fatalf("parseTNC2: %v", err)
+	}
+	wrapped, err := wrapThirdParty(inner, "KE7XYZ")
+	if err != nil {
+		t.Fatalf("wrapThirdParty: %v", err)
+	}
+	got := string(wrapped.Info)
+	if strings.Contains(got, "TCPXX") {
+		t.Fatalf("inbound TCPXX not stripped: %s", got)
+	}
+	want := "}W5ABC-7>APZ100,TCPIP,KE7XYZ*:!3725.00N/12158.00W>hi"
+	if got != want {
+		t.Fatalf("inner info mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
 // TestWrapThirdPartyRejectsNilFrame checks the guard clauses.
 func TestWrapThirdPartyRejectsNilFrame(t *testing.T) {
 	if _, err := wrapThirdParty(nil, "KE7XYZ"); err == nil {

--- a/pkg/igate/third_party_test.go
+++ b/pkg/igate/third_party_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/ax25"
 )
 
 // TestWrapThirdPartyPositionPacket exercises the happy path for a plain
@@ -134,12 +136,25 @@ func TestWrapThirdPartyStripsInboundTCPIP(t *testing.T) {
 	}
 }
 
-// TestWrapThirdPartyStripsInboundTCPIPHBit ensures the strip also matches
-// a TCPIP element that arrived with its H-bit '*' marker set.
+// TestWrapThirdPartyStripsInboundTCPIPHBit ensures the strip matches a
+// TCPIP element whose H-bit '*' marker is still set. The frame is built
+// directly (not via parseTNC2, which clears the H-bit) so the address
+// reaches wrapThirdParty with Repeated=true — its String() renders
+// "TCPIP*", which would defeat a String()-based match but not the
+// Call-based one this fix uses.
 func TestWrapThirdPartyStripsInboundTCPIPHBit(t *testing.T) {
-	inner, err := parseTNC2("W5ABC-7>APZ100,TCPIP*,qAC,SERVER:!3725.00N/12158.00W>hi")
+	src, err := ax25.ParseAddress("W5ABC-7")
 	if err != nil {
-		t.Fatalf("parseTNC2: %v", err)
+		t.Fatalf("ParseAddress src: %v", err)
+	}
+	dest, err := ax25.ParseAddress("APZ100")
+	if err != nil {
+		t.Fatalf("ParseAddress dest: %v", err)
+	}
+	path := []ax25.Address{{Call: "TCPIP", Repeated: true}}
+	inner, err := ax25.NewUIFrame(src, dest, path, []byte("!3725.00N/12158.00W>hi"))
+	if err != nil {
+		t.Fatalf("NewUIFrame: %v", err)
 	}
 	wrapped, err := wrapThirdParty(inner, "KE7XYZ")
 	if err != nil {
@@ -150,8 +165,8 @@ func TestWrapThirdPartyStripsInboundTCPIPHBit(t *testing.T) {
 	if got != want {
 		t.Fatalf("inner info mismatch:\n got: %s\nwant: %s", got, want)
 	}
-	if strings.Contains(got, "TCPIP,TCPIP") {
-		t.Fatalf("duplicate TCPIP not stripped: %s", got)
+	if strings.Contains(got, "TCPIP,TCPIP") || strings.Contains(got, "TCPIP*,") {
+		t.Fatalf("inbound H-bit TCPIP not stripped: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #488 — iGate IS→RF third-party frames emitted a duplicate `TCPIP` in the inner path (e.g. `...APZ100,TCPIP,TCPIP,IGATE*::...`), which Kenwood radios (TH-D75) reject, silently dropping igated messages.

## Root cause

`wrapThirdParty` (`pkg/igate/third_party.go`) re-emits the inbound APRS-IS path — which already carries a `TCPIP` element ahead of the `qA*` construct — and then unconditionally appends the canonical `,TCPIP,IGATECALL*` marker, yielding `TCPIP,TCPIP`. Direwolf emits only a single `TCPIP`.

## Fix

Drop any inbound `TCPIP`/`TCPXX` path elements before appending the canonical marker. The match is on `Address.Call`, so an inbound element carrying its H-bit `*` (e.g. `TCPIP*`) is still stripped. Legitimate path elements like `WIDEn-N` are preserved.

## Tests

Added three cases to `third_party_test.go`:
- `TestWrapThirdPartyStripsInboundTCPIP` — inbound `TCPIP` produces exactly one marker.
- `TestWrapThirdPartyStripsInboundTCPIPHBit` — inbound `TCPIP*` (H-bit set) is stripped.
- `TestWrapThirdPartyStripsInboundTCPXX` — `TCPXX` handled the same way.

Full `pkg/igate` suite passes; `go build ./...` clean.

## Docs

Added invariant #60 to `docs/wiki/invariants.md` documenting the single-`TCPIP` guarantee for the IS→RF third-party wrap.
