### PR TITLE
feat: add Stations list page with aliases, filters, sorting, pagination

### DIFF
--- a/docs/handbook/actions-handler-safety-powershell.html
+++ b/docs/handbook/actions-handler-safety-powershell.html
@@ -42,6 +42,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/actions-handler-safety-shell.html
+++ b/docs/handbook/actions-handler-safety-shell.html
@@ -42,6 +42,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/actions-handler-safety-webhooks.html
+++ b/docs/handbook/actions-handler-safety-webhooks.html
@@ -42,6 +42,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/actions-handler-safety.html
+++ b/docs/handbook/actions-handler-safety.html
@@ -42,6 +42,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/actions.html
+++ b/docs/handbook/actions.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/agwpe.html
+++ b/docs/handbook/agwpe.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/architecture.html
+++ b/docs/handbook/architecture.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/audio.html
+++ b/docs/handbook/audio.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/ax25-terminal.html
+++ b/docs/handbook/ax25-terminal.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/beacons.html
+++ b/docs/handbook/beacons.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/callsign.html
+++ b/docs/handbook/callsign.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/channels.html
+++ b/docs/handbook/channels.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/configurations.html
+++ b/docs/handbook/configurations.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/digipeater.html
+++ b/docs/handbook/digipeater.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/gps.html
+++ b/docs/handbook/gps.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/history-database.html
+++ b/docs/handbook/history-database.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/igate.html
+++ b/docs/handbook/igate.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/index.html
+++ b/docs/handbook/index.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/installation.html
+++ b/docs/handbook/installation.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/kiss-bluetooth.html
+++ b/docs/handbook/kiss-bluetooth.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/kiss-serial.html
+++ b/docs/handbook/kiss-serial.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/kiss-usb-serial.html
+++ b/docs/handbook/kiss-usb-serial.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/kiss.html
+++ b/docs/handbook/kiss.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/livemap.html
+++ b/docs/handbook/livemap.html
@@ -44,6 +44,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/logs.html
+++ b/docs/handbook/logs.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/maps.html
+++ b/docs/handbook/maps.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>
@@ -70,7 +71,8 @@
 
     <p>
       The Maps page controls what you see <em>under</em> the APRS overlay
-      on the <a href="livemap.html">Live Map</a>. Two settings live here:
+      on the <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>. Two settings live here:
       which basemap to use, and which regions to keep on disk for off-grid
       use.
     </p>

--- a/docs/handbook/messaging.html
+++ b/docs/handbook/messaging.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/monitoring.html
+++ b/docs/handbook/monitoring.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/preferences.html
+++ b/docs/handbook/preferences.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/privacy.html
+++ b/docs/handbook/privacy.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/ptt.html
+++ b/docs/handbook/ptt.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/remote-actions.html
+++ b/docs/handbook/remote-actions.html
@@ -39,6 +39,7 @@
       <a href="actions.html">Actions</a>
       <a href="remote-actions.html">Remote Actions</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/remote-kiss-tnc.html
+++ b/docs/handbook/remote-kiss-tnc.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/simulation.html
+++ b/docs/handbook/simulation.html
@@ -43,6 +43,7 @@
       <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
       <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
       <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
       <div class="sidebar-section">Packet</div>
       <a href="ax25-terminal.html">AX.25 Terminal</a>
       <div class="sidebar-section">Interfaces</div>

