### PR TITLE
web: render tab headers and messages in Inconsolata

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1800,9 +1800,9 @@ into an otherwise-monospace app.
 
 Two intentional exceptions, neither a UI text font:
 
-- Emoji-only spans (e.g. the `.bolt` zap glyph, avatar emoji) use an
-  `'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', system-ui,
-  sans-serif` stack to render color emoji, not Latin text.
+- Emoji-only spans (e.g. the `.bolt` zap glyph) use an `'Apple Color
+  Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', system-ui, sans-serif`
+  stack to render color emoji, not Latin text.
 - MapLibre label layers name glyph sets (`'Open Sans ...'`, `'Arial
   Unicode MS ...'` in `web/src/lib/map/layers/fronts.js`) that must match
   the tile server's font stack; these are map-render font names, not CSS.

--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1781,3 +1781,31 @@ Source: [`../../pkg/messages/store.go`](../../pkg/messages/store.go)
 (`TestListCursorHighVolumeNoSkips`),
 [`../../web/src/lib/messagesTransport.js`](../../web/src/lib/messagesTransport.js)
 (`fetchDelta`).
+
+### 64. Web UI renders in Inconsolata everywhere; no system/Helvetica stack
+
+Every visible glyph in the web UI is Inconsolata. The font is applied
+through the `--font-mono` custom property (`'Inconsolata', 'Courier New',
+monospace`), set on `body` by both `chonky-ui` and `web/src/app.css` and
+inherited by headings and controls. Component CSS must not override
+`font-family` with a system stack (`-apple-system`, `BlinkMacSystemFont`,
+`system-ui`, `'Helvetica Neue'`, `Arial`, `sans-serif`); use
+`var(--font-mono)`. The Messages surface (bubbles, invite text, compose
+box) once carried an iOS-style stack "to feel like messaging" -- that was
+removed so the product reads as one typeface (graywolf #576).
+
+*Why:* a lone component reintroducing the platform font is exactly the
+regression this issue fixed; it looks like a native iOS control dropped
+into an otherwise-monospace app.
+
+Two intentional exceptions, neither a UI text font:
+
+- Emoji-only spans (e.g. the `.bolt` zap glyph, avatar emoji) use an
+  `'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', system-ui,
+  sans-serif` stack to render color emoji, not Latin text.
+- MapLibre label layers name glyph sets (`'Open Sans ...'`, `'Arial
+  Unicode MS ...'` in `web/src/lib/map/layers/fronts.js`) that must match
+  the tile server's font stack; these are map-render font names, not CSS.
+
+The per-tab page header (`web/src/components/PageHeader.svelte`,
+`.page-title`) is pinned to `var(--font-mono)` at 22px.

--- a/web/src/components/PageHeader.svelte
+++ b/web/src/components/PageHeader.svelte
@@ -26,7 +26,8 @@
     flex-wrap: wrap;
   }
   .page-title {
-    font-size: 20px;
+    font-family: var(--font-mono);
+    font-size: 22px;
     font-weight: 600;
   }
   .page-subtitle {

--- a/web/src/components/messages/ComposeBar.svelte
+++ b/web/src/components/messages/ComposeBar.svelte
@@ -513,8 +513,7 @@
     border: 1px solid var(--color-border);
     border-radius: var(--radius);
     color: var(--color-text);
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui,
-      'Helvetica Neue', Arial, sans-serif;
+    font-family: var(--font-mono);
     font-size: 14px;
     line-height: 1.4;
     overflow-y: auto;

--- a/web/src/components/messages/MessageBubble.svelte
+++ b/web/src/components/messages/MessageBubble.svelte
@@ -638,10 +638,7 @@
 
   .bubble-text {
     margin: 0;
-    /* Override the app's monospace body font for bubble content only;
-       keeps bubbles feeling like messaging, not a terminal. */
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui,
-      'Helvetica Neue', Arial, sans-serif;
+    font-family: var(--font-mono);
     font-size: 14px;
     white-space: pre-wrap;
   }
@@ -784,8 +781,7 @@
   }
   .invite-text {
     margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui,
-      'Helvetica Neue', Arial, sans-serif;
+    font-family: var(--font-mono);
     font-size: 14px;
     line-height: 1.35;
   }


### PR DESCRIPTION
## What

Makes the web UI render entirely in Inconsolata and removes the iOS-style system-font stack.

- **Tab headers** (`PageHeader.svelte` `.page-title`) are pinned to `var(--font-mono)` at **22px** (was 20px, and relied on inheritance). This is the per-tab header on every settings/config page.
- **Messages surface** — message bubbles, invite text, and the compose box dropped their `-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, 'Helvetica Neue', Arial, sans-serif` stack in favor of `var(--font-mono)`. These were the only Helvetica-ish text fonts left in the app.

## Why

The Messages views used the literal iOS system-font stack ("to feel like messaging"), which renders as Helvetica/SF and read as a native control dropped into an otherwise-monospace app. Everything is now one typeface.

## Not touched (intentional)

- Emoji-only spans (zap glyph, avatar emoji) keep an `Apple Color Emoji`/`Noto Color Emoji` stack — that renders color emoji, not Latin text.
- MapLibre label layers name glyph sets (`Open Sans`, `Arial Unicode MS`) that must match the tile server; those are map-render font names, not CSS.

## Verification

- `npm run build` succeeds (pre-existing chunk-size / `state_referenced_locally` warnings unrelated).
- Recorded the all-Inconsolata rule as invariant #64 in `docs/wiki/invariants.md`.
