### PR TITLE
messages: fix high-volume thread pagination stranding messages (GH #521)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1710,3 +1710,38 @@ Source: [`../../pkg/app/rxfanout.go`](../../pkg/app/rxfanout.go)
 (`setMod128`, `Mod128`),
 [`../../pkg/ax25conn/manager_test.go`](../../pkg/ax25conn/manager_test.go)
 (`TestManager_DispatchRawMod128Delivers`).
+
+### 63. `messages.Store.List` keyset order MUST match the cursor predicate's whole-second resolution
+
+The chat UI pages through messages with a forward cursor
+(`web/src/lib/messagesTransport.js` `fetchDelta`), so `(*Store).List`
+does keyset pagination on `(updated_at, id)`. The cursor stores
+`updated_at` at **whole-second** resolution (`strftime('%s', ...)`), so
+the `ORDER BY` MUST truncate to the same resolution --
+`CAST(strftime('%s', updated_at) AS INTEGER) ASC, id ASC`. Do NOT
+"optimize" it back to `ORDER BY updated_at ASC` (full precision): that
+mismatch makes the sort key finer than the cursor and silently strands
+rows. Concretely, when an older/lower-id row's `updated_at` is bumped
+into the same second as a newer, higher-id insert (routine ack
+correlation / retry bookkeeping on a busy two-way thread), the older row
+sorts after the cursor tip yet loses the `id` tiebreak and is never
+returned again -- messages stop appearing in the chat window under
+sustained volume (graywolf #521).
+
+Full-precision text comparison is not an escape hatch: glebarez stores
+time as trailing-zero-trimmed RFC3339Nano, whose lexicographic order is
+not chronological (`".9Z"` sorts after `".90000001Z"`), and SQLite cannot
+recover sub-second precision from the text via `strftime`/`julianday`
+without loss. Whole-second resolution keeps the keyset key unique (id
+breaks ties) and monotonic, which is all forward pagination needs.
+
+*Why:* keyset pagination is correct only when the `ORDER BY` expression
+is identical to the cursor predicate; any resolution gap between them
+drops rows.
+
+Source: [`../../pkg/messages/store.go`](../../pkg/messages/store.go)
+(`(*Store).List`, `encodeCursor`),
+[`../../pkg/messages/store_pagination_test.go`](../../pkg/messages/store_pagination_test.go)
+(`TestListCursorHighVolumeNoSkips`),
+[`../../web/src/lib/messagesTransport.js`](../../web/src/lib/messagesTransport.js)
+(`fetchDelta`).

--- a/pkg/messages/store.go
+++ b/pkg/messages/store.go
@@ -240,10 +240,26 @@ func (s *Store) GetConversationPrefs(ctx context.Context, kind, key string) (*co
 // cursor points at the last row in the page and can be fed back into a
 // subsequent List call to page forward deterministically.
 //
-// Ordering: (UpdatedAt ASC, ID ASC). UpdatedAt is populated by GORM on
-// every Create/Save and also advances when the row is touched by ack
-// correlation or retry bookkeeping, so a polling client seeing an
+// Ordering: (whole-second UpdatedAt ASC, ID ASC). UpdatedAt is populated
+// by GORM on every Create/Save and also advances when the row is touched
+// by ack correlation or retry bookkeeping, so a polling client seeing an
 // updated row after the initial sync will find it past its cursor.
+//
+// The ORDER BY key MUST match the cursor predicate below exactly, or
+// keyset pagination silently strands rows. The cursor stores UpdatedAt at
+// whole-second resolution (strftime('%s', ...)), so the ORDER BY must
+// truncate to the same resolution — otherwise a row that sorts after the
+// cursor tip at sub-second precision but carries a lower id (e.g. an older
+// message whose updated_at was just bumped by an ack into the same second
+// as a newer, higher-id insert) falls on the wrong side of the id
+// tiebreak and is never returned again. On a busy two-way thread that
+// collision is common, and the effect is messages that stop appearing in
+// the chat window (GH #521). Comparing the raw text column at full
+// precision is not an option: GORM stores time as trailing-zero-trimmed
+// RFC3339Nano, whose lexicographic order does not match chronological
+// order (".9Z" sorts after ".90000001Z"). Second resolution keeps the
+// keyset key unique (id breaks ties) and monotonic, which is what
+// forward pagination requires.
 func (s *Store) List(ctx context.Context, f Filter) ([]configstore.Message, string, error) {
 	limit := f.Limit
 	if limit <= 0 {
@@ -286,7 +302,10 @@ func (s *Store) List(ctx context.Context, f Filter) ([]configstore.Message, stri
 			c.UpdatedAtNanos, c.UpdatedAtNanos, c.ID,
 		)
 	}
-	q = q.Order("updated_at ASC").Order("id ASC").Limit(limit)
+	// Truncate to whole seconds so this matches the cursor predicate's
+	// strftime('%s', ...) resolution exactly (see the doc comment).
+	q = q.Order("CAST(strftime('%s', updated_at) AS INTEGER) ASC").
+		Order("id ASC").Limit(limit)
 
 	var out []configstore.Message
 	if err := q.Find(&out).Error; err != nil {

--- a/pkg/messages/store_pagination_test.go
+++ b/pkg/messages/store_pagination_test.go
@@ -1,0 +1,98 @@
+package messages
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/configstore"
+)
+
+// TestListCursorHighVolumeNoSkips drives a busy two-way thread through the
+// polling client's forward-cursor loop and asserts every message is
+// delivered exactly the way the chat UI would see it.
+//
+// The failure this guards against (GH #521): on high-traffic APRSOTA
+// threads, messages eventually stop showing up in the chat window. Root
+// cause was a keyset-pagination mismatch — List ordered rows by
+// full-precision updated_at but the cursor predicate compared updated_at
+// truncated to whole seconds. When an older row's updated_at was bumped
+// into the same second as newer, higher-id inserts (routine ack
+// correlation on a busy thread), the older row sorted after the cursor tip
+// yet fell behind on the id tiebreak and was stranded forever.
+//
+// This reproduces that at volume: many rows share each whole second, and
+// within every second the sub-second updated_at order is INVERTED relative
+// to id — exactly what ack/retry churn produces. Before the fix the client
+// silently dropped a large fraction of the thread.
+func TestListCursorHighVolumeNoSkips(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newTestStore(t)
+
+	const total = 300 // messages in the thread
+	const perSecond = 40
+
+	want := make(map[uint64]bool, total)
+	for i := 0; i < total; i++ {
+		dir, from, to := "in", "W1ABC", "K0ABC"
+		if i%2 == 1 { // alternate inbound/outbound like a real conversation
+			dir, from, to = "out", "K0ABC", "W1ABC"
+		}
+		m := seedMsg(dir, "K0ABC", from, to, fmt.Sprintf("msg-%d", i), fmt.Sprintf("%02d", i%100))
+		m.ThreadKind = ThreadKindDM
+		if err := store.Insert(ctx, m); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+		want[m.ID] = true
+
+		// Force updated_at: pack perSecond rows into each whole second, and
+		// invert the sub-second order within a second relative to insert
+		// (id) order so the lower-id row lands LATER in the second.
+		sec := i / perSecond
+		pos := i % perSecond
+		frac := perSecond - pos // higher-id => smaller frac => earlier
+		ts := fmt.Sprintf("2026-08-23T20:%02d:%02d.%09dZ", sec/60, sec%60, frac*1_000_000)
+		if err := store.db.WithContext(ctx).
+			Exec("UPDATE messages SET updated_at = ? WHERE id = ?", ts, m.ID).Error; err != nil {
+			t.Fatalf("bump updated_at: %v", err)
+		}
+	}
+
+	// Poll exactly like web/src/lib/messagesTransport.js fetchDelta: page
+	// forward from an advancing cursor at the default page size until the
+	// cursor stops moving.
+	seen := make(map[uint64]bool, total)
+	cursor := ""
+	for iter := 0; iter < 1000; iter++ {
+		rows, next, err := store.List(ctx, Filter{Cursor: cursor})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		for _, r := range rows {
+			seen[r.ID] = true
+		}
+		if next == cursor || len(rows) == 0 {
+			break
+		}
+		cursor = next
+	}
+
+	if len(seen) != total {
+		var missing []uint64
+		for id := range want {
+			if !seen[id] {
+				missing = append(missing, id)
+			}
+		}
+		t.Fatalf("polling client delivered %d/%d messages; %d stranded (e.g. %v)",
+			len(seen), total, len(missing), firstN(missing, 10))
+	}
+	_ = configstore.Message{}
+}
+
+func firstN(ids []uint64, n int) []uint64 {
+	if len(ids) < n {
+		return ids
+	}
+	return ids[:n]
+}

--- a/pkg/messages/store_pagination_test.go
+++ b/pkg/messages/store_pagination_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-
-	"github.com/chrissnell/graywolf/pkg/configstore"
 )
 
 // TestListCursorHighVolumeNoSkips drives a busy two-way thread through the
@@ -87,7 +85,6 @@ func TestListCursorHighVolumeNoSkips(t *testing.T) {
 		t.Fatalf("polling client delivered %d/%d messages; %d stranded (e.g. %v)",
 			len(seen), total, len(missing), firstN(missing, 10))
 	}
-	_ = configstore.Message{}
 }
 
 func firstN(ids []uint64, n int) []uint64 {


### PR DESCRIPTION
## Summary

Fixes GH #521 — on high-traffic APRSOTA threads, messages eventually stop showing up in the Graywolf chat window (both received and sent) even though raw packets keep flowing on the dashboard.

## Root cause

The chat UI pages through messages with a forward cursor (`web/src/lib/messagesTransport.js` `fetchDelta`), so `messages.Store.List` does keyset pagination on `(updated_at, id)`. But the two halves of the keyset disagreed on resolution:

- `ORDER BY updated_at ASC, id ASC` — **full sub-second** precision (glebarez stores time as RFC3339Nano text; string sort is chronological).
- Cursor predicate — **whole-second** precision: `strftime('%s', updated_at) * 1e9`, and the cursor itself is encoded with `UpdatedAt.Unix()` (seconds).

Keyset pagination is correct only when the `ORDER BY` expression is identical to the cursor predicate. Here the sort key was finer than the cursor, so rows got stranded: when an older/lower-id row's `updated_at` was bumped into the same whole second as a newer, higher-id insert — routine ack correlation and retry bookkeeping on a busy two-way thread — the older row sorted *after* the cursor tip at sub-second resolution but *lost* the `id` tiebreak in the second-granular predicate. It was then never returned again. Under sustained volume the polling client silently dropped a growing fraction of the thread.

## Fix

Align the `ORDER BY` to the cursor predicate's whole-second resolution:

```
ORDER BY CAST(strftime('%s', updated_at) AS INTEGER) ASC, id ASC
```

Now the sort key and the cursor compare at the same granularity, the key stays unique (id breaks ties) and monotonic, and forward pagination never skips.

A full-precision text comparison was considered and rejected: glebarez stores time as trailing-zero-trimmed RFC3339Nano, whose lexicographic order is **not** chronological (`".9Z"` sorts after `".90000001Z"`), and SQLite cannot recover sub-second precision from the text via `strftime`/`julianday` without loss.

## Test

`TestListCursorHighVolumeNoSkips` drives 300 messages through the exact client paging loop, packing many rows into each whole second with sub-second `updated_at` **inverted** against id (what ack/retry churn produces). It strands 59/300 messages before the fix and passes after. `go test ./pkg/messages/...` is green.

## Notes

- Change is confined to `pkg/messages/store.go` plus the new test and an invariants wiki entry (#63) documenting why the two resolutions must match.
- `go build ./...` passes. Full `go test ./...` is green except a pre-existing, unrelated `pkg/platformproto` proto-drift failure present on a clean checkout in this environment (needs `make proto`), untouched by this change.
