### PR TITLE
Fix KISS TCP server losing gate_tx_to_is on config save

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -648,6 +648,26 @@ The two switches are independent; omitting #2 means a config write calls `Stop()
 
 *Why:* There is no shared dispatch table -- each switch is a separate match on the stored `InterfaceType` string, so a new type added to one switch must be consciously added to the other.
 
+**This extends to every field, not just the type arms.** Each arm builds a
+`kiss.ServerConfig` / `ClientConfig` / `SerialConfig` struct literal by hand at
+both sites, so a `KissInterface` column that one literal sets and the other
+omits silently takes its zero value on whichever path skipped it. Adding a
+per-interface flag means touching **both** literals for **every** arm that
+supports it. The failure is quiet by construction: the boot path is correct,
+so the feature works until the operator saves the config, and then works
+again after the next restart.
+
+The concrete instance this rule was written from: `GateTxToIs` reached the
+`tcp` (server-listen) arm at boot but not in `notifyKissManager`, so any save
+of a KISS TNC config -- including saving with the box freshly checked --
+restarted the server with APRS-IS forwarding off until the next restart. RF TX
+kept working throughout (that leg is `Sink.Submit`, which does not consult the
+flag), which is what made it look like a routing bug rather than a config-
+threading one. Regression coverage:
+[`../../pkg/webapi/kiss_gate_tx_to_is_test.go`](../../pkg/webapi/kiss_gate_tx_to_is_test.go)
+drives a real socket and asserts the gate hook fires after a hot reload; a
+mock-based field assertion would not have caught the omission.
+
 Source: [`../../pkg/app/wiring.go`](../../pkg/app/wiring.go) (`kissComponent`),
 [`../../pkg/webapi/kiss.go`](../../pkg/webapi/kiss.go) (`notifyKissManager`).
 

