### PR TITLE
messages: treat AX.25 SSID -0 as the bare call when routing DMs

### DIFF
--- a/graywolf-modem/src/audio/stdin_raw.rs
+++ b/graywolf-modem/src/audio/stdin_raw.rs
@@ -46,8 +46,8 @@ fn read_loop(
             Ok(n) => {
                 let n = n & !1; // drop trailing half-sample on odd read
                 let mut chunk: Vec<i16> = Vec::with_capacity(n / 2);
-                for pair in buf[..n].chunks_exact(2) {
-                    chunk.push(i16::from_le_bytes([pair[0], pair[1]]));
+                for pair in buf[..n].as_chunks::<2>().0 {
+                    chunk.push(i16::from_le_bytes(*pair));
                 }
                 if sink.send(chunk).is_err() {
                     return;

--- a/graywolf-modem/src/bin/demod_bench.rs
+++ b/graywolf-modem/src/bin/demod_bench.rs
@@ -124,8 +124,8 @@ fn read_wav(path: &str) -> io::Result<AudioData> {
             if bits_per_sample == 16 {
                 let mut sample_buf = vec![0u8; chunk_size as usize];
                 reader.read_exact(&mut sample_buf)?;
-                for chunk in sample_buf.chunks_exact(2) {
-                    let s = i16::from_le_bytes([chunk[0], chunk[1]]);
+                for chunk in sample_buf.as_chunks::<2>().0 {
+                    let s = i16::from_le_bytes(*chunk);
                     data_samples.push(s);
                 }
             } else if bits_per_sample == 8 {
@@ -159,8 +159,10 @@ fn read_raw_pcm(path: &str, sample_rate: u32) -> io::Result<AudioData> {
     file.read_to_end(&mut data)?;
 
     let samples: Vec<i16> = data
-        .chunks_exact(2)
-        .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|chunk| i16::from_le_bytes(*chunk))
         .collect();
 
     Ok(AudioData {

--- a/graywolf-modem/src/bin/demod_multi.rs
+++ b/graywolf-modem/src/bin/demod_multi.rs
@@ -114,8 +114,8 @@ fn read_wav(path: &str) -> io::Result<(Vec<i16>, u32, u32)> {
             if bps == 16 {
                 let mut buf = vec![0u8; size as usize];
                 r.read_exact(&mut buf)?;
-                for c in buf.chunks_exact(2) {
-                    data.push(i16::from_le_bytes([c[0], c[1]]));
+                for c in buf.as_chunks::<2>().0 {
+                    data.push(i16::from_le_bytes(*c));
                 }
             } else {
                 return Err(io::Error::new(

--- a/graywolf-modem/src/sdr/mod.rs
+++ b/graywolf-modem/src/sdr/mod.rs
@@ -110,8 +110,8 @@ fn recv_loop(
 fn decode_s16le(data: &[u8]) -> Vec<i16> {
     let n = data.len() / 2;
     let mut out = Vec::with_capacity(n);
-    for pair in data[..n * 2].chunks_exact(2) {
-        out.push(i16::from_le_bytes([pair[0], pair[1]]));
+    for pair in data[..n * 2].as_chunks::<2>().0 {
+        out.push(i16::from_le_bytes(*pair));
     }
     out
 }
@@ -119,8 +119,8 @@ fn decode_s16le(data: &[u8]) -> Vec<i16> {
 fn decode_f32le(data: &[u8]) -> Vec<i16> {
     let n = data.len() / 4;
     let mut out = Vec::with_capacity(n);
-    for quad in data[..n * 4].chunks_exact(4) {
-        let f = f32::from_le_bytes([quad[0], quad[1], quad[2], quad[3]]);
+    for quad in data[..n * 4].as_chunks::<4>().0 {
+        let f = f32::from_le_bytes(*quad);
         out.push((f.clamp(-1.0, 1.0) * 32767.0) as i16);
     }
     out

--- a/pkg/messages/router.go
+++ b/pkg/messages/router.go
@@ -352,10 +352,12 @@ func (r *Router) classify(ctx context.Context, pkt *aprs.DecodedAPRSPacket) {
 	// Step 2 — self-filter. Full-call match (SSID-aware) or LocalTxRing
 	// hit. Base-call match is intentionally NOT used: two stations under
 	// the same base callsign with different SSIDs are distinct peers and
-	// must be able to message each other (e.g. NW5W-5 ↔ NW5W-13). The
-	// LocalTxRing already covers the precise (source, msgid) loopback
-	// case if a same-base packet is genuinely our own echo.
-	if ourCallFull != "" && source == ourCallFull {
+	// must be able to message each other (e.g. NW5W-5 ↔ NW5W-13). A
+	// trailing "-0" is canonicalized first so a radio that echoes our own
+	// traffic as <base>-0 is still recognized as us (canonicalCall keeps
+	// non-zero SSIDs distinct). The LocalTxRing already covers the precise
+	// (source, msgid) loopback case if a same-base packet is our own echo.
+	if ourCallFull != "" && canonicalCall(source) == canonicalCall(ourCallFull) {
 		r.mClassified.WithLabelValues("self_filter").Inc()
 		return
 	}
@@ -654,6 +656,19 @@ func baseCall(s string) string {
 	return s
 }
 
+// canonicalCall collapses the AX.25 SSID 0 to the bare call. Per AX.25,
+// SSID 0 is canonically the station with no SSID, so <base>-0 is the same
+// station as bare <base> (some radios, e.g. the BTech DA-7X2, always emit
+// the "-0" form). Every other SSID identifies a distinct peer and is left
+// intact, so this does not weaken same-base different-SSID separation
+// (K0TFU-1 vs K0TFU-7 stay distinct). Input should already be trimmed.
+func canonicalCall(s string) string {
+	if i := strings.IndexByte(s, '-'); i >= 0 && s[i+1:] == "0" {
+		return s[:i]
+	}
+	return s
+}
+
 // joinPath renders pkt.Path (already a []string in TNC-2 form) into a
 // comma-separated display string.
 func joinPath(p []string) string {
@@ -820,9 +835,9 @@ type AddresseeMatch struct {
 // MatchAddressee reports whether addressee is one we should handle.
 // ourCall is the primary station callsign (with or without SSID). The
 // match against ourCall is SSID-aware (see callAddressedToUs): an exact
-// full-call match, or a bare base-call address with no SSID. A distinct
-// SSID of our base call is a separate peer and does not match. tactical
-// may be nil.
+// full-call match, or a bare base-call address with no SSID; a trailing
+// "-0" SSID is treated as the bare call. A distinct, non-zero SSID of our
+// base call is a separate peer and does not match. tactical may be nil.
 func MatchAddressee(ourCall, addressee string, tactical *TacticalSet) AddresseeMatch {
 	addr := strings.ToUpper(strings.TrimSpace(addressee))
 	if addr == "" {
@@ -840,14 +855,16 @@ func MatchAddressee(ourCall, addressee string, tactical *TacticalSet) AddresseeM
 // callAddressedToUs reports whether a directed-message addressee targets
 // our station, SSID-aware. It matches when the addressee is an exact
 // full-call match of our call, or a bare base-call address (no SSID)
-// whose base equals our base call. A different SSID of our base call
+// whose base equals our base call. A trailing "-0" SSID is canonically
+// the bare call (see canonicalCall), so <base>-0 and bare <base> match
+// each other and our station. A different, non-zero SSID of our base call
 // (e.g. our K0TFU-1 vs addressee K0TFU-7) is a distinct peer and does
 // NOT match — this mirrors the router self-filter's full-call logic so
 // addressee matching and self-filtering treat SSIDs consistently. Both
 // arguments may carry or omit an SSID and need not be pre-normalized.
 func callAddressedToUs(addressee, ourCall string) bool {
-	addr := strings.ToUpper(strings.TrimSpace(addressee))
-	our := strings.ToUpper(strings.TrimSpace(ourCall))
+	addr := canonicalCall(strings.ToUpper(strings.TrimSpace(addressee)))
+	our := canonicalCall(strings.ToUpper(strings.TrimSpace(ourCall)))
 	if addr == "" || our == "" {
 		return false
 	}

--- a/pkg/messages/router.go
+++ b/pkg/messages/router.go
@@ -857,7 +857,9 @@ func MatchAddressee(ourCall, addressee string, tactical *TacticalSet) AddresseeM
 // full-call match of our call, or a bare base-call address (no SSID)
 // whose base equals our base call. A trailing "-0" SSID is canonically
 // the bare call (see canonicalCall), so <base>-0 and bare <base> match
-// each other and our station. A different, non-zero SSID of our base call
+// each other and our station; a <base>-0 addressee therefore also inherits
+// the generic bare-call semantics below (any station on that base answers
+// it). A different, non-zero SSID of our base call
 // (e.g. our K0TFU-1 vs addressee K0TFU-7) is a distinct peer and does
 // NOT match — this mirrors the router self-filter's full-call logic so
 // addressee matching and self-filtering treat SSIDs consistently. Both

--- a/pkg/messages/router_test.go
+++ b/pkg/messages/router_test.go
@@ -416,6 +416,25 @@ func TestRouterDMBareBaseCallAddressClaimed(t *testing.T) {
 	}, "auto-ACK submitted for bare base-call address")
 }
 
+func TestRouterDMDashZeroSSIDOfOurBareCallClaimed(t *testing.T) {
+	// We run as bare K0TFU. A radio that always appends "-0" replies to
+	// K0TFU-0; per AX.25 that is the same station, so the reply must be
+	// filed and auto-ACKed so it lands in the DM thread (graywolf#500).
+	r, store, sink, _, _, _, cleanup := buildRouter(t, "K0TFU", nil)
+	defer cleanup()
+
+	pkt := makeMessagePacket(t, "W1ABC", "K0TFU-0", "reply from a -0 radio", "001", aprs.DirectionRF)
+	_ = r.SendPacket(context.Background(), pkt)
+
+	waitFor(t, time.Second, func() bool {
+		ms, _, _ := store.List(context.Background(), Filter{})
+		return len(ms) == 1
+	}, "row persisted for -0 SSID of our bare call")
+	waitFor(t, time.Second, func() bool {
+		return len(sink.list()) >= 1
+	}, "auto-ACK submitted for -0 SSID of our bare call")
+}
+
 func TestMatchAddresseeSSIDAware(t *testing.T) {
 	tac := NewTacticalSet()
 	tac.Store(map[string]struct{}{"NET": {}})
@@ -436,6 +455,12 @@ func TestMatchAddresseeSSIDAware(t *testing.T) {
 		{"different base", "K0TFU-1", "W1ABC", false, false},
 		{"tactical alias", "K0TFU-1", "NET", true, true},
 		{"empty addressee", "K0TFU-1", "", false, false},
+		// AX.25 SSID 0 is canonically the bare call, so <base>-0 and bare
+		// <base> address the same station (graywolf#500).
+		{"dash-zero addressee for bare our call", "K0TFU", "K0TFU-0", true, false},
+		{"bare addressee for dash-zero our call", "K0TFU-0", "K0TFU", true, false},
+		{"dash-zero both sides", "K0TFU-0", "K0TFU-0", true, false},
+		{"dash-zero addressee for ssid our call", "K0TFU-1", "K0TFU-0", true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -443,6 +468,35 @@ func TestMatchAddresseeSSIDAware(t *testing.T) {
 			if got.IsForUs != tc.wantForUs || got.IsTactical != tc.wantTac {
 				t.Fatalf("MatchAddressee(%q,%q) = %+v, want ForUs=%v Tactical=%v",
 					tc.ourCall, tc.addressee, got, tc.wantForUs, tc.wantTac)
+			}
+		})
+	}
+}
+
+func TestCallAddressedToUsDashZeroSSID(t *testing.T) {
+	// Per AX.25, SSID 0 is the same station as the bare call, so a "-0"
+	// SSID collapses to the bare call on either side. Every other SSID
+	// identifies a distinct peer and must stay distinct (graywolf#500).
+	cases := []struct {
+		name      string
+		addressee string
+		ourCall   string
+		want      bool
+	}{
+		{"dash-zero addressee, bare our call", "CALL-0", "CALL", true},
+		{"bare addressee, dash-zero our call", "CALL", "CALL-0", true},
+		{"dash-zero both sides", "CALL-0", "CALL-0", true},
+		{"dash-zero addressee, ssid our call", "CALL-0", "CALL-7", true},
+		{"distinct non-zero ssids do not match", "CALL-7", "CALL-1", false},
+		{"same non-zero ssid matches", "CALL-7", "CALL-7", true},
+		{"different base does not match", "CALL-0", "OTHER", false},
+		{"case insensitive dash-zero", "call-0", "CALL", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := callAddressedToUs(tc.addressee, tc.ourCall); got != tc.want {
+				t.Fatalf("callAddressedToUs(%q, %q) = %v, want %v",
+					tc.addressee, tc.ourCall, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Some radios (e.g. BTech DA-7X2) normalize a bare callsign into `<call>-0`. Per AX.25, SSID 0 is canonically the same station as the bare call (`F4FXL` == `F4FXL-0`), so when such a radio replies, the addressee comes back as `<call>-0`. A Graywolf station configured as bare `<call>` did not treat that reply's addressee as us, so the message never landed in the DM thread.

## Change

- Add `canonicalCall`, which collapses a trailing `-0` SSID to the bare call while leaving every other SSID intact.
- Apply it in `callAddressedToUs` (addressee matching) and the router self-filter, so both treat `-0` consistently.
- Same-base, non-zero SSID peers (`K0TFU-1` vs `K0TFU-7`) remain distinct — only `-0` collapses to the bare call, preserving the deliberate distinct-peer behavior.

This is the minimal, standards-correct fix and avoids the config/UI churn of a separate SSID field (which would also break aprs.fi iGating, which needs the bare call).

## Tests

- New `TestCallAddressedToUsDashZeroSSID` table test covering the acceptance matrix: `("CALL-0","CALL")`, `("CALL","CALL-0")`, `("CALL-0","CALL-0")` all match; `("CALL-7","CALL-1")` does not.
- `-0` cases added to `TestMatchAddresseeSSIDAware`.
- New router-level `TestRouterDMDashZeroSSIDOfOurBareCallClaimed` end-to-end (persist + auto-ACK).
- `go test ./...` passes for affected packages. (One pre-existing, unrelated failure remains: `TestProtoBindingsDoNotDrift` in `pkg/platformproto`, which reports `pkg/platformproto` is out of date with `proto/platform.proto` — untouched by this PR.)

Fixes #500
