### PR TITLE
Fix outbound TX egress overriding KISS-TNC channel to the modem channel (#503)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -224,6 +224,15 @@ Source: [`../../pkg/webapi/dto/kiss.go`](../../pkg/webapi/dto/kiss.go),
 [`../../pkg/configstore/store.go`](../../pkg/configstore/store.go) (`normalizeKissInterface`),
 [`../../pkg/configstore/migrate.go`](../../pkg/configstore/migrate.go) (`migrateKissTcpClientTxDefault`).
 
+### 16c. `resolveTxChannel` honors KISS-TNC channels, not just modem channels
+
+`App.resolveTxChannel` (`pkg/app/wiring.go`) picks the default TX egress channel for messages / iGate traffic. A channel is a valid egress target if it has **either** a modem input device (`Channel.InputDeviceID != nil`) **or** a KISS-TNC governor backend -- an enabled `Mode=tnc` interface with `AllowTxFromGovernor=true` and `Channel != 0`. The KISS-TNC set is computed by `kissTxChannelSet`, mirroring `buildTxBackendSnapshot`'s eligibility as a pure config projection (it does **not** require the interface's queue to be live, matching how the modem side ignores bridge-subprocess health). A configured channel that maps to either backend is returned as-is; otherwise the resolver falls back to the lowest modem channel, then to the lowest KISS-TNC channel, then to the lowest channel ID overall.
+
+*Why:* A KISS-TNC channel legitimately has no `InputDeviceID`. The earlier modem-only resolver skipped it and silently overrode the operator's KISS channel to the first modem channel whenever both were configured, so messages routed to KISS were logged but egressed on the internal APRS modem (graywolf#503). Any change to what counts as a governor egress target must update `buildTxBackendSnapshot` and `kissTxChannelSet` together, or resolution and dispatch drift apart.
+
+Source: [`../../pkg/app/wiring.go`](../../pkg/app/wiring.go) (`resolveTxChannel`, `kissTxChannelSet`, `buildTxBackendSnapshot`),
+[`../../pkg/app/resolve_tx_channel_test.go`](../../pkg/app/resolve_tx_channel_test.go).
+
 ### 17. RX fanout carries provenance via `ingress.Source` (in-process)
 
 *Why:* Lets KISS broadcast suppress its own loopback without leaking a transport detail into the proto -- the provenance tag is in-process only, never on the wire.

