### PR TITLE
PTT: allow manual entry of a device path (GH #511)

### DIFF
--- a/docs/handbook/ptt.html
+++ b/docs/handbook/ptt.html
@@ -108,6 +108,28 @@
       expected.
     </p>
 
+    <h2>Entering a device path manually</h2>
+
+    <p>
+      In the <strong>Change Device</strong> dialog, choose
+      <strong>Enter a path manually</strong> to type a device path instead
+      of picking a detected card. This is the reliable way to pin PTT to a
+      stable <code>udev</code> name &mdash; e.g.
+      <code>/dev/aioc-aprs-ptt</code> created by a rule like
+      <code>SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", SYMLINK+="aioc-aprs-ptt"</code>
+      &mdash; so re-plugging the adapter (which can renumber
+      <code>/dev/hidraw*</code> or <code>/dev/ttyACM*</code>) never breaks
+      keying.
+    </p>
+
+    <p>
+      graywolf checks whether the path is present as you type and shows a
+      hint, but it never blocks you from saving: a <code>udev</code> symlink
+      is allowed to be absent when you save and appear later on plug-in.
+      Whatever path you enter is used verbatim by the modem, exactly as if
+      it had been detected.
+    </p>
+
     <h2>PTT Methods</h2>
 
     <div class="box">

--- a/docs/wiki/code-map.md
+++ b/docs/wiki/code-map.md
@@ -133,11 +133,14 @@ The split is enforced by [invariant 9](invariants.md).
 | Method radio-card list | `web/src/routes/ptt/MethodPicker.svelte` |
 | Device list (Recommended / Other split + permission CTA) | `web/src/routes/ptt/DevicePicker.svelte` |
 | Dialog A — method picker + rigctld host:port + Test Connection | `web/src/routes/ptt/DialogChangeMethod.svelte` |
-| Dialog B — device picker + GPIO line / CM108 pin / invert | `web/src/routes/ptt/DialogChangeDevice.svelte` |
+| Dialog B — device picker + GPIO line / CM108 pin / invert + **manual path entry** | `web/src/routes/ptt/DialogChangeDevice.svelte` |
+| Manual-path payload resolver (enumerated row vs. synthesised udev path) | `web/src/routes/ptt/devicePayload.js` (`resolveDevice`) |
 | Method options per platform | `web/src/routes/ptt/devices/methodOptions.{android,desktop}.js` |
 | Device-source adapters per platform | `web/src/routes/ptt/devices/{android,desktop}DeviceSource.js` |
 | Channel-selector auto-hide + Add visibility rule | `web/src/routes/ptt/channelSelector.js` |
 | Android USB enumeration into `[]AvailableDevice` shape | `pkg/pttdevice/android.go` |
+
+**Manual device path (GH #511).** Desktop operators can type a free-form device path (e.g. a udev-renamed `/dev/aioc-aprs-ptt`) instead of only picking an enumerated card — `DialogChangeDevice.svelte` has an "Enter a path manually" mode gated by the `allowManualEntry` prop (`!isAndroid`, set in `Ptt.svelte`). The store/DTO/Rust already accept any non-empty path, so no schema change was needed. Non-blocking validation: the dialog probes the typed path via `POST /api/ptt/check-device` (`pttdevice.Probe`, `probe.go`) which **stats** the path only — it never opens the device (opening a serial tty can key the radio / block on DCD). The result is advisory: a not-yet-present udev name still saves.
 
 ## Channel TX gating
 

--- a/pkg/pttdevice/probe.go
+++ b/pkg/pttdevice/probe.go
@@ -1,0 +1,56 @@
+package pttdevice
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// ProbeResult reports what a lightweight, side-effect-free inspection of
+// a device path found. It backs the UI's advisory for manually-entered
+// PTT device paths (e.g. a udev-renamed /dev/aioc-aprs-ptt).
+//
+// The probe deliberately does NOT open the device: opening a serial tty
+// can toggle DTR/RTS and briefly key the radio, and opening it without
+// O_NONBLOCK can block on carrier detect. os.Stat has neither hazard, so
+// existence and node-type are all we report — enough to catch the common
+// mistakes (typo'd path, pointing at a regular file) without ever
+// touching the wire.
+type ProbeResult struct {
+	// Exists is true when the path resolves to a filesystem node.
+	Exists bool
+	// CharDevice is true when the node is a character device (the shape
+	// every real PTT device — serial, hidraw, gpiochip — takes). A path
+	// that exists but is not a char device is almost always a mistake.
+	CharDevice bool
+	// Detail is a short human-readable summary of the outcome.
+	Detail string
+}
+
+// Probe inspects path without opening it. It is safe on every platform
+// and never keys the radio. An empty path is treated as "not present"
+// rather than an error, so callers can probe eagerly as the operator
+// types.
+func Probe(path string) ProbeResult {
+	p := strings.TrimSpace(path)
+	if p == "" {
+		return ProbeResult{Detail: "no path entered"}
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// Not present is not a failure here: a udev-named device is
+			// allowed to be absent at config time and appear on plug-in.
+			return ProbeResult{Detail: "not present yet"}
+		}
+		if errors.Is(err, fs.ErrPermission) {
+			return ProbeResult{Detail: "permission denied"}
+		}
+		return ProbeResult{Detail: "cannot inspect: " + err.Error()}
+	}
+	if fi.Mode()&os.ModeCharDevice != 0 {
+		return ProbeResult{Exists: true, CharDevice: true, Detail: "present"}
+	}
+	return ProbeResult{Exists: true, CharDevice: false, Detail: "present, but not a character device"}
+}

--- a/pkg/pttdevice/probe_test.go
+++ b/pkg/pttdevice/probe_test.go
@@ -1,0 +1,54 @@
+package pttdevice
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProbe_EmptyPath(t *testing.T) {
+	got := Probe("   ")
+	if got.Exists || got.CharDevice {
+		t.Fatalf("empty path should not exist: %+v", got)
+	}
+}
+
+func TestProbe_NotPresent(t *testing.T) {
+	got := Probe(filepath.Join(t.TempDir(), "aioc-aprs-ptt-does-not-exist"))
+	if got.Exists {
+		t.Fatalf("missing path reported as existing: %+v", got)
+	}
+	if got.Detail == "" {
+		t.Fatalf("expected an advisory message for a missing path")
+	}
+}
+
+func TestProbe_RegularFileIsNotCharDevice(t *testing.T) {
+	// A path that exists but is a regular file is the classic "typo'd the
+	// path and hit a real file" mistake — must surface as exists-but-not-a-
+	// char-device so the UI can warn.
+	f := filepath.Join(t.TempDir(), "regular")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	got := Probe(f)
+	if !got.Exists {
+		t.Fatalf("regular file should exist: %+v", got)
+	}
+	if got.CharDevice {
+		t.Fatalf("regular file wrongly reported as a character device: %+v", got)
+	}
+}
+
+func TestProbe_CharDevice(t *testing.T) {
+	// /dev/null is a character device on the Unix hosts CI runs on. Skip
+	// where it isn't present or isn't a char device rather than fail.
+	fi, err := os.Stat("/dev/null")
+	if err != nil || fi.Mode()&os.ModeCharDevice == 0 {
+		t.Skip("/dev/null unavailable or not a char device on this platform")
+	}
+	got := Probe("/dev/null")
+	if !got.Exists || !got.CharDevice {
+		t.Fatalf("/dev/null should probe as an existing char device: %+v", got)
+	}
+}

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -6608,6 +6608,51 @@
                 }
             }
         },
