### PR TITLE
Fixed the RX and TX count being zero when the main channel is a Kiss TNC

### DIFF
--- a/pkg/webapi/channels.go
+++ b/pkg/webapi/channels.go
@@ -705,7 +705,12 @@ func (s *Server) getChannelStats(w http.ResponseWriter, r *http.Request) {
 		badRequest(w, "invalid channel id")
 		return
 	}
-	if s.bridge != nil {
+	// Only consult the modem bridge for channels with an audio input device.
+	// On Android the modem always emits StatusUpdate for its default channel_id
+	// even without a ConfigureChannel (pure KISS-only setup), producing a
+	// zero-stats cache entry that would mask the KISS manager's real counts.
+	ch, _ := s.store.GetChannel(r.Context(), id)
+	if s.bridge != nil && (ch == nil || ch.InputDeviceID != nil) {
 		if stats, ok := s.bridge.GetChannelStats(id); ok {
 			writeJSON(w, http.StatusOK, stats)
 			return

--- a/pkg/webapi/status.go
+++ b/pkg/webapi/status.go
@@ -137,7 +137,14 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 			sc.InputDeviceID = *ch.InputDeviceID
 		}
 		haveBridgeStats := false
-		if s.bridge != nil {
+		// Only consult the Rust modem bridge for channels that have an audio
+		// input device (modem-backed). On Android the modem always emits
+		// StatusUpdate for its default channel_id even when no ConfigureChannel
+		// was sent (pure KISS-only setup), which puts a zero-stats entry in the
+		// bridge cache. Consulting the bridge for a KISS-only channel (BLE,
+		// Bluetooth, serial, tcp-client) would set haveBridgeStats=true and
+		// permanently mask the KISS manager's real RX/TX counts.
+		if s.bridge != nil && ch.InputDeviceID != nil {
 			if stats, ok := s.bridge.GetChannelStats(uint32(ch.ID)); ok {
 				haveBridgeStats = true
 				sc.RxFrames = stats.RxFrames


### PR DESCRIPTION
This fixes an issue where the RX and TX counts when using a Kiss TNC backed channel was not incrementing the RX and TX counts on the dashboard page.