### PR TITLE
igate: add packet-type filter to IS->RF gating rules

### DIFF
--- a/docs/handbook/igate.html
+++ b/docs/handbook/igate.html
@@ -511,6 +511,19 @@
       <span class="callout-icon">&#9432;</span>
       <div class="callout-body">
         <p>
+          A weather station&rsquo;s position report is classified as
+          <strong>Weather</strong>, not <strong>Position</strong> &mdash;
+          the weather data determines the category. If you want to gate
+          weather stations, use the Weather category; a Position rule will
+          not match them.
+        </p>
+      </div>
+    </div>
+
+    <div class="callout info">
+      <span class="callout-icon">&#9432;</span>
+      <div class="callout-body">
+        <p>
           Packet Type rules still pass through the hardcoded policy gate:
           non-message types only transmit when the packet is sourced from
           one of your own station SSIDs, and directed messages only

--- a/docs/handbook/igate.html
+++ b/docs/handbook/igate.html
@@ -263,7 +263,7 @@
           <tbody>
             <tr>
               <td>Type</td>
-              <td>Match type: Callsign, Prefix, Message Dest, or Object</td>
+              <td>Match type: Callsign, Prefix, Message Dest, Object, or Packet Type</td>
             </tr>
             <tr>
               <td>Pattern</td>
@@ -491,6 +491,36 @@
       </div>
     </div>
 
+    <h4>Packet Type</h4>
+
+    <p>
+      Match on the <strong>type of the APRS packet</strong> rather than on
+      any callsign or name. Instead of a free-text pattern, the Pattern
+      field becomes a drop-down of packet-type categories mapped to the
+      standard aprs.is <code>t/&hellip;</code> filter classes:
+      <strong>Message</strong>, <strong>Position</strong>,
+      <strong>Weather</strong>, <strong>Object</strong>,
+      <strong>Item</strong>, <strong>Telemetry</strong>,
+      <strong>Status</strong>, and <strong>Query</strong>.
+      (Position also covers Mic-E reports.) This lets you gate only a
+      chosen kind of traffic to RF &mdash; for example, messages only in
+      areas where no iGate should transmit anything else on the air.
+    </p>
+
+    <div class="callout info">
+      <span class="callout-icon">&#9432;</span>
+      <div class="callout-body">
+        <p>
+          Packet Type rules still pass through the hardcoded policy gate:
+          non-message types only transmit when the packet is sourced from
+          one of your own station SSIDs, and directed messages only
+          transmit to a station heard directly on RF in the last 30
+          minutes. A Packet Type rule narrows <em>what</em> is gated; it
+          never widens who or what the policy gate already allows.
+        </p>
+      </div>
+    </div>
+
     <h3>Example: Gate a Single Station</h3>
 
     <p>
@@ -534,6 +564,31 @@ Priority: 100</code></pre>
       filter, graywolf would still receive (and evaluate) every message
       on APRS-IS; without the gating rule, graywolf would receive those
       messages but never transmit them.
+    </p>
+
+    <h3>Example: Gate Messages Only</h3>
+
+    <p>
+      To transmit <strong>only messages</strong> to RF and nothing else,
+      add a single Packet Type rule. The default-deny policy handles the
+      rest: any packet that isn&rsquo;t a message falls through to deny.
+      Pair it with a <code>t/m</code> server filter so APRS-IS only sends
+      you message traffic in the first place:
+    </p>
+
+<pre><code>APRS-IS Server Filter: t/m
+
+Type:     Packet Type
+Pattern:  Message
+Action:   Allow
+Priority: 100</code></pre>
+
+    <p>
+      This is the recommended setup for service areas where an iGate
+      should relay directed messages to local stations but must never put
+      position, weather, object, or telemetry traffic on the air. The
+      heard-direct check still applies, so a message only transmits when
+      its addressee was recently heard directly on RF.
     </p>
 
     <h2 id="simulation-mode">Simulation Mode</h2>

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -183,7 +183,15 @@ IS->RF transmission requires **both** tiers to allow a packet:
   (`sourceIsOwnSSID`). Not operator-configurable.
 - **Tier 2 — the rule engine** (`filters.Engine.Allow`): priority-ordered,
   first-match-wins, **default deny**. Rule types: `callsign`, `prefix`,