--- a/pkg/webapi/kiss.go
+++ b/pkg/webapi/kiss.go
@@ -328,6 +328,7 @@ func (s *Server) notifyKissManager(ki configstore.KissInterface) {
 			TncIngressBurst:     ki.TncIngressBurst,
 			AllowTxFromGovernor: ki.AllowTxFromGovernor,
 			AllowConnectedMode:  ki.AllowConnectedMode,
+			GateTxToIs:          ki.GateTxToIs,
 		})
 	case configstore.KissTypeSerial:
 		if ki.Device == "" || ki.BaudRate == 0 {

--- a/pkg/webapi/kiss_gate_tx_to_is_test.go
+++ b/pkg/webapi/kiss_gate_tx_to_is_test.go
@@ -1,0 +1,163 @@
+package webapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chrissnell/graywolf/pkg/ax25"
+	"github.com/chrissnell/graywolf/pkg/kiss"
+	"github.com/chrissnell/graywolf/pkg/txgovernor"
+	"github.com/chrissnell/graywolf/pkg/webapi/dto"
+)
+
+// recordingSink stands in for the TX governor. Submit always succeeds so
+// the server reaches the gate-hook branch of dispatchDataFrame.
+type recordingSink struct{ submits atomic.Int32 }
+
+func (s *recordingSink) Submit(context.Context, uint32, *ax25.Frame, txgovernor.SubmitSource) error {
+	s.submits.Add(1)
+	return nil
+}
+
+// freeTCPPort returns a port that was bindable a moment ago. Good enough
+// for a test that immediately rebinds it via the KISS manager.
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe for free port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+// TestNotifyKissManager_TCPThreadsGateTxToIs is the regression test for
+// the tcp (server-listen) arm of notifyKissManager dropping GateTxToIs.
+//
+// The flag only ever reached a running server through the boot path in
+// pkg/app/wiring.go, so an operator who checked "also forward
+// transmissions from connected clients to APRS-IS" and saved got a
+// server restarted with the flag at its zero value. RF TX kept working
+// (that leg goes through Sink.Submit, which does not consult the flag),
+// so the failure was invisible except as packets silently never reaching
+// APRS-IS until the next graywolf restart re-ran the boot path.
+//
+// End-to-end on purpose: a struct-literal omission is exactly the kind of
+// bug a field-by-field mock assertion can be written to miss, so this
+// drives a real socket and asserts the observable outcome — the gate hook
+// fires — instead of inspecting the config that was passed.
+func TestNotifyKissManager_TCPThreadsGateTxToIs(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	sink := &recordingSink{}
+	var gated atomic.Int32
+	mgr := kiss.NewManager(kiss.ManagerConfig{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Sink:   sink,
+		OnClientTxAccepted: func(context.Context, uint32, uint32, *ax25.Frame) {
+			gated.Add(1)
+		},
+	})
+	srv.kissManager = mgr
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		mgr.StopAll()
+	})
+	srv.kissCtx = ctx
+
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	// Create a modem-mode tcp server-listen interface with the gate on.
+	// createKiss dispatches through notifyKissManager, the same path a
+	// later PUT takes, so the create alone reproduces the bug.
+	port := freeTCPPort(t)
+	body, _ := json.Marshal(map[string]any{
+		"type":          "tcp",
+		"tcp_port":      port,
+		"local_only":    true,
+		"channel":       1,
+		"mode":          "modem",
+		"gate_tx_to_is": true,
+	})
+	rr := doPost(mux, "/api/kiss", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create tcp interface: %d %s", rr.Code, rr.Body.String())
+	}
+	var created dto.KissResponse
+	if err := json.NewDecoder(rr.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if !created.GateTxToIs {
+		t.Fatalf("persisted gate_tx_to_is = false, want true (store/DTO regression, not the manager)")
+	}
+
+	// Dial the listener the manager just brought up. It binds on its own
+	// goroutine, so retry until the connect succeeds.
+	var conn net.Conn
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	for deadline := time.Now().Add(3 * time.Second); time.Now().Before(deadline); {
+		c, err := net.Dial("tcp", addr)
+		if err == nil {
+			conn = c
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if conn == nil {
+		t.Fatalf("kiss server never became connectable on %s", addr)
+	}
+	defer conn.Close()
+
+	// Send one APRS message frame, the traffic shape from the bug report.
+	src, err := ax25.ParseAddress("N0CALL-5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst, err := ax25.ParseAddress("APRS")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := ax25.NewUIFrame(src, dst, nil, []byte(":TEST     :ping{01"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := f.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write(kiss.Encode(0, raw)); err != nil {
+		t.Fatalf("write kiss frame: %v", err)
+	}
+
+	// The RF leg is independent of the flag; assert it first so a failure
+	// here points at the TX path rather than at the gate.
+	if !pollCount(&sink.submits, 1, time.Now().Add(2*time.Second)) {
+		t.Fatalf("frame never reached the TX sink (submits=%d)", sink.submits.Load())
+	}
+	if !pollCount(&gated, 1, time.Now().Add(2*time.Second)) {
+		t.Errorf("gate hook never fired: notifyKissManager dropped GateTxToIs " +
+			"for the tcp arm, so APRS-IS forwarding is off until the next restart")
+	}
+}
+
+// pollCount waits for an atomic counter to reach want before deadline.
+func pollCount(c *atomic.Int32, want int32, deadline time.Time) bool {
+	for time.Now().Before(deadline) {
+		if c.Load() >= want {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

The `tcp` (server-listen) arm of `notifyKissManager` builds its `kiss.ServerConfig` without `GateTxToIs`, so every hot reload restarts the KISS server with the flag at its zero value.

The boot path in `kissComponent` sets it correctly, which is what makes this hard to spot: **"Also forward transmissions from connected clients to APRS-IS" works after a graywolf restart, and stops the moment the operator saves the KISS TNC config** -- including the very save that turns the box on. It stays off until the next restart.

The `tcp-client`, `serial`, `bluetooth`, and `usbserial` arms all thread the flag already. `tcp` is the sole omission, and has been since the feature landed in #205 (that PR never touched `pkg/webapi/kiss.go`).

## Scope: APRS-IS only, RF TX is unaffected

Worth stating plainly, because it is what made this look like a routing bug. The RF leg goes through `Sink.Submit`, which does not consult the flag, so the packet still reaches the radio and still appears in the packet log as a `TX` entry. Only the APRS-IS leg goes quiet -- and with `GateTxToIs` false the `kiss gate-tx-to-is` hook never fires, so there is no log line explaining the drop either.

## Evidence

Reported by an operator running a digirig-backed channel with a digipeater, an iGate, and a KISS TCP server on port 6700 all bound to the same channel, with an aprs.fi iOS client connected.

**Working**, immediately after a graywolf restart -- gate log line, plus both an `IS` and a `TX` row:

```
11:44:43.043 level=INFO msg="kiss gate-tx-to-is" iface=10 channel=4 source=K0TFU-5 dest=APFII0 path=WIDE1-1,WIDE2-1 reason=gated
```
```
"2026-08-26T11:44:43.043016948-06:00","IS","Digirig Mobile","K0TFU-5","APFII0","K0TFU-5>APFII0,WIDE1-1,WIDE2-1,qAR,K0TFU-6::OTA      :ping pc15{F2FBE"
"2026-08-26T11:44:43.04460421-06:00","TX","Digirig Mobile","K0TFU-5","APFII0","K0TFU-5>APFII0,WIDE1-1,WIDE2-1::OTA      :ping pc15{F2FBE"
```

The operator then edited the KISS TNC config (checked "Allow connected-mode frames from KISS clients") and saved. The server restarted via `notifyKissManager` -- note the `component=webapi` logger tag, which distinguishes a hot-reload-started server from a boot-started one:

```
11:48:15.039 level=INFO msg="kiss client disconnected" kiss_iface=kiss-tcp-6700 remote=192.168.6.184:49841
11:48:15.057 level=INFO msg="kiss server listening" component=webapi kiss_iface=kiss-tcp-6700 addr=[::]:6700
11:48:19.782 level=INFO msg="kiss client connected" component=webapi kiss_iface=kiss-tcp-6700 remote=192.168.6.184:49854
```

**Broken**, next message sent through the same client -- `TX` row present, no `IS` row, and no `kiss gate-tx-to-is` line anywhere in the log:

```
"2026-08-26T11:48:22.93406294-06:00","TX","Digirig Mobile","K0TFU-5","APFII0","K0TFU-5>APFII0,WIDE1-1,WIDE2-1::OTA      :ping pc16{A63FE"
```

Restarting graywolf restored APRS-IS forwarding, with no config change.

(For completeness: that log also carries `ConfigurePtt: build driver for channel 4 (serial_rts): open /dev/ttyUSB0: ENOENT` and a `TransmitFrame: no PTT driver registered for channel 4` on every transmit. That is an unrelated local hardware problem on the reporter's box -- it is why nothing reached the air -- and is not what this PR addresses. The `TX` packet-log rows above are the relevant signal: graywolf's TX path did its job.)

## Reproduction

1. Configure a working channel and a working iGate.
2. Create a KISS TNC interface (type `tcp`, mode `modem`) bound to that channel.
3. Check "Also forward transmissions from connected clients to APRS-IS" and save.
4. Restart graywolf. Connect a KISS client and send a message -- it reaches APRS-IS.
5. Save the KISS TNC config again, changing anything or nothing. Send another message -- it transmits on RF but never reaches APRS-IS, until the next restart.

Because `createKiss` also dispatches through `notifyKissManager`, a freshly created KISS TNC never gates to APRS-IS until its first restart.

## The fix

One line, restoring parity with the other four arms and with `kissComponent`:

```go
AllowConnectedMode:  ki.AllowConnectedMode,
GateTxToIs:          ki.GateTxToIs,
```

## Tests

`TestNotifyKissManager_TCPThreadsGateTxToIs` drives a real socket -- creates the interface over the HTTP API, dials the listener the manager brought up, sends one APRS message frame, and asserts the gate hook fires.

End-to-end deliberately, rather than asserting on the `ServerConfig` that was passed: a struct-literal omission is precisely the failure mode a field-level mock assertion can be written to miss. The test also asserts the TX sink received the frame, which independently documents that the RF leg is unaffected -- that assertion passes with or without the fix.

Verified failing before the fix:

```
--- FAIL: TestNotifyKissManager_TCPThreadsGateTxToIs (2.03s)
    kiss_gate_tx_to_is_test.go:149: gate hook never fired: notifyKissManager dropped GateTxToIs for the tcp arm, so APRS-IS forwarding is off until the next restart
```

and passing after. `./pkg/webapi`, `./pkg/kiss`, and `./pkg/app` all green; `go vet` clean; both touched files gofmt-clean.

## Wiki

Invariant 34 already required the two `switch ki.InterfaceType` dispatch sites to stay in lockstep, but only for adding or changing an *InterfaceType*. Extended it to cover per-field parity: each arm hand-builds a config struct literal at both sites, so a `KissInterface` column set in one literal and omitted in the other silently takes its zero value on whichever path skipped it -- quiet by construction, since the boot path stays correct.

## Not included

The same reporter's logs prompted a look at `Manager.Start`, which cancels a running server and rebinds without waiting for `ListenAndServe` to return -- the contract `TestKissServerPortFreeAfterCancel` exists to guard. It is a real latent race, but it did not fire in this incident (the rebind above won by 18ms), and it is unrelated to this fix. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
