### PR TITLE
Add Send Beacon button to Messages view (GH #522)

### DIFF
--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -186,6 +186,18 @@ in the new-message dialog. Zero = the configured default `tx_channel`.
 | REST | `webapi/messages.go` — `sendMessage` copies `dto.SendMessageRequest.Channel` (`*uint32`, already in the DTO) into `svcReq.Channel`, and rejects a packet-mode override with 400 (same `ModeForChannel` guard as `putMessagesConfig`; a missing row reads as APRS, matching the fail-open TX-gating convention, so existence is not hard-validated). |
 | UI | `web/src/components/messages/ComposeNewModal.svelte` — `<details class="advanced">` with a channel `Select` (non-packet channels + "Default" sentinel, same filter as `MessagesSettings.svelte`); threaded through `Messages.svelte` `handleNewSend`/`optimisticSend` → `sendMessage({channel})`. The override resets on the modal's open→true transition (NOT in `close()`), because `ComposeBar` calls `onSend`/`close` once per part of a multi-part message — resetting on close would zero the channel after part 1. |
 
+## Send Beacon from Messages (GH #522)
+
+Lets an APRSOTA operator fire a position beacon without leaving the inbox
+(they must beacon while working a summit / hosting a session). Pure UI reuse
+— no new backend path.
+
+| Concern | Where |
+|---|---|
+| Trigger | `web/src/routes/Messages.svelte` — "Send Beacon" button in the list-pane `.route-toolbar` (beside "Manage OTP Secrets"). `onSendBeaconClick`: 0 offered beacons → toast pointing at the Beacons page; 1 → send it; >1 → open a picker menu. `onMount` loads `GET /beacons` + `GET /station/config`. |
+| Send | Reuses `POST /beacons/{id}/send` (same call as `Beacons.svelte` `handleSendNow`). The endpoint carries no body, so position source (live GPS vs fixed coords) is whatever the chosen beacon is configured with — nothing to duplicate. `toasts.success`/`toasts.error` feedback. |
+| Which beacons | `web/src/lib/messagesBeacon.js` — `sendableBeacons(rows, stationCallsign)` keeps only enabled beacons (disabled = parked, scheduler never sends), labels each via `beaconLabel`. Tested in `messagesBeacon.test.js`. |
+
 ## Message call-sign blocklist (issue #465)
 
 Mutes inbound messages from specific senders (e.g. a station that

--- a/web/src/lib/messagesBeacon.js
+++ b/web/src/lib/messagesBeacon.js
@@ -1,0 +1,17 @@
+import { beaconLabel } from './beaconLabel.js';
+
+// Beacons offered by the Messages "Send Beacon" control. Only enabled
+// beacons are sendable: a disabled beacon is configured-but-parked and the
+// scheduler never transmits it, so surfacing it here would let an operator
+// fire a beacon they had deliberately switched off. Order is preserved so
+// the picker matches the Beacons page listing.
+//
+// Each option carries the id the send call needs and a human label (reusing
+// beaconLabel so every surface names a beacon the same way). Pure helper so
+// the Messages view and its test share one source of truth.
+export function sendableBeacons(beacons, stationCallsign = '') {
+  if (!Array.isArray(beacons)) return [];
+  return beacons
+    .filter((b) => b && b.id != null && b.enabled !== false)
+    .map((b) => ({ id: b.id, label: beaconLabel(b, stationCallsign) }));
+}

--- a/web/src/lib/messagesBeacon.test.js
+++ b/web/src/lib/messagesBeacon.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sendableBeacons } from './messagesBeacon.js';
+
+test('sendableBeacons: keeps enabled beacons, shaped as {id, label}', () => {
+  const rows = [
+    { id: 1, type: 'position', callsign: 'W1AW-9', enabled: true },
+    { id: 2, type: 'object', object_name: 'FIELDDAY', callsign: '', enabled: true },
+  ];
+  assert.deepEqual(sendableBeacons(rows, 'N0CAL'), [
+    { id: 1, label: 'W1AW-9' },
+    { id: 2, label: 'FIELDDAY' },
+  ]);
+});
+
+test('sendableBeacons: drops disabled beacons', () => {
+  const rows = [
+    { id: 1, callsign: 'W1AW-9', enabled: false },
+    { id: 2, callsign: 'W1AW-1', enabled: true },
+  ];
+  assert.deepEqual(sendableBeacons(rows, ''), [{ id: 2, label: 'W1AW-1' }]);
+});
+
+test('sendableBeacons: falls back to the station callsign for a blank per-row callsign', () => {
+  const rows = [{ id: 3, type: 'position', callsign: '', enabled: true }];
+  assert.deepEqual(sendableBeacons(rows, 'N0CAL'), [{ id: 3, label: 'N0CAL' }]);
+});
+
+test('sendableBeacons: preserves list order', () => {
+  const rows = [
+    { id: 5, callsign: 'C', enabled: true },
+    { id: 4, callsign: 'B', enabled: true },
+    { id: 6, callsign: 'A', enabled: true },
+  ];
+  assert.deepEqual(sendableBeacons(rows).map((b) => b.id), [5, 4, 6]);
+});
+
+test('sendableBeacons: skips rows with no id', () => {
+  const rows = [{ callsign: 'W1AW', enabled: true }, { id: 7, callsign: 'W2AW', enabled: true }];
+  assert.deepEqual(sendableBeacons(rows), [{ id: 7, label: 'W2AW' }]);
+});
+
+test('sendableBeacons: tolerates a non-array input', () => {
+  assert.deepEqual(sendableBeacons(null), []);
+  assert.deepEqual(sendableBeacons(undefined), []);
+});

--- a/web/src/routes/Messages.svelte
+++ b/web/src/routes/Messages.svelte
@@ -114,18 +114,28 @@
   // logic to duplicate here. `sendableBeacons` (lib/messagesBeacon.js) decides
   // which configured beacons are offered.
   let beaconOptions = $state([]); // [{ id, label }]
+  let beaconsLoadFailed = $state(false);
   let beaconMenuOpen = $state(false);
   let sendingBeacon = $state(false);
 
   async function loadBeaconOptions() {
+    // The station callsign only labels a beacon that carries no per-row
+    // callsign, so it is best-effort: a station-config hiccup must not decide
+    // whether the control works. Load it separately from the beacon list.
+    let stationCallsign = '';
     try {
-      const [rows, st] = await Promise.all([
-        api.get('/beacons'),
-        api.get('/station/config'),
-      ]);
-      beaconOptions = sendableBeacons(rows || [], (st && st.callsign) || '');
+      const st = await api.get('/station/config');
+      stationCallsign = (st && st.callsign) || '';
+    } catch {
+      // Leave blank; beaconLabel falls back to the (unset) sentinel.
+    }
+    try {
+      const rows = await api.get('/beacons');
+      beaconOptions = sendableBeacons(rows || [], stationCallsign);
+      beaconsLoadFailed = false;
     } catch {
       beaconOptions = [];
+      beaconsLoadFailed = true;
     }
   }
   onMount(loadBeaconOptions);
@@ -149,7 +159,13 @@
   // point the operator at the Beacons page instead of a dead click.
   function onSendBeaconClick() {
     if (beaconOptions.length === 0) {
-      toasts.error('No beacons configured. Add one on the Beacons page first.');
+      if (beaconsLoadFailed) {
+        // Retry once so a transient failure doesn't strand the control.
+        loadBeaconOptions();
+        toasts.error('Could not load beacons. Check your connection and try again.');
+      } else {
+        toasts.error('No beacons configured. Add one on the Beacons page first.');
+      }
       return;
     }
     if (beaconOptions.length === 1) {
@@ -159,16 +175,23 @@
     beaconMenuOpen = !beaconMenuOpen;
   }
 
-  // Close the picker on any click outside the control. Capture phase so this
-  // runs before the toggle button's own handler, which would otherwise
-  // reopen a menu this had just closed.
+  // Dismiss the picker on an outside click or Escape. The click listener is
+  // registered only while the menu is open, so the opening click (already
+  // propagated by the time this effect runs) can't self-close it.
   $effect(() => {
     if (!beaconMenuOpen) return;
     const onDocClick = (e) => {
       if (!e.target?.closest?.('.beacon-control')) beaconMenuOpen = false;
     };
-    window.addEventListener('click', onDocClick, true);
-    return () => window.removeEventListener('click', onDocClick, true);
+    const onKey = (e) => {
+      if (e.key === 'Escape') beaconMenuOpen = false;
+    };
+    window.addEventListener('click', onDocClick);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('click', onDocClick);
+      window.removeEventListener('keydown', onKey);
+    };
   });
 
   // ---------- responsive breakpoint ----------

--- a/web/src/routes/Messages.svelte
+++ b/web/src/routes/Messages.svelte
@@ -33,6 +33,7 @@
   import { refreshNow } from '../lib/messagesTransport.js';
   import { toasts } from '../lib/stores.js';
   import { api } from '../lib/api.js';
+  import { sendableBeacons } from '../lib/messagesBeacon.js';
 
   // ---------- query param parsing ----------
   let qs = $state('');
@@ -103,6 +104,72 @@
       ? 'APRS-IS is off. ANSRVR replies and messages from internet-only peers will not arrive.'
       : 'APRS-IS not connected. ANSRVR replies and messages from internet-only peers will not arrive until the session reconnects.',
   );