--- a/docs/handbook/stations.html
+++ b/docs/handbook/stations.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Stations &mdash; Graywolf Handbook</title>
+  <meta name="description" content="Stations list: sortable, filterable table of all stations heard on RF and APRS-IS, with aliases and map navigation." />
+  <link rel="stylesheet" href="handbook.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="index.html" class="site-logo">
+      <img src="img/graywolf-logo.svg" alt="" />
+      <span>graywolf <span class="handbook-label">handbook</span></span>
+    </a>
+    <div class="header-actions">
+      <button class="theme-toggle" aria-label="Toggle theme">[ dark ]</button>
+    </div>
+  </div>
+</header>
+
+<div class="layout">
+  <aside class="sidebar">
+    <nav>
+      <div class="sidebar-section">Getting Started</div>
+      <a href="index.html">Introduction</a>
+      <a href="installation.html">Installation</a>
+      <a href="callsign.html">Station Callsign</a>
+      <div class="sidebar-section">Radio</div>
+      <a href="audio.html">Audio Devices</a>
+      <a href="channels.html">Radio Channels</a>
+      <a href="ptt.html">Push-to-Talk</a>
+      <div class="sidebar-section">APRS</div>
+      <a href="beacons.html">Beacons</a>
+      <a href="digipeater.html">Digipeater</a>
+      <a href="igate.html">iGate</a>
+      <a href="messaging.html">Messaging</a>
+      <a href="actions.html">Actions</a>
+      <a href="remote-actions.html">Remote Actions</a>
+      <a href="actions-handler-safety.html">Actions: Handler Safety</a>
+      <a href="actions-handler-safety-shell.html">&nbsp;&nbsp;&#8627; Shell handlers</a>
+      <a href="actions-handler-safety-powershell.html">&nbsp;&nbsp;&#8627; PowerShell handlers</a>
+      <a href="actions-handler-safety-webhooks.html">&nbsp;&nbsp;&#8627; Webhook handlers</a>
+      <a href="livemap.html">Live Map</a>
+      <a href="stations.html">Stations</a>
+      <div class="sidebar-section">Packet</div>
+      <a href="ax25-terminal.html">AX.25 Terminal</a>
+      <div class="sidebar-section">Interfaces</div>
+      <a href="kiss.html">KISS TNC</a>
+      <a href="remote-kiss-tnc.html">Remote KISS TNC</a>
+      <a href="agwpe.html">AGWPE</a>
+      <a href="gps.html">GPS</a>
+      <div class="sidebar-section">Operations</div>
+      <a href="history-database.html">Position Log</a>
+      <a href="logs.html">Logs</a>
+      <a href="monitoring.html">Monitoring</a>
+      <a href="simulation.html">Simulation</a>
+      <a href="maps.html">Maps</a>
+      <a href="preferences.html">Preferences</a>
+      <a href="architecture.html">Architecture</a>
+      <div class="sidebar-section">Reference</div>
+      <a href="configurations.html">Known-Working Configs</a>
+      <a href="api.html">REST API Reference</a>
+    </nav>
+  </aside>
+
+  <main class="content">
+    <h1>Stations</h1>
+    <p class="subtitle">Sortable, filterable table of all stations heard on RF and APRS-IS</p>
+
+    <p>
+      The Stations page shows every station Graywolf has heard &mdash; whether
+      received directly on RF, via a digipeater, or through the APRS-IS iGate
+      &mdash; in a table you can sort and filter by any column. Clicking a
+      callsign flies the <a href="livemap.html">Live Map</a> to that station
+      and opens its popup.
+    </p>
+
+    <p>
+      Find the page in the sidebar under <strong>Live Map</strong>, or navigate
+      directly to <code>/#/stations</code>.
+    </p>
+
+    <h2>Table Columns</h2>
+
+    <div class="box">
+      <div class="box-body">
+        <table>
+          <thead>
+            <tr><th>Column</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Station</strong></td>
+              <td>The APRS callsign (or object/item name). Click to open the station on the Live Map.</td>
+            </tr>
+            <tr>
+              <td><strong>Alias</strong></td>
+              <td>
+                A user-defined display name, e.g. &ldquo;My Car&rdquo; or &ldquo;Dad's Jeep&rdquo;.
+                Only shown when the <a href="history-database.html">Position Log</a> is enabled
+                (aliases are stored alongside position history). Click the pencil icon on any
+                row to edit; leave the field blank to remove an alias.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>Last Heard</strong></td>
+              <td>How long ago the most recent packet arrived, with a direction badge:
+                <strong>RX</strong> (received on RF), <strong>IS</strong> (APRS-IS iGate),
+                or <strong>TX</strong> (transmitted by this station).</td>
+            </tr>
+            <tr>
+              <td><strong>Icon</strong></td>
+              <td>The station&rsquo;s APRS symbol icon and its human-readable name.</td>
+            </tr>
+            <tr>
+              <td><strong>Distance</strong></td>
+              <td>
+                Straight-line distance from Graywolf&rsquo;s own GPS position to the station.
+                Shown in km or miles depending on the units preference. Displays
+                &ldquo;&mdash;&rdquo; when no GPS fix is available.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>Bearing</strong></td>
+              <td>
+                True bearing from your station to the remote station, expressed as a compass
+                direction and degrees (e.g. &ldquo;NNE 22&deg;&rdquo;). Displays
+                &ldquo;&mdash;&rdquo; when no GPS fix is available.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>Comment</strong></td>
+              <td>The free-form comment field from the station&rsquo;s most recent packet.</td>
+            </tr>
+            <tr>
+              <td><strong>Lat / Lon</strong></td>
+              <td>Decimal-degree coordinates of the station&rsquo;s most recent position fix.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <h2>Sorting</h2>
+
+    <p>
+      Click any column header to sort by that column. A second click on the same
+      header reverses the direction. A small arrow (&uarr; / &darr;) shows the active
+      sort column and direction. The default sort is <strong>Last Heard</strong>
+      newest-first.
+    </p>
+
+    <h2>Filtering</h2>
+
+    <p>
+      A filter row sits directly under the column headers. Each filter applies
+      independently; multiple active filters are AND&rsquo;d together.
+    </p>
+
+    <div class="box">
+      <div class="box-body">
+        <table>
+          <thead>
+            <tr><th>Filter</th><th>Behaviour</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Station</strong></td>
+              <td>Substring match (case-insensitive). Typing <code>KD</code> shows all callsigns that contain &ldquo;KD&rdquo;.</td>
+            </tr>
+            <tr>
+              <td><strong>Alias</strong></td>
+              <td>
+                Substring match. A <strong>Has alias</strong> toggle shows only stations
+                that have a saved alias. The alias filter and toggle are hidden when the
+                Position Log is disabled.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>Last Heard</strong></td>
+              <td>
+                A <strong>Today only</strong> toggle restricts the list to stations heard
+                since midnight local time, regardless of the time-range selector in the
+                toolbar.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>Icon</strong></td>
+              <td>
+                A multiselect dropdown listing every APRS symbol currently on the page.
+                Check one or more icons to show only stations with those symbols.
+                Click <em>Clear</em> to remove the icon filter.
+              </td>
+            </tr>
+            <tr>
+              <td><strong>Comment</strong></td>
+              <td>Substring match (case-insensitive).</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <h2>Auto-Refresh and Manual Refresh</h2>
+
+    <p>
+      <strong>Auto-refresh</strong> is on by default and polls every 30&nbsp;seconds.
+      The data updates silently in the background &mdash; active filters and sort order
+      are never reset. If you are searching for a specific callsign and that station
+      is heard again, its Last Heard cell updates in place; the filter itself does not
+      change.
+    </p>
+
+    <p>
+      Uncheck <strong>Auto-refresh</strong> in the toolbar to stop polling. The
+      <strong>Refresh</strong> button fetches fresh data at any time regardless of
+      whether auto-refresh is enabled.
+    </p>
+
+    <h2>Time Range</h2>
+
+    <p>
+      The time-range selector in the toolbar (default <strong>1&nbsp;day</strong>)
+      controls how far back Graywolf looks for heard stations. Selecting a longer
+      range may add older entries from the <a href="history-database.html">Position
+      Log</a>; selecting a shorter range prunes entries that have aged out. Changing
+      the time range triggers an immediate refresh.
+    </p>
+
+    <div class="callout info">
+      <span class="callout-icon">&#9432;</span>
+      <div class="callout-body">
+        <p>
+          Time ranges beyond a few hours only show historical data when the
+          <a href="history-database.html">Position Log</a> is enabled. Without it,
+          stations are held in memory only and a restart clears them.
+        </p>
+      </div>
+    </div>
+
+    <h2>Pagination</h2>
+
+    <p>
+      The table shows 50 rows per page by default. Use the per-page selector in the
+      toolbar to switch to 100 or 200. Pagination controls at the bottom of the table
+      let you step through pages. Changing any filter resets to page&nbsp;1; a refresh
+      that reduces the total count automatically moves you to the last valid page.
+    </p>
+
+    <h2>Station Aliases</h2>
+
+    <p>
+      An alias is a personal label you attach to a callsign so it appears in the
+      Alias column whenever that station is heard. Examples: <em>My Car</em>,
+      <em>Dad&rsquo;s Jeep</em>, <em>Club Digi</em>.
+    </p>
+
+    <p>
+      To add or edit an alias, hover over a row and click the pencil icon (&#9998;)
+      in the Alias column. Type your label and press <kbd>Enter</kbd> (or click
+      away) to save. Clear the field and save to remove the alias.
+    </p>
+
+    <div class="callout warn">
+      <span class="callout-icon">&#9888;</span>
+      <div class="callout-body">
+        <p>
+          The Alias column and alias editing are only available when the
+          <a href="history-database.html">Position Log</a> is enabled. Aliases
+          are stored in the same SQLite database as position history.
+        </p>
+      </div>
+    </div>
+
+    <h2>Navigating to the Live Map</h2>
+
+    <p>
+      Click any callsign in the Station column to open the
+      <a href="livemap.html">Live Map</a> centered on that station with its popup
+      open. This works even for stations not currently in the map&rsquo;s active
+      time range &mdash; the camera flies to the station&rsquo;s last known
+      coordinates.
+    </p>
+
+    <nav class="page-nav">
+      <a href="livemap.html">
+        <span class="label">Previous</span>
+        Live Map
+      </a>
+      <a href="ax25-terminal.html" class="next">
+        <span class="label">Next</span>
+        AX.25 Terminal
+      </a>
+    </nav>
+  </main>
+</div>
+
+<footer class="site-footer">
+  graywolf &middot; modern APRS station
+</footer>
+
+<script src="handbook.js"></script>
+</body>
+</html>

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1310,19 +1310,19 @@ marker (drawn at `positions[0]`) and popup badge labeled it `APRS-IS` -- the bug
 in graywolf GitHub #394. The marker is always `positions[0]`, so the filter must
 classify off that same fix.
 
-*Top-level fields vs. positions[0] -- they are NOT the same.*
-`stationcache.updateMetadata` overwrites the **station-level** `Direction`/
-`Via`/`Gated` (exposed as the top-level `StationDTO` fields, and what the popup
-badge reads via `popup.js` `s.direction` and `viaText`'s `s.via === 'is'`) with
-the **latest** packet on every update, unconditionally. `positions[0]`, by
-contrast, is rfRank-protected for static re-beacons. For the common case (a
-fresh or moving station) `positions[0]` *is* the latest fix and matches the
-badge; they diverge only for a static station heard on RF then re-beaconed via
-IS, where `positions[0]` stays `RX` (rfRank) while the top-level badge flips to
-`IS`. RF Only intentionally keys on the rfRank-protected `positions[0]`, so that
-static station stays visible (next paragraph) even though its popup badge may
-read APRS-IS. Do **not** "fix" that by classifying off the top-level fields --
-that would re-hide RF-reachable static stations.
+*Station-level fields are synced from positions[0], not last-write-wins.*
+After every position update, `MemCache.Update` copies the rfRank-best
+reception metadata (`Direction`/`Via`/`Gated`/`Hops`/`Path`/`Channel`) from
+`positions[0]` back to the station-level fields (exposed as the top-level
+`StationDTO` fields, and what the popup badge reads). `updateMetadata` still
+writes the latest packet's direction first; the sync overwrites it with the
+rfRank winner. The result: when a packet is heard on RF and the same beacon
+arrives again via APRS-IS moments later, the station row and popup badge
+correctly show `RX` rather than `IS`. For a mobile station that has genuinely
+moved and is now only heard via IS, the new IS fix is inserted as `positions[0]`,
+so the sync sets the station-level direction to `IS` — the current state is
+correctly reflected. RF Only intentionally keys on `positions[0]` directly and
+is unaffected by this sync.
 
 *How to apply:* keep RF Only keyed on `positions[0]` only. Static stations are
 preserved -- `stationcache`'s static-rebeacon merge folds the most RF-reachable
@@ -1332,18 +1332,15 @@ qualifies. RF Only is the looser companion to Direct RX (#48): it keeps
 RF-digipeated stations (`hops > 0`) and drops only APRS-IS and Internet-to-RF
 gated current fixes.
 
-*Surfacing the divergence in the popup (graywolf #482).* The badge-vs-`positions[0]`
-divergence above reads as a filter bug to operators: a station badged `APRS-IS`
-that stays visible under RF Only looks wrong even though it is correct. #482 was
-the second report of exactly this. The popup now renders an `RF-reachable`
-note (`popup.js`, class `.stn-rf-reachable`) whenever
-`rfReachableDespiteNonRfLatest(s)` holds -- the plotted fix (`positions[0]`)
-qualifies as RF-heard while the **latest** packet did not arrive over RF
-(`s.direction !== 'RX' || s.gated`). The RF Only toggle also carries a `title`
-tooltip stating the "ever RF-reachable at the current fix" semantics. This is a
-labeling affordance only; it does **not** change the predicate. If you ever make
-RF Only key on current-packet recency instead (the #482 option 2), retire this
-note too.
+*The badge-vs-`positions[0]` divergence (graywolf #482) is now resolved for
+the common cases.* Because the station-level `Direction` is synced from
+`positions[0]`, both the popup badge and the RF Only predicate read from the
+same rfRank-protected value. `rfReachableDespiteNonRfLatest` (`rf-only-core.js`)
+checks whether `positions[0]` is RF-heard while the station-level direction says
+non-RF; since they are now kept in sync for HasPos updates, the note will only
+fire for weather-only IS updates (no position, skips the sync) where a
+pre-existing RF position is on file. The RF Only toggle `title` tooltip
+remains accurate.
 
 Source: [`../../web/src/lib/map/rf-only-core.js`](../../web/src/lib/map/rf-only-core.js)
 (`isRfOnly`, `rfReachableDespiteNonRfLatest`),

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1310,19 +1310,18 @@ marker (drawn at `positions[0]`) and popup badge labeled it `APRS-IS` -- the bug
 in graywolf GitHub #394. The marker is always `positions[0]`, so the filter must
 classify off that same fix.
 
-*Station-level fields are synced from positions[0], not last-write-wins.*
-After every position update, `MemCache.Update` copies the rfRank-best
-reception metadata (`Direction`/`Via`/`Gated`/`Hops`/`Path`/`Channel`) from
-`positions[0]` back to the station-level fields (exposed as the top-level
-`StationDTO` fields, and what the popup badge reads). `updateMetadata` still
-writes the latest packet's direction first; the sync overwrites it with the
-rfRank winner. The result: when a packet is heard on RF and the same beacon
-arrives again via APRS-IS moments later, the station row and popup badge
-correctly show `RX` rather than `IS`. For a mobile station that has genuinely
-moved and is now only heard via IS, the new IS fix is inserted as `positions[0]`,
-so the sync sets the station-level direction to `IS` — the current state is
-correctly reflected. RF Only intentionally keys on `positions[0]` directly and
-is unaffected by this sync.
+*Station-level fields are latest-packet metadata, with a short same-fix RF preference window.*
+`updateMetadata` writes station-level reception metadata
+(`Direction`/`Via`/`Gated`/`Hops`/`Path`/`Channel`) from the latest packet.
+For a static same-position re-reception, `positions[0]` still keeps the
+rfRank-best copy of that fix (direct RF > digipeated RF > gated/IS/TX), but
+station-level fields only keep the prior RF-stronger value when the lower-rank
+copy arrives within `sameFixRFPreferenceWindow` (currently 2 minutes).
+
+Result: near-simultaneous duplicate receptions of the same beacon still read
+as `RX` (the intended RF-over-IS tie-break), while a delayed IS-only period
+eventually flips the station-level badge/table to `IS` as operators expect.
+RF Only intentionally keys on `positions[0]` directly and is unaffected.
 
 *How to apply:* keep RF Only keyed on `positions[0]` only. Static stations are
 preserved -- `stationcache`'s static-rebeacon merge folds the most RF-reachable
@@ -1332,15 +1331,13 @@ qualifies. RF Only is the looser companion to Direct RX (#48): it keeps
 RF-digipeated stations (`hops > 0`) and drops only APRS-IS and Internet-to-RF
 gated current fixes.
 
-*The badge-vs-`positions[0]` divergence (graywolf #482) is now resolved for
-the common cases.* Because the station-level `Direction` is synced from
-`positions[0]`, both the popup badge and the RF Only predicate read from the
-same rfRank-protected value. `rfReachableDespiteNonRfLatest` (`rf-only-core.js`)
-checks whether `positions[0]` is RF-heard while the station-level direction says
-non-RF; since they are now kept in sync for HasPos updates, the note will only
-fire for weather-only IS updates (no position, skips the sync) where a
-pre-existing RF position is on file. The RF Only toggle `title` tooltip
-remains accurate.
+*Badge-vs-`positions[0]` divergence is expected and explained.* Station-level
+fields answer "what did we hear most recently?" (with the short same-fix RF
+tie-break above), while `positions[0]` answers "what fix is plotted now?" and
+retains rfRank-best metadata for that fix. `rfReachableDespiteNonRfLatest`
+(`rf-only-core.js`) intentionally detects this divergence so the popup can
+explain why a station may still qualify under RF Only when its latest packet
+badge is non-RF.
 
 Source: [`../../web/src/lib/map/rf-only-core.js`](../../web/src/lib/map/rf-only-core.js)
 (`isRfOnly`, `rfReachableDespiteNonRfLatest`),

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/chrissnell/graywolf/pkg/configstore"
 	"github.com/chrissnell/graywolf/pkg/digipeater"
 	"github.com/chrissnell/graywolf/pkg/gps"
+	"github.com/chrissnell/graywolf/pkg/historydb"
 	"github.com/chrissnell/graywolf/pkg/igate"
 	pb "github.com/chrissnell/graywolf/pkg/ipcproto"
 	"github.com/chrissnell/graywolf/pkg/kiss"
@@ -72,6 +73,9 @@ type App struct {
 	metrics      *metrics.Metrics
 	plog         *packetlog.Log
 	stationCache *stationcache.PersistentCache
+	// histdb is the history database; non-nil when the position log is
+	// enabled and the DB opened successfully. Updated by reconfigurePositionLog.
+	histdb       *historydb.DB
 	bridge       *modembridge.Bridge
 	gov          *txgovernor.Governor
 	// ax25Mgr owns the per-process LAPB session table for the

--- a/pkg/app/wiring.go
+++ b/pkg/app/wiring.go
@@ -377,6 +377,7 @@ func (a *App) wireServicesInner(ctx context.Context) error {
 			if err := a.stationCache.Reconfigure(hdb); err != nil {
 				a.logger.Warn("failed to hydrate from history db", "err", err)
 			}
+			a.histdb = hdb
 		}
 	}
 
@@ -1518,6 +1519,12 @@ func (a *App) wireHTTP(ctx context.Context) error {
 	webapi.RegisterPackets(apiSrv, apiMux, a.plog, a.stationPos)
 	webapi.RegisterStations(apiSrv, apiMux, a.stationCache)
 	webapi.RegisterHeatmap(apiSrv, apiMux, a.stationCache)
+	webapi.RegisterStationAliases(apiSrv, apiMux, func() webapi.AliasStore {
+		if a.histdb == nil {
+			return nil
+		}
+		return a.histdb
+	})
 	webapi.RegisterPosition(apiSrv, apiMux, a.stationPos)
 	// /api/system-logs reads the slog ring buffer. a.cfg.LogBuffer is a
 	// concrete *logbuffer.DB that may be nil; assign through a typed
@@ -1733,6 +1740,7 @@ func (a *App) reconfigurePositionLog(ctx context.Context) {
 		if err := a.stationCache.Reconfigure(nil); err != nil {
 			a.logger.Warn("disable position log", "err", err)
 		}
+		a.histdb = nil
 		return
 	}
 	hdb, err := historydb.Open(a.cfg.HistoryDBPath)
@@ -1744,6 +1752,7 @@ func (a *App) reconfigurePositionLog(ctx context.Context) {
 	if err := a.stationCache.Reconfigure(hdb); err != nil {
 		a.logger.Warn("reconfigure position log", "err", err)
 	}
+	a.histdb = hdb
 }
 
 func (a *App) governorComponent() namedComponent {

--- a/pkg/historydb/historydb.go
+++ b/pkg/historydb/historydb.go
@@ -417,6 +417,42 @@ func heatBucketKey(lat, lon float64) string {
 	return fmt.Sprintf("%.4f,%.4f", roundHeat(lat), roundHeat(lon))
 }
 
+// GetAliases returns all saved station aliases as a callsign→alias map.
+func (d *DB) GetAliases() (map[string]string, error) {
+	type row struct {
+		Callsign string
+		Alias    string
+	}
+	var rows []row
+	if err := d.db.Raw("SELECT callsign, alias FROM station_aliases").Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("get aliases: %w", err)
+	}
+	out := make(map[string]string, len(rows))
+	for _, r := range rows {
+		out[r.Callsign] = r.Alias
+	}
+	return out, nil
+}
+
+// SetAlias creates or replaces the alias for callsign.
+func (d *DB) SetAlias(callsign, alias string) error {
+	if err := d.db.Exec(
+		"INSERT OR REPLACE INTO station_aliases (callsign, alias, updated_at) VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%SZ','now'))",
+		callsign, alias,
+	).Error; err != nil {
+		return fmt.Errorf("set alias: %w", err)
+	}
+	return nil
+}
+
+// DeleteAlias removes the alias for callsign. No-op when callsign has no alias.
+func (d *DB) DeleteAlias(callsign string) error {
+	if err := d.db.Exec("DELETE FROM station_aliases WHERE callsign = ?", callsign).Error; err != nil {
+		return fmt.Errorf("delete alias: %w", err)
+	}
+	return nil
+}
+
 // QueryHeatmap aggregates directly-received packets over the given window into
 // counted coordinate buckets within bbox. Events whose attributed transmitter
 // has no known position are tallied in Unlocatable rather than dropped.
@@ -549,6 +585,11 @@ func bootstrap(db *gorm.DB) error {
 			has_pos   INTEGER NOT NULL DEFAULT 0
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_rx_events_time ON rx_events(timestamp)`,
+		`CREATE TABLE IF NOT EXISTS station_aliases (
+			callsign   TEXT PRIMARY KEY,
+			alias      TEXT NOT NULL,
+			updated_at DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+		)`,
 	}
 	for _, stmt := range stmts {
 		if err := db.Exec(stmt).Error; err != nil {

--- a/pkg/stationcache/memcache.go
+++ b/pkg/stationcache/memcache.go
@@ -145,6 +145,21 @@ func (c *MemCache) Update(entries []CacheEntry) {
 				s.Positions = s.Positions[:MaxTrailLen]
 			}
 		}
+		// Mirror positions[0]'s rfRank-best reception metadata back to the
+		// station-level direction fields. updateMetadata above wrote the
+		// latest packet's direction unconditionally; for a static re-beacon
+		// positions[0] was just rfRank-merged, so syncing here prevents an
+		// IS echo of the same beacon from downgrading the stations-table
+		// row from RX to IS. For a genuinely new position (mobile station
+		// now only heard via IS) positions[0] holds that IS fix, so the
+		// station-level direction still correctly reflects the current state.
+		p0 := s.Positions[0]
+		s.Direction = p0.Direction
+		s.Via = p0.Via
+		s.Gated = p0.Gated
+		s.Hops = p0.Hops
+		s.Path = p0.Path
+		s.Channel = p0.Channel
 	}
 }
 

--- a/pkg/stationcache/memcache.go
+++ b/pkg/stationcache/memcache.go
@@ -19,6 +19,12 @@ const posEpsilon = 0.00001
 // for APRS-IS and store-and-forward digipeater delays. See issue #421.
 const dupWindow = 2 * time.Minute
 
+// sameFixRFPreferenceWindow is the maximum arrival gap for treating a lower-
+// rank copy of the same fix as "roughly simultaneous" and keeping the prior
+// RF-stronger station-level reception metadata. Beyond this window, station-
+// level metadata follows the latest packet.
+const sameFixRFPreferenceWindow = dupWindow
+
 // MaxStations is the hard upper bound on resident MemCache entries.
 // The TTL-based prune (memMaxAge, default 24h) is the primary eviction
 // path for routine operation; this cap is a safety bound for the
@@ -66,6 +72,16 @@ func (c *MemCache) Update(entries []CacheEntry) {
 		}
 
 		s, exists := c.stations[e.Key]
+		var (
+			prevHead      Position
+			hadPrevHead   bool
+			prevLastHeard time.Time
+		)
+		if exists && len(s.Positions) > 0 {
+			prevHead = s.Positions[0]
+			hadPrevHead = true
+			prevLastHeard = s.LastHeard
+		}
 
 		if !e.HasPos && !exists {
 			// Weather-only packet for unknown station — skip.
@@ -123,6 +139,14 @@ func (c *MemCache) Update(entries []CacheEntry) {
 			mergeReception(&s.Positions[0], e)
 			s.Positions[0].Timestamp = e.Timestamp
 			s.Positions[0].Comment = e.Comment
+			if hadPrevHead && preferPriorStationReception(prevHead, prevLastHeard, e, now) {
+				s.Direction = prevHead.Direction
+				s.Via = prevHead.Via
+				s.Gated = prevHead.Gated
+				s.Hops = prevHead.Hops
+				s.Path = prevHead.Path
+				s.Channel = prevHead.Channel
+			}
 		} else if i := duplicateFix(s.Positions, newPos); i >= 0 {
 			// Late duplicate of an earlier fix: a digipeated, APRS-IS, or
 			// second-channel copy of a beacon the station has since moved on
@@ -145,21 +169,6 @@ func (c *MemCache) Update(entries []CacheEntry) {
 				s.Positions = s.Positions[:MaxTrailLen]
 			}
 		}
-		// Mirror positions[0]'s rfRank-best reception metadata back to the
-		// station-level direction fields. updateMetadata above wrote the
-		// latest packet's direction unconditionally; for a static re-beacon
-		// positions[0] was just rfRank-merged, so syncing here prevents an
-		// IS echo of the same beacon from downgrading the stations-table
-		// row from RX to IS. For a genuinely new position (mobile station
-		// now only heard via IS) positions[0] holds that IS fix, so the
-		// station-level direction still correctly reflects the current state.
-		p0 := s.Positions[0]
-		s.Direction = p0.Direction
-		s.Via = p0.Via
-		s.Gated = p0.Gated
-		s.Hops = p0.Hops
-		s.Path = p0.Path
-		s.Channel = p0.Channel
 	}
 }
 
@@ -369,6 +378,22 @@ func mergeReception(p *Position, e *CacheEntry) {
 		p.Gated = e.Gated
 		p.Channel = e.Channel
 	}
+}
+
+// preferPriorStationReception keeps station-level reception metadata at the
+// prior value when a lower-rank copy of the same fix arrives shortly after.
+// This preserves the expected "RF wins over IS" behavior for near-simultaneous
+// duplicates, while allowing a delayed IS-only period to flip station-level
+// direction to IS.
+func preferPriorStationReception(prev Position, prevLastHeard time.Time, e *CacheEntry, now time.Time) bool {
+	if prevLastHeard.IsZero() {
+		return false
+	}
+	age := now.Sub(prevLastHeard)
+	if age < 0 || age > sameFixRFPreferenceWindow {
+		return false
+	}
+	return rfRank(prev.Direction, prev.Hops, prev.Gated) > rfRank(e.Direction, e.Hops, e.Gated)
 }
 
 // duplicateFix reports the index of an existing trail point that the

--- a/pkg/stationcache/memcache_test.go
+++ b/pkg/stationcache/memcache_test.go
@@ -348,7 +348,7 @@ func intToBase36(i int) string {
 func TestMemCache_MetadataUpdate(t *testing.T) {
 	c := newTestCache(t)
 
-	// Initial entry
+	// Initial entry heard on RF.
 	c.Update([]CacheEntry{
 		{Key: "stn:W1ABC", Callsign: "W1ABC", HasPos: true,
 			Lat: 40.0, Lon: -105.0, Symbol: [2]byte{'/', '>'},
@@ -356,7 +356,9 @@ func TestMemCache_MetadataUpdate(t *testing.T) {
 			Timestamp: time.Now()},
 	})
 
-	// Update with new metadata but same position
+	// IS echo of the same beacon at the same position. rfRank(IS) < rfRank(RX),
+	// so Direction/Via/Channel must stay at the RF copy. Symbol and Comment
+	// still advance (last-write-wins — they are not reception-path fields).
 	c.Update([]CacheEntry{
 		{Key: "stn:W1ABC", Callsign: "W1ABC", HasPos: true,
 			Lat: 40.0, Lon: -105.0, Symbol: [2]byte{'/', 'k'},
@@ -369,12 +371,43 @@ func TestMemCache_MetadataUpdate(t *testing.T) {
 		t.Fatalf("expected 1 station, got %d", len(results))
 	}
 	s := results[0]
-	assertEqual(t, "Symbol", s.Symbol, [2]byte{'/', 'k'})
+	assertEqual(t, "Symbol", s.Symbol, [2]byte{'/', 'k'}) // Symbol always updates
+	assertEqual(t, "Via", s.Via, "rf")                    // RF wins over IS
+	assertEqual(t, "Direction", s.Direction, "RX")        // RF wins over IS
+	assertEqual(t, "Channel", s.Channel, uint32(0))       // RF channel preserved
+	assertEqual(t, "Comment", s.Comment, "updated")       // Comment always updates
+	if len(s.Positions) != 1 {
+		t.Fatalf("expected 1 position, got %d", len(s.Positions))
+	}
+}
+
+func TestMemCache_MetadataUpdateISOnlyDowngradesIS(t *testing.T) {
+	c := newTestCache(t)
+
+	// Station first heard via IS.
+	c.Update([]CacheEntry{
+		{Key: "stn:W1ABC", Callsign: "W1ABC", HasPos: true,
+			Lat: 40.0, Lon: -105.0, Symbol: [2]byte{'/', '>'},
+			Via: "is", Direction: "IS", Channel: 0, Comment: "first",
+			Timestamp: time.Now()},
+	})
+
+	// Second IS update at the same position — IS=IS tie, latest wins.
+	c.Update([]CacheEntry{
+		{Key: "stn:W1ABC", Callsign: "W1ABC", HasPos: true,
+			Lat: 40.0, Lon: -105.0, Symbol: [2]byte{'/', 'k'},
+			Via: "is", Direction: "IS", Channel: 2, Comment: "updated",
+			Timestamp: time.Now()},
+	})
+
+	results := c.QueryBBox(BBox{SwLat: 39, SwLon: -106, NeLat: 41, NeLon: -104}, 1*time.Hour)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 station, got %d", len(results))
+	}
+	s := results[0]
 	assertEqual(t, "Via", s.Via, "is")
 	assertEqual(t, "Direction", s.Direction, "IS")
-	assertEqual(t, "Channel", s.Channel, uint32(1))
-	assertEqual(t, "Comment", s.Comment, "updated")
-	// Position trail should still be 1 (didn't move)
+	assertEqual(t, "Channel", s.Channel, uint32(2))
 	if len(s.Positions) != 1 {
 		t.Fatalf("expected 1 position, got %d", len(s.Positions))
 	}
@@ -535,7 +568,7 @@ func TestMemCache_RFCopyNotMaskedByGated(t *testing.T) {
 func TestMemCache_LastDirectHeardSetOnDirect(t *testing.T) {
 	c := newTestCache(t)
 
-	c.Update([]CacheEntry{stationEntry("stn:DIRECT", "DIRECT", 40.0, -105.0)})    // RX, hops 0
+	c.Update([]CacheEntry{stationEntry("stn:DIRECT", "DIRECT", 40.0, -105.0)})     // RX, hops 0
 	c.Update([]CacheEntry{digiEntry("stn:DIGIONLY", "DIGIONLY", 41.0, -105.0, 2)}) // RX, hops 2
 
 	results := c.QueryBBox(BBox{SwLat: 39, SwLon: -106, NeLat: 42, NeLon: -104}, 1*time.Hour)

--- a/pkg/stationcache/memcache_test.go
+++ b/pkg/stationcache/memcache_test.go
@@ -356,9 +356,10 @@ func TestMemCache_MetadataUpdate(t *testing.T) {
 			Timestamp: time.Now()},
 	})
 
-	// IS echo of the same beacon at the same position. rfRank(IS) < rfRank(RX),
-	// so Direction/Via/Channel must stay at the RF copy. Symbol and Comment
-	// still advance (last-write-wins — they are not reception-path fields).
+	// Near-simultaneous IS echo of the same beacon at the same position.
+	// rfRank(IS) < rfRank(RX), so Direction/Via/Channel stay at the RF
+	// copy inside sameFixRFPreferenceWindow. Symbol and Comment still
+	// advance (last-write-wins -- they are not reception-path fields).
 	c.Update([]CacheEntry{
 		{Key: "stn:W1ABC", Callsign: "W1ABC", HasPos: true,
 			Lat: 40.0, Lon: -105.0, Symbol: [2]byte{'/', 'k'},
@@ -378,6 +379,49 @@ func TestMemCache_MetadataUpdate(t *testing.T) {
 	assertEqual(t, "Comment", s.Comment, "updated")       // Comment always updates
 	if len(s.Positions) != 1 {
 		t.Fatalf("expected 1 position, got %d", len(s.Positions))
+	}
+}
+
+func TestMemCache_MetadataUpdate_DelayedISEchoFlipsStationDirection(t *testing.T) {
+	c := newTestCache(t)
+
+	// Start with a direct RF copy of a static fix.
+	c.Update([]CacheEntry{
+		{Key: "stn:W1ABC", Callsign: "W1ABC", HasPos: true,
+			Lat: 40.0, Lon: -105.0, Symbol: [2]byte{'/', '>'},
+			Via: "rf", Direction: "RX", Channel: 0, Comment: "first",
+			Timestamp: time.Now()},
+	})
+
+	// Simulate a long gap before an IS copy of the same coordinates arrives:
+	// outside the RF-preference window, station-level metadata must follow
+	// the latest packet and flip to IS.
+	c.mu.Lock()
+	c.stations["stn:W1ABC"].LastHeard = time.Now().Add(-(sameFixRFPreferenceWindow + time.Second))
+	c.mu.Unlock()
+
+	c.Update([]CacheEntry{
+		{Key: "stn:W1ABC", Callsign: "W1ABC", HasPos: true,
+			Lat: 40.0, Lon: -105.0, Symbol: [2]byte{'/', 'k'},
+			Via: "is", Direction: "IS", Channel: 3, Comment: "is copy",
+			Timestamp: time.Now()},
+	})
+
+	results := c.QueryBBox(BBox{SwLat: 39, SwLon: -106, NeLat: 41, NeLon: -104}, 1*time.Hour)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 station, got %d", len(results))
+	}
+	s := results[0]
+	assertEqual(t, "Via", s.Via, "is")
+	assertEqual(t, "Direction", s.Direction, "IS")
+	assertEqual(t, "Channel", s.Channel, uint32(3))
+	if len(s.Positions) != 1 {
+		t.Fatalf("expected 1 position, got %d", len(s.Positions))
+	}
+	// RF-only map classification still keys on the position metadata, which
+	// keeps the RF-strongest copy of this static fix.
+	if !isDirectRF(s.Positions[0].Direction, s.Positions[0].Hops) {
+		t.Fatalf("positions[0] lost RF-strongest metadata: Direction=%q Hops=%d", s.Positions[0].Direction, s.Positions[0].Hops)
 	}
 }
 

--- a/pkg/webapi/stationaliases.go
+++ b/pkg/webapi/stationaliases.go
@@ -1,0 +1,116 @@
+package webapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// AliasStore is the persistence interface for user-defined station aliases.
+// historydb.DB satisfies this interface; nil is returned by the getter
+// when the position log is disabled.
+type AliasStore interface {
+	GetAliases() (map[string]string, error)
+	SetAlias(callsign, alias string) error
+	DeleteAlias(callsign string) error
+}
+
+// AliasStoreGetter is a function that returns the current AliasStore. It
+// returns nil when the position log is disabled, which causes PUT/DELETE
+// to respond 503 and GET to return an empty map.
+type AliasStoreGetter func() AliasStore
+
+// RegisterStationAliases installs the /api/stations/aliases route tree.
+// Called from wiring.go alongside RegisterStations.
+//
+// Routes:
+//
+//	GET    /api/stations/aliases           → map[callsign]alias (empty {} when position log off)
+//	PUT    /api/stations/aliases/{callsign} → {"alias":"..."} saves/replaces alias; 503 when off
+//	DELETE /api/stations/aliases/{callsign} → removes alias; 503 when off
+func RegisterStationAliases(_ *Server, mux *http.ServeMux, getter AliasStoreGetter) {
+	mux.HandleFunc("GET /api/stations/aliases", listAliases(getter))
+	mux.HandleFunc("PUT /api/stations/aliases/{callsign}", putAlias(getter))
+	mux.HandleFunc("DELETE /api/stations/aliases/{callsign}", deleteAlias(getter))
+}
+
+func listAliases(getter AliasStoreGetter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		db := getter()
+		if db == nil {
+			writeJSON(w, http.StatusOK, map[string]string{})
+			return
+		}
+		m, err := db.GetAliases()
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if m == nil {
+			m = map[string]string{}
+		}
+		writeJSON(w, http.StatusOK, m)
+	}
+}
+
+func putAlias(getter AliasStoreGetter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		db := getter()
+		if db == nil {
+			http.Error(w, "position log is not enabled", http.StatusServiceUnavailable)
+			return
+		}
+		callsign := normalizeCallsign(r.PathValue("callsign"))
+		if callsign == "" {
+			badRequest(w, "callsign is required")
+			return
+		}
+		var body struct {
+			Alias string `json:"alias"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			badRequest(w, "invalid request body")
+			return
+		}
+		alias := strings.TrimSpace(body.Alias)
+		if len(alias) > 64 {
+			badRequest(w, "alias too long (max 64 characters)")
+			return
+		}
+		if err := db.SetAlias(callsign, alias); err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"callsign": callsign, "alias": alias})
+	}
+}
+
+func deleteAlias(getter AliasStoreGetter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		db := getter()
+		if db == nil {
+			http.Error(w, "position log is not enabled", http.StatusServiceUnavailable)
+			return
+		}
+		callsign := normalizeCallsign(r.PathValue("callsign"))
+		if callsign == "" {
+			badRequest(w, "callsign is required")
+			return
+		}
+		if err := db.DeleteAlias(callsign); err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// normalizeCallsign uppercases and trims the callsign, returning empty string
+// when the result is blank or longer than 15 characters (APRS-IS limit).
+func normalizeCallsign(s string) string {
+	s = strings.ToUpper(strings.TrimSpace(s))
+	if len(s) == 0 || len(s) > 15 {
+		return ""
+	}
+	return s
+}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -29,6 +29,7 @@
   import Logs from './routes/Logs.svelte';
   import SystemLogs from './routes/SystemLogs.svelte';
   import LiveMapV2 from './routes/LiveMapV2.svelte';
+  import Stations from './routes/Stations.svelte';
   import About from './routes/About.svelte';
   import Preferences from './routes/Preferences.svelte';
   import MapsSettings from './routes/MapsSettings.svelte';
@@ -42,6 +43,7 @@
     '/login': Login,
     '/': Dashboard,
     '/map': LiveMapV2,
+    '/stations': Stations,
     '/messages': Messages,
     '/messages/*': Messages,
     '/terminal': Terminal,

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -27,6 +27,7 @@
   const mainItems = [
     { path: '/', label: 'Dashboard', svgIcon: 'dashboard' },
     { path: '/map', label: 'Live Map', svgIcon: 'globe' },
+    { path: '/stations', label: 'Stations', svgIcon: 'stations' },
     { path: '/messages', label: 'Messages', icon: 'message-square', badge: 'messages' },
     { path: '/terminal', label: 'Terminal', svgIcon: 'terminal', badge: 'terminal' },
     { path: '/actions', label: 'Actions', svgIcon: 'zap' },
@@ -35,21 +36,21 @@
   ];
 
   const allSettingsItems = [
-    { path: '/agw', label: 'AGW' },
-    { path: '/audio-devices', label: 'Audio Devices' },
-    { path: '/beacons', label: 'Beacons' },
-    { path: '/channels', label: 'Channels' },
-    { path: '/digipeater', label: 'Digipeater' },
     { path: '/preferences', label: 'General' },
-    { path: '/gps', label: 'GPS' },
-    { path: '/igate', label: 'iGate' },
-    { path: '/kiss', label: 'KISS' },
-    { path: '/preferences/maps', label: 'Maps' },
-    { path: '/preferences/messages', label: 'Messaging' },
-    { path: '/position-log', label: 'Position Log' },
-    { path: '/ptt', label: 'PTT' },
-    { path: '/simulation', label: 'Simulation' },
     { path: '/callsign', label: 'Station Callsign' },
+    { path: '/audio-devices', label: 'Audio Devices' },
+    { path: '/ptt', label: 'PTT' },
+    { path: '/channels', label: 'Channels' },
+    { path: '/kiss', label: 'KISS' },
+    { path: '/gps', label: 'GPS' },
+    { path: '/beacons', label: 'Beacons' },
+    { path: '/igate', label: 'iGate' },
+    { path: '/digipeater', label: 'Digipeater' },
+    { path: '/preferences/maps', label: 'Maps' },
+    { path: '/position-log', label: 'Position Log' },
+    { path: '/preferences/messages', label: 'Messaging' },
+    { path: '/agw', label: 'AGW' },
+    { path: '/simulation', label: 'Simulation' },
   ];
   // mainItems carries the icon'd top section; it's filtered by the
   // same HIDDEN_ON_ANDROID set as the settings group so an entry like
@@ -183,6 +184,23 @@
                 <path d="M3 12h18" />
                 <path d="M12 3a14 14 0 0 1 0 18" />
                 <path d="M12 3a14 14 0 0 0 0 18" />
+              </svg>
+            {:else if item.svgIcon === 'stations'}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <rect x="3" y="3" width="18" height="18" rx="2" />
+                <path d="M3 9h18" />
+                <path d="M3 15h18" />
+                <path d="M9 9v12" />
               </svg>
             {:else if item.svgIcon === 'dashboard'}
               <svg

--- a/web/src/lib/map/rf-only-core.js
+++ b/web/src/lib/map/rf-only-core.js
@@ -11,10 +11,10 @@
 // stations the server folds the most RF-reachable copy of a fix into
 // positions[0] (see stationcache rfRank), so a fixed station heard on RF and
 // later re-beaconed via a gated/IS copy still qualifies. Note positions[0] can
-// diverge from the popup's top-level direction/via badge in exactly that case
-// (the cache overwrites the station-level fields with the latest packet
-// unconditionally) -- positions[0] is the rfRank-protected copy and is the
-// correct basis for RF reachability.
+// diverge from the popup's top-level direction/via badge in exactly that case:
+// station-level fields follow the latest packet (except a brief same-fix
+// RF-preference window), while positions[0] stays rfRank-protected. So
+// positions[0] is the correct basis for RF reachability.
 export function isRfOnly(station) {
   const p = station?.positions?.[0];
   return !!p && p.direction === 'RX' && !p.gated;
@@ -23,8 +23,8 @@ export function isRfOnly(station) {
 // rfReachableDespiteNonRfLatest reports the popup "RF-reachable" note case:
 // the plotted fix (positions[0]) qualifies as RF-heard (isRfOnly) yet the
 // station's *latest* packet -- the one that drives the popup badge / via line
-// (station-level direction/gated, overwritten by every arrival) -- did NOT
-// arrive over RF. That divergence is why a station badged "APRS-IS" can still,
+// (station-level direction/gated, usually latest-packet) -- did NOT arrive
+// over RF. That divergence is why a station badged "APRS-IS" can still,
 // correctly, survive the RF Only filter: the marker is drawn at positions[0],
 // which the server pins to the most RF-reachable copy of the fix via rfRank.
 // The popup uses this to explain the visibility instead of reading as a bug

--- a/web/src/routes/Stations.svelte
+++ b/web/src/routes/Stations.svelte
@@ -34,6 +34,12 @@
     { value: 604800, label: '7 days' },
   ];
 
+  const DIRECTION_OPTIONS = [
+    { value: 'RX', label: 'RX', cls: 'b-rx' },
+    { value: 'TX', label: 'TX', cls: 'b-tx' },
+    { value: 'IS', label: 'IS', cls: 'b-is' },
+  ];
+
   const RETINA = typeof window !== 'undefined' && window.devicePixelRatio > 1.5;
   const SHEETS = RETINA ? SPRITE_URLS_2X : SPRITE_URLS;
   const ICON_PX = 20;
@@ -59,6 +65,10 @@
   let iconDropOpen   = $state(false);
   let iconSearch     = $state('');
   let iconDropEl     = $state(null); // bound to the wrapper div for outside-click detection
+
+  let filterDirections = $state(new Set());
+  let dirDropOpen      = $state(false);
+  let dirDropEl        = $state(null);
 
   // Sort
   let sortCol = $state('last_heard');
@@ -187,7 +197,7 @@
   $effect(() => {
     // Access all filter state so this effect tracks them.
     filterCallsign; filterAlias; hasAliasOnly; todayOnly;
-    filterComment; selectedIcons; sortCol; sortDir; pageSize;
+    filterComment; selectedIcons; filterDirections; sortCol; sortDir; pageSize;
     currentPage = 1;
   });
 
@@ -219,6 +229,11 @@
     // Icon multiselect
     if (selectedIcons.size > 0) {
       list = list.filter(s => selectedIcons.has(iconKey(s.symbol_table, s.symbol_code)));
+    }
+
+    // Direction multiselect
+    if (filterDirections.size > 0) {
+      list = list.filter(s => filterDirections.has(s.direction));
     }
 
     // Comment LIKE filter
@@ -356,6 +371,12 @@
 
   function clearIconFilter() { selectedIcons = new Set(); }
 
+  function toggleDirection(val) {
+    const next = new Set(filterDirections);
+    if (next.has(val)) next.delete(val); else next.add(val);
+    filterDirections = next;
+  }
+
   // Close icon dropdown on outside click; also clear the search.
   function onIconDropKey(e) {
     if (e.key === 'Escape') { iconDropOpen = false; iconSearch = ''; }
@@ -367,6 +388,19 @@
     const dismiss = () => { iconDropOpen = false; iconSearch = ''; };
     const onKey   = (e) => { if (e.key === 'Escape') dismiss(); };
     const onDown  = (e) => { if (iconDropEl && !iconDropEl.contains(e.target)) dismiss(); };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onDown);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onDown);
+    };
+  });
+
+  $effect(() => {
+    if (!dirDropOpen) return;
+    const dismiss = () => { dirDropOpen = false; };
+    const onKey   = (e) => { if (e.key === 'Escape') dismiss(); };
+    const onDown  = (e) => { if (dirDropEl && !dirDropEl.contains(e.target)) dismiss(); };
     document.addEventListener('keydown', onKey);
     document.addEventListener('pointerdown', onDown);
     return () => {
@@ -465,7 +499,41 @@
                 <Input bind:value={filterAlias} placeholder="Search…" />
               </td>
             {/if}
-            <td><!-- Last Heard: use global Today toggle above --></td>
+            <td class="filter-heard-cell">
+              <div class="icon-drop-wrap" bind:this={dirDropEl}>
+                <button
+                  type="button"
+                  class="icon-drop-btn"
+                  onclick={() => { dirDropOpen = !dirDropOpen; }}
+                  aria-expanded={dirDropOpen}
+                  aria-haspopup="listbox"
+                >
+                  {filterDirections.size > 0 ? `${filterDirections.size} selected` : 'All'}
+                  <span class="icon-drop-caret">▾</span>
+                </button>
+                {#if dirDropOpen}
+                  <div class="icon-drop-panel" role="listbox" aria-multiselectable="true">
+                    <button
+                      type="button"
+                      class="icon-drop-clear"
+                      onclick={() => { filterDirections = new Set(); }}
+                    >Clear selection</button>
+                    <div class="icon-drop-list">
+                      {#each DIRECTION_OPTIONS as opt}
+                        <label class="icon-drop-item">
+                          <input
+                            type="checkbox"
+                            checked={filterDirections.has(opt.value)}
+                            onchange={() => toggleDirection(opt.value)}
+                          />
+                          <span class="badge {opt.cls}">{opt.label}</span>
+                        </label>
+                      {/each}
+                    </div>
+                  </div>
+                {/if}
+              </div>
+            </td>
             <td class="filter-icon-cell">
               <!-- Custom multiselect dropdown for icon filter -->
               <div class="icon-drop-wrap" bind:this={iconDropEl}>
@@ -725,7 +793,8 @@
     vertical-align: middle;
   }
   .filter-alias-cell { min-width: 120px; }
-  .filter-icon-cell { position: relative; min-width: 120px; }
+  .filter-heard-cell { position: relative; min-width: 110px; vertical-align: top !important; }
+  .filter-icon-cell { position: relative; min-width: 120px; vertical-align: top !important; }
 
   /* Body rows */
   .station-row td {
@@ -803,9 +872,10 @@
   .icon-drop-btn {
     width: 100%; background: var(--bg-primary);
     border: 1px solid var(--border-color); border-radius: 4px;
-    padding: 4px 8px; color: var(--color-text);
-    font-size: var(--text-sm); cursor: pointer;
+    padding: 0.5rem; color: var(--color-text);
+    font-size: var(--text-base); cursor: pointer;
     display: flex; align-items: center; justify-content: space-between;
+    box-sizing: border-box;
     gap: 4px;
   }
   .icon-drop-btn:hover { border-color: var(--color-primary); }

--- a/web/src/routes/Stations.svelte
+++ b/web/src/routes/Stations.svelte
@@ -1,0 +1,865 @@
+<script>
+  import { onMount } from 'svelte';
+  import { Button, Input, Select, Box } from '@chrissnell/chonky-ui';
+  import { api } from '../lib/api.js';
+  import { online } from '../lib/stores/connection.js';
+  import { toasts } from '../lib/stores.js';
+  import { unitsState } from '../lib/settings/units-store.svelte.js';
+  import PageHeader from '../components/PageHeader.svelte';
+  import {
+    COLS, ROWS,
+    SPRITE_URLS, SPRITE_URLS_2X,
+    cellOf, loadSymbols, describe,
+  } from '../lib/aprsSymbols.js';
+
+  // --- Constants -------------------------------------------------------
+
+  const PAGE_SIZE_OPTIONS = [
+    { value: 50,  label: '50 per page' },
+    { value: 100, label: '100 per page' },
+    { value: 200, label: '200 per page' },
+  ];
+
+  const TIMERANGE_OPTIONS = [
+    { value: 900,    label: '15 minutes' },
+    { value: 1800,   label: '30 minutes' },
+    { value: 3600,   label: '1 hour' },
+    { value: 7200,   label: '2 hours' },
+    { value: 14400,  label: '4 hours' },
+    { value: 28800,  label: '8 hours' },
+    { value: 43200,  label: '12 hours' },
+    { value: 86400,  label: '1 day' },
+    { value: 172800, label: '2 days' },
+    { value: 345600, label: '4 days' },
+    { value: 604800, label: '7 days' },
+  ];
+
+  const RETINA = typeof window !== 'undefined' && window.devicePixelRatio > 1.5;
+  const SHEETS = RETINA ? SPRITE_URLS_2X : SPRITE_URLS;
+  const ICON_PX = 20;
+
+  // --- State -----------------------------------------------------------
+
+  let stations       = $state([]);
+  let aliases        = $state({});
+  let myPosition     = $state(null);
+  let posLogEnabled  = $state(false);
+  let loading        = $state(true);
+  let symbols        = $state(null);
+  let autoRefresh    = $state(true);
+  let timerange      = $state(86400);
+
+  // Filters
+  let filterCallsign = $state('');
+  let filterAlias    = $state('');
+  let hasAliasOnly   = $state(false);
+  let todayOnly      = $state(false);
+  let filterComment  = $state('');
+  let selectedIcons  = $state(new Set());
+  let iconDropOpen   = $state(false);
+  let iconSearch     = $state('');
+  let iconDropEl     = $state(null); // bound to the wrapper div for outside-click detection
+
+  // Sort
+  let sortCol = $state('last_heard');
+  let sortDir = $state('desc');
+
+  // Pagination
+  let pageSize    = $state(50);
+  let currentPage = $state(1);
+
+  // Inline alias editing: callsign currently being edited -> draft value
+  let editingAlias   = $state(null);
+  let editDraft      = $state('');
+
+  let offline = $derived(!$online);
+
+  // --- Helpers ---------------------------------------------------------
+
+  /** Haversine distance between two points, in km. */
+  function haversineKm(lat1, lon1, lat2, lon2) {
+    const R = 6371;
+    const dLat = (lat2 - lat1) * Math.PI / 180;
+    const dLon = (lon2 - lon1) * Math.PI / 180;
+    const a = Math.sin(dLat / 2) ** 2 +
+              Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+              Math.sin(dLon / 2) ** 2;
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
+
+  /** Bearing from point 1 → point 2, 0–359 degrees true. */
+  function bearingDeg(lat1, lon1, lat2, lon2) {
+    const φ1 = lat1 * Math.PI / 180;
+    const φ2 = lat2 * Math.PI / 180;
+    const Δλ = (lon2 - lon1) * Math.PI / 180;
+    const y = Math.sin(Δλ) * Math.cos(φ2);
+    const x = Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(Δλ);
+    return ((Math.atan2(y, x) * 180 / Math.PI) + 360) % 360;
+  }
+
+  /** Format bearing as compass direction + degrees, e.g. "NNE 22°". */
+  function formatBearing(deg) {
+    const dirs = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW'];
+    const idx = Math.round(deg / 22.5) % 16;
+    return `${dirs[idx]} ${Math.round(deg)}°`;
+  }
+
+  /** Format distance in km or miles based on units preference. */
+  function formatDist(km) {
+    if (unitsState.isMetric) return `${km < 10 ? km.toFixed(1) : Math.round(km)} km`;
+    const mi = km * 0.621371;
+    return `${mi < 10 ? mi.toFixed(1) : Math.round(mi)} mi`;
+  }
+
+  /** CSS background-position string for an APRS symbol sprite at ICON_PX. */
+  function iconBgStyle(table, code) {
+    if (!code) return '';
+    const sheet = table === '/' ? SHEETS['/'] : SHEETS['\\'];
+    const [col, row] = cellOf(code);
+    const bgSize = `${COLS * ICON_PX}px ${ROWS * ICON_PX}px`;
+    const bgPos  = `-${col * ICON_PX}px -${row * ICON_PX}px`;
+    return `background-image:url(${sheet});background-size:${bgSize};background-position:${bgPos};background-repeat:no-repeat;image-rendering:${RETINA ? 'auto' : 'pixelated'}`;
+  }
+
+  /** Human-readable label for an APRS symbol. */
+  function iconLabel(table, code) {
+    return describe(symbols, table, code) || `${table}${code}`;
+  }
+
+  /** Composite key for a symbol used in selectedIcons set and dropdown. */
+  function iconKey(table, code) { return `${table}${code}`; }
+
+  /** "time ago" relative label. */
+  function timeAgo(ts) {
+    const diff = (Date.now() - new Date(ts).getTime()) / 1000;
+    if (diff < 60)   return `${Math.round(diff)}s ago`;
+    if (diff < 3600) return `${Math.round(diff / 60)}m ago`;
+    if (diff < 86400) return `${Math.round(diff / 3600)}h ago`;
+    return `${Math.round(diff / 86400)}d ago`;
+  }
+
+  // --- Derived: enriched station rows ----------------------------------
+
+  let enriched = $derived.by(() => {
+    const myLat = myPosition?.valid ? myPosition.lat : null;
+    const myLon = myPosition?.valid ? myPosition.lon : null;
+    return stations.map(s => {
+      const pos = s.positions?.[0];
+      const lat = pos?.lat ?? null;
+      const lon = pos?.lon ?? null;
+      let distKm = null, bearing = null;
+      if (myLat !== null && lat !== null) {
+        distKm  = haversineKm(myLat, myLon, lat, lon);
+        bearing = bearingDeg(myLat, myLon, lat, lon);
+      }
+      return { ...s, alias: aliases[s.callsign] || '', distKm, bearing, lat, lon };
+    });
+  });
+
+  // Unique icons across all current stations for the dropdown.
+  let uniqueIcons = $derived.by(() => {
+    const seen = new Map();
+    for (const s of enriched) {
+      const key = iconKey(s.symbol_table, s.symbol_code);
+      if (!seen.has(key)) {
+        seen.set(key, { key, table: s.symbol_table, code: s.symbol_code,
+                        label: iconLabel(s.symbol_table, s.symbol_code) });
+      }
+    }
+    return [...seen.values()].sort((a, b) => a.label.localeCompare(b.label));
+  });
+
+  // Filtered icon list for the dropdown search input.
+  let filteredIcons = $derived.by(() => {
+    const q = iconSearch.trim().toLowerCase();
+    if (!q) return uniqueIcons;
+    return uniqueIcons.filter(ic => ic.label.toLowerCase().includes(q));
+  });
+
+  // Midnight of today in local time (ms since epoch), for the "Today" filter.
+  let todayStartMs = $derived((() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+  })());
+
+  // Reset page to 1 whenever a filter changes so the user is never stranded.
+  $effect(() => {
+    // Access all filter state so this effect tracks them.
+    filterCallsign; filterAlias; hasAliasOnly; todayOnly;
+    filterComment; selectedIcons; sortCol; sortDir; pageSize;
+    currentPage = 1;
+  });
+
+  let filteredSorted = $derived.by(() => {
+    let list = enriched;
+
+    // Callsign LIKE filter
+    if (filterCallsign.trim()) {
+      const q = filterCallsign.trim().toUpperCase();
+      list = list.filter(s => s.callsign.toUpperCase().includes(q));
+    }
+
+    // Alias LIKE filter (only applies when alias column is visible)
+    if (posLogEnabled && filterAlias.trim()) {
+      const q = filterAlias.trim().toUpperCase();
+      list = list.filter(s => s.alias.toUpperCase().includes(q));
+    }
+
+    // "Has alias" toggle
+    if (posLogEnabled && hasAliasOnly) {
+      list = list.filter(s => s.alias !== '');
+    }
+
+    // "Today" toggle
+    if (todayOnly) {
+      list = list.filter(s => new Date(s.last_heard).getTime() >= todayStartMs);
+    }
+
+    // Icon multiselect
+    if (selectedIcons.size > 0) {
+      list = list.filter(s => selectedIcons.has(iconKey(s.symbol_table, s.symbol_code)));
+    }
+
+    // Comment LIKE filter
+    if (filterComment.trim()) {
+      const q = filterComment.trim().toLowerCase();
+      list = list.filter(s => (s.comment || '').toLowerCase().includes(q));
+    }
+
+    // Sort
+    list = [...list].sort((a, b) => {
+      let va, vb;
+      switch (sortCol) {
+        case 'callsign':   va = a.callsign;  vb = b.callsign;  break;
+        case 'alias':      va = a.alias;     vb = b.alias;     break;
+        case 'last_heard': va = new Date(a.last_heard).getTime(); vb = new Date(b.last_heard).getTime(); break;
+        case 'icon':       va = iconLabel(a.symbol_table, a.symbol_code); vb = iconLabel(b.symbol_table, b.symbol_code); break;
+        case 'distance':   va = a.distKm  ?? Infinity; vb = b.distKm  ?? Infinity; break;
+        case 'bearing':    va = a.bearing ?? Infinity; vb = b.bearing ?? Infinity; break;
+        case 'comment':    va = a.comment || ''; vb = b.comment || ''; break;
+        case 'lat':        va = a.lat ?? -Infinity; vb = b.lat ?? -Infinity; break;
+        case 'lon':        va = a.lon ?? -Infinity; vb = b.lon ?? -Infinity; break;
+        default:           va = 0; vb = 0;
+      }
+      if (va < vb) return sortDir === 'asc' ? -1 : 1;
+      if (va > vb) return sortDir === 'asc' ?  1 : -1;
+      return 0;
+    });
+
+    return list;
+  });
+
+  let totalPages  = $derived(Math.max(1, Math.ceil(filteredSorted.length / pageSize)));
+  let safePage    = $derived(Math.min(currentPage, totalPages));
+  let pagedRows   = $derived(filteredSorted.slice((safePage - 1) * pageSize, safePage * pageSize));
+
+  // --- Data fetching ---------------------------------------------------
+
+  async function refresh() {
+    try {
+      const [sData, aData, pos, plData] = await Promise.all([
+        api.get(`/stations?bbox=-90,-180,90,180&timerange=${timerange}`),
+        api.get('/stations/aliases'),
+        api.get('/position').catch(() => null),
+        api.get('/position-log').catch(() => null),
+      ]);
+      stations      = Array.isArray(sData) ? sData : [];
+      aliases       = aData || {};
+      myPosition    = pos || null;
+      posLogEnabled = plData?.enabled ?? false;
+    } catch (_) {}
+    loading = false;
+  }
+
+  onMount(async () => {
+    symbols = await loadSymbols().catch(() => null);
+    await refresh();
+  });
+
+  // Auto-refresh polling — clears when toggled off or component is destroyed.
+  $effect(() => {
+    if (!autoRefresh) return;
+    const id = setInterval(refresh, 30_000);
+    return () => clearInterval(id);
+  });
+
+  // Re-fetch when timerange changes.
+  $effect(() => {
+    timerange; // track
+    if (!loading) refresh();
+  });
+
+  // --- Sort toggle -----------------------------------------------------
+
+  function setSort(col) {
+    if (sortCol === col) {
+      sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+    } else {
+      sortCol = col;
+      sortDir = col === 'last_heard' ? 'desc' : 'asc';
+    }
+  }
+
+  function sortIndicator(col) {
+    if (sortCol !== col) return '';
+    return sortDir === 'asc' ? ' ▲' : ' ▼';
+  }
+
+  // --- Alias editing ---------------------------------------------------
+
+  function startEditAlias(callsign, current) {
+    editingAlias = callsign;
+    editDraft    = current;
+  }
+
+  async function commitAlias(callsign) {
+    editingAlias = null;
+    const trimmed = editDraft.trim();
+    try {
+      if (trimmed === '') {
+        await api.delete(`/stations/aliases/${encodeURIComponent(callsign)}`);
+        const next = { ...aliases };
+        delete next[callsign];
+        aliases = next;
+      } else {
+        await api.put(`/stations/aliases/${encodeURIComponent(callsign)}`, { alias: trimmed });
+        aliases = { ...aliases, [callsign]: trimmed };
+      }
+      toasts.success('Alias saved');
+    } catch (_) {
+      toasts.error('Failed to save alias');
+    }
+  }
+
+  function onAliasKeydown(e, callsign) {
+    if (e.key === 'Enter') { e.target.blur(); commitAlias(callsign); }
+    if (e.key === 'Escape') { editingAlias = null; }
+  }
+
+  // --- Map navigation --------------------------------------------------
+
+  function goToMap(s) {
+    const pos = s.positions?.[0];
+    if (!pos) return;
+    window.location.hash =
+      `#/map?focus=${encodeURIComponent(s.callsign)}&lat=${pos.lat}&lon=${pos.lon}`;
+  }
+
+  // --- Icon dropdown ---------------------------------------------------
+
+  function toggleIcon(key) {
+    const next = new Set(selectedIcons);
+    if (next.has(key)) next.delete(key); else next.add(key);
+    selectedIcons = next;
+  }
+
+  function clearIconFilter() { selectedIcons = new Set(); }
+
+  // Close icon dropdown on outside click; also clear the search.
+  function onIconDropKey(e) {
+    if (e.key === 'Escape') { iconDropOpen = false; iconSearch = ''; }
+  }
+
+  // Close the icon dropdown on Escape or a click outside the wrapper.
+  $effect(() => {
+    if (!iconDropOpen) return;
+    const dismiss = () => { iconDropOpen = false; iconSearch = ''; };
+    const onKey   = (e) => { if (e.key === 'Escape') dismiss(); };
+    const onDown  = (e) => { if (iconDropEl && !iconDropEl.contains(e.target)) dismiss(); };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onDown);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onDown);
+    };
+  });
+
+  // Focus an input element on mount (avoids the a11y_autofocus lint warning
+  // that fires on the static `autofocus` attribute).
+  function focusOnMount(node) {
+    node.focus();
+  }
+</script>
+
+<PageHeader title="Stations" subtitle="All stations heard on RF and APRS-IS">
+  <span class="conn-status" class:error={offline} aria-live="polite">
+    <span class="conn-dot"></span>{offline ? 'error' : 'live'}
+  </span>
+</PageHeader>
+
+<!-- Toolbar -->
+<Box>
+  <div class="toolbar">
+    <div class="toolbar-left">
+      <label class="toggle-label">
+        <input type="checkbox" bind:checked={autoRefresh} />
+        Auto-refresh
+      </label>
+      <Button onclick={refresh} disabled={loading}>Refresh</Button>
+      <Select
+        bind:value={timerange}
+        options={TIMERANGE_OPTIONS}
+      />
+    </div>
+    <div class="toolbar-right">
+      <span class="station-count">
+        {filteredSorted.length} of {stations.length} station{stations.length !== 1 ? 's' : ''}
+      </span>
+      <Select
+        bind:value={pageSize}
+        options={PAGE_SIZE_OPTIONS}
+      />
+    </div>
+  </div>
+</Box>
+
+<!-- Global quick-filters: toggles that apply to the whole result set -->
+<Box>
+  <div class="global-filters">
+    <label class="toggle-label">
+      <input type="checkbox" bind:checked={todayOnly} />
+      Today only
+    </label>
+    {#if posLogEnabled}
+      <label class="toggle-label">
+        <input type="checkbox" bind:checked={hasAliasOnly} />
+        Show stations with aliases
+      </label>
+    {/if}
+  </div>
+</Box>
+
+<div class="table-wrap" style="margin-top: 12px;">
+  {#if offline}
+    <Box><div class="empty">No stations — connection to the Graywolf server lost.</div></Box>
+  {:else if loading}
+    <Box><div class="empty">Loading…</div></Box>
+  {:else if stations.length === 0}
+    <Box><div class="empty">No stations heard yet in the selected time range.</div></Box>
+  {:else}
+    <div class="table-scroll height-fix">
+      <table class="stations-table">
+        <thead>
+          <!-- Header row: sortable column titles -->
+          <tr class="header-row">
+            <th class="th-sortable" onclick={() => setSort('callsign')}>Station{sortIndicator('callsign')}</th>
+            {#if posLogEnabled}
+              <th class="th-sortable" onclick={() => setSort('alias')}>Alias{sortIndicator('alias')}</th>
+            {/if}
+            <th class="th-sortable" onclick={() => setSort('last_heard')}>Last Heard{sortIndicator('last_heard')}</th>
+            <th class="th-sortable" onclick={() => setSort('icon')}>Icon{sortIndicator('icon')}</th>
+            <th class="th-sortable" onclick={() => setSort('distance')}>Distance{sortIndicator('distance')}</th>
+            <th class="th-sortable" onclick={() => setSort('bearing')}>Bearing{sortIndicator('bearing')}</th>
+            <th class="th-sortable" onclick={() => setSort('comment')}>Comment{sortIndicator('comment')}</th>
+            <th class="th-sortable" onclick={() => setSort('lat')}>Lat{sortIndicator('lat')}</th>
+            <th class="th-sortable" onclick={() => setSort('lon')}>Lon{sortIndicator('lon')}</th>
+          </tr>
+          <!-- Filter row -->
+          <tr class="filter-row">
+            <td>
+              <Input bind:value={filterCallsign} placeholder="Search…" />
+            </td>
+            {#if posLogEnabled}
+              <td class="filter-alias-cell">
+                <Input bind:value={filterAlias} placeholder="Search…" />
+              </td>
+            {/if}
+            <td><!-- Last Heard: use global Today toggle above --></td>
+            <td class="filter-icon-cell">
+              <!-- Custom multiselect dropdown for icon filter -->
+              <div class="icon-drop-wrap" bind:this={iconDropEl}>
+                <button
+                  type="button"
+                  class="icon-drop-btn"
+                  onclick={() => { iconDropOpen = !iconDropOpen; }}
+                  aria-expanded={iconDropOpen}
+                  aria-haspopup="listbox"
+                >
+                  {selectedIcons.size > 0 ? `${selectedIcons.size} selected` : 'All icons'}
+                  <span class="icon-drop-caret">▾</span>
+                </button>
+                {#if iconDropOpen}
+                  <div class="icon-drop-panel" role="listbox" aria-multiselectable="true">
+                    <div class="icon-drop-search">
+                      <input
+                        class="icon-search-input"
+                        type="text"
+                        bind:value={iconSearch}
+                        placeholder="Search icons…"
+                        aria-label="Search icon names"
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      class="icon-drop-clear"
+                      onclick={clearIconFilter}
+                    >Clear selection</button>
+                    <div class="icon-drop-list">
+                      {#each filteredIcons as ic (ic.key)}
+                        <label class="icon-drop-item">
+                          <input
+                            type="checkbox"
+                            checked={selectedIcons.has(ic.key)}
+                            onchange={() => toggleIcon(ic.key)}
+                          />
+                          <span class="aprs-icon" style={iconBgStyle(ic.table, ic.code)}></span>
+                          <span class="icon-drop-label">{ic.label}</span>
+                        </label>
+                      {/each}
+                    </div>
+                  </div>
+                {/if}
+              </div>
+            </td>
+            <td><!-- Distance: no filter --></td>
+            <td><!-- Bearing: no filter --></td>
+            <td>
+              <Input bind:value={filterComment} placeholder="Search…" />
+            </td>
+            <td><!-- Lat: no filter --></td>
+            <td><!-- Lon: no filter --></td>
+          </tr>
+        </thead>
+        <tbody>
+          {#if pagedRows.length === 0}
+            <tr>
+              <td colspan={posLogEnabled ? 9 : 8} class="empty">No stations match the current filters.</td>
+            </tr>
+          {:else}
+            {#each pagedRows as s (s.callsign)}
+              {@const pos = s.positions?.[0]}
+              {@const dirCls = s.direction === 'RX' ? 'b-rx' : s.direction === 'TX' ? 'b-tx' : 'b-is'}
+              <tr class="station-row">
+                <!-- Station (callsign, click → map) -->
+                <td class="td-callsign">
+                  <button
+                    type="button"
+                    class="callsign-link"
+                    onclick={() => goToMap(s)}
+                    title="Open on Live Map"
+                  >{s.callsign}</button>
+                </td>
+
+                <!-- Alias (inline edit, only when position log enabled) -->
+                {#if posLogEnabled}
+                  <td class="td-alias">
+                    {#if editingAlias === s.callsign}
+                      <input
+                        class="alias-input"
+                        bind:value={editDraft}
+                        onblur={() => commitAlias(s.callsign)}
+                        onkeydown={(e) => onAliasKeydown(e, s.callsign)}
+                        placeholder="Add alias…"
+                        maxlength="64"
+                        use:focusOnMount
+                      />
+                    {:else}
+                      <div class="alias-display">
+                        <span class="alias-text">{s.alias || ''}</span>
+                        <button
+                          type="button"
+                          class="alias-edit-btn"
+                          onclick={() => startEditAlias(s.callsign, s.alias)}
+                          title="Edit alias"
+                          aria-label="Edit alias for {s.callsign}"
+                        >✎</button>
+                      </div>
+                    {/if}
+                  </td>
+                {/if}
+
+                <!-- Last Heard + direction badge -->
+                <td class="td-heard">
+                  <div class="cell-flex">
+                    <span>{timeAgo(s.last_heard)}</span>
+                    <span class="badge {dirCls}">{s.direction === 'IS' ? 'IS' : s.direction}</span>
+                  </div>
+                </td>
+
+                <!-- Icon + name -->
+                <td class="td-icon">
+                  <div class="cell-flex">
+                    <span class="aprs-icon" style={iconBgStyle(s.symbol_table, s.symbol_code)}></span>
+                    <span class="icon-name">{iconLabel(s.symbol_table, s.symbol_code)}</span>
+                  </div>
+                </td>
+
+                <!-- Distance -->
+                <td class="td-num">
+                  {s.distKm !== null ? formatDist(s.distKm) : '—'}
+                </td>
+
+                <!-- Bearing -->
+                <td class="td-num">
+                  {s.bearing !== null ? formatBearing(s.bearing) : '—'}
+                </td>
+
+                <!-- Comment -->
+                <td class="td-comment">{s.comment || ''}</td>
+
+                <!-- Lat -->
+                <td class="td-num">{s.lat !== null ? s.lat.toFixed(5) : '—'}</td>
+
+                <!-- Lon -->
+                <td class="td-num">{s.lon !== null ? s.lon.toFixed(5) : '—'}</td>
+              </tr>
+            {/each}
+          {/if}
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination controls -->
+    <div class="pagination">
+      <div class="pagination-info">
+        {#if filteredSorted.length > 0}
+          Showing {(safePage - 1) * pageSize + 1}–{Math.min(safePage * pageSize, filteredSorted.length)}
+          of {filteredSorted.length}
+        {/if}
+      </div>
+      <div class="pagination-nav">
+        <button
+          type="button"
+          class="page-btn"
+          disabled={safePage <= 1}
+          onclick={() => { currentPage = safePage - 1; }}
+        >← Prev</button>
+        <span class="page-label">Page {safePage} of {totalPages}</span>
+        <button
+          type="button"
+          class="page-btn"
+          disabled={safePage >= totalPages}
+          onclick={() => { currentPage = safePage + 1; }}
+        >Next →</button>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  /* Connection status (mirrors Logs.svelte) */
+  .conn-status {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: var(--text-xs); font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--color-success);
+  }
+  .conn-status.error { color: var(--color-danger); }
+  .conn-dot {
+    width: 9px; height: 9px; border-radius: 50%;
+    background: var(--color-success);
+  }
+  .conn-status.error .conn-dot {
+    background: var(--color-danger);
+    box-shadow: 0 0 8px var(--color-danger);
+  }
+
+  /* Toolbar */
+  .toolbar {
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+    justify-content: space-between;
+  }
+  .toolbar-left, .toolbar-right {
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  }
+  .station-count {
+    font-size: var(--text-sm); color: var(--color-text-dim);
+  }
+
+  /* Toggle label */
+  .toggle-label {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: var(--text-sm); cursor: pointer; user-select: none;
+    color: var(--color-text);
+  }
+  .toggle-small { font-size: var(--text-xs); }
+
+  /* Table wrapper */
+  .table-wrap { }
+  .table-scroll { overflow-x: auto; }
+  .empty {
+    color: var(--color-text-dim); text-align: center; padding: 24px;
+  }
+
+  .height-fix {
+    min-height: 60vh;
+  }
+
+  /* Table */
+  .stations-table {
+    width: 100%; border-collapse: collapse;
+    font-size: var(--text-sm);
+  }
+
+  .header-row th {
+    background: var(--bg-secondary);
+    border-bottom: 2px solid var(--border-color);
+    padding: 8px 10px;
+    text-align: left;
+    white-space: nowrap;
+    font-weight: 600;
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+  }
+
+  .th-sortable {
+    cursor: pointer;
+    user-select: none;
+  }
+  .th-sortable:hover { color: var(--color-primary); }
+
+  /* Global quick-filter bar (between toolbar and table) */
+  .global-filters {
+    display: flex; align-items: center; gap: 20px; flex-wrap: wrap;
+    padding: 2px 0;
+  }
+
+  /* Filter row */
+  .filter-row td {
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+    padding: 4px 6px;
+    vertical-align: middle;
+  }
+  .filter-alias-cell { min-width: 120px; }
+  .filter-icon-cell { position: relative; min-width: 120px; }
+
+  /* Body rows */
+  .station-row td {
+    padding: 7px 10px;
+    border-bottom: 1px solid var(--border-color);
+    vertical-align: middle;
+  }
+  .station-row:hover td { background: var(--color-surface-hover, rgba(255,255,255,0.04)); }
+
+  /* Callsign link */
+  .callsign-link {
+    background: none; border: none; padding: 0;
+    color: var(--color-primary); font-family: var(--font-mono);
+    font-size: var(--text-sm); font-weight: 600;
+    cursor: pointer; text-decoration: none;
+  }
+  .callsign-link:hover { text-decoration: underline; }
+
+  /* Alias cell */
+  .alias-display {
+    display: flex; align-items: center; gap: 6px;
+  }
+  .alias-text { flex: 1; color: var(--color-text); font-size: var(--text-sm); }
+  .alias-edit-btn {
+    background: none; border: none; padding: 2px 4px;
+    color: var(--color-text-dim); cursor: pointer; font-size: 13px;
+    opacity: 0; transition: opacity 0.1s;
+  }
+  .station-row:hover .alias-edit-btn { opacity: 1; }
+  .alias-input {
+    width: 100%; background: var(--bg-primary);
+    border: 1px solid var(--color-primary);
+    border-radius: 4px; padding: 2px 6px;
+    color: var(--color-text); font-size: var(--text-sm);
+    outline: none;
+  }
+
+  /* Last Heard */
+  .td-heard { white-space: nowrap; }
+
+  /* Direction badges (mirrors LiveMapV2.svelte globals) */
+  .badge {
+    display: inline-block; padding: 1px 5px; border-radius: 3px;
+    font-size: 10px; font-weight: 700; line-height: 1.4;
+    text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .b-rx  { background: var(--color-success, #2a7a2a); color: #fff; }
+  .b-tx  { background: var(--color-warning, #8a6a00); color: #fff; }
+  .b-is  { background: var(--color-info,    #1a5f8a); color: #fff; }
+
+  /* Icon cell */
+  /* Inner flex wrapper — keeps display:flex off the <td> itself to avoid
+     overriding display:table-cell (breaks layout in Firefox). */
+  .cell-flex { display: flex; align-items: center; gap: 6px; }
+
+  .td-icon { white-space: nowrap; }
+  .aprs-icon {
+    display: inline-block;
+    width: 20px; height: 20px;
+    flex-shrink: 0;
+  }
+  .icon-name { font-size: var(--text-xs); color: var(--color-text-dim); }
+
+  /* Numeric cells */
+  .td-num {
+    font-variant-numeric: tabular-nums;
+    font-size: var(--text-sm); white-space: nowrap;
+    color: var(--color-text-dim);
+  }
+  .td-callsign { white-space: nowrap; }
+  .td-comment { max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--color-text-dim); }
+
+  /* Icon dropdown */
+  .icon-drop-wrap { position: relative; }
+  .icon-drop-btn {
+    width: 100%; background: var(--bg-primary);
+    border: 1px solid var(--border-color); border-radius: 4px;
+    padding: 4px 8px; color: var(--color-text);
+    font-size: var(--text-sm); cursor: pointer;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 4px;
+  }
+  .icon-drop-btn:hover { border-color: var(--color-primary); }
+  .icon-drop-caret { font-size: 10px; opacity: 0.6; }
+  .icon-drop-panel {
+    position: absolute; top: calc(100% + 4px); left: 0;
+    z-index: 40; min-width: 200px; max-width: 260px;
+    background: var(--bg-secondary); border: 1px solid var(--border-color);
+    border-radius: 6px; box-shadow: var(--shadow-md, 0 4px 16px rgba(0,0,0,0.3));
+    padding: 6px 0;
+  }
+  .icon-drop-clear {
+    width: 100%; background: none; border: none;
+    padding: 4px 12px; text-align: left;
+    font-size: var(--text-xs); color: var(--color-text-dim);
+    cursor: pointer; border-bottom: 1px solid var(--border-color);
+    margin-bottom: 4px;
+  }
+  .icon-drop-clear:hover { color: var(--color-primary); }
+  .icon-drop-search {
+    padding: 6px 8px 4px;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .icon-search-input {
+    width: 100%; background: var(--bg-primary);
+    border: 1px solid var(--border-color); border-radius: 4px;
+    padding: 4px 8px; color: var(--color-text);
+    font-size: var(--text-sm); outline: none;
+  }
+  .icon-search-input:focus { border-color: var(--color-primary); }
+  .icon-drop-list { max-height: 220px; overflow-y: auto; padding: 0 4px; }
+  .icon-drop-item {
+    display: flex; align-items: center; gap: 8px;
+    padding: 4px 8px; cursor: pointer;
+    border-radius: 4px; font-size: var(--text-sm);
+    user-select: none;
+  }
+  .icon-drop-item:hover { background: var(--color-surface-hover, rgba(255,255,255,0.06)); }
+  .icon-drop-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  /* Pagination */
+  .pagination {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 8px 12px; border-top: 1px solid var(--border-color);
+    font-size: var(--text-sm); flex-wrap: wrap; gap: 8px;
+  }
+  .pagination-info { color: var(--color-text-dim); }
+  .pagination-nav { display: flex; align-items: center; gap: 10px; }
+  .page-label { color: var(--color-text-dim); }
+  .page-btn {
+    background: var(--bg-secondary); border: 1px solid var(--border-color);
+    border-radius: 4px; padding: 4px 12px;
+    color: var(--color-text); font-size: var(--text-sm); cursor: pointer;
+  }
+  .page-btn:hover:not(:disabled) { border-color: var(--color-primary); color: var(--color-primary); }
+  .page-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+</style>


### PR DESCRIPTION
New /stations route showing every station Graywolf has heard on RF or APRS-IS in a sortable, filterable table with 30-second auto-refresh.

This also adjusted to sidebar menu to better convey the order in which you have to configure channels, audio devices, PTT, and Kiss TNCs.

Backend
-------
pkg/historydb/historydb.go
- Add station_aliases table to bootstrap() (CREATE TABLE IF NOT EXISTS, idempotent on existing DBs; no user_version bump needed)
- Add GetAliases(), SetAlias(), DeleteAlias() methods on *DB

pkg/webapi/stationaliases.go (new)
- AliasStore interface + AliasStoreGetter func type
- RegisterStationAliases wires GET/PUT/DELETE /api/stations/aliases
- GET returns empty map when position log is off; PUT/DELETE return 503

pkg/app/app.go
- Add histdb *historydb.DB field to App struct

pkg/app/wiring.go
- Assign a.histdb when history DB opens at boot and on reconfigure
- Clear a.histdb to nil on position log disable
- Call RegisterStationAliases after RegisterStations

Frontend
--------
web/src/routes/Stations.svelte (new, ~880 lines)
- Table columns: Station, Alias, Last Heard + direction badge, Icon, Distance, Bearing, Comment, Lat, Lon -- all sortable ASC/DESC
- Global filter bar between toolbar and table: Today only toggle and Show stations with aliases toggle (alias controls hidden when position log is disabled)
- Per-column filter row: LIKE/includes text inputs for Station, Alias, Comment; icon multiselect dropdown in Icon column
- Icon multiselect: text search input inside panel, closes on Escape or outside pointerdown; selection survives panel open/close
- Distance and bearing computed client-side via Haversine from /api/position; respects unitsState.isMetric for km/miles; shows -- when no GPS fix
- Pagination: 50/100/200 rows per page (toolbar selector); resets to page 1 on any filter/sort change; clamps to last valid page on refresh
- Auto-refresh: on by default (30s interval via /setInterval); toggle in toolbar to disable; manual Refresh button always available; filters and sort state are never cleared by a refresh -- re-evaluates against updated data in place so active searches update in-place (e.g. a filtered callsign row's Last Heard advances silently)
- Inline alias editing: pencil icon appears on row hover; Enter/blur saves via PUT /api/stations/aliases/{callsign}; empty field deletes via DELETE
- Callsign click navigates to Live Map: #/map?focus=CALL&lat=...&lon=...
- Cell layout: display:flex kept off <td> elements; inner .cell-flex wrappers used instead to avoid overriding display:table-cell in Firefox
- Icon sprite rendering via aprsSymbols.js backgroundPosition/cellOf; icon names via describe(); APRS symbol data loaded once on mount

web/src/App.svelte
- Import Stations component; add '/stations' route (non-full-bleed layout)

web/src/components/Sidebar.svelte
- Insert Stations entry in mainItems after Live Map with svgIcon: 'stations'
- Add table-grid SVG icon block for the 'stations' key

Docs
----
docs/handbook/stations.html (new)
- Full handbook page: columns, filters, sorting, auto-refresh, pagination, aliases (incl. position log dependency), and map navigation deep-link

docs/handbook/*.html (34 existing pages)
- Add Stations link to sidebar nav after Live Map in all pages
