### PR TITLE
Fix: Kenwood TH-D75A acks dropped (trailing CR in parsed message ID)

### DIFF
--- a/pkg/aprs/message.go
+++ b/pkg/aprs/message.go
@@ -66,6 +66,10 @@ func parseMessage(pkt *DecodedAPRSPacket, info []byte) error {
 		msg.MessageID = rest[3:]
 		rest = ""
 	}
+	// Some radios (e.g. Kenwood TH-D75A) append a trailing CR/whitespace
+	// to the info field, contaminating the extracted msgid (e.g. "018\r").
+	// Trim it so correlation against stored outbound IDs still matches.
+	msg.MessageID = strings.TrimRight(msg.MessageID, " \r\n\t")
 	msg.Text = rest
 	if strings.HasPrefix(addressee, "BLN") {
 		msg.IsBulletin = true

--- a/pkg/aprs/message.go
+++ b/pkg/aprs/message.go
@@ -69,7 +69,11 @@ func parseMessage(pkt *DecodedAPRSPacket, info []byte) error {
 	// Some radios (e.g. Kenwood TH-D75A) append a trailing CR/whitespace
 	// to the info field, contaminating the extracted msgid (e.g. "018\r").
 	// Trim it so correlation against stored outbound IDs still matches.
+	// The reply-ack trailer's piggybacked ack id (the "YY" in "text{XX}YY")
+	// sits at the very end of the field, so the CR lands there instead —
+	// trim it too or correlateReplyAck misses the same way.
 	msg.MessageID = strings.TrimRight(msg.MessageID, " \r\n\t")
+	msg.ReplyAck = strings.TrimRight(msg.ReplyAck, " \r\n\t")
 	msg.Text = rest
 	if strings.HasPrefix(addressee, "BLN") {
 		msg.IsBulletin = true

--- a/pkg/aprs/message_test.go
+++ b/pkg/aprs/message_test.go
@@ -33,6 +33,21 @@ func TestParseMessageAck(t *testing.T) {
 	}
 }
 
+func TestParseMessageAckTrailingCR(t *testing.T) {
+	// Kenwood TH-D75A appends a trailing CR to its ack info field.
+	info := []byte(":D3DKY   :ack018\r")
+	pkt, err := ParseInfo(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pkt.Message.IsAck {
+		t.Fatalf("expected ack, got %+v", pkt.Message)
+	}
+	if pkt.Message.MessageID != "018" {
+		t.Errorf("id %q, want %q", pkt.Message.MessageID, "018")
+	}
+}
+
 func TestParseBulletin(t *testing.T) {
 	info := []byte(":BLN1     :Net tonight at 2000z")
 	pkt, err := ParseInfo(info)

--- a/pkg/messages/router.go
+++ b/pkg/messages/router.go
@@ -808,8 +808,10 @@ func unwrapThirdParty(pkt *aprs.DecodedAPRSPacket) (string, *aprs.Message) {
 		out.Text = ""
 	}
 	// Mirror parseMessage: strip any trailing CR/whitespace a radio
-	// appended to the info field so the msgid correlates cleanly.
+	// appended to the info field so the msgid (and reply-ack piggyback id,
+	// which trails the field) correlate cleanly.
 	out.MessageID = strings.TrimRight(out.MessageID, " \r\n\t")
+	out.ReplyAck = strings.TrimRight(out.ReplyAck, " \r\n\t")
 	return innerSrc, out
 }
 

--- a/pkg/messages/router.go
+++ b/pkg/messages/router.go
@@ -807,6 +807,9 @@ func unwrapThirdParty(pkt *aprs.DecodedAPRSPacket) (string, *aprs.Message) {
 		out.MessageID = out.Text[3:]
 		out.Text = ""
 	}
+	// Mirror parseMessage: strip any trailing CR/whitespace a radio
+	// appended to the info field so the msgid correlates cleanly.
+	out.MessageID = strings.TrimRight(out.MessageID, " \r\n\t")
 	return innerSrc, out
 }
 

--- a/pkg/messages/router_test.go
+++ b/pkg/messages/router_test.go
@@ -646,6 +646,39 @@ func TestRouterReplyAckCorrelationDMClosesAsAcked(t *testing.T) {
 	}, "DM reply-ack flip")
 }
 