--- a/pkg/app/resolve_tx_channel_test.go
+++ b/pkg/app/resolve_tx_channel_test.go
@@ -144,3 +144,126 @@ func TestResolveTxChannel(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveTxChannelKissTnc is the regression guard for graywolf#503:
+// with both an internal APRS modem channel and a KISS-TNC channel
+// configured, a message directed to the KISS channel must resolve to
+// that channel — the earlier modem-only resolver overrode it to the
+// modem channel, so KISS traffic was logged but egressed on the wrong
+// interface. A KISS-TNC channel has no InputDeviceID; it earns a
+// governor TX backend via an enabled tnc-mode interface with
+// AllowTxFromGovernor.
+func TestResolveTxChannelKissTnc(t *testing.T) {
+	ctx := context.Background()
+
+	// mkChannel creates a channel; modem=true binds an audio input device.
+	newStore := func(t *testing.T) *configstore.Store {
+		t.Helper()
+		s, err := configstore.OpenMemory()
+		if err != nil {
+			t.Fatalf("OpenMemory: %v", err)
+		}
+		t.Cleanup(func() { _ = s.Close() })
+		return s
+	}
+	mkChannel := func(t *testing.T, s *configstore.Store, name string, modem bool) uint32 {
+		t.Helper()
+		ch := &configstore.Channel{
+			Name:      name,
+			ModemType: "afsk", BitRate: 1200, MarkFreq: 1200, SpaceFreq: 2200,
+			Profile: "A", NumSlicers: 1, FixBits: "none",
+		}
+		if modem {
+			dev := &configstore.AudioDevice{
+				Name: name + "-dev", Direction: "input", SourceType: "flac",
+				SourcePath: "/tmp/x.flac", SampleRate: 44100, Channels: 1, Format: "s16le",
+			}
+			if err := s.CreateAudioDevice(ctx, dev); err != nil {
+				t.Fatalf("CreateAudioDevice: %v", err)
+			}
+			ch.InputDeviceID = configstore.U32Ptr(dev.ID)
+		}
+		if err := s.CreateChannel(ctx, ch); err != nil {
+			t.Fatalf("CreateChannel %q: %v", name, err)
+		}
+		return ch.ID
+	}
+	mkKissTnc := func(t *testing.T, s *configstore.Store, name string, channel uint32, allowTx bool) {
+		t.Helper()
+		ki := &configstore.KissInterface{
+			Name:                name,
+			InterfaceType:       "tcp",
+			ListenAddr:          ":8001",
+			Channel:             channel,
+			Enabled:             true,
+			Mode:                configstore.KissModeTnc,
+			AllowTxFromGovernor: allowTx,
+		}
+		if err := s.CreateKissInterface(ctx, ki); err != nil {
+			t.Fatalf("CreateKissInterface %q: %v", name, err)
+		}
+	}
+
+	newApp := func(s *configstore.Store) (*App, *bytes.Buffer) {
+		buf := &bytes.Buffer{}
+		return &App{
+			store:  s,
+			logger: slog.New(slog.NewTextHandler(io.Writer(buf), nil)),
+		}, buf
+	}
+
+	t.Run("modem plus kiss configured to kiss returns kiss", func(t *testing.T) {
+		s := newStore(t)
+		mkChannel(t, s, "modem", true)
+		kissCh := mkChannel(t, s, "kiss", false)
+		mkKissTnc(t, s, "vara", kissCh, true)
+
+		a, buf := newApp(s)
+		if got := a.resolveTxChannel(ctx, kissCh); got != kissCh {
+			t.Fatalf("got channel %d, want kiss channel %d", got, kissCh)
+		}
+		if strings.Contains(buf.String(), "level=WARN") {
+			t.Fatalf("unexpected warn honoring configured kiss channel: %s", buf.String())
+		}
+	})
+
+	t.Run("modem plus kiss configured to modem returns modem", func(t *testing.T) {
+		s := newStore(t)
+		modemCh := mkChannel(t, s, "modem", true)
+		kissCh := mkChannel(t, s, "kiss", false)
+		mkKissTnc(t, s, "vara", kissCh, true)
+
+		a, _ := newApp(s)
+		if got := a.resolveTxChannel(ctx, modemCh); got != modemCh {
+			t.Fatalf("got channel %d, want modem channel %d", got, modemCh)
+		}
+	})
+
+	t.Run("kiss only configured to zero falls back to kiss", func(t *testing.T) {
+		s := newStore(t)
+		kissCh := mkChannel(t, s, "kiss", false)
+		mkKissTnc(t, s, "vara", kissCh, true)
+
+		a, _ := newApp(s)
+		if got := a.resolveTxChannel(ctx, 0); got != kissCh {
+			t.Fatalf("got channel %d, want kiss channel %d", got, kissCh)
+		}
+	})
+
+	t.Run("tnc without allow_tx is not an egress target", func(t *testing.T) {
+		s := newStore(t)
+		modemCh := mkChannel(t, s, "modem", true)
+		kissCh := mkChannel(t, s, "kiss", false)
+		mkKissTnc(t, s, "rx-only", kissCh, false)
+
+		a, buf := newApp(s)
+		// Configured KISS channel has no TX backend (AllowTxFromGovernor
+		// false), so it is overridden to the modem channel as before.
+		if got := a.resolveTxChannel(ctx, kissCh); got != modemCh {
+			t.Fatalf("got channel %d, want modem channel %d", got, modemCh)
+		}
+		if !strings.Contains(buf.String(), "no modem backend") {
+			t.Fatalf("expected override warn, got: %s", buf.String())
+		}
+	})
+}

--- a/pkg/app/resolve_tx_channel_test.go
+++ b/pkg/app/resolve_tx_channel_test.go
@@ -156,7 +156,6 @@ func TestResolveTxChannel(t *testing.T) {
 func TestResolveTxChannelKissTnc(t *testing.T) {
 	ctx := context.Background()
 
-	// mkChannel creates a channel; modem=true binds an audio input device.
 	newStore := func(t *testing.T) *configstore.Store {
 		t.Helper()
 		s, err := configstore.OpenMemory()
@@ -166,6 +165,7 @@ func TestResolveTxChannelKissTnc(t *testing.T) {
 		t.Cleanup(func() { _ = s.Close() })
 		return s
 	}
+	// mkChannel creates a channel; modem=true binds an audio input device.
 	mkChannel := func(t *testing.T, s *configstore.Store, name string, modem bool) uint32 {
 		t.Helper()
 		ch := &configstore.Channel{
@@ -247,6 +247,24 @@ func TestResolveTxChannelKissTnc(t *testing.T) {
 		a, _ := newApp(s)
 		if got := a.resolveTxChannel(ctx, 0); got != kissCh {
 			t.Fatalf("got channel %d, want kiss channel %d", got, kissCh)
+		}
+	})
+
+	t.Run("no modem configured to unbacked falls back to kiss and warns", func(t *testing.T) {
+		s := newStore(t)
+		// A channel with no modem and no governor backend (dead), plus a
+		// separate KISS-TNC egress channel. Configuring the dead channel
+		// must fall back to the KISS channel and log the override.
+		deadCh := mkChannel(t, s, "dead", false)
+		kissCh := mkChannel(t, s, "kiss", false)
+		mkKissTnc(t, s, "vara", kissCh, true)
+
+		a, buf := newApp(s)
+		if got := a.resolveTxChannel(ctx, deadCh); got != kissCh {
+			t.Fatalf("got channel %d, want kiss channel %d", got, kissCh)
+		}
+		if !strings.Contains(buf.String(), "no tx backend") {
+			t.Fatalf("expected override warn, got: %s", buf.String())
 		}
 	})
 

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -2204,16 +2204,51 @@ func (a *App) buildTxBackendSnapshot() *txbackend.Snapshot {
 	return txbackend.BuildSnapshot(modem, modemChannels, kissBackends)
 }
 
+// kissTxChannelSet returns the set of channel IDs that have a KISS-TNC
+// governor backend, mirroring buildTxBackendSnapshot's config-level
+// eligibility (enabled, Mode==tnc, AllowTxFromGovernor, Channel != 0).
+// Unlike the snapshot builder it does NOT require the interface's queue
+// to be live — like the modem side of resolveTxChannel it is a pure
+// config projection, so a KISS channel resolves correctly even before
+// the kiss manager has started the instance (startup ordering) or after
+// a config reload. Queue liveness is a submit-time health concern.
+func (a *App) kissTxChannelSet(ctx context.Context) map[uint32]bool {
+	ifaces, err := a.store.ListKissInterfaces(ctx)
+	if err != nil {
+		return nil
+	}
+	var set map[uint32]bool
+	for _, ki := range ifaces {
+		if !ki.Enabled || ki.Mode != configstore.KissModeTnc || !ki.AllowTxFromGovernor || ki.Channel == 0 {
+			continue
+		}
+		if set == nil {
+			set = make(map[uint32]bool)
+		}
+		set[ki.Channel] = true
+	}
+	return set
+}
+
 // resolveTxChannel picks a usable TX channel for igate / messages
-// traffic. Returns the configured channel when it has a modem input
-// device bound (i.e. buildTxBackendSnapshot will register a modem
-// backend for it). Otherwise falls back to the lowest channel ID with
-// a modem input device, then to the lowest channel ID overall, then 0.
+// traffic. Returns the configured channel when it has a governor TX
+// backend — either a modem input device (buildTxBackendSnapshot
+// registers a ModemBackend) or a KISS-TNC interface with
+// AllowTxFromGovernor (a KissTncBackend). Otherwise falls back to the
+// lowest channel ID with a modem input device, then to any KISS-TNC TX
+// channel, then to the lowest channel ID overall, then 0.
+//
+// Honoring a configured KISS-TNC channel is the fix for graywolf#503:
+// a KISS-TNC channel has no InputDeviceID, so the earlier
+// modem-only resolver silently overrode the operator's KISS channel to
+// the internal APRS modem channel whenever both were configured, and
+// messages routed to KISS were logged but egressed on the wrong (modem)
+// interface.
 //
 // Logs a warning when a non-zero configured value is overridden so an
 // operator can correlate stale TxChannel references against the on-box
 // logs without having to read the DB. Also logs a distinct warning
-// when no channel has a modem backend at all — the returned ID will
+// when no channel has any TX backend at all — the returned ID will
 // fail at submit time but is the least-bad option, and the dedicated
 // log line is the operator's diagnostic for that case.
 //
@@ -2221,6 +2256,15 @@ func (a *App) buildTxBackendSnapshot() *txbackend.Snapshot {
 // reloadIgate / Service.ReloadConfig on iGate-config saves so a
 // runtime channel renumbering propagates without a service restart.
 func (a *App) resolveTxChannel(ctx context.Context, configured uint32) uint32 {
+	kissTx := a.kissTxChannelSet(ctx)
+
+	// A configured KISS-TNC channel is a legitimate egress target even
+	// though it has no modem input device. Honor it before any modem
+	// fallback so a mixed modem+KISS config does not override it.
+	if configured != 0 && kissTx[configured] {
+		return configured
+	}
+
 	chs, err := a.store.ListChannels(ctx)
 	if err != nil || len(chs) == 0 {
 		return configured
@@ -2238,8 +2282,17 @@ func (a *App) resolveTxChannel(ctx context.Context, configured uint32) uint32 {
 		}
 	}
 	if firstWithModem == 0 {
+		// No modem channel. Prefer a KISS-TNC egress channel (it has a
+		// real backend) over an arbitrary channel row that has none.
+		if kissFallback := lowestKey(kissTx); kissFallback != 0 {
+			if configured != 0 && configured != kissFallback {
+				a.logger.Warn("tx channel fallback: configured channel has no tx backend",
+					"configured", configured, "using", kissFallback)
+			}
+			return kissFallback
+		}
 		fallback := chs[0].ID
-		a.logger.Warn("tx channel fallback: no channel has a modem backend; tx will fail at submit",
+		a.logger.Warn("tx channel fallback: no channel has a tx backend; tx will fail at submit",
 			"configured", configured, "using", fallback)
 		return fallback
 	}
@@ -2248,6 +2301,17 @@ func (a *App) resolveTxChannel(ctx context.Context, configured uint32) uint32 {
 			"configured", configured, "using", firstWithModem)
 	}
 	return firstWithModem
+}
+
+// lowestKey returns the smallest key in set, or 0 when the set is empty.
+func lowestKey(set map[uint32]bool) uint32 {
+	var lowest uint32
+	for k := range set {
+		if lowest == 0 || k < lowest {
+			lowest = k
+		}
+	}
+	return lowest
 }
 
 func (a *App) digipeaterComponent() namedComponent {


### PR DESCRIPTION
## Root cause

`App.resolveTxChannel` (`pkg/app/wiring.go`) picks the default TX egress channel for messages / iGate traffic. It treated a channel as usable **only** if it had a modem input device (`Channel.InputDeviceID != nil`). A KISS-TNC channel legitimately has no input device, so when both an internal APRS modem channel and a KISS-TNC channel were configured, a configured KISS channel was skipped by the `InputDeviceID == nil` guard and the resolver returned the first modem-backed channel instead.

The frame was then stamped with the modem channel id and dispatched to the modem backend — so the message was logged (it was accepted/submitted) but egressed on the wrong interface and never reached the KISS TNC. This matches the report exactly:

- **KISS only / after deleting the modem channel:** no modem channel exists, the resolver falls through to the lowest channel id (the KISS channel), TX works.
- **Modem + KISS together:** the configured KISS channel is overridden to the modem channel, TX silently egresses on the modem.

Every downstream layer (sender `channelFor`, governor stamping, dispatcher `ByChannel` lookup, snapshot builder) already honored the channel id correctly. The single wrong decision was in `resolveTxChannel`.

## Fix

Treat a channel as a valid egress target when it has **either** a modem input device **or** a KISS-TNC governor backend — an enabled `Mode=tnc` interface with `AllowTxFromGovernor=true` and a non-zero channel. The KISS-TNC set is computed by a new `kissTxChannelSet` helper that mirrors `buildTxBackendSnapshot`'s eligibility as a pure config projection (it does not require the interface's queue to be live, matching how the modem side ignores bridge-subprocess health).

A configured KISS-TNC channel is now returned as-is. The fallback order is: configured channel (if backed) → lowest modem channel → lowest KISS-TNC channel → lowest channel overall.

## Tests

`TestResolveTxChannelKissTnc` (`pkg/app/resolve_tx_channel_test.go`) covers the multi-channel egress selection:

- modem + KISS configured to the KISS channel → resolves to KISS (the regression guard for this bug)
- modem + KISS configured to the modem channel → resolves to modem
- KISS-only, configured 0 → falls back to the KISS channel
- a `tnc` interface without `AllowTxFromGovernor` is not an egress target (still overridden to modem)

The existing `TestResolveTxChannel` truth table still passes. `go test ./...` passes (the only failure is the pre-existing `pkg/platformproto` proto-drift guard, which fails identically on a clean checkout because the CI protoc tool version differs from the local one — untouched by this change).

Closes #503.