+
+  // ---------- send-beacon control ----------
+  // APRSOTA operators have to beacon their position while working a summit or
+  // hosting a session, and shouldn't have to leave the inbox to do it. This
+  // reuses the existing per-beacon send path (POST /beacons/{id}/send) — the
+  // backend transmits with whatever position source (live GPS or fixed
+  // coords) the chosen beacon is configured with, so there is no position
+  // logic to duplicate here. `sendableBeacons` (lib/messagesBeacon.js) decides
+  // which configured beacons are offered.
+  let beaconOptions = $state([]); // [{ id, label }]
+  let beaconMenuOpen = $state(false);
+  let sendingBeacon = $state(false);
+
+  async function loadBeaconOptions() {
+    try {
+      const [rows, st] = await Promise.all([
+        api.get('/beacons'),
+        api.get('/station/config'),
+      ]);
+      beaconOptions = sendableBeacons(rows || [], (st && st.callsign) || '');
+    } catch {
+      beaconOptions = [];
+    }
+  }
+  onMount(loadBeaconOptions);
+
+  async function sendBeacon(id) {
+    beaconMenuOpen = false;
+    if (sendingBeacon) return;
+    const opt = beaconOptions.find((b) => b.id === id);
+    sendingBeacon = true;
+    try {
+      await api.post(`/beacons/${id}/send`, {});
+      toasts.success(`Beacon sent: ${opt?.label || id}`);
+    } catch (err) {
+      toasts.error(err?.message || 'Beacon send failed');
+    } finally {
+      sendingBeacon = false;
+    }
+  }
+
+  // One beacon → fire it straight away; several → open a picker; none →
+  // point the operator at the Beacons page instead of a dead click.
+  function onSendBeaconClick() {
+    if (beaconOptions.length === 0) {
+      toasts.error('No beacons configured. Add one on the Beacons page first.');
+      return;
+    }
+    if (beaconOptions.length === 1) {
+      sendBeacon(beaconOptions[0].id);
+      return;
+    }
+    beaconMenuOpen = !beaconMenuOpen;
+  }
+
+  // Close the picker on any click outside the control. Capture phase so this
+  // runs before the toggle button's own handler, which would otherwise
+  // reopen a menu this had just closed.
+  $effect(() => {
+    if (!beaconMenuOpen) return;
+    const onDocClick = (e) => {
+      if (!e.target?.closest?.('.beacon-control')) beaconMenuOpen = false;
+    };
+    window.addEventListener('click', onDocClick, true);
+    return () => window.removeEventListener('click', onDocClick, true);
+  });
 
   // ---------- responsive breakpoint ----------
   let isMobile = $state(false);