+func TestRouterReplyAckCorrelationTrailingCRClosesAsAcked(t *testing.T) {
+	// Regression for GH #507: a radio that appends a trailing CR puts it
+	// at the tail of the info field, i.e. inside the reply-ack piggyback
+	// id ("yo{12}100\r"). The parsed ReplyAck must be trimmed to "100" so
+	// correlateReplyAck flips the outbound.
+	r, store, _, _, _, _, cleanup := buildRouter(t, "N0CALL", nil)
+	defer cleanup()
+	ctx := context.Background()
+
+	out := &configstore.Message{
+		Direction:  "out",
+		OurCall:    "N0CALL",
+		FromCall:   "N0CALL",
+		ToCall:     "W1ABC",
+		Text:       "hi",
+		MsgID:      "100",
+		ThreadKind: ThreadKindDM,
+	}
+	if err := store.Insert(ctx, out); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	pkt := makeReplyAckPacket(t, "W1ABC", "N0CALL", "yo", "12", "100\r")
+	if pkt.Message.ReplyAck != "100" {
+		t.Fatalf("expected trimmed reply-ack %q, got %q", "100", pkt.Message.ReplyAck)
+	}
+	_ = r.SendPacket(ctx, pkt)
+	waitFor(t, time.Second, func() bool {
+		got, _ := store.GetByID(ctx, out.ID)
+		return got != nil && got.AckState == AckStateAcked
+	}, "DM reply-ack flip with trailing CR")
+}
+
 func TestRouterReplyAckTacticalSetsReceivedByCallOnly(t *testing.T) {
 	r, store, _, _, _, _, cleanup := buildRouter(t, "N0CALL", []string{"NET"})
 	defer cleanup()

--- a/pkg/messages/router_test.go
+++ b/pkg/messages/router_test.go
@@ -559,6 +559,40 @@ func TestRouterDMAckCorrelationFlipsOutbound(t *testing.T) {
 	}
 }
 
+func TestRouterDMAckCorrelationTrailingCRFlipsOutbound(t *testing.T) {
+	// Regression for GH #507: a Kenwood TH-D75A appends a trailing CR to
+	// its ack info field (":N0CALL:ack042\r"). The parsed msgid must be
+	// trimmed so it correlates against the stored outbound "042".
+	r, store, _, _, _, _, cleanup := buildRouter(t, "N0CALL", nil)
+	defer cleanup()
+
+	ctx := context.Background()
+	out := &configstore.Message{
+		Direction:  "out",
+		OurCall:    "N0CALL",
+		FromCall:   "N0CALL",
+		ToCall:     "W1ABC",
+		Text:       "ping",
+		MsgID:      "042",
+		ThreadKind: ThreadKindDM,
+		Source:     "rf",
+	}
+	if err := store.Insert(ctx, out); err != nil {
+		t.Fatalf("Insert out: %v", err)
+	}
+
+	pkt := makeAckRejPacket(t, "W1ABC", "N0CALL", "ack", "042\r")
+	if pkt.Message.MessageID != "042" {
+		t.Fatalf("expected trimmed msgid %q, got %q", "042", pkt.Message.MessageID)
+	}
+	_ = r.SendPacket(ctx, pkt)
+
+	waitFor(t, time.Second, func() bool {
+		got, _ := store.GetByID(ctx, out.ID)
+		return got != nil && got.AckState == AckStateAcked
+	}, "ack state flip with trailing CR")
+}
+
 func TestRouterDMRejCorrelationFlipsOutbound(t *testing.T) {
 	r, store, _, _, _, _, cleanup := buildRouter(t, "N0CALL", nil)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Fixes #507 — directed messages from a Kenwood TH-D75A stayed at "Sent" and kept getting retransmitted even though the radio acked them.

## Root cause

The TH-D75A appends a trailing carriage return to its ack info field, e.g. `:D3DKY   :ack018\r`. `parseMessage` extracted the message ID as `rest[3:]`, so `MessageID` became `018\r`. `Router.correlateAck` then looked up `018\r` against the stored outbound `018`, never matched, and the ack was dropped — delivery was never confirmed and retries continued.

## Fix

Trim trailing whitespace/CR/LF from the extracted `MessageID` at the parse boundary so every form (plain msgid, `{id}` reply-ack, `ack`/`rej`) is covered:

- `pkg/aprs/message.go` `parseMessage` — single `strings.TrimRight(msg.MessageID, " \r\n\t")` after all extraction branches.
- `pkg/messages/router.go` `unwrapThirdParty` — mirror the same trim for third-party envelopes.

The trim is conservative, so legitimate IDs are untouched.

## Tests

- `TestParseMessageAckTrailingCR` — an `ack` body with a trailing `\r` parses to a clean `MessageID`.
- `TestRouterDMAckCorrelationTrailingCRFlipsOutbound` — `correlateAck` flips an outbound to acked when the inbound ack msgid carries a trailing `\r`.

Both fail without the fix and pass with it. Full `go test ./...` passes except a pre-existing `TestProtoBindingsDoNotDrift` failure in `pkg/platformproto` (a local protoc toolchain version mismatch that also fails on the base branch, unrelated to this change).
