### PR TITLE
igate: drop inbound TCPIP/TCPXX marker from IS->RF third-party wrap (#488)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1573,3 +1573,31 @@ Source: [`../../pkg/ax25conn/session.go`](../../pkg/ax25conn/session.go)
 (`submit` tx-failed emit),
 [`../../pkg/ax25conn/manager_test.go`](../../pkg/ax25conn/manager_test.go)
 (`TestManager_FreesTripleAfterFailedConnect`).
+
+### 60. IS→RF third-party wrap must not re-emit the inbound TCPIP/TCPXX marker
+
+`wrapThirdParty` appends the canonical `,TCPIP,IGATECALL*` marker to the
+inner third-party header itself. The inbound APRS-IS path it copies from
+often already carries a `TCPIP*` (or `TCPXX`) element positioned *before*
+the `qA*` construct, so `parseTNC2` — which only truncates at `qA*` —
+leaves it in the frame's `Path`. Any such element MUST be dropped while
+building the inner header, or the result has a duplicated `TCPIP`
+(`}SRC>DEST,TCPIP,TCPIP,IGATECALL*:…`). Kenwood handhelds (verified on a
+TH-D75) silently reject the malformed inner path, so IS→RF directed
+messages never reach the recipient and no ACK is generated.
+
+*Why:* graywolf#488 -- messages gated from APRS-IS to RF never appeared on
+the recipient's Kenwood radio; the sender kept retransmitting because no
+ACK came back.
+
+*How to apply:* the filter lives in the inner-header loop of
+[`wrapThirdParty`](../../pkg/igate/third_party.go) (skip any path address
+whose `Call` upper-cases to `TCPIP`/`TCPXX`). This is distinct from the
+RF→IS loop-prevention gate in
+[`pkg/igate/igate.go`](../../pkg/igate/igate.go), which *refuses to gate*
+RF packets already bearing those markers — different direction, different
+purpose.
+
+Source: [`../../pkg/igate/third_party.go`](../../pkg/igate/third_party.go),
+[`../../pkg/igate/third_party_test.go`](../../pkg/igate/third_party_test.go)
+(`TestWrapThirdPartyStripsInboundTCPIP`, `TestWrapThirdPartyStripsInboundTCPXX`).

--- a/pkg/igate/third_party.go
+++ b/pkg/igate/third_party.go
@@ -54,6 +54,15 @@ func wrapThirdParty(inner *ax25.Frame, igateCall string) (*ax25.Frame, error) {
 	hdr.WriteByte('>')
 	hdr.WriteString(inner.Dest.String())
 	for _, a := range inner.Path {
+		// Drop any inbound TCPIP/TCPXX marker from the APRS-IS path. We
+		// append the canonical ",TCPIP,IGATECALL*" marker below, so
+		// re-emitting the one already present would produce a duplicate
+		// TCPIP element — a malformed inner path that Kenwood handhelds
+		// (e.g. TH-D75) silently reject, dropping the igated message
+		// (graywolf#488).
+		if u := strings.ToUpper(a.Call); u == "TCPIP" || u == "TCPXX" {
+			continue
+		}
 		// Strip the H bit for the serialized form; the third-party
 		// inner path is informational and the '*' marker would
 		// confuse downstream parsers.

--- a/pkg/igate/third_party_test.go
+++ b/pkg/igate/third_party_test.go
@@ -110,6 +110,51 @@ func TestWrapThirdPartyPreservesPath(t *testing.T) {
 	}
 }
 
+// TestWrapThirdPartyStripsInboundTCPIP verifies the inbound APRS-IS
+// "TCPIP" path marker is dropped so the wrapper's own canonical
+// ",TCPIP,IGATECALL*" marker is not duplicated. A duplicated TCPIP
+// element makes Kenwood handhelds silently drop the igated message
+// (graywolf#488).
+func TestWrapThirdPartyStripsInboundTCPIP(t *testing.T) {
+	inner, err := parseTNC2("W5ABC-7>APRS,TCPIP*,qAC,T2TEXAS::KE7XYZ   :hello{1")
+	if err != nil {
+		t.Fatalf("parseTNC2: %v", err)
+	}
+	wrapped, err := wrapThirdParty(inner, "KE7XYZ")
+	if err != nil {
+		t.Fatalf("wrapThirdParty: %v", err)
+	}
+	want := "}W5ABC-7>APRS,TCPIP,KE7XYZ*::KE7XYZ   :hello{1"
+	if string(wrapped.Info) != want {
+		t.Fatalf("inner info mismatch:\n got: %s\nwant: %s", wrapped.Info, want)
+	}
+	header := string(wrapped.Info[:bytes.IndexByte(wrapped.Info, ':')])
+	if strings.Count(strings.ToUpper(header), "TCPIP") != 1 {
+		t.Fatalf("expected exactly one TCPIP in inner header, got: %s", header)
+	}
+}
+
+// TestWrapThirdPartyStripsInboundTCPXX mirrors the TCPIP case for the
+// TCPXX marker (used for unverified/unregistered login sources).
+func TestWrapThirdPartyStripsInboundTCPXX(t *testing.T) {
+	inner, err := parseTNC2("W5ABC-7>APRS,WIDE1-1,TCPXX,qAX,SERVER::KE7XYZ   :hi{2")
+	if err != nil {
+		t.Fatalf("parseTNC2: %v", err)
+	}
+	wrapped, err := wrapThirdParty(inner, "KE7XYZ")
+	if err != nil {
+		t.Fatalf("wrapThirdParty: %v", err)
+	}
+	want := "}W5ABC-7>APRS,WIDE1-1,TCPIP,KE7XYZ*::KE7XYZ   :hi{2"
+	if string(wrapped.Info) != want {
+		t.Fatalf("inner info mismatch:\n got: %s\nwant: %s", wrapped.Info, want)
+	}
+	header := string(wrapped.Info[:bytes.IndexByte(wrapped.Info, ':')])
+	if strings.Contains(strings.ToUpper(header), "TCPXX") {
+		t.Fatalf("inbound TCPXX not stripped: %s", header)
+	}
+}
+
 // TestWrapThirdPartyRejectsNilFrame checks the guard clauses.
 func TestWrapThirdPartyRejectsNilFrame(t *testing.T) {
 	if _, err := wrapThirdParty(nil, "KE7XYZ"); err == nil {


### PR DESCRIPTION
## Summary

Fixes #488 -- iGate IS->RF third-party frames contained a duplicate `TCPIP` in the inner path, causing Kenwood radios to silently drop igated messages.

## Root cause

An inbound APRS-IS packet's path typically carries a `TCPIP*` (or `TCPXX`) marker *before* the `qA*` construct, e.g.:

```
W5ABC-7>APRS,TCPIP*,qAC,T2TEXAS::KE7XYZ   :hello{1
```

`parseTNC2` only truncates the path at the `qA*` construct, so the `TCPIP` element stays in the frame's `Path`. `wrapThirdParty` then re-emitted that path and appended its own canonical `,TCPIP,IGATECALL*` marker, producing a duplicated element:

```
}W5ABC-7>APRS,TCPIP,TCPIP,KE7XYZ*::KE7XYZ   :hello{1
```

Kenwood handhelds silently reject the malformed inner path, so IS->RF directed messages never reach the recipient and no ACK is generated -- the sender keeps retransmitting.

## Fix

Drop any inbound `TCPIP`/`TCPXX` path element while building the inner third-party header, before appending the canonical marker. This is distinct from the RF->IS loop-prevention gate in `igate.go` (which refuses to *gate* RF packets already bearing those markers -- different direction, different purpose).

## Tests

- `TestWrapThirdPartyStripsInboundTCPIP` -- inbound `TCPIP*` is stripped, exactly one `TCPIP` remains.
- `TestWrapThirdPartyStripsInboundTCPXX` -- same for `TCPXX`.
- Existing third-party wrap tests continue to pass.

## Docs

Added invariant #60 to `docs/wiki/invariants.md` documenting the rule and its distinction from the RF->IS gate.

Verified on-air with a Kenwood TH-D75 handheld (per the reporter).
