### PR TITLE
Fix SSID-insensitive addressee matching in message router (#490)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1601,3 +1601,39 @@ Source: [`../../pkg/igate/third_party.go`](../../pkg/igate/third_party.go)
 (`TestWrapThirdPartyStripsInboundTCPIP`,
 `TestWrapThirdPartyStripsInboundTCPIPHBit`,
 `TestWrapThirdPartyStripsInboundTCPXX`).
+
+### 61. Directed-message addressee matching is SSID-aware, symmetric with the self-filter
+
+The router only claims a directed (DM) message as its own when the
+addressee is an **exact full-call match** of our station call, or a
+**bare base-call address** (no SSID) sharing our base call. A distinct
+SSID of our base call is a separate peer: running as `K0TFU-1` we do
+**not** claim, file, or auto-ACK a message addressed to `K0TFU-7`. Both
+`Router.classify` and the exported `MatchAddressee` helper (used by the
+Actions classifier) route through `callAddressedToUs`, so the DM match
+uses the same SSID granularity as the router self-filter (which already
+compared full calls).
+
+*Why:* the self-filter compared full calls but the addressee match
+compared only base calls, an asymmetry that let one station steal a
+sibling SSID's traffic. The sender then received a false delivery
+confirmation -- a bot ACKed by `K0TFU-1` believed its message reached
+`K0TFU-7` when it never did (graywolf #490). Two stations under one base
+call with different SSIDs are distinct peers by design (same principle as
+invariant on same-base delivery -- `NW5W-5` ↔ `NW5W-13`).
+
+*How to apply:* never reintroduce a base-call-only DM addressee compare.
+A bare base-call address stays generic on purpose -- every station
+sharing the base call answers it. Route any new addressee-matching call
+site through `callAddressedToUs` / `MatchAddressee`, never a hand-rolled
+`baseCall(addr) == baseCall(our)`.
+
+Source: [`../../pkg/messages/router.go`](../../pkg/messages/router.go)
+(`Router.classify`, `MatchAddressee`, `callAddressedToUs`),
+[`../../pkg/messages/router_test.go`](../../pkg/messages/router_test.go)
+(`TestRouterDMDifferentSSIDOfOurBaseNotClaimed`,
+`TestRouterDMExactSSIDMatchClaimed`,
+`TestRouterDMBareBaseCallAddressClaimed`,
+`TestMatchAddresseeSSIDAware`),
+[`../../pkg/actions/classifier.go`](../../pkg/actions/classifier.go)
+(`Classify`).

--- a/pkg/messages/router.go
+++ b/pkg/messages/router.go
@@ -35,20 +35,20 @@ func (realRouterClock) Now() time.Time { return time.Now().UTC() }
 // RouterConfig captures the router's collaborators. All fields except
 // Logger, Registerer, and Clock are required.
 type RouterConfig struct {
-	Store         *Store
-	TxSink        txgovernor.TxSink
-	IGateSender   IGateLineSender
-	OurCall       func() string // returns our primary callsign (possibly with SSID)
-	LocalTxRing   *LocalTxRing
-	TacticalSet   *TacticalSet
+	Store       *Store
+	TxSink      txgovernor.TxSink
+	IGateSender IGateLineSender
+	OurCall     func() string // returns our primary callsign (possibly with SSID)
+	LocalTxRing *LocalTxRing
+	TacticalSet *TacticalSet
 	// BlockedSet is the enabled call-sign blocklist. Optional: when nil
 	// the router constructs an empty set so nothing is blocked. Swapped
 	// by Service.ReloadBlockedCallsigns on CRUD mutations.
-	BlockedSet    *BlocklistSet
-	EventHub      *EventHub
-	Logger        *slog.Logger
-	Registerer    prometheus.Registerer
-	Clock         RouterClock
+	BlockedSet *BlocklistSet
+	EventHub   *EventHub
+	Logger     *slog.Logger
+	Registerer prometheus.Registerer
+	Clock      RouterClock
 	// AutoAckChannel is the RF channel used when submitting auto-ACKs.
 	// Defaults to 1 (mirrors IGateConfig.TxChannel semantics). Forwarded
 	// into Preflight when Preflight is nil.
@@ -375,12 +375,17 @@ func (r *Router) classify(ctx context.Context, pkt *aprs.DecodedAPRSPacket) {
 	}
 
 	addressee := strings.ToUpper(strings.TrimSpace(effMsg.Addressee))
-	baseAddressee := baseCall(addressee)
 
-	// Step 5 — addressee match determines thread_kind.
+	// Step 5 — addressee match determines thread_kind. The DM match is
+	// SSID-aware (see callAddressedToUs), mirroring the self-filter: a
+	// message to a different SSID of our base call (e.g. we are K0TFU-1,
+	// addressee K0TFU-7) belongs to a distinct peer and must NOT be
+	// claimed, filed, or auto-ACKed by us. Matching only on the base
+	// call here would let us send the sender a false delivery
+	// confirmation for a message that never reached the intended station.
 	var threadKind, threadKey string
 	switch {
-	case ourCall != "" && baseAddressee == ourCall:
+	case callAddressedToUs(addressee, ourCallFull):
 		threadKind = ThreadKindDM
 		threadKey = source
 	case r.cfg.TacticalSet.Contains(addressee):
@@ -813,20 +818,46 @@ type AddresseeMatch struct {
 }
 
 // MatchAddressee reports whether addressee is one we should handle.
-// ourCall is the primary station callsign (with or without SSID); the
-// match against ourCall is base-call only. tactical may be nil.
+// ourCall is the primary station callsign (with or without SSID). The
+// match against ourCall is SSID-aware (see callAddressedToUs): an exact
+// full-call match, or a bare base-call address with no SSID. A distinct
+// SSID of our base call is a separate peer and does not match. tactical
+// may be nil.
 func MatchAddressee(ourCall, addressee string, tactical *TacticalSet) AddresseeMatch {
 	addr := strings.ToUpper(strings.TrimSpace(addressee))
 	if addr == "" {
 		return AddresseeMatch{}
 	}
-	base := baseCall(addr)
-	our := baseCallUpper(ourCall)
-	if our != "" && base == our {
+	if callAddressedToUs(addr, ourCall) {
 		return AddresseeMatch{IsForUs: true}
 	}
 	if tactical != nil && tactical.Contains(addr) {
 		return AddresseeMatch{IsForUs: true, IsTactical: true}
 	}
 	return AddresseeMatch{}
+}
+
+// callAddressedToUs reports whether a directed-message addressee targets
+// our station, SSID-aware. It matches when the addressee is an exact
+// full-call match of our call, or a bare base-call address (no SSID)
+// whose base equals our base call. A different SSID of our base call
+// (e.g. our K0TFU-1 vs addressee K0TFU-7) is a distinct peer and does
+// NOT match — this mirrors the router self-filter's full-call logic so
+// addressee matching and self-filtering treat SSIDs consistently. Both
+// arguments may carry or omit an SSID and need not be pre-normalized.
+func callAddressedToUs(addressee, ourCall string) bool {
+	addr := strings.ToUpper(strings.TrimSpace(addressee))
+	our := strings.ToUpper(strings.TrimSpace(ourCall))
+	if addr == "" || our == "" {
+		return false
+	}
+	if addr == our {
+		return true
+	}
+	// A bare base-call address (no SSID) is generic: any station sharing
+	// that base call answers it. addr has no '-', so addr == baseCall(addr).
+	if !strings.ContainsRune(addr, '-') && addr == baseCall(our) {
+		return true
+	}
+	return false
 }

--- a/pkg/messages/router_test.go
+++ b/pkg/messages/router_test.go
@@ -359,6 +359,95 @@ func TestRouterDMInboundNotForUsDropped(t *testing.T) {
 	}
 }
 
+func TestRouterDMDifferentSSIDOfOurBaseNotClaimed(t *testing.T) {
+	// We run as K0TFU-1. A message addressed to K0TFU-7 belongs to a
+	// distinct peer sharing our base call. It must NOT be filed locally
+	// or auto-ACKed — otherwise the sender receives a false delivery
+	// confirmation for a message that never reached K0TFU-7 (graywolf#490).
+	r, store, sink, _, _, _, cleanup := buildRouter(t, "K0TFU-1", nil)
+	defer cleanup()
+
+	pkt := makeMessagePacket(t, "W1ABC", "K0TFU-7", "for the other SSID", "001", aprs.DirectionRF)
+	_ = r.SendPacket(context.Background(), pkt)
+	time.Sleep(50 * time.Millisecond)
+
+	ms, _, _ := store.List(context.Background(), Filter{})
+	if len(ms) != 0 {
+		t.Fatalf("expected no persist for a different SSID of our base, got %d rows", len(ms))
+	}
+	if got := len(sink.list()); got != 0 {
+		t.Fatalf("expected no auto-ACK for a different SSID of our base, got %d", got)
+	}
+}
+
+func TestRouterDMExactSSIDMatchClaimed(t *testing.T) {
+	// We run as K0TFU-1. A message addressed to our exact full call must
+	// be claimed and auto-ACKed.
+	r, store, sink, _, _, _, cleanup := buildRouter(t, "K0TFU-1", nil)
+	defer cleanup()
+
+	pkt := makeMessagePacket(t, "W1ABC", "K0TFU-1", "for us exactly", "001", aprs.DirectionRF)
+	_ = r.SendPacket(context.Background(), pkt)
+
+	waitFor(t, time.Second, func() bool {
+		ms, _, _ := store.List(context.Background(), Filter{})
+		return len(ms) == 1
+	}, "row persisted for exact SSID match")
+	waitFor(t, time.Second, func() bool {
+		return len(sink.list()) >= 1
+	}, "auto-ACK submitted for exact SSID match")
+}
+
+func TestRouterDMBareBaseCallAddressClaimed(t *testing.T) {
+	// We run as K0TFU-1. A bare base-call address (no SSID) is generic
+	// and answered by any station sharing that base call, so we claim it.
+	r, store, sink, _, _, _, cleanup := buildRouter(t, "K0TFU-1", nil)
+	defer cleanup()
+
+	pkt := makeMessagePacket(t, "W1ABC", "K0TFU", "for the base call", "001", aprs.DirectionRF)
+	_ = r.SendPacket(context.Background(), pkt)
+
+	waitFor(t, time.Second, func() bool {
+		ms, _, _ := store.List(context.Background(), Filter{})
+		return len(ms) == 1
+	}, "row persisted for bare base-call address")
+	waitFor(t, time.Second, func() bool {
+		return len(sink.list()) >= 1
+	}, "auto-ACK submitted for bare base-call address")
+}
+
+func TestMatchAddresseeSSIDAware(t *testing.T) {
+	tac := NewTacticalSet()
+	tac.Store(map[string]struct{}{"NET": {}})
+
+	cases := []struct {
+		name      string
+		ourCall   string
+		addressee string
+		wantForUs bool
+		wantTac   bool
+	}{
+		{"exact full call", "K0TFU-1", "K0TFU-1", true, false},
+		{"different ssid same base", "K0TFU-1", "K0TFU-7", false, false},
+		{"bare base call for ssid station", "K0TFU-1", "K0TFU", true, false},
+		{"ssid station for bare our call", "K0TFU", "K0TFU-1", false, false},
+		{"exact bare match", "K0TFU", "K0TFU", true, false},
+		{"case insensitive", "k0tfu-1", "k0tfu-1", true, false},
+		{"different base", "K0TFU-1", "W1ABC", false, false},
+		{"tactical alias", "K0TFU-1", "NET", true, true},
+		{"empty addressee", "K0TFU-1", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MatchAddressee(tc.ourCall, tc.addressee, tac)
+			if got.IsForUs != tc.wantForUs || got.IsTactical != tc.wantTac {
+				t.Fatalf("MatchAddressee(%q,%q) = %+v, want ForUs=%v Tactical=%v",
+					tc.ourCall, tc.addressee, got, tc.wantForUs, tc.wantTac)
+			}
+		})
+	}
+}
+
 func TestRouterTacticalInboundPersistsNoAutoACK(t *testing.T) {
 	r, store, sink, _, _, _, cleanup := buildRouter(t, "N0CALL", []string{"NET"})
 	defer cleanup()


### PR DESCRIPTION
## Summary

Fixes #490. The inbound message router claimed directed messages addressed to a **different SSID** of the station's base call, producing false inbox entries and spurious ACKs.

The router self-filter compared full callsigns (SSID-aware), but the addressee-matching logic compared only base calls. Running as `K0TFU-1`, the router would claim, file, and auto-ACK a message addressed to `K0TFU-7` — a distinct peer sharing the base call. The original sender then received a false delivery confirmation for a message that never reached the intended station; a bot could get an ACK from `K0TFU-1` and believe its message reached `K0TFU-7`.

## Change

- New `callAddressedToUs(addressee, ourCall)` helper: a message is ours only when the addressee is an **exact full-call match**, or a **bare base-call address** (no SSID) sharing our base call. A different SSID of our base call no longer matches — mirroring the self-filter's granularity.
- Both `Router.classify` (DM/tactical classification) and the exported `MatchAddressee` helper (used by the Actions classifier) now route through it, so addressee matching and self-filtering treat SSIDs consistently.
- Bare base-call addresses (e.g. `K0TFU` with no SSID) stay generic and are still claimed — any station sharing the base call answers them. This preserves the existing `TestRouterDMInboundForOurCallWithSSID` behavior.

## Tests

- `TestRouterDMDifferentSSIDOfOurBaseNotClaimed` — the core regression: `K0TFU-1` does not persist or auto-ACK a message to `K0TFU-7`.
- `TestRouterDMExactSSIDMatchClaimed`, `TestRouterDMBareBaseCallAddressClaimed` — the two paths that still match.
- `TestMatchAddresseeSSIDAware` — table test over the helper (exact, sibling-SSID, bare, tactical, case-insensitive, empty).
- All existing `pkg/messages` and `pkg/actions` tests pass.

Wiki: added invariant #61 documenting the SSID-aware, self-filter-symmetric addressee rule.
