### PR TITLE
docs: clarify no system libhidapi needed on Arch/CachyOS (GH #512)

### DIFF
--- a/docs/handbook/installation.html
+++ b/docs/handbook/installation.html
@@ -215,6 +215,22 @@ makepkg -si</code></pre>
 
 <pre><code>sudo systemctl enable --now graywolf-aprs</code></pre>
 
+        <div class="callout info">
+          <span class="callout-icon">&#9432;</span>
+          <div class="callout-body">
+            <p>
+              <strong>No <code>hidapi</code> system package is required.</strong>
+              Graywolf's modem uses a pure-Rust <code>hidraw</code> backend for
+              CM108 PTT, so it does not link the system <code>libhidapi</code> C
+              library. If an older AUR build (0.10.x or earlier) failed with
+              <code>undefined symbol: hid_enumerate</code> /
+              <code>hid_init</code> under the <code>lld</code> linker, update to
+              the current package -- v0.13.13 and later removed that C link
+              dependency entirely.
+            </p>
+          </div>
+        </div>
+
       </div>
 
       <!-- ── Windows ── -->
@@ -402,8 +418,17 @@ volumes:
           <li>Go 1.22+</li>
           <li>Node.js 22+ and npm (for the web UI)</li>
           <li>GNU Make</li>
-          <li>ALSA development headers (<code>libasound2-dev</code> on Debian/Ubuntu)</li>
+          <li>ALSA development headers (<code>libasound2-dev</code> on Debian/Ubuntu, <code>alsa-lib</code> on Arch)</li>
         </ul>
+
+        <p>
+          <code>libhidapi</code> and <code>libudev</code> are <strong>not</strong>
+          required: the Rust modem uses a pure-Rust <code>hidraw</code> backend
+          for CM108 PTT and enumerates HID devices via <code>/sys</code>
+          directly, so nothing links the system <code>libhidapi</code> C library
+          (the source of the old <code>undefined symbol: hid_enumerate</code>
+          link error on Arch/CachyOS).
+        </p>
 
         <h2>Build</h2>
 

--- a/docs/wiki/build-pipelines.md
+++ b/docs/wiki/build-pipelines.md
@@ -41,6 +41,34 @@ The pre-commit hook in [`../../.githooks/`](../../.githooks/) (wired via
 `make install-hooks`) runs the same `docs-check` / `api-client-check`
 guards locally.
 
+## Rust modem uses the pure-Rust HID backend (no system libhidapi/libudev)
+
+The CM108 HID PTT path depends on `hidapi`, but
+[`../../graywolf-modem/Cargo.toml`](../../graywolf-modem/Cargo.toml) pins it
+with `default-features = false, features = ["linux-native-basic-udev"]` on
+non-Android targets. That selects hidapi's **pure-Rust hidraw backend** plus
+the pure-Rust `basic-udev` enumeration crate:
+
+- **No system `libhidapi`** is compiled or linked on Linux -- the C backend
+  (which emits `hid_init` / `hid_enumerate` / `hid_free_enumeration` and needs
+  `-lhidapi` at link time) is never selected. `cargo tree -e features -i hidapi`
+  should show only the `linux-native-basic-udev` feature.
+- **No `libudev`** build/runtime dependency (device discovery walks
+  `/sys/class/hidraw/` directly). Deliberately avoid the plain `linux-native`
+  feature -- it pulls the libudev-FFI `udev` crate and re-triggers the cross-rs
+  armv6 link failure.
+- macOS (IOKit) and Windows (SetupAPI) backends are `cfg(target_os = ...)`
+  gated and unaffected.
+
+Historical context: GH [#512](https://github.com/chrissnell/graywolf/issues/512)
+reported `undefined symbol: hid_enumerate` building on CachyOS/Arch. That was an
+**old release (0.10.1)** that predated this backend selection and linked the C
+backend without system libhidapi present. The pure-Rust backend landed in
+`cbfa1c4b` (first shipped in v0.13.13); any release from v0.13.13 on links no
+C hidapi and needs no `hidapi` system package. To verify a fresh build:
+`readelf -d target/release/graywolf-modem | grep -i hidapi` prints nothing and
+`nm -D` shows no undefined `hid_*` symbols.
+
 ## Two 32-bit ARM builds share one dpkg arch
 
 There are two distinct 32-bit ARM hard-float builds, and both the Go


### PR DESCRIPTION
## Summary

Closes the investigation for GH #512 (build failure on CachyOS/Arch: `undefined symbol: hid_enumerate` / `hid_init` / `hid_free_enumeration`).

**The fix already landed.** `graywolf-modem/Cargo.toml` pins hidapi with the pure-Rust hidraw backend (`default-features = false, features = ["linux-native-basic-udev"]`), so no system `libhidapi` C library is ever linked. This backend was introduced in `cbfa1c4b` and first shipped in **v0.13.13**. The reporter built AUR `graywolf-aprs` **0.10.1**, which predates it and linked the C backend without system libhidapi present.

This PR is docs-only — no code change was needed. It documents the invariant so future Arch/CachyOS users and agents don't chase a resolved problem:

- **`docs/handbook/installation.html`** — a callout on the Arch tab and a note in the Build-from-Source requirements stating that `libhidapi`/`libudev` are not required, and that the old link error is a pre-0.13.13 artifact.
- **`docs/wiki/build-pipelines.md`** — a section explaining the pure-Rust HID backend selection, why `linux-native` (libudev-FFI) is deliberately avoided, and how to verify a clean build.

## Verification

Reproduced the reporter's environment (no system `libhidapi`, no `libudev`) and built current `main`:

- `cargo tree -e features -i hidapi` → only the `linux-native-basic-udev` feature is enabled; nothing re-enables the C backend.
- `cargo build --release --bin graywolf-modem` → clean build with no system libhidapi installed.
- `readelf -d target/release/graywolf-modem` → NEEDED libs are `libasound`, `libgcc_s`, `libm`, `libc`, `ld-linux` only. No `libhidapi`.
- `nm -D` → zero undefined `hid_*` symbols (the exact symbols in the bug report). 28 hid symbols are compiled in from the pure-Rust crate.

Since there are zero undefined `hid_*` symbols, the choice of linker (bfd/gold/lld/mold) is immaterial — no linker can fail resolving symbols that aren't referenced.

**AUR packaging** (`packaging/aur/PKGBUILD`) is already at `pkgver=0.14.12` and needs no change; `makedepends` correctly omits `hidapi`.