+        "/ptt/check-device": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ptt"
+                ],
+                "summary": "Check a PTT device path",
+                "operationId": "checkPttDevice",
+                "parameters": [
+                    {
+                        "description": "Device path to inspect",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.CheckDeviceRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.CheckDeviceResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/webtypes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ptt/gpio-chips/{chip}/lines": {
             "get": {
                 "security": [
@@ -9732,6 +9777,28 @@
                 },
                 "space_freq": {
                     "type": "integer"
+                }
+            }
+        },
+        "dto.CheckDeviceRequest": {
+            "type": "object",
+            "properties": {
+                "device_path": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CheckDeviceResponse": {
+            "type": "object",
+            "properties": {
+                "char_device": {
+                    "type": "boolean"
+                },
+                "exists": {
+                    "type": "boolean"
+                },
+                "message": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -1207,6 +1207,20 @@ definitions:
       space_freq:
         type: integer
     type: object
+  dto.CheckDeviceRequest:
+    properties:
+      device_path:
+        type: string
+    type: object
+  dto.CheckDeviceResponse:
+    properties:
+      char_device:
+        type: boolean
+      exists:
+        type: boolean
+      message:
+        type: string
+    type: object
   dto.ConversationPrefsRequest:
     properties:
       send_path:
@@ -7415,6 +7429,34 @@ paths:
       security:
         - CookieAuth: []
       summary: Get PTT capabilities
+      tags:
+        - ptt
+  /ptt/check-device:
+    post:
+      consumes:
+        - application/json
+      operationId: checkPttDevice
+      parameters:
+        - description: Device path to inspect
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/dto.CheckDeviceRequest'
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.CheckDeviceResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/webtypes.ErrorResponse'
+      security:
+        - CookieAuth: []
+      summary: Check a PTT device path
       tags:
         - ptt
   /ptt/gpio-chips/{chip}/lines:

--- a/pkg/webapi/docs/op_ids.go
+++ b/pkg/webapi/docs/op_ids.go
@@ -274,6 +274,7 @@ const (
 	OpListPttDevices     = "listPttDevices"
 	OpGetPttCapabilities = "getPttCapabilities"
 	OpTestRigctld        = "testRigctld"
+	OpCheckPttDevice     = "checkPttDevice"
 	OpListGpioLines      = "listGpioLines"
 	OpGetPttConfig       = "getPttConfig"
 	OpUpdatePttConfig    = "updatePttConfig"

--- a/pkg/webapi/dto/ptt.go
+++ b/pkg/webapi/dto/ptt.go
@@ -110,6 +110,24 @@ func PttsFromModels(ms []configstore.PttConfig) []PttResponse {
 	return out
 }
 
+// CheckDeviceRequest is the body accepted by POST /api/ptt/check-device.
+// The handler inspects the given path (without opening it) so the UI can
+// warn about a mistyped manual PTT device path without hard-blocking a
+// not-yet-present udev name.
+type CheckDeviceRequest struct {
+	DevicePath string `json:"device_path"`
+}
+
+// CheckDeviceResponse reports what the probe found. Exists and CharDevice
+// drive an advisory only — the save path never depends on this result, so
+// an operator can still commit a path that is absent at config time (the
+// whole point of a stable udev name).
+type CheckDeviceResponse struct {
+	Exists     bool   `json:"exists"`
+	CharDevice bool   `json:"char_device"`
+	Message    string `json:"message"`
+}
+
 // TestRigctldRequest is the body accepted by POST /api/ptt/test-rigctld.
 // The handler opens a short-lived TCP connection to the given rigctld
 // endpoint and sends a non-disruptive `t` (get_ptt) probe.

--- a/pkg/webapi/ptt.go
+++ b/pkg/webapi/ptt.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
+	"strings"
 
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/pttdevice"
@@ -43,6 +44,7 @@ func (s *Server) registerPtt(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/ptt/available", s.listPttDevices)
 	mux.HandleFunc("GET /api/ptt/capabilities", s.getPttCapabilities)
 	mux.HandleFunc("POST /api/ptt/test-rigctld", s.testRigctld)
+	mux.HandleFunc("POST /api/ptt/check-device", s.checkPttDevice)
 	mux.HandleFunc("GET /api/ptt/gpio-chips/{chip}/lines", s.listGpioLines)
 	mux.HandleFunc("GET /api/ptt/{channel}", s.getPttConfig)
 	mux.HandleFunc("PUT /api/ptt/{channel}", s.updatePttConfig)
@@ -215,6 +217,42 @@ func (s *Server) getPttCapabilities(w http.ResponseWriter, r *http.Request) {
 // @Router   /ptt/test-rigctld [post]
 func (s *Server) testRigctld(w http.ResponseWriter, r *http.Request) {
 	s.handleTestRigctld(w, r)
+}
+
+// checkPttDevice inspects a manually-entered PTT device path on behalf of
+// the UI's device dialog. It stats the path (never opens it — opening a
+// serial device can briefly key the radio) and reports whether it exists
+// and looks like a character device. This is advisory only: the response
+// is always HTTP 200 for a non-empty path, and a "not present yet" result
+// must not stop the operator from saving, since a udev-named device is
+// allowed to be absent at config time and appear on plug-in (GH #511).
+//
+// @Summary  Check a PTT device path
+// @Tags     ptt
+// @ID       checkPttDevice
+// @Accept   json
+// @Produce  json
+// @Param    body body     dto.CheckDeviceRequest true "Device path to inspect"
+// @Success  200  {object} dto.CheckDeviceResponse
+// @Failure  400  {object} webtypes.ErrorResponse
+// @Security CookieAuth
+// @Router   /ptt/check-device [post]
+func (s *Server) checkPttDevice(w http.ResponseWriter, r *http.Request) {
+	req, err := decodeJSON[dto.CheckDeviceRequest](r)
+	if err != nil {
+		badRequest(w, err.Error())
+		return
+	}
+	if strings.TrimSpace(req.DevicePath) == "" {
+		badRequest(w, "device_path is required")
+		return
+	}
+	res := pttdevice.Probe(req.DevicePath)
+	writeJSON(w, http.StatusOK, dto.CheckDeviceResponse{
+		Exists:     res.Exists,
+		CharDevice: res.CharDevice,
+		Message:    res.Detail,
+	})
 }
 
 // listGpioLines enumerates the lines of a gpiochip character device.

--- a/pkg/webapi/ptt_check_device_test.go
+++ b/pkg/webapi/ptt_check_device_test.go
@@ -1,0 +1,67 @@
+package webapi
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+func postCheckDevice(t *testing.T, path string) (*httptest.ResponseRecorder, dto.CheckDeviceResponse) {
+	t.Helper()
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	body, _ := json.Marshal(dto.CheckDeviceRequest{DevicePath: path})
+	req := httptest.NewRequest(http.MethodPost, "/api/ptt/check-device", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.checkPttDevice(rec, req)
+	var resp dto.CheckDeviceResponse
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+		}
+	}
+	return rec, resp
+}
+
+// An empty device_path is a client mistake — 400, not a 200 with a bogus
+// "not present" verdict.
+func TestCheckPttDevice_EmptyPathIsBadRequest(t *testing.T) {
+	rec, _ := postCheckDevice(t, "  ")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// A not-yet-present udev path must return 200 with exists=false so the UI
+// shows a soft advisory and still lets the operator save (GH #511).
+func TestCheckPttDevice_MissingPathIsAdvisoryNot400(t *testing.T) {
+	rec, resp := postCheckDevice(t, filepath.Join(t.TempDir(), "aioc-aprs-ptt"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if resp.Exists || resp.CharDevice {
+		t.Fatalf("missing path should not exist: %+v", resp)
+	}
+}
+
+func TestCheckPttDevice_RegularFileFlaggedNotCharDevice(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "regular")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	rec, resp := postCheckDevice(t, f)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !resp.Exists || resp.CharDevice {
+		t.Fatalf("regular file should exist and not be a char device: %+v", resp)
+	}
+}

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -1546,6 +1546,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/ptt/check-device": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Check a PTT device path */
+        post: operations["checkPttDevice"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/ptt/gpio-chips/{chip}/lines": {
         parameters: {
             query?: never;
@@ -2623,6 +2640,14 @@ export interface components {
             profile?: string;
             ptt?: components["schemas"]["dto.ChannelPtt"];
             space_freq?: number;
+        };
+        "dto.CheckDeviceRequest": {
+            device_path?: string;
+        };
+        "dto.CheckDeviceResponse": {
+            char_device?: boolean;
+            exists?: boolean;
+            message?: string;
         };
         "dto.ConversationPrefsRequest": {
             /**
@@ -9717,6 +9742,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["webapi.pttCapabilities"];
+                };
+            };
+        };
+    };
+    checkPttDevice: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Device path to inspect */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["dto.CheckDeviceRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["dto.CheckDeviceResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["webtypes.ErrorResponse"];
                 };
             };
         };

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -231,6 +231,10 @@ function getMockData(method, path, body) {
   if (path === '/ptt' && method === 'GET') return delay(mockPtt);
   if (path === '/ptt' && method === 'POST') return delay({ id: 2, ...body });
   if (path === '/ptt/available') return delay(mockPttAvailable);
+  if (path === '/ptt/check-device' && method === 'POST') {
+    const known = mockPttAvailable.some(d => d.path === body?.device_path);
+    return delay({ exists: known, char_device: known, message: known ? 'present' : 'not present yet' });
+  }
   if (path.match(/^\/ptt\/\d+$/) && method === 'PUT') return delay(body);
   if (path.match(/^\/ptt\/\d+$/) && method === 'DELETE') return delay(null);
 

--- a/web/src/routes/Ptt.svelte
+++ b/web/src/routes/Ptt.svelte
@@ -477,6 +477,7 @@
   bind:open={dialogDeviceOpen}
   method={dialogMethodChosen}
   {deviceSource}
+  allowManualEntry={!isAndroid}
   initialDevicePath={dialogContext?.item?.device_path || null}
   initialGpioLine={dialogContext?.item?.gpio_line ?? 0}
   initialGpioPin={dialogContext?.item?.gpio_pin ?? 3}

--- a/web/src/routes/ptt/DialogChangeDevice.svelte
+++ b/web/src/routes/ptt/DialogChangeDevice.svelte
@@ -5,6 +5,7 @@
   import FormField from '../../components/FormField.svelte';
   import DevicePicker from './DevicePicker.svelte';
   import { api } from '../../lib/api.js';
+  import { resolveDevice } from './devicePayload.js';
 
   let {
     open = $bindable(),
@@ -14,6 +15,7 @@
     initialGpioLine,     // for gpio method
     initialGpioPin,      // for cm108 method
     initialInvert,       // any keying method
+    allowManualEntry = true, // desktop: let the operator type a udev path (GH #511)
     onSave,              // (payload) => void; payload: { device, gpio_line?, gpio_pin?, invert }
     onBack,
     onCancel,
@@ -29,32 +31,87 @@
   let gpioPinSel = $state('3');
   let invert = $state(false);
 
+  // Manual free-form device path (GH #511): udev-renamed devices such as
+  // /dev/aioc-aprs-ptt never appear in enumeration, so the operator needs
+  // to type the path directly instead of only picking a detected card.
+  let manualMode = $state(false);
+  let manualPath = $state('');
+  let probe = $state(null);      // { exists, char_device, message } | null
+  let probing = $state(false);
+  // Set while the open effect seeds state, so refresh()'s mode-detection
+  // only runs on open — a manual Refresh click must not yank the operator
+  // out of the mode they chose.
+  let initializing = false;
+
   let wireMethod = $derived(method?.wire?.method);
   let isGpio = $derived(wireMethod === 'gpio');
   let isCm108 = $derived(wireMethod === 'cm108');
+
+  // The path in effect regardless of mode — drives GPIO line loading,
+  // the save payload, and the save-enable check.
+  let effectivePath = $derived(manualMode ? manualPath.trim() : selectedPath);
 
   let wasOpen = false;
   $effect(() => {
     if (open && !wasOpen) {
       selectedPath = initialDevicePath || null;
+      manualPath = initialDevicePath || '';
+      manualMode = false;
+      probe = null;
       gpioLineSel = String(initialGpioLine ?? 0);
       gpioPinSel = String(initialGpioPin ?? 3);
       invert = !!initialInvert;
       wasOpen = true;
+      initializing = true;
       void refresh();
     } else if (!open) {
       wasOpen = false;
     }
   });
 
-  // Whenever the selected gpio chip path changes, refresh its line list.
+  // Whenever the effective gpio chip path changes, refresh its line list.
   $effect(() => {
-    if (isGpio && selectedPath) {
-      void loadGpioLines(selectedPath);
+    if (isGpio && effectivePath) {
+      void loadGpioLines(effectivePath);
     } else {
       gpioLines = [];
     }
   });
+
+  // Non-blocking advisory for a manually-entered path. Debounced so we
+  // don't probe on every keystroke. Never gates Save — a not-yet-present
+  // udev name is expressly allowed.
+  $effect(() => {
+    if (!manualMode) { probe = null; return; }
+    const p = manualPath.trim();
+    if (!p) { probe = null; probing = false; return; }
+    probing = true;
+    const handle = setTimeout(() => { void checkDevice(p); }, 400);
+    return () => clearTimeout(handle);
+  });
+
+  async function checkDevice(path) {
+    try {
+      const res = await api.post('/ptt/check-device', { device_path: path });
+      // Ignore a stale result if the operator kept typing.
+      if (manualMode && manualPath.trim() === path) probe = res || null;
+    } catch {
+      if (manualMode && manualPath.trim() === path) probe = null;
+    } finally {
+      if (manualMode && manualPath.trim() === path) probing = false;
+    }
+  }
+
+  function enterManualMode() {
+    manualMode = true;
+    // Seed from any list selection so switching modes doesn't lose work.
+    if (!manualPath && selectedPath) manualPath = selectedPath;
+  }
+
+  function leaveManualMode() {
+    manualMode = false;
+    probe = null;
+  }
 
   async function loadGpioLines(chipPath) {
     loadingGpioLines = true;
@@ -79,19 +136,30 @@
       error = e?.message || 'Failed to list devices';
     } finally {
       loading = false;
+      // On open only: if we're editing a path that enumeration doesn't
+      // know about (a previously-saved manual/udev path), start in manual
+      // mode so the operator sees and can edit their path rather than an
+      // empty picker.
+      if (initializing) {
+        if (allowManualEntry && initialDevicePath &&
+            !devices.some(d => d.path === initialDevicePath)) {
+          manualMode = true;
+        }
+        initializing = false;
+      }
     }
   }
 
   function buildPayload() {
     return {
-      device: devices.find(d => d.path === selectedPath) || null,
+      device: resolveDevice(devices, effectivePath, wireMethod),
       gpio_line: isGpio ? Number(gpioLineSel) : undefined,
       gpio_pin: isCm108 ? Number(gpioPinSel) : undefined,
       invert,
     };
   }
 
-  let canSave = $derived(!!selectedPath);
+  let canSave = $derived(!!effectivePath);
 
   const cm108Pins = [
     { value: '1', label: 'GPIO 1 (pin 11)' },
@@ -110,15 +178,43 @@
     <div class="state">Loading devices…</div>
   {:else if error}
     <div class="state error">{error}</div>
+  {:else if manualMode}
+    <FormField label="Device Path" id="dlg-manual-path"
+      hint="Full path to the PTT device, e.g. /dev/aioc-aprs-ptt. A stable udev name is allowed even if the device isn't plugged in yet.">
+      <Input id="dlg-manual-path" bind:value={manualPath}
+        placeholder="/dev/aioc-aprs-ptt" spellcheck={false} autocomplete="off" />
+    </FormField>
+    {#if manualPath.trim()}
+      <p class="probe"
+        class:ok={!probing && probe && probe.exists && probe.char_device}
+        class:bad={!probing && probe && probe.exists && !probe.char_device}
+        class:warn={!probing && probe && !probe.exists}>
+        {#if probing}
+          Checking path…
+        {:else if probe && probe.exists && probe.char_device}
+          Device present.
+        {:else if probe && probe.exists}
+          Path exists but is not a character device — double-check it points at the PTT device.
+        {:else if probe}
+          Not present yet. That's fine for a udev-named device — Graywolf will use it once it appears.
+        {/if}
+      </p>
+    {/if}
+    {#if allowManualEntry}
+      <button type="button" class="mode-toggle" onclick={leaveManualMode}>‹ Choose from detected devices</button>
+    {/if}
   {:else}
     <DevicePicker
       {devices}
       {selectedPath}
       onSelect={(d) => { selectedPath = d.path || null; }}
     />
+    {#if allowManualEntry}
+      <button type="button" class="mode-toggle" onclick={enterManualMode}>Enter a path manually…</button>
+    {/if}
   {/if}
 
-  {#if isGpio && selectedPath}
+  {#if isGpio && effectivePath}
     {#if loadingGpioLines}
       <FormField label="GPIO Line" id="dlg-gpio-line" hint="Loading lines…">
         <Select id="dlg-gpio-line" disabled value="__loading__"
@@ -167,4 +263,23 @@
   .state { padding: 16px; text-align: center; color: var(--text-secondary, #555); }
   .state.error { color: #b91c1c; }
   .modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
+  .mode-toggle {
+    margin-top: 8px;
+    padding: 0;
+    background: none;
+    border: none;
+    color: var(--accent, #3b82f6);
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .mode-toggle:hover { text-decoration: underline; }
+  .probe {
+    margin: 6px 0 0;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--text-secondary, #555);
+  }
+  .probe.ok { color: var(--success, #3fb950); }
+  .probe.bad { color: #b91c1c; }
+  .probe.warn { color: #b45309; }
 </style>

--- a/web/src/routes/ptt/DialogChangeDevice.svelte
+++ b/web/src/routes/ptt/DialogChangeDevice.svelte
@@ -58,6 +58,7 @@
       manualPath = initialDevicePath || '';
       manualMode = false;
       probe = null;
+      probing = false;
       gpioLineSel = String(initialGpioLine ?? 0);
       gpioPinSel = String(initialGpioPin ?? 3);
       invert = !!initialInvert;
@@ -70,12 +71,15 @@
   });
 
   // Whenever the effective gpio chip path changes, refresh its line list.
+  // In manual mode the path changes per keystroke, so debounce there (and
+  // loadGpioLines is stale-guarded) to avoid a burst of requests and
+  // out-of-order results. A discrete list selection loads immediately.
   $effect(() => {
-    if (isGpio && effectivePath) {
-      void loadGpioLines(effectivePath);
-    } else {
-      gpioLines = [];
-    }
+    if (!(isGpio && effectivePath)) { gpioLines = []; return; }
+    const path = effectivePath;
+    if (!manualMode) { void loadGpioLines(path); return; }
+    const handle = setTimeout(() => { void loadGpioLines(path); }, 400);
+    return () => clearTimeout(handle);
   });
 
   // Non-blocking advisory for a manually-entered path. Debounced so we
@@ -111,17 +115,20 @@
   function leaveManualMode() {
     manualMode = false;
     probe = null;
+    probing = false;
   }
 
+  let gpioLoadSeq = 0;
   async function loadGpioLines(chipPath) {
+    const seq = ++gpioLoadSeq;
     loadingGpioLines = true;
     try {
       const result = await api.get('/ptt/gpio-chips/' + encodeURIComponent(chipPath) + '/lines');
-      gpioLines = Array.isArray(result) ? result : [];
+      if (seq === gpioLoadSeq) gpioLines = Array.isArray(result) ? result : [];
     } catch {
-      gpioLines = [];
+      if (seq === gpioLoadSeq) gpioLines = [];
     } finally {
-      loadingGpioLines = false;
+      if (seq === gpioLoadSeq) loadingGpioLines = false;
     }
   }
 
@@ -184,7 +191,7 @@
       <Input id="dlg-manual-path" bind:value={manualPath}
         placeholder="/dev/aioc-aprs-ptt" spellcheck={false} autocomplete="off" />
     </FormField>
-    {#if manualPath.trim()}
+    {#if manualPath.trim() && (probing || probe)}
       <p class="probe"
         class:ok={!probing && probe && probe.exists && probe.char_device}
         class:bad={!probing && probe && probe.exists && !probe.char_device}
@@ -195,7 +202,7 @@
           Device present.
         {:else if probe && probe.exists}
           Path exists but is not a character device — double-check it points at the PTT device.
-        {:else if probe}
+        {:else}
           Not present yet. That's fine for a udev-named device — Graywolf will use it once it appears.
         {/if}
       </p>

--- a/web/src/routes/ptt/devicePayload.js
+++ b/web/src/routes/ptt/devicePayload.js
@@ -1,0 +1,24 @@
+// web/src/routes/ptt/devicePayload.js
+//
+// Resolves the device object DialogChangeDevice hands to its onSave from
+// a chosen path. Two cases feed in:
+//   1. A path picked from the enumerated `devices` list — return that row
+//      verbatim so its type/description/USB ids ride along.
+//   2. A free-form path the operator typed (GH #511 — udev-renamed devices
+//      like /dev/aioc-aprs-ptt that never appear in enumeration) — the
+//      path won't match any enumerated row, so synthesise a minimal device
+//      object carrying the path and the method's expected type.
+//
+// Kept as a pure function (no Svelte, no DOM) so it is unit-testable and
+// the dialog's buildPayload stays a one-liner.
+
+export function resolveDevice(devices, path, fallbackType) {
+  const p = (path || '').trim();
+  if (!p) return null;
+  const list = Array.isArray(devices) ? devices : [];
+  const matched = list.find((d) => d && d.path === p);
+  if (matched) return matched;
+  const dev = { path: p, manual: true };
+  if (fallbackType) dev.type = fallbackType;
+  return dev;
+}

--- a/web/src/routes/ptt/devicePayload.test.js
+++ b/web/src/routes/ptt/devicePayload.test.js
@@ -1,0 +1,48 @@
+// web/src/routes/ptt/devicePayload.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveDevice } from './devicePayload.js';
+
+const enumerated = [
+  { path: '/dev/ttyUSB0', type: 'serial', name: 'ttyUSB0', recommended: true },
+  { path: '/dev/hidraw0', type: 'cm108', name: 'hidraw0' },
+];
+
+test('returns the enumerated row verbatim when the path matches', () => {
+  const d = resolveDevice(enumerated, '/dev/ttyUSB0', 'serial');
+  assert.equal(d, enumerated[0]);
+  assert.equal(d.recommended, true);
+});
+
+test('synthesises a manual device for a path not in the list', () => {
+  const d = resolveDevice(enumerated, '/dev/aioc-aprs-ptt', 'serial');
+  assert.deepEqual(d, { path: '/dev/aioc-aprs-ptt', manual: true, type: 'serial' });
+});
+
+test('trims surrounding whitespace before matching and emitting', () => {
+  assert.equal(resolveDevice(enumerated, '  /dev/ttyUSB0  ', 'serial'), enumerated[0]);
+  assert.deepEqual(resolveDevice(enumerated, '  /dev/custom  ', 'cm108'), {
+    path: '/dev/custom',
+    manual: true,
+    type: 'cm108',
+  });
+});
+
+test('returns null for an empty or whitespace-only path', () => {
+  assert.equal(resolveDevice(enumerated, '', 'serial'), null);
+  assert.equal(resolveDevice(enumerated, '   ', 'serial'), null);
+  assert.equal(resolveDevice(enumerated, null, 'serial'), null);
+});
+
+test('omits type when no fallback type is supplied', () => {
+  assert.deepEqual(resolveDevice([], '/dev/x'), { path: '/dev/x', manual: true });
+});
+
+test('tolerates a non-array device list', () => {
+  assert.deepEqual(resolveDevice(undefined, '/dev/x', 'gpio'), {
+    path: '/dev/x',
+    manual: true,
+    type: 'gpio',
+  });
+});


### PR DESCRIPTION
## What

Adds an **"Enter a path manually"** mode to the PTT **Change Device** dialog so operators can type a device path directly instead of only picking from the enumerated device list. Addresses #511.

The motivating case is a udev-renamed device (e.g. `/dev/aioc-aprs-ptt`): a stable symlink never appears in hardware enumeration, so the dropdown-only UI couldn't target it. Pinning PTT to a udev name keeps keying working across USB re-enumeration (which renumbers `/dev/hidraw*` / `/dev/ttyACM*`). The prior workaround was a raw `UPDATE ptt_configs SET device=...`.

## How

- **The frontend was the only thing restricting the path.** The store (`PttConfig.Device`), DTO (`PttRequest.DevicePath`), and Rust modem already persist and open any non-empty path verbatim -- no schema or driver change needed. The dialog previously resolved the payload device by matching the selection against the enumerated list, so a typed path resolved to `null`.
- New `resolveDevice()` helper (`web/src/routes/ptt/devicePayload.js`) returns the enumerated row when the path matches, otherwise synthesises a minimal device object for the typed path.
- `DialogChangeDevice.svelte` gains a manual-entry mode (`allowManualEntry` prop) with a free-form input; GPIO-line loading, the save payload, and the save-enable check all key off an `effectivePath` that works in either mode. Editing an existing config whose path isn't enumerated opens straight into manual mode so the operator sees their path.
- Manual entry is **desktop-only** (`allowManualEntry={!isAndroid}`); Android PTT targets USB descriptors, not filesystem paths.

## Validation (advisory, never blocking)

- New `POST /api/ptt/check-device` (`pttdevice.Probe`) **stats** the typed path and reports `exists` / `char_device`. It deliberately **never opens** the device -- opening a serial tty can briefly key the radio or block on carrier detect.
- The dialog shows a soft hint (present / not-a-char-device / not-present-yet) but always allows Save. A not-yet-present udev name is expressly allowed -- that is the point of a stable symlink.

## Tests

- Go: `pkg/pttdevice/probe_test.go` (empty / missing / regular-file / char-device) and `pkg/webapi/ptt_check_device_test.go` (empty -> 400, missing -> 200 advisory, regular file flagged).
- Web: `web/src/routes/ptt/devicePayload.test.js` (enumerated match, synthesised manual path, trimming, empty/null).
- `go test ./pkg/pttdevice/ ./pkg/webapi/` and the web `node --test` suite pass locally; `make docs-check`, `make docs-lint`, api-client drift check, and `tsc` api:check all clean. Regenerated OpenAPI spec + TS client are committed.

## Docs

- Handbook: new "Entering a device path manually" section in `docs/handbook/ptt.html`.
- Wiki: `docs/wiki/code-map.md` PTT section updated with the manual-path flow and the `check-device` probe.