@@ -423,6 +490,35 @@
   {#if showList}
     <div class="pane list-pane">
       <div class="route-toolbar">
+        <div class="beacon-control">
+          <button
+            type="button"
+            class="route-toolbar-item beacon-send"
+            onclick={onSendBeaconClick}
+            disabled={sendingBeacon}
+            data-testid="send-beacon"
+            aria-haspopup={beaconOptions.length > 1 ? 'menu' : undefined}
+            aria-expanded={beaconOptions.length > 1 ? beaconMenuOpen : undefined}
+            aria-label="Send Beacon"
+            title="Send an APRS position beacon now"
+          >
+            {sendingBeacon ? 'Sending…' : 'Send Beacon'}
+          </button>
+          {#if beaconMenuOpen && beaconOptions.length > 1}
+            <div class="beacon-menu" role="menu" data-testid="send-beacon-menu">
+              {#each beaconOptions as opt (opt.id)}
+                <button
+                  type="button"
+                  role="menuitem"
+                  class="beacon-menu-item"
+                  onclick={() => sendBeacon(opt.id)}
+                >
+                  {opt.label}
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </div>
         <button
           type="button"
           class="route-toolbar-item"
@@ -507,6 +603,50 @@
     background: var(--color-surface-raised);
     color: var(--color-primary);
     border-color: var(--color-border);
+  }
+  .route-toolbar-item:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+  /* Send Beacon is the primary action here, so give it a standing accent
+     rather than the muted resting state the other toolbar items use. */
+  .beacon-send {
+    color: var(--color-primary);
+    border-color: var(--color-border);
+  }
+  .beacon-control {
+    position: relative;
+    display: inline-flex;
+  }
+  .beacon-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 20;
+    min-width: 160px;
+    display: flex;
+    flex-direction: column;
+    padding: 4px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    background: var(--color-surface);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28);
+  }
+  .beacon-menu-item {
+    background: transparent;
+    border: 0;
+    border-radius: var(--radius);
+    color: var(--color-text);
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    text-align: left;
+    padding: 6px 10px;
+    white-space: nowrap;
+  }
+  .beacon-menu-item:hover {
+    background: var(--color-surface-raised);
+    color: var(--color-primary);
   }
   .messages-shell {
     display: grid;


### PR DESCRIPTION
## What

Adds a **Send Beacon** button to the Messages view so APRSOTA operators can beacon their position without leaving the inbox while working a summit or hosting a session.

Closes #522.

## How

- New "Send Beacon" control in the Messages list-pane toolbar (beside "Manage OTP Secrets").
- Reuses the existing per-beacon send path `POST /beacons/{id}/send` — the same call `Beacons.svelte` already uses for "Beacon Now". The endpoint carries no body, so the beacon's configured **position source** (live GPS / GPSD or fixed coordinates) is honored automatically; no position logic is duplicated.
- Behavior scales to the station's config:
  - **1 enabled beacon** -> sends immediately on click.
  - **several** -> opens a small picker menu to choose which beacon.
  - **none** -> a toast points the operator to the Beacons page.
- Success / failure feedback via the standard `toasts` used elsewhere.
- The "which beacons are offered" rule (enabled beacons only, labeled via `beaconLabel`) lives in a pure helper `web/src/lib/messagesBeacon.js` with unit tests.

## Testing

- `npm test` (web): 479/479 pass, including the new `messagesBeacon.test.js`.
- `npm run build` (web): succeeds.

## Docs

- `docs/wiki/code-map.md` gains a "Send Beacon from Messages" section.
