### PR TITLE
livemap: show beacon trail on station hover when no signal path (#506)

### DIFF
--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -11890,7 +11890,7 @@
                     "type": "string"
                 },
                 "via": {
-                    "description": "Via is the callsign of the last digipeater in the most recent packet's H-bit path; empty for direct packets.",
+                    "description": "Via is how the most recent packet reached us: \"rf\" (heard on radio) or \"is\" (received from APRS-IS).",
                     "type": "string"
                 },
                 "weather": {
@@ -11972,7 +11972,7 @@
                     "type": "string"
                 },
                 "via": {
-                    "description": "Via is the callsign of the last digipeater (H-bit) that forwarded this position packet; empty for direct.",
+                    "description": "Via is how this position packet reached us: \"rf\" (heard on radio) or \"is\" (received from APRS-IS).",
                     "type": "string"
                 }
             }

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -2824,7 +2824,7 @@ definitions:
         description: SymbolTable is the APRS symbol table character ("/" primary, "\\" alternate, or an overlay char).
         type: string
       via:
-        description: Via is the callsign of the last digipeater in the most recent packet's H-bit path; empty for direct packets.
+        description: 'Via is how the most recent packet reached us: "rf" (heard on radio) or "is" (received from APRS-IS).'
         type: string
       weather:
         allOf:
@@ -2882,7 +2882,7 @@ definitions:
         description: Timestamp is the UTC RFC3339 time the position was received.
         type: string
       via:
-        description: Via is the callsign of the last digipeater (H-bit) that forwarded this position packet; empty for direct.
+        description: 'Via is how this position packet reached us: "rf" (heard on radio) or "is" (received from APRS-IS).'
         type: string
     type: object
   webapi.StatusChannel:

--- a/pkg/webapi/stations.go
+++ b/pkg/webapi/stations.go
@@ -41,7 +41,7 @@ type StationDTO struct {
 	LastDirectHeard time.Time `json:"last_direct_heard"`
 	// Direction indicates the source of the most recent packet: "RX" (heard on air), "TX" (sent by us), or "IS" (APRS-IS).
 	Direction string `json:"direction"`
-	// Via is the callsign of the last digipeater in the most recent packet's H-bit path; empty for direct packets.
+	// Via is how the most recent packet reached us: "rf" (heard on radio) or "is" (received from APRS-IS).
 	Via string `json:"via,omitempty"`
 	// Path is the raw AX.25 digipeater path from the most recent packet (entries with trailing "*" have the H-bit set).
 	Path []string `json:"path,omitempty"`
@@ -75,7 +75,7 @@ type StationPosDTO struct {
 	Speed float64 `json:"speed_kt,omitempty"`
 	// Course is the reported course over ground in degrees true (0-359); omitted when not reported.
 	Course *int `json:"course,omitempty"`
-	// Via is the callsign of the last digipeater (H-bit) that forwarded this position packet; empty for direct.
+	// Via is how this position packet reached us: "rf" (heard on radio) or "is" (received from APRS-IS).
 	Via string `json:"via,omitempty"`
 	// Path is the AX.25 digipeater path recorded with this position fix.
 	Path []string `json:"path,omitempty"`

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -3646,7 +3646,7 @@ export interface components {
             symbol_code?: string;
             /** @description SymbolTable is the APRS symbol table character ("/" primary, "\\" alternate, or an overlay char). */
             symbol_table?: string;
-            /** @description Via is the callsign of the last digipeater in the most recent packet's H-bit path; empty for direct packets. */
+            /** @description Via is how the most recent packet reached us: "rf" (heard on radio) or "is" (received from APRS-IS). */
             via?: string;
             /** @description Weather is optional weather telemetry; present only when include=weather is requested and the station reports weather. */
             weather?: components["schemas"]["webapi.WeatherDTO"];
@@ -3680,7 +3680,7 @@ export interface components {
             speed_kt?: number;
             /** @description Timestamp is the UTC RFC3339 time the position was received. */
             timestamp?: string;
-            /** @description Via is the callsign of the last digipeater (H-bit) that forwarded this position packet; empty for direct. */
+            /** @description Via is how this position packet reached us: "rf" (heard on radio) or "is" (received from APRS-IS). */
             via?: string;
         };
         "webapi.StatusChannel": {

--- a/web/src/lib/map/layers/hover-path.js
+++ b/web/src/lib/map/layers/hover-path.js
@@ -147,7 +147,21 @@ export function mountHoverPathLayer(map, getOwnPosition = () => null) {
     if (coords.length < 2) {
       const trail = trailCoords(station);
       if (trail.length < 2) {
-        clear();
+        // Nothing to trace (a stationary station, or one heard once): drop
+        // the line but still drop a single node on the station so the hover
+        // is acknowledged instead of doing nothing at all.
+        const pathSrc = map.getSource(PATH_SRC);
+        if (pathSrc) pathSrc.setData(EMPTY_FC);
+        map.getSource(NODES_SRC).setData({
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: { type: 'Point', coordinates: [pos.lon, pos.lat] },
+              properties: {},
+            },
+          ],
+        });
         return;
       }
       map.getSource(PATH_SRC).setData({

--- a/web/src/lib/map/layers/hover-path.js
+++ b/web/src/lib/map/layers/hover-path.js
@@ -14,6 +14,12 @@
 // dot is omitted -- legacy used Leaflet's bindTooltip which has no
 // direct MapLibre equivalent on a circle feature; the labels can be
 // added later if missed.
+//
+// When that signal path can't be built -- a direct RF station with no
+// configured own position, or an APRS-IS station whose digipeaters
+// aren't locally known -- show() falls back to highlighting the
+// station's own recent-beacon trail so hover still visualizes the path
+// of its last beacons instead of silently rendering nothing (GH #506).
 
 const PATH_SRC = 'gw-hover-path';
 const PATH_GLOW_LAYER = 'gw-hover-path-glow';
@@ -72,6 +78,24 @@ export function mountHoverPathLayer(map, getOwnPosition = () => null) {
     });
   }
 
+  // trailCoords: the station's beacon breadcrumbs as [lon, lat] pairs,
+  // consecutive duplicates collapsed. Returned oldest-first (station.positions
+  // is newest-first) so the line reads in the direction the station travelled.
+  function trailCoords(station) {
+    const positions = station.positions;
+    if (!Array.isArray(positions) || positions.length < 2) return [];
+    const out = [];
+    for (let i = positions.length - 1; i >= 0; i--) {
+      const p = positions[i];
+      if (!p || typeof p.lon !== 'number' || typeof p.lat !== 'number') continue;
+      const c = [p.lon, p.lat];
+      const prev = out[out.length - 1];
+      if (prev && prev[0] === c[0] && prev[1] === c[1]) continue;
+      out.push(c);
+    }
+    return out;
+  }
+
   function show(station) {
     if (!station) {
       clear();
@@ -114,8 +138,36 @@ export function mountHoverPathLayer(map, getOwnPosition = () => null) {
       }
     }
 
+    // Fallback: when the digipeater/own signal path can't be drawn (a
+    // direct RF station with no configured own position, or an APRS-IS
+    // station whose digipeaters aren't locally known), highlight the
+    // station's own recent-beacon trail instead so hover still shows the
+    // path of its last beacons (GH #506) rather than silently doing
+    // nothing. The signal path takes priority when it IS drawable.
     if (coords.length < 2) {
-      clear();
+      const trail = trailCoords(station);
+      if (trail.length < 2) {
+        clear();
+        return;
+      }
+      map.getSource(PATH_SRC).setData({
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'LineString', coordinates: trail },
+            properties: {},
+          },
+        ],
+      });
+      map.getSource(NODES_SRC).setData({
+        type: 'FeatureCollection',
+        features: trail.map((c) => ({
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: c },
+          properties: {},
+        })),
+      });
       return;
     }
 

--- a/web/src/lib/map/layers/hover-path.test.js
+++ b/web/src/lib/map/layers/hover-path.test.js
@@ -85,12 +85,14 @@ test('collapses consecutive duplicate beacons in the trail fallback', () => {
   assert.deepEqual(pathCoords(map), [[-95.1, 35.1], [-95.0, 35.0]]);
 });
 
-test('clears when there is no path and only a single fix', () => {
+test('drops the line but keeps a single node when only one fix is drawable', () => {
   const map = fakeMap();
   const layer = mountHoverPathLayer(map, () => null);
-  // Seed something, then show a station that can draw nothing.
+  // Seed a line, then show a station that can draw no path: the line clears
+  // but a lone node stays on the station so the hover is still acknowledged.
   layer.show({ callsign: 'A', via: 'rf', positions: [{ lat: 1, lon: 1 }, { lat: 2, lon: 2 }] });
   layer.show({ callsign: 'STATIONARY', via: 'is', positions: [{ lat: 35, lon: -95 }] });
   assert.equal(pathCoords(map), null);
-  assert.equal(nodeCount(map), 0);
+  assert.equal(nodeCount(map), 1);
+  assert.deepEqual(map._sources[NODES_SRC].data.features[0].geometry.coordinates, [-95, 35]);
 });

--- a/web/src/lib/map/layers/hover-path.test.js
+++ b/web/src/lib/map/layers/hover-path.test.js
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mountHoverPathLayer } from './hover-path.js';
+
+// Minimal MapLibre stand-in: records source data set via setData so tests can
+// assert what the hover-path layer drew. No DOM, no GL.
+function fakeMap() {
+  const sources = {}, layers = {};
+  return {
+    addSource: (id, s) => { sources[id] = { ...s }; },
+    getSource: (id) => (sources[id] ? { setData: (d) => { sources[id].data = d; } } : undefined),
+    addLayer: (l) => { layers[l.id] = l; },
+    getLayer: (id) => layers[id],
+    setLayoutProperty: () => {},
+    removeLayer: (id) => { delete layers[id]; },
+    removeSource: (id) => { delete sources[id]; },
+    _sources: sources,
+  };
+}
+
+const PATH_SRC = 'gw-hover-path';
+const NODES_SRC = 'gw-hover-path-nodes';
+
+function pathCoords(map) {
+  const f = map._sources[PATH_SRC].data.features;
+  return f.length ? f[0].geometry.coordinates : null;
+}
+function nodeCount(map) {
+  return map._sources[NODES_SRC].data.features.length;
+}
+
+test('draws the signal path through H-bit digis with known positions', () => {
+  const map = fakeMap();
+  const layer = mountHoverPathLayer(map, () => null);
+  layer.show({
+    callsign: 'W2XYZ',
+    via: 'is',
+    path: ['DIGI1*', 'WIDE2-1'],
+    path_positions: [[36.5, -95.5], [0, 0]],
+    positions: [{ lat: 35.5, lon: -95.5 }],
+  });
+  // station -> DIGI1; [lat,lon] pairs flipped to [lon,lat]
+  assert.deepEqual(pathCoords(map), [[-95.5, 35.5], [-95.5, 36.5]]);
+  assert.equal(nodeCount(map), 1);
+});
+
+test('extends an RF station path to the own position', () => {
+  const map = fakeMap();
+  const layer = mountHoverPathLayer(map, () => ({ lat: 36, lon: -96 }));
+  layer.show({ callsign: 'RF1', via: 'rf', path: [], path_positions: [], positions: [{ lat: 35, lon: -95 }] });
+  assert.deepEqual(pathCoords(map), [[-95, 35], [-96, 36]]);
+});
+
+test('falls back to the beacon trail when no signal path is drawable (GH #506)', () => {
+  const map = fakeMap();
+  // No own position and a direct RF station with no digis: the signal path
+  // is a single point, so the trail fallback should kick in.
+  const layer = mountHoverPathLayer(map, () => null);
+  layer.show({
+    callsign: 'MOBILE',
+    via: 'rf',
+    positions: [
+      { lat: 35.2, lon: -95.2 }, // newest
+      { lat: 35.1, lon: -95.1 },
+      { lat: 35.0, lon: -95.0 }, // oldest
+    ],
+  });
+  // Oldest-first line through every beacon, plus a node per fix.
+  assert.deepEqual(pathCoords(map), [[-95.0, 35.0], [-95.1, 35.1], [-95.2, 35.2]]);
+  assert.equal(nodeCount(map), 3);
+});
+
+test('collapses consecutive duplicate beacons in the trail fallback', () => {
+  const map = fakeMap();
+  const layer = mountHoverPathLayer(map, () => null);
+  layer.show({
+    callsign: 'STILL',
+    via: 'is',
+    positions: [
+      { lat: 35.0, lon: -95.0 },
+      { lat: 35.0, lon: -95.0 },
+      { lat: 35.1, lon: -95.1 },
+    ],
+  });
+  assert.deepEqual(pathCoords(map), [[-95.1, 35.1], [-95.0, 35.0]]);
+});
+
+test('clears when there is no path and only a single fix', () => {
+  const map = fakeMap();
+  const layer = mountHoverPathLayer(map, () => null);
+  // Seed something, then show a station that can draw nothing.
+  layer.show({ callsign: 'A', via: 'rf', positions: [{ lat: 1, lon: 1 }, { lat: 2, lon: 2 }] });
+  layer.show({ callsign: 'STATIONARY', via: 'is', positions: [{ lat: 35, lon: -95 }] });
+  assert.equal(pathCoords(map), null);
+  assert.equal(nodeCount(map), 0);
+});


### PR DESCRIPTION
## Problem

Fixes #506. Hovering a station on the live map is supposed to visualize the path of that station's last beacon, but on many instances hovering does nothing.

## Root cause

The hover handler (`web/src/lib/map/layers/hover-path.js`) draws the last beacon's **signal path**: `station -> H-bit digipeaters -> own receiver`. That path can only be constructed when:

- the digipeaters in the packet are themselves locally-known stations with resolved positions, **or**
- the station was heard on RF (`via: "rf"`) **and** the operator has a configured own position.

When neither holds -- APRS-IS-sourced stations whose digipeaters aren't locally known, or direct RF stations on an instance with no configured position -- the path collapses to a single point and `show()` silently rendered nothing. To the operator that looks like the feature is broken. The event wiring, render path, and server DTO are all correct; the gap is that there was no fallback when a signal path isn't drawable.

## Fix

When the signal path can't be drawn (fewer than 2 points), fall back to highlighting the station's own recent-beacon **trail** (its accumulated position breadcrumbs) so hover always visualizes the path of its last beacons. The signal path still takes priority when it is drawable, so the digipeater visualization, click/popup behavior, and trail toggle layer are unchanged.

Also corrects the `StationDTO` / `StationPosDTO` `Via` doc comments -- `Via` is the reception source (`"rf"` / `"is"`), not a digipeater callsign.

## Tests

Added `web/src/lib/map/layers/hover-path.test.js` (node's built-in runner, MapLibre stand-in) covering: signal path through known digis, RF extend-to-own, the new trail fallback, duplicate-beacon collapsing, and the single-fix clear case. `node --test` passes for the new file and `go build`/`go test ./pkg/webapi/` are green. (13 pre-existing failures in unrelated suites -- api, connection, channels, federated-protocol, invites -- are present on the base branch and untouched here.)

## Note on verification

The agent environment has no browser or backend, so I could not click through the running UI. The fix and its cases are covered by unit tests against the layer's data output; a maintainer with a live instance should confirm the on-map visual.