-  `message_dest`, `object`.
+  `message_dest`, `object`, `packet_type`. `packet_type` matches on the
+  decoded `aprs.PacketType`; its Pattern is a fixed category key (`message`,
+  `position`, `weather`, `object`, `item`, `telemetry`, `status`, `query`)
+  mapped to the aprs.is `t/…` classes, not a wildcard string. The category
+  set lives in `packetTypeCategories` (`pkg/igate/filters/filters.go`) and is
+  mirrored as strings in the DTO validator (`packetTypeCategoryKeys`,
+  `pkg/webapi/dto/igate.go`) and the Svelte `packetTypeOptions` — keep the
+  three in sync. Messages-only IS→RF gating is one allow rule of type
+  `packet_type` = `message` (graywolf #518).
 
 A bare `*` pattern is a flooding footgun for source-side rules
 (`callsign`/`prefix`) and a silent no-op elsewhere, so it is rejected —

--- a/pkg/configstore/models.go
+++ b/pkg/configstore/models.go
@@ -371,13 +371,14 @@ type IGateConfig struct {
 	UpdatedAt       time.Time `json:"-"`
 }
 
-// IGateRfFilter is a per-channel allow/deny rule used to decide which
-// RF-originated packets are forwarded to APRS-IS. Evaluation: lowest
+// IGateRfFilter is a per-channel allow/deny rule for the IS->RF gate: it
+// decides which packets received from APRS-IS are forwarded out to RF
+// (tier 2 of the gate; see pkg/igate/filters). Evaluation: lowest
 // Priority first (ascending order); first match determines action.
 type IGateRfFilter struct {
 	ID        uint32    `gorm:"primaryKey;autoIncrement" json:"id"`
 	Channel   uint32    `gorm:"not null;index" json:"channel"`
-	Type      string    `gorm:"not null" json:"type"` // callsign|prefix|message_dest|object
+	Type      string    `gorm:"not null" json:"type"` // callsign|prefix|message_dest|object|packet_type
 	Pattern   string    `gorm:"not null" json:"pattern"`
 	Action    string    `gorm:"not null;default:'allow'" json:"action"` // allow|deny
 	Priority  uint32    `gorm:"not null;default:100" json:"priority"`

--- a/pkg/igate/filters/filters.go
+++ b/pkg/igate/filters/filters.go
@@ -19,6 +19,7 @@ const (
 	TypePrefix      RuleType = "prefix"       // source callsign prefix (no SSID)
 	TypeMessageDest RuleType = "message_dest" // message addressee match
 	TypeObject      RuleType = "object"       // object/item name match
+	TypePacketType  RuleType = "packet_type"  // APRS packet-type category match
 )
 
 // Action is the outcome when a rule matches.
@@ -36,6 +37,35 @@ type Rule struct {
 	Type     RuleType
 	Pattern  string // interpretation depends on Type
 	Action   Action
+}
+
+// packetTypeCategories maps a TypePacketType rule Pattern (a stable
+// category key exposed in the UI and validated by the DTO layer) to the
+// set of aprs.PacketType values it covers. The keys mirror the aprs.is
+// javAPRSFilter `t/...` classes (https://www.aprs-is.net/javAPRSFilter.aspx):
+//
+//	message (t/m), position (t/p), weather (t/w), object (t/o),
+//	item (t/i), telemetry (t/t), status (t/s), query (t/q).
+//
+// `position` folds in Mic-E, which is a position report at heart. The key
+// set is duplicated (as strings, no aprs import) in the DTO validator
+// pkg/webapi/dto.packetTypeCategoryKeys — keep the two in sync.
+var packetTypeCategories = map[string][]aprs.PacketType{
+	"message":   {aprs.PacketMessage},
+	"position":  {aprs.PacketPosition, aprs.PacketMicE},
+	"weather":   {aprs.PacketWeather},
+	"object":    {aprs.PacketObject},
+	"item":      {aprs.PacketItem},
+	"telemetry": {aprs.PacketTelemetry},
+	"status":    {aprs.PacketStatus},
+	"query":     {aprs.PacketQuery},
+}
+
+// PacketTypeCategory reports whether s is a recognized TypePacketType
+// category key (case-insensitive, whitespace-trimmed, matching matches()).
+func PacketTypeCategory(s string) bool {
+	_, ok := packetTypeCategories[strings.ToLower(strings.TrimSpace(s))]
+	return ok
 }
 
 // Engine evaluates rules against decoded packets.
@@ -125,6 +155,17 @@ func matches(r Rule, pkt *aprs.DecodedAPRSPacket) bool {
 			return false
 		}
 		return matchPattern(r.Pattern, name)
+	case TypePacketType:
+		cats, ok := packetTypeCategories[strings.ToLower(strings.TrimSpace(r.Pattern))]
+		if !ok {
+			return false
+		}
+		for _, t := range cats {
+			if pkt.Type == t {
+				return true
+			}
+		}
+		return false
 	}
 	return false
 }

