### PR TITLE
messages: fix chat window dropping newest messages on busy threads (GH #521)

### DIFF
--- a/docs/wiki/invariants.md
+++ b/docs/wiki/invariants.md
@@ -1775,6 +1775,11 @@ breaks ties) and monotonic, which is all forward pagination needs.
 is identical to the cursor predicate; any resolution gap between them
 drops rows.
 
+Note: this invariant governs the **forward delta-sync feed** (cursor
+present, no `thread_key`). The chat window itself opens a conversation
+through the separate **tail-window** read (invariant #65), which orders by
+`id DESC` and does not use this cursor at all.
+
 Source: [`../../pkg/messages/store.go`](../../pkg/messages/store.go)
 (`(*Store).List`, `encodeCursor`),
 [`../../pkg/messages/store_pagination_test.go`](../../pkg/messages/store_pagination_test.go)
@@ -1809,3 +1814,48 @@ Two intentional exceptions, neither a UI text font:
 
 The per-tab page header (`web/src/components/PageHeader.svelte`,
 `.page-title`) is pinned to `var(--font-mono)` at 22px.
+
+### 65. The chat window reads a thread as a "tail window" (newest by id), not the forward cursor page
+
+Opening a conversation in the chat window (`web/src/components/messages/
+MessageThread.svelte` `fetchThread`) issues a **cursor-less, thread-scoped**
+`GET /api/messages?thread_kind=...&thread_key=...&limit=N`. The handler
+(`pkg/webapi/messages.go` `listMessages`) sets `Filter.Newest` whenever a
+`thread_key` is present and no cursor is supplied, and `(*Store).List`
+then returns the newest `N` rows by **insertion order (`id DESC`)** with an
+empty cursor -- NOT the forward `updated_at ASC` page.
+
+This split is load-bearing and must be preserved:
+
+- The forward `updated_at ASC` page (invariant #63) is the **delta-sync
+  feed** used by the transport poll/SSE (`messagesTransport.js`
+  `fetchDelta`, never sends `thread_key`). It orders by `updated_at` so
+  bumped rows resurface for sync.
+- A bounded read of that same `updated_at ASC` order returns the
+  *least-recently-updated* rows, so once a thread grows past `limit` the
+  newest sends and receives fall off the end and stop rendering. Outbound
+  rows churn `updated_at` fastest (sent/retry/ack `Store.Update` in
+  `retry.go`/`router.go`), so they vanish first -- the "incoming shows,
+  outgoing doesn't" half of graywolf #521 that survived the #63 fix.
+
+`id DESC` is used (not `created_at`/`updated_at`) because `id` is
+autoincrement -- exactly "the N most recently inserted messages", unique,
+monotonic, and immune to the glebarez trailing-zero-trimmed RFC3339Nano
+text-sort hazard (`".9Z"` sorts after `".90000001Z"`) that invariant #63
+also calls out. The client re-sorts the returned rows chronologically for
+display. Do NOT route the chat window through a cursor and do NOT reorder
+the tail window by a time text column.
+
+*Why:* "fetch a conversation" and "sync deltas forward" are different
+queries with opposite ends of the same ordering; collapsing them into one
+bounded `updated_at ASC` read silently hides the newest messages on any
+busy thread.
+
+Source: [`../../pkg/messages/store.go`](../../pkg/messages/store.go)
+(`(*Store).List`, `Filter.Newest`),
+[`../../pkg/webapi/messages.go`](../../pkg/webapi/messages.go)
+(`listMessages`),
+[`../../pkg/messages/store_pagination_test.go`](../../pkg/messages/store_pagination_test.go)
+(`TestListNewestWindowReturnsMostRecent`),
+[`../../web/src/components/messages/MessageThread.svelte`](../../web/src/components/messages/MessageThread.svelte)
+(`fetchThread`).

--- a/pkg/messages/store.go
+++ b/pkg/messages/store.go
@@ -102,6 +102,16 @@ type Filter struct {
 	// When non-empty, results are ordered by (UpdatedAt, ID) ascending
 	// strictly greater than the cursor.
 	Cursor string
+	// Newest, when true and Cursor is empty, flips List into "tail
+	// window" mode: it returns the most recent Limit rows by insertion
+	// order (id DESC) instead of the forward updated_at page. This is
+	// what a thread-detail view (the chat window) wants — the latest
+	// slice of a conversation, regardless of how much older-row churn
+	// (ack/retry updated_at bumps) has happened. Ignored when Cursor is
+	// set, because cursor paging is always the forward updated_at keyset.
+	// See the List doc comment for why id DESC and not an updated_at or
+	// created_at order.
+	Newest bool
 	// UnreadOnly limits to rows with Unread=true.
 	UnreadOnly bool
 	// Limit caps the result set. Values <= 0 apply the package
@@ -236,9 +246,26 @@ func (s *Store) GetConversationPrefs(ctx context.Context, kind, key string) (*co
 	return &c, nil
 }
 
-// List returns a page of messages matching the filter. The returned
-// cursor points at the last row in the page and can be fed back into a
-// subsequent List call to page forward deterministically.
+// List has two modes.
+//
+// Tail-window mode (Filter.Newest, no cursor) returns the most recent
+// Limit rows by insertion order (id DESC) and an empty cursor. This is
+// the "open a conversation" read used by the chat window: it wants the
+// newest slice of a thread, full stop. It deliberately does NOT order by
+// updated_at — on a busy two-way thread outbound rows have their
+// updated_at bumped repeatedly by sent/retry/ack bookkeeping, so an
+// updated_at-ordered window drifts away from "the latest messages" and,
+// at the default page size, silently drops the newest sends and receives
+// off the end (GH #521, the recurrence after the #527 keyset fix). id is
+// autoincrement, so id DESC is exactly "the N most recently inserted
+// messages" — monotonic, unique, and immune to the glebarez text-sort
+// hazard that rules out ordering by a created_at/updated_at text column
+// directly (".9Z" sorts after ".90000001Z"). The caller re-sorts the
+// returned rows chronologically for display.
+//
+// Forward-cursor mode (everything else) returns a page and a cursor that
+// points at the last row and can be fed back into a subsequent List call
+// to page forward deterministically. It is the delta-sync feed.
 //
 // Ordering: (whole-second UpdatedAt ASC, ID ASC). UpdatedAt is populated
 // by GORM on every Create/Save and also advances when the row is touched
@@ -291,6 +318,19 @@ func (s *Store) List(ctx context.Context, f Filter) ([]configstore.Message, stri
 	if f.UnreadOnly {
 		q = q.Where("unread = ?", true)
 	}
+	// Tail-window mode: newest Limit rows by insertion order. No cursor
+	// is returned — the tail row of an id-DESC page is the OLDEST in the
+	// window, so a forward updated_at cursor built from it would be
+	// meaningless, and the caller (chat window) does not page.
+	if f.Newest && f.Cursor == "" {
+		q = q.Order("id DESC").Limit(limit)
+		var out []configstore.Message
+		if err := q.Find(&out).Error; err != nil {
+			return nil, "", err
+		}
+		return out, "", nil
+	}
+
 	if f.Cursor != "" {
 		c, err := decodeCursor(f.Cursor)
 		if err != nil {

--- a/pkg/messages/store_pagination_test.go
+++ b/pkg/messages/store_pagination_test.go
@@ -4,7 +4,107 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 )
+
+// TestListNewestWindowReturnsMostRecent guards the chat-window read path
+// (GH #521 recurrence). The thread-detail view opens a conversation with
+// a cursor-less, bounded List; it must get the NEWEST slice of the
+// thread. The regression it protects: List's default forward page orders
+// updated_at ASC, so a bounded read returns the LEAST-recently-updated
+// rows and silently drops the newest sends/receives once a thread grows
+// past the page size -- and outbound rows, whose updated_at is bumped
+// repeatedly by sent/retry/ack bookkeeping, drift out of an
+// updated_at-ordered window first (matching "incoming show, outgoing
+// don't"). The tail window orders by id DESC, so it is immune to that
+// churn.
+func TestListNewestWindowReturnsMostRecent(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newTestStore(t)
+
+	const total = 300
+	const window = 200
+	base := time.Date(2026, 8, 25, 0, 0, 0, 0, time.UTC)
+
+	idsInOrder := make([]uint64, 0, total)
+	for i := 0; i < total; i++ {
+		dir, from, to := "in", "W1ABC", "K0ABC"
+		if i%2 == 1 {
+			dir, from, to = "out", "K0ABC", "W1ABC"
+		}
+		m := seedMsg(dir, "K0ABC", from, to, fmt.Sprintf("msg-%d", i), fmt.Sprintf("%03d", i%1000))
+		m.ThreadKind = ThreadKindDM
+		if err := store.Insert(ctx, m); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+		idsInOrder = append(idsInOrder, m.ID)
+		// updated_at strictly increasing with insertion so the default
+		// forward (updated_at ASC) page is deterministic.
+		ts := base.Add(time.Duration(i) * time.Second).Format(time.RFC3339Nano)
+		if err := store.db.WithContext(ctx).
+			Exec("UPDATE messages SET updated_at = ? WHERE id = ?", ts, m.ID).Error; err != nil {
+			t.Fatalf("set updated_at: %v", err)
+		}
+	}
+	newestID := idsInOrder[total-1]
+	oldestID := idsInOrder[0]
+
+	// Simulate ack/retry churn: the OLDEST row's updated_at jumps to the
+	// most recent of all. id DESC must ignore this and still exclude it
+	// from the newest window.
+	churned := base.Add(time.Duration(total+1000) * time.Second).Format(time.RFC3339Nano)
+	if err := store.db.WithContext(ctx).
+		Exec("UPDATE messages SET updated_at = ? WHERE id = ?", churned, oldestID).Error; err != nil {
+		t.Fatalf("churn updated_at: %v", err)
+	}
+
+	f := Filter{ThreadKind: ThreadKindDM, ThreadKey: "W1ABC", Newest: true, Limit: window}
+	rows, cur, err := store.List(ctx, f)
+	if err != nil {
+		t.Fatalf("list newest: %v", err)
+	}
+	if cur != "" {
+		t.Errorf("tail window should not return a paging cursor, got %q", cur)
+	}
+	if len(rows) != window {
+		t.Fatalf("newest window size = %d, want %d", len(rows), window)
+	}
+	got := make(map[uint64]bool, len(rows))
+	for _, r := range rows {
+		got[r.ID] = true
+	}
+	// The window must be exactly the newest `window` ids by insertion.
+	for _, id := range idsInOrder[total-window:] {
+		if !got[id] {
+			t.Errorf("newest window missing id %d (should be present)", id)
+		}
+	}
+	// ...and must exclude older ids, including the churned oldest row.
+	for _, id := range idsInOrder[:total-window] {
+		if got[id] {
+			t.Errorf("newest window unexpectedly contains old id %d", id)
+		}
+	}
+	if !got[newestID] {
+		t.Errorf("newest window dropped the most recent message id %d", newestID)
+	}
+	if got[oldestID] {
+		t.Errorf("newest window included churned oldest id %d despite bumped updated_at", oldestID)
+	}
+
+	// Control: the default forward page (no Newest, no cursor) returns the
+	// OLDEST-updated rows and drops the newest message -- the exact GH #521
+	// symptom the tail window fixes.
+	ctrl, _, err := store.List(ctx, Filter{ThreadKind: ThreadKindDM, ThreadKey: "W1ABC", Limit: window})
+	if err != nil {
+		t.Fatalf("list control: %v", err)
+	}
+	for _, r := range ctrl {
+		if r.ID == newestID {
+			t.Fatalf("control precondition broken: forward page already includes newest id %d", newestID)
+		}
+	}
+}
 
 // TestListCursorHighVolumeNoSkips drives a busy two-way thread through the
 // polling client's forward-cursor loop and asserts every message is

--- a/pkg/webapi/docs/gen/swagger.json
+++ b/pkg/webapi/docs/gen/swagger.json
@@ -1421,7 +1421,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1469,7 +1468,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1526,7 +1524,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1567,7 +1564,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Profile ID",
                         "name": "id",
                         "in": "path",
@@ -1760,7 +1756,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -1802,7 +1797,6 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "format": "int32",
                         "description": "Transcript session ID",
                         "name": "id",
                         "in": "path",
@@ -8149,8 +8143,7 @@
                     "description": "original AX.25 frame bytes",
                     "type": "array",
                     "items": {
-                        "type": "integer",
-                        "format": "int32"
+                        "type": "integer"
                     }
                 },
                 "source": {
@@ -8400,8 +8393,7 @@
             "properties": {
                 "altitude": {
                     "description": "meters (0 if none reported)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "ambiguity": {
                     "description": "0..4, digits of ambiguity introduced by spaces",
@@ -8416,8 +8408,7 @@
                 },
                 "daodatum": {
                     "description": "DAO datum byte (APRS101 DAO extension), 0 if not present",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasAlt": {
                     "type": "boolean"
@@ -8427,8 +8418,7 @@
                 },
                 "latitude": {
                     "description": "decimal degrees, positive north",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "localTime": {
                     "description": "true if the timestamp was the '/' local-time form (APRS101 ch 6)",
@@ -8436,8 +8426,7 @@
                 },
                 "longitude": {
                     "description": "decimal degrees, positive east",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "phg": {
                     "description": "decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present",
@@ -8449,8 +8438,7 @@
                 },
                 "speed": {
                     "description": "knots",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "symbol": {
                     "$ref": "#/definitions/aprs.Symbol"
@@ -8465,12 +8453,10 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "table": {
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 }
             }
         },
@@ -8480,8 +8466,7 @@
                 "analog": {
                     "type": "array",
                     "items": {
-                        "type": "number",
-                        "format": "float64"
+                        "type": "number"
                     }
                 },
                 "analogHas": {
@@ -8497,8 +8482,7 @@
                 },
                 "digital": {
                     "description": "bits 0..7 (only lower 8)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "hasDigital": {
                     "type": "boolean"
@@ -8514,8 +8498,7 @@
             "properties": {
                 "bits": {
                     "description": "BITS. sense-bits bitmap (active-high per bit)",
-                    "type": "integer",
-                    "format": "int32"
+                    "type": "integer"
                 },
                 "eqns": {
                     "description": "a, b, c coefficients per analog channel",
@@ -8523,8 +8506,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -8599,21 +8581,17 @@
                 },
                 "pressure": {
                     "description": "tenths of millibar (e.g. 10132 = 1013.2)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain1Hour": {
                     "description": "hundredths of an inch",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rain24Hour": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rainSinceMid": {
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "rawRainCounter": {
                     "description": "raw rain counter ('#' field)",
@@ -8621,8 +8599,7 @@
                 },
                 "snowfall24h": {
                     "description": "inches (via 's' after 'g')",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "softwareType": {
                     "description": "one-letter software code (e.g. 'w', 'x', 'd')",
@@ -8630,8 +8607,7 @@
                 },
                 "temperature": {
                     "description": "degrees F",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "weatherUnitTag": {
                     "description": "2..4 ASCII letters identifying the unit/model",
@@ -8643,13 +8619,11 @@
                 },
                 "windGust": {
                     "description": "mph (5-minute peak)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "windSpeed": {
                     "description": "mph (1-minute sustained)",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 }
             }
         },
@@ -11749,11 +11723,6 @@
                 "DirRX": "heard on the air",
                 "DirTX": "transmitted by us"
             },
-            "x-enum-descriptions": [
-                "heard on the air",
-                "transmitted by us",
-                "APRS-IS upload/download (iGate)"
-            ],
             "x-enum-varnames": [
                 "DirRX",
                 "DirTX",
@@ -12068,8 +12037,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },
@@ -12162,8 +12130,7 @@
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },

--- a/pkg/webapi/docs/gen/swagger.yaml
+++ b/pkg/webapi/docs/gen/swagger.yaml
@@ -50,7 +50,6 @@ definitions:
       raw:
         description: original AX.25 frame bytes
         items:
-          format: int32
           type: integer
         type: array
       source:
@@ -229,7 +228,6 @@ definitions:
     properties:
       altitude:
         description: meters (0 if none reported)
-        format: float64
         type: number
       ambiguity:
         description: 0..4, digits of ambiguity introduced by spaces
@@ -241,7 +239,6 @@ definitions:
         type: integer
       daodatum:
         description: DAO datum byte (APRS101 DAO extension), 0 if not present
-        format: int32
         type: integer
       hasAlt:
         type: boolean
@@ -249,14 +246,12 @@ definitions:
         type: boolean
       latitude:
         description: decimal degrees, positive north
-        format: float64
         type: number
       localTime:
         description: true if the timestamp was the '/' local-time form (APRS101 ch 6)
         type: boolean
       longitude:
         description: decimal degrees, positive east
-        format: float64
         type: number
       phg:
         allOf:
@@ -264,7 +259,6 @@ definitions:
         description: decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present
       speed:
         description: knots
-        format: float64
         type: number
       symbol:
         $ref: '#/definitions/aprs.Symbol'
@@ -275,17 +269,14 @@ definitions:
   aprs.Symbol:
     properties:
       code:
-        format: int32
         type: integer
       table:
-        format: int32
         type: integer
     type: object
   aprs.Telemetry:
     properties:
       analog:
         items:
-          format: float64
           type: number
         type: array
       analogHas:
@@ -298,7 +289,6 @@ definitions:
         type: string
       digital:
         description: bits 0..7 (only lower 8)
-        format: int32
         type: integer
       hasDigital:
         type: boolean
@@ -310,13 +300,11 @@ definitions:
     properties:
       bits:
         description: BITS. sense-bits bitmap (active-high per bit)
-        format: int32
         type: integer
       eqns:
         description: a, b, c coefficients per analog channel
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -369,31 +357,25 @@ definitions:
         type: integer
       pressure:
         description: tenths of millibar (e.g. 10132 = 1013.2)
-        format: float64
         type: number
       rain1Hour:
         description: hundredths of an inch
-        format: float64
         type: number
       rain24Hour:
-        format: float64
         type: number
       rainSinceMid:
-        format: float64
         type: number
       rawRainCounter:
         description: raw rain counter ('#' field)
         type: integer
       snowfall24h:
         description: inches (via 's' after 'g')
-        format: float64
         type: number
       softwareType:
         description: one-letter software code (e.g. 'w', 'x', 'd')
         type: string
       temperature:
         description: degrees F
-        format: float64
         type: number
       weatherUnitTag:
         description: 2..4 ASCII letters identifying the unit/model
@@ -403,11 +385,9 @@ definitions:
         type: integer
       windGust:
         description: mph (5-minute peak)
-        format: float64
         type: number
       windSpeed:
         description: mph (1-minute sustained)
-        format: float64
         type: number
     type: object
   configstore.Referrer:
@@ -2662,10 +2642,6 @@ definitions:
       DirIS: APRS-IS upload/download (iGate)
       DirRX: heard on the air
       DirTX: transmitted by us
-    x-enum-descriptions:
-      - heard on the air
-      - transmitted by us
-      - APRS-IS upload/download (iGate)
     x-enum-varnames:
       - DirRX
       - DirTX
@@ -2887,7 +2863,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -2954,7 +2929,6 @@ definitions:
         description: PathPositions lists [lat, lon] pairs resolved for H-bit digipeaters in Path; zero pair when position is unknown.
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -4124,7 +4098,6 @@ paths:
       operationId: deleteAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4145,7 +4118,6 @@ paths:
       operationId: getAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4176,7 +4148,6 @@ paths:
       operationId: updateAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4218,7 +4189,6 @@ paths:
       operationId: pinAX25Profile
       parameters:
         - description: Profile ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4339,7 +4309,6 @@ paths:
       operationId: deleteAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true
@@ -4360,7 +4329,6 @@ paths:
       operationId: getAX25Transcript
       parameters:
         - description: Transcript session ID
-          format: int32
           in: path
           name: id
           required: true

--- a/pkg/webapi/messages.go
+++ b/pkg/webapi/messages.go
@@ -157,6 +157,12 @@ func (s *Server) listMessages(w http.ResponseWriter, r *http.Request) {
 		}
 		f.Limit = n
 	}
+	// A cursor-less read of a specific thread is the chat window opening a
+	// conversation: it wants the newest slice, not the forward
+	// updated_at page (which drops the latest sends/receives off the end
+	// once a thread gets busy -- GH #521). With a cursor, this is the
+	// forward delta-sync feed and keeps the keyset ordering.
+	f.Newest = f.ThreadKey != "" && f.Cursor == ""
 	rows, cursor, err := store.List(r.Context(), f)
 	if err != nil {
 		s.internalError(w, r, "list messages", err)

--- a/web/src/api/generated/api.d.ts
+++ b/web/src/api/generated/api.d.ts
@@ -2129,50 +2129,33 @@ export interface components {
         /** @enum {string} */
         "aprs.PacketType": "unknown" | "position" | "message" | "telemetry" | "weather" | "object" | "item" | "mic-e" | "status" | "capabilities" | "df-report" | "query" | "third-party";
         "aprs.Position": {
-            /**
-             * Format: float64
-             * @description meters (0 if none reported)
-             */
+            /** @description meters (0 if none reported) */
             altitude?: number;
             /** @description 0..4, digits of ambiguity introduced by spaces */
             ambiguity?: number;
             compressed?: boolean;
             /** @description degrees true (0..359) */
             course?: number;
-            /**
-             * Format: int32
-             * @description DAO datum byte (APRS101 DAO extension), 0 if not present
-             */
+            /** @description DAO datum byte (APRS101 DAO extension), 0 if not present */
             daodatum?: number;
             hasAlt?: boolean;
             hasCourse?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive north
-             */
+            /** @description decimal degrees, positive north */
             latitude?: number;
             /** @description true if the timestamp was the '/' local-time form (APRS101 ch 6) */
             localTime?: boolean;
-            /**
-             * Format: float64
-             * @description decimal degrees, positive east
-             */
+            /** @description decimal degrees, positive east */
             longitude?: number;
             /** @description decoded Power/Height/Gain/Directivity extension (APRS101 ch 7), nil if not present */
             phg?: components["schemas"]["aprs.PHG"];
-            /**
-             * Format: float64
-             * @description knots
-             */
+            /** @description knots */
             speed?: number;
             symbol?: components["schemas"]["aprs.Symbol"];
             /** @description nil if positionless or no embedded time */
             timestamp?: string;
         };
         "aprs.Symbol": {
-            /** Format: int32 */
             code?: number;
-            /** Format: int32 */
             table?: number;
         };
         "aprs.Telemetry": {
@@ -2181,20 +2164,14 @@ export interface components {
             analogHas?: boolean[];
             /** @description trailing free-form */
             comment?: string;
-            /**
-             * Format: int32
-             * @description bits 0..7 (only lower 8)
-             */
+            /** @description bits 0..7 (only lower 8) */
             digital?: number;
             hasDigital?: boolean;
             /** @description 0..999, -1 if absent */
             seq?: number;
         };
         "aprs.TelemetryMeta": {
-            /**
-             * Format: int32
-             * @description BITS. sense-bits bitmap (active-high per bit)
-             */
+            /** @description BITS. sense-bits bitmap (active-high per bit) */
             bits?: number;
             /** @description a, b, c coefficients per analog channel */
             eqns?: number[][];
@@ -2222,47 +2199,27 @@ export interface components {
             humidity?: number;
             /** @description watts/m^2 */
             luminosity?: number;
-            /**
-             * Format: float64
-             * @description tenths of millibar (e.g. 10132 = 1013.2)
-             */
+            /** @description tenths of millibar (e.g. 10132 = 1013.2) */
             pressure?: number;
-            /**
-             * Format: float64
-             * @description hundredths of an inch
-             */
+            /** @description hundredths of an inch */
             rain1Hour?: number;
-            /** Format: float64 */
             rain24Hour?: number;
-            /** Format: float64 */
             rainSinceMid?: number;
             /** @description raw rain counter ('#' field) */
             rawRainCounter?: number;
-            /**
-             * Format: float64
-             * @description inches (via 's' after 'g')
-             */
+            /** @description inches (via 's' after 'g') */
             snowfall24h?: number;
             /** @description one-letter software code (e.g. 'w', 'x', 'd') */
             softwareType?: string;
-            /**
-             * Format: float64
-             * @description degrees F
-             */
+            /** @description degrees F */
             temperature?: number;
             /** @description 2..4 ASCII letters identifying the unit/model */
             weatherUnitTag?: string;
             /** @description degrees true */
             windDirection?: number;
-            /**
-             * Format: float64
-             * @description mph (5-minute peak)
-             */
+            /** @description mph (5-minute peak) */
             windGust?: number;
-            /**
-             * Format: float64
-             * @description mph (1-minute sustained)
-             */
+            /** @description mph (1-minute sustained) */
             windSpeed?: number;
         };
         "configstore.Referrer": {

--- a/web/src/components/messages/MessageThread.svelte
+++ b/web/src/components/messages/MessageThread.svelte
@@ -95,8 +95,10 @@
         limit: 200,
       });
       const list = (env?.changes || []).map(c => c.message).filter(Boolean);
-      // Newest-first? API returns newest-first per cursor docs; we
-      // want chronological ascending, so reverse.
+      // A cursor-less thread read is a "tail window": the API returns the
+      // newest `limit` messages of this conversation (newest-first, by
+      // insertion order). We re-sort ascending by message time so the
+      // chat renders oldest-at-top / newest-at-bottom.
       list.sort((a, b) => {
         const at = Date.parse(a.sent_at || a.received_at || a.created_at || 0) || 0;
         const bt = Date.parse(b.sent_at || b.received_at || b.created_at || 0) || 0;


### PR DESCRIPTION
## Summary

Fixes the recurrence of GH #521 — on busy APRSOTA threads the chat window stops showing new messages (both sent and received), while raw packets keep flowing.

This is a **second, independent defect** from the #527 keyset fix. #527 fixed the forward *delta-sync* feed. The chat window never uses that cursor.

## Root cause

The thread-detail view (`web/src/components/messages/MessageThread.svelte` `fetchThread`) opens a conversation with a **cursor-less, bounded** `GET /api/messages?thread_kind=…&thread_key=…&limit=200`. That read fell through to `Store.List`'s forward page, which orders **`updated_at ASC`** — so it returned the *least-recently-updated* 200 rows. Once a thread grows past the page size, the newest sends and receives (largest `updated_at`) sort past position 200 and are never fetched → they stop appearing.

Outbound rows churn `updated_at` fastest — sent/retry/ack bookkeeping calls `Store.Update` repeatedly (`pkg/messages/retry.go`, `router.go`) — so they drift out of the window first. That's the "incoming shows, outgoing doesn't" half of the report. Deleting + re-adding the chat only helped because it soft-deletes the rows, dropping the live thread back under the limit until it refills. The reporter's "some sort of limit" is literally the `limit: 200`.

## Fix

Add a `Newest` mode to `messages.Filter`. A **cursor-less, thread-scoped** read now returns the most recent `Limit` rows by **insertion order (`id DESC`)** with an empty cursor, instead of the forward `updated_at` page. The handler sets it whenever a `thread_key` is present and no cursor is supplied.

`id DESC` is used deliberately (not `created_at`/`updated_at`):
- `id` is autoincrement, so `id DESC` is exactly "the N most recently inserted messages" — monotonic, unique, and unaffected by `updated_at` churn.
- It avoids the glebarez trailing-zero-trimmed RFC3339Nano text-sort hazard that #527 documented (`".9Z"` sorts after `".90000001Z"`), which also rules out ordering by any time text column directly.

The forward `updated_at` keyset delta feed is untouched. The client already re-sorts chronologically for display, so no functional client change was needed (only a corrected comment).

No new query param, so no OpenAPI/TS-client surface change.

## Test

`TestListNewestWindowReturnsMostRecent` builds a 300-message thread, bumps the oldest row's `updated_at` to the most-recent of all (simulating ack/retry churn), and asserts the tail window is **exactly the newest 200 by id** — includes the latest send, excludes the churned old row — and that the old forward page would have dropped the newest message. `go test ./pkg/messages/ ./pkg/webapi/` is green.

## Notes

- New invariant #65 in `docs/wiki/invariants.md` documents the tail-window vs forward-feed split, cross-linked from #63.
- Follow-up (not in scope here): the chat window has no "load older" pager and doesn't live-append while open — separate enhancements, unrelated to this data-loss bug.