--- a/pkg/igate/filters/filters_test.go
+++ b/pkg/igate/filters/filters_test.go
@@ -357,6 +357,13 @@ func TestPacketTypeMatch(t *testing.T) {
 		{"status_matches_status", "status", aprs.PacketStatus, true},
 		{"query_matches_query", "query", aprs.PacketQuery, true},
 		{"status_rejects_message", "status", aprs.PacketMessage, false},
+		// Fail-safe: packet types with no category must never gate to RF.
+		// This locks in default-deny for uncovered types so a future
+		// taxonomy change can't silently start keying up the radio.
+		{"message_rejects_thirdparty", "message", aprs.PacketThirdParty, false},
+		{"message_rejects_capabilities", "message", aprs.PacketCapabilities, false},
+		{"message_rejects_df", "message", aprs.PacketDF, false},
+		{"message_rejects_unknown", "message", aprs.PacketUnknown, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/igate/filters/filters_test.go
+++ b/pkg/igate/filters/filters_test.go
@@ -328,3 +328,99 @@ func TestPrefixStarIsLiteralNotWildcard(t *testing.T) {
 		t.Fatal("Prefix pattern NW5W* must not match NW5W (source has no literal '*')")
 	}
 }
+
+// typedPkt builds a decoded packet carrying only a PacketType, which is
+// all the packet_type rule inspects.
+func typedPkt(t aprs.PacketType) *aprs.DecodedAPRSPacket {
+	return &aprs.DecodedAPRSPacket{Source: "N0CALL-1", Type: t}
+}
+
+func TestPacketTypeMatch(t *testing.T) {
+	// One allow rule per category, evaluated against every packet type.
+	// want is true only when the packet's type is covered by the category.
+	tests := []struct {
+		name     string
+		category string
+		pktType  aprs.PacketType
+		want     bool
+	}{
+		{"message_matches_message", "message", aprs.PacketMessage, true},
+		{"message_rejects_position", "message", aprs.PacketPosition, false},
+		{"position_matches_position", "position", aprs.PacketPosition, true},
+		{"position_matches_mice", "position", aprs.PacketMicE, true},
+		{"position_rejects_weather", "position", aprs.PacketWeather, false},
+		{"weather_matches_weather", "weather", aprs.PacketWeather, true},
+		{"object_matches_object", "object", aprs.PacketObject, true},
+		{"object_rejects_item", "object", aprs.PacketItem, false},
+		{"item_matches_item", "item", aprs.PacketItem, true},
+		{"telemetry_matches_telemetry", "telemetry", aprs.PacketTelemetry, true},
+		{"status_matches_status", "status", aprs.PacketStatus, true},
+		{"query_matches_query", "query", aprs.PacketQuery, true},
+		{"status_rejects_message", "status", aprs.PacketMessage, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := New([]Rule{
+				{ID: 1, Priority: 10, Type: TypePacketType, Pattern: tc.category, Action: Allow},
+			})
+			if got := e.Allow(typedPkt(tc.pktType)); got != tc.want {
+				t.Fatalf("packet_type=%q vs pkt=%q: Allow=%v want %v",
+					tc.category, tc.pktType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPacketTypeCaseAndWhitespaceInsensitive(t *testing.T) {
+	e := New([]Rule{
+		{ID: 1, Priority: 10, Type: TypePacketType, Pattern: "  Message  ", Action: Allow},
+	})
+	if !e.Allow(typedPkt(aprs.PacketMessage)) {
+		t.Fatal("packet_type category should match case- and whitespace-insensitively")
+	}
+}
+
+func TestPacketTypeUnknownCategoryNeverMatches(t *testing.T) {
+	e := New([]Rule{
+		{ID: 1, Priority: 10, Type: TypePacketType, Pattern: "bogus", Action: Allow},
+	})
+	if e.Allow(typedPkt(aprs.PacketMessage)) {
+		t.Fatal("unknown category must never match")
+	}
+}
+
+// TestPacketTypeComposesWithOtherRules exercises the "messages-only" use
+// case (GH #518): an allow rule for message packets, with a lower-priority
+// deny catch-all, gates messages while denying everything else. It also
+// confirms a higher-priority source deny still wins over the type allow.
+func TestPacketTypeComposesWithOtherRules(t *testing.T) {
+	e := New([]Rule{
+		{ID: 1, Priority: 5, Type: TypeCallsign, Pattern: "BADACTR-1", Action: Deny},
+		{ID: 2, Priority: 10, Type: TypePacketType, Pattern: "message", Action: Allow},
+	})
+	msg := &aprs.DecodedAPRSPacket{Source: "N0CALL-1", Type: aprs.PacketMessage}
+	if !e.Allow(msg) {
+		t.Fatal("message from ordinary source should be allowed by packet_type rule")
+	}
+	pos := &aprs.DecodedAPRSPacket{Source: "N0CALL-1", Type: aprs.PacketPosition}
+	if e.Allow(pos) {
+		t.Fatal("non-message should fall through to default deny")
+	}
+	badMsg := &aprs.DecodedAPRSPacket{Source: "BADACTR-1", Type: aprs.PacketMessage}
+	if e.Allow(badMsg) {
+		t.Fatal("higher-priority source deny must win over packet_type allow")
+	}
+}
+
+func TestPacketTypeCategoryHelper(t *testing.T) {
+	for _, ok := range []string{"message", "POSITION", "  weather  ", "query"} {
+		if !PacketTypeCategory(ok) {
+			t.Errorf("PacketTypeCategory(%q) = false, want true", ok)
+		}
+	}
+	for _, bad := range []string{"", "bogus", "mic-e", "unknown"} {
+		if PacketTypeCategory(bad) {
+			t.Errorf("PacketTypeCategory(%q) = true, want false", bad)
+		}
+	}
+}

--- a/pkg/webapi/dto/igate.go
+++ b/pkg/webapi/dto/igate.go
@@ -194,6 +194,17 @@ func validateIGateRfFilterPattern(ruleType, pattern string) error {
 	if trimmed == "" {
 		return fmt.Errorf("pattern must not be empty")
 	}
+	// packet_type: the pattern is a fixed category key (mapped to the
+	// aprs.is `t/...` classes), not a wildcard string. Validate membership
+	// so the UI and engine agree on what a rule means — an unknown
+	// category silently never matches in the engine. Return early: the
+	// wildcard rules below do not apply to a category key.
+	if ruleType == filtersTypePacketType {
+		if !isPacketTypeCategory(trimmed) {
+			return fmt.Errorf("packet_type pattern must be one of: %s", strings.Join(packetTypeCategoryKeys, ", "))
+		}
+		return nil
+	}
 	// A bare `*` means "any value". It is only permitted for
 	// message_dest, where it means "any addressee": the iGate's tier-1
 	// heard-direct check already bounds IS->RF directed-message delivery
@@ -235,7 +246,26 @@ const (
 	filtersTypeCallsign    = "callsign"
 	filtersTypePrefix      = "prefix"
 	filtersTypeMessageDest = "message_dest"
+	filtersTypePacketType  = "packet_type"
 )
+
+// packetTypeCategoryKeys mirrors the keys of packetTypeCategories in
+// pkg/igate/filters. Duplicated here (as plain strings) rather than
+// imported so the DTO layer doesn't pull the filter engine (and its aprs
+// dependency) into every handler build — matching the filtersType*
+// mirroring above. Keep in sync with pkg/igate/filters/filters.go.
+var packetTypeCategoryKeys = []string{
+	"message", "position", "weather", "object", "item", "telemetry", "status", "query",
+}
+
+func isPacketTypeCategory(s string) bool {
+	for _, k := range packetTypeCategoryKeys {
+		if strings.EqualFold(strings.TrimSpace(s), k) {
+			return true
+		}
+	}
+	return false
+}
 
 func (r IGateRfFilterRequest) ToModel() configstore.IGateRfFilter {
 	return configstore.IGateRfFilter{

--- a/pkg/webapi/dto/igate_test.go
+++ b/pkg/webapi/dto/igate_test.go
@@ -250,6 +250,30 @@ func TestIGateRfFilterRequestValidate(t *testing.T) {
 			req:     IGateRfFilterRequest{Type: "object", Pattern: "WX* X"},
 			wantErr: errTrailingOnly,
 		},
+
+		// --- packet_type: fixed category, not a wildcard string ----------
+		{
+			name: "accept_packet_type_message",
+			req:  IGateRfFilterRequest{Type: "packet_type", Pattern: "message"},
+		},
+		{
+			name: "accept_packet_type_position",
+			req:  IGateRfFilterRequest{Type: "packet_type", Pattern: "position"},
+		},
+		{
+			name: "accept_packet_type_case_insensitive_padded",
+			req:  IGateRfFilterRequest{Type: "packet_type", Pattern: "  Weather  "},
+		},
+		{
+			name:    "reject_packet_type_unknown_category",
+			req:     IGateRfFilterRequest{Type: "packet_type", Pattern: "bogus"},
+			wantErr: "packet_type pattern must be one of: message, position, weather, object, item, telemetry, status, query",
+		},
+		{
+			name:    "reject_packet_type_wildcard",
+			req:     IGateRfFilterRequest{Type: "packet_type", Pattern: "message*"},
+			wantErr: "packet_type pattern must be one of: message, position, weather, object, item, telemetry, status, query",
+		},
 	}
 
 	for _, tc := range tests {

--- a/web/src/routes/Igate.svelte
+++ b/web/src/routes/Igate.svelte
@@ -143,7 +143,25 @@
     { value: 'prefix', label: 'Prefix' },
     { value: 'message_dest', label: 'Message Dest' },
     { value: 'object', label: 'Object' },
+    { value: 'packet_type', label: 'Packet Type' },
   ];
+
+  // Packet-type categories for the Pattern <select> shown when the rule
+  // type is `packet_type`. Values mirror the aprs.is `t/...` filter
+  // classes and MUST stay in sync with packetTypeCategories in
+  // pkg/igate/filters/filters.go and packetTypeCategoryKeys in
+  // pkg/webapi/dto/igate.go.
+  const packetTypeOptions = [
+    { value: 'message', label: 'Message' },
+    { value: 'position', label: 'Position' },
+    { value: 'weather', label: 'Weather' },
+    { value: 'object', label: 'Object' },
+    { value: 'item', label: 'Item' },
+    { value: 'telemetry', label: 'Telemetry' },
+    { value: 'status', label: 'Status' },
+    { value: 'query', label: 'Query' },
+  ];
+  const packetTypeValues = packetTypeOptions.map((o) => o.value);
 
   const actionOptions = [
     { value: 'allow', label: 'Allow' },
@@ -167,6 +185,8 @@
       // the wildcard form is what this phase is introducing, and a
       // literal like "WX-001" would imply objects are exact-match only.
       case 'object':       return 'WX-*';
+      // packet_type uses a <select>, not a free-text input, so no
+      // placeholder is shown.
       default:             return '';
     }
   }
@@ -191,6 +211,12 @@
         return 'Matches the object or item name. Exact match by default, or use ' +
                'a trailing `*` as a prefix wildcard (e.g. WX-* matches all WX- ' +
                'objects). See warning above.';
+      case 'packet_type':
+        return 'Matches the APRS packet type (mapped to the aprs.is t/… filter ' +
+               'classes). Use an Allow rule of type Message for messages-only ' +
+               'IS→RF gating. Non-message types are still bounded by the ' +
+               'hardcoded gate — they only transmit when sourced from your ' +
+               'own station SSID.';
       default:
         return '';
     }
@@ -212,6 +238,15 @@
     const trimmed = (pattern ?? '').trim();
     if (trimmed === '') {
       return 'Pattern must not be empty.';
+    }
+    // packet_type: the pattern is a fixed category key, not a wildcard
+    // string. Validate membership (the <select> already constrains input,
+    // but keep parity with dto.validateIGateRfFilterPattern). Return
+    // early — the wildcard rules below don't apply to a category key.
+    if (type === 'packet_type') {
+      return packetTypeValues.includes(trimmed.toLowerCase())
+        ? ''
+        : 'Select a packet type.';
     }
     // A bare `*` ("any addressee") is only meaningful for message_dest,
     // where the hardcoded heard-direct check bounds delivery to stations
@@ -241,6 +276,27 @@
   let patternError = $derived.by(() => {
     if (!patternTouched && (filterForm.pattern ?? '').trim() === '') return '';
     return validatePattern(filterForm.type, filterForm.pattern);
+  });
+
+  // Normalize the Pattern when the rule type flips into or out of
+  // packet_type. packet_type edits a fixed category via a <select>, so a
+  // leftover free-text pattern (e.g. "W5") would leave the select on a
+  // stale value; seed a valid category instead. Flipping back to a
+  // text type clears the seeded category so the input starts empty. The
+  // prevType guard ensures this fires only on an actual type change, not
+  // on every pattern keystroke.
+  let prevType = filterForm.type;
+  $effect(() => {
+    const t = filterForm.type;
+    if (t === prevType) return;
+    const wasPacket = prevType === 'packet_type';
+    prevType = t;
+    if (t === 'packet_type') {
+      if (!packetTypeValues.includes(filterForm.pattern)) filterForm.pattern = 'message';
+    } else if (wasPacket) {
+      filterForm.pattern = '';
+      patternTouched = false;
+    }
   });
 
   // ------------------------------------------------------------------
@@ -837,13 +893,22 @@
       error={patternError}
     >
       {#snippet children(describedBy)}
-        <Input
-          id="flt-pattern"
-          bind:value={filterForm.pattern}
-          placeholder={placeholderFor(filterForm.type)}
-          aria-describedby={describedBy}
-          oninput={() => { patternTouched = true; }}
-        />
+        {#if filterForm.type === 'packet_type'}
+          <Select
+            id="flt-pattern"
+            bind:value={filterForm.pattern}
+            options={packetTypeOptions}
+            aria-describedby={describedBy}
+          />
+        {:else}
+          <Input
+            id="flt-pattern"
+            bind:value={filterForm.pattern}
+            placeholder={placeholderFor(filterForm.type)}
+            aria-describedby={describedBy}
+            oninput={() => { patternTouched = true; }}
+          />
+        {/if}
       {/snippet}
     </FormField>
     <FormField label="Action" id="flt-action">


### PR DESCRIPTION
## Summary

Adds a **Packet Type** filter to the iGate APRS-IS→RF gating rules so an operator can gate only certain kinds of traffic to RF — e.g. messages-only in service areas where no iGate should transmit anything else on the air.

Closes #518.

## What changed

- **Engine** (`pkg/igate/filters`): new `packet_type` rule type. Its `Pattern` is a fixed category key mapped to the aprs.is `t/…` filter classes — `message`, `position` (incl. Mic-E), `weather`, `object`, `item`, `telemetry`, `status`, `query`. Matching is case- and whitespace-insensitive; an unknown category never matches. Added a `PacketTypeCategory` helper.
- **DTO** (`pkg/webapi/dto`): `packet_type` patterns are validated against the known category set (keys mirrored as plain strings so the DTO layer keeps its no-`aprs`-import property). Wildcard rules don't apply to a category key.
- **UI** (`web/src/routes/Igate.svelte`): "Packet Type" appears in the rule-type dropdown; when selected, the Pattern field becomes a category `<select>`. Client-side validation mirrors the server, plus hint copy and a small effect that seeds a valid category when the type flips.
- **Docs**: handbook gains a Packet Type rule-type section and a messages-only example; wiki invariant 15 lists the new type and category set.

## Design notes

`packet_type` is a new **standalone rule type**, consistent with the existing one-condition-per-rule, priority-ordered, first-match-wins, **default-deny** engine. It composes with existing rules by ordering/priority and requires no schema migration (the `type`/`pattern` columns already carry it). Default behavior is unchanged when no `packet_type` rule is defined.

Messages-only gating is a single rule: `Allow` / type `Packet Type` / `message`. The hardcoded tier-1 policy still applies underneath (non-message types only transmit from your own SSID; directed messages only to stations heard directly on RF), so a `packet_type` rule narrows *what* is gated without widening the policy gate.

## Testing

- `go test ./...` passes (except a pre-existing, unrelated `TestProtoBindingsDoNotDrift` drift on `pkg/platformproto`, present on `main` before this change).
- New table-driven engine tests over representative packet types + composition/priority coverage; new DTO validation cases.
- `web` build succeeds and `npm test` (490 tests) passes.
